### PR TITLE
Version Packages

### DIFF
--- a/.changeset/dashboard-tui-console-capture.md
+++ b/.changeset/dashboard-tui-console-capture.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Dashboard TUI now surfaces engine log output in the Logs tab. Previously, the engine's `createLogger()` writes (scheduler, executor, triage, merger, PR monitor, heartbeat, etc.) went straight to `console.error` and were rendered beneath the alt-screen TUI — effectively invisible. `DashboardLogSink.captureConsole()` now intercepts `console.log/warn/error` while the TUI is running and routes each line into the ring buffer, parsing a leading `[prefix]` tag so entries carry the subsystem prefix. Originals are restored on TUI shutdown.

--- a/.changeset/dashboard-tui-logs-inspection.md
+++ b/.changeset/dashboard-tui-logs-inspection.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Add keyboard navigation and inspection features to the Dashboard TUI Logs tab: arrow keys and j/k to navigate entries, Enter to expand selected entry, Esc to close expanded view, and w to toggle wrap mode for long messages.

--- a/.changeset/dashboard-tui-status-first.md
+++ b/.changeset/dashboard-tui-status-first.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-`fn dashboard` TTY mode now opens on the System tab first so users immediately see host, port, URL, and auth token access details.

--- a/.changeset/fix-dashboard-tui-log-navigation.md
+++ b/.changeset/fix-dashboard-tui-log-navigation.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Fix dashboard TUI log navigation: add Home/End shortcuts for jumping to first/last log entry, add Space and e keys as alternatives to Enter for expanding logs, improve word wrap to handle long unbroken tokens (URLs, stack traces) by hard-wrapping them at terminal width.

--- a/.changeset/fix-ios-terminal-input.md
+++ b/.changeset/fix-ios-terminal-input.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Fix iOS terminal typing in the dashboard. On touch-primary devices, tapping the terminal opened the on-screen keyboard but keystrokes were silently dropped because the bubble-phase `handleTerminalGestureFocus` handler re-focused the helper textarea and reset its selection during touchstart/pointerdown, disrupting iOS's input-event attribution. The CSS fix in commit c7266b7f already positions the textarea to receive taps natively, so the JS handler is now a no-op on `(hover: none) and (pointer: coarse)` devices and desktop retains click-to-focus.

--- a/.changeset/fix-project-default-executor-model.md
+++ b/.changeset/fix-project-default-executor-model.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Fix executor model resolution precedence so project `defaultProviderOverride`/`defaultModelIdOverride` is honored before falling back to global `defaultProvider`/`defaultModelId` across execute, hot-swap, and step-session paths.

--- a/.changeset/fn-2312-dashboard-tui-log-fixes.md
+++ b/.changeset/fn-2312-dashboard-tui-log-fixes.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Fix dashboard TUI log behavior so log navigation can reach all entries still present in the ring buffer and streamed merge output is buffered into log lines instead of writing raw fragments into the interactive terminal UI.

--- a/.changeset/fts5-runtime-guard.md
+++ b/.changeset/fts5-runtime-guard.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Guard SQLite FTS5 usage so Fusion starts cleanly on Node builds whose bundled `node:sqlite` was compiled without FTS5. On affected systems, `fn dashboard` previously crashed on first run with `Error: no such module: fts5` during schema migration. The Database and ArchiveDatabase now probe for FTS5 at startup and skip the virtual table + triggers when unavailable; `TaskStore.searchTasks` and `ArchiveDatabase.search` fall back to LIKE-based scans. Set `FUSION_DISABLE_FTS5=1` to force the fallback on runtimes where FTS5 is present but undesirable.

--- a/.changeset/update-tui-header-branding.md
+++ b/.changeset/update-tui-header-branding.md
@@ -1,5 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-Update dashboard TUI header branding from "fn board" to "fusion" for consistent product naming.

--- a/packages/cli-alias/CHANGELOG.md
+++ b/packages/cli-alias/CHANGELOG.md
@@ -1,5 +1,20 @@
 # runfusion.ai
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [39f7709]
+- Updated dependencies [585e480]
+- Updated dependencies [86fd24e]
+- Updated dependencies [585e480]
+- Updated dependencies [7d31b21]
+- Updated dependencies [ff5df16]
+- Updated dependencies [df2836c]
+- Updated dependencies [bbdd11a]
+- Updated dependencies [0bb0100]
+  - @runfusion/fusion@0.1.1
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/cli-alias/package.json
+++ b/packages/cli-alias/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runfusion.ai",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "description": "Launch Fusion with `npx runfusion.ai` — tiny alias for @runfusion/fusion.",
   "homepage": "https://runfusion.ai",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @runfusion/fusion
 
+## 0.1.1
+
+### Patch Changes
+
+- 39f7709: Dashboard TUI now surfaces engine log output in the Logs tab. Previously, the engine's `createLogger()` writes (scheduler, executor, triage, merger, PR monitor, heartbeat, etc.) went straight to `console.error` and were rendered beneath the alt-screen TUI — effectively invisible. `DashboardLogSink.captureConsole()` now intercepts `console.log/warn/error` while the TUI is running and routes each line into the ring buffer, parsing a leading `[prefix]` tag so entries carry the subsystem prefix. Originals are restored on TUI shutdown.
+- 585e480: Add keyboard navigation and inspection features to the Dashboard TUI Logs tab: arrow keys and j/k to navigate entries, Enter to expand selected entry, Esc to close expanded view, and w to toggle wrap mode for long messages.
+- 86fd24e: `fn dashboard` TTY mode now opens on the System tab first so users immediately see host, port, URL, and auth token access details.
+- 585e480: Fix dashboard TUI log navigation: add Home/End shortcuts for jumping to first/last log entry, add Space and e keys as alternatives to Enter for expanding logs, improve word wrap to handle long unbroken tokens (URLs, stack traces) by hard-wrapping them at terminal width.
+- 7d31b21: Fix iOS terminal typing in the dashboard. On touch-primary devices, tapping the terminal opened the on-screen keyboard but keystrokes were silently dropped because the bubble-phase `handleTerminalGestureFocus` handler re-focused the helper textarea and reset its selection during touchstart/pointerdown, disrupting iOS's input-event attribution. The CSS fix in commit c7266b7f already positions the textarea to receive taps natively, so the JS handler is now a no-op on `(hover: none) and (pointer: coarse)` devices and desktop retains click-to-focus.
+- ff5df16: Fix executor model resolution precedence so project `defaultProviderOverride`/`defaultModelIdOverride` is honored before falling back to global `defaultProvider`/`defaultModelId` across execute, hot-swap, and step-session paths.
+- df2836c: Fix dashboard TUI log behavior so log navigation can reach all entries still present in the ring buffer and streamed merge output is buffered into log lines instead of writing raw fragments into the interactive terminal UI.
+- bbdd11a: Guard SQLite FTS5 usage so Fusion starts cleanly on Node builds whose bundled `node:sqlite` was compiled without FTS5. On affected systems, `fn dashboard` previously crashed on first run with `Error: no such module: fts5` during schema migration. The Database and ArchiveDatabase now probe for FTS5 at startup and skip the virtual table + triggers when unavailable; `TaskStore.searchTasks` and `ArchiveDatabase.search` fall back to LIKE-based scans. Set `FUSION_DISABLE_FTS5=1` to force the fallback on runtimes where FTS5 is present but undesirable.
+- 0bb0100: Update dashboard TUI header branding from "fn board" to "fusion" for consistent product naming.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runfusion/fusion",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "description": "Fusion CLI: HTTP API server, daemon, dashboard launcher, and task tooling for the Fusion AI coding agent.",
   "homepage": "https://github.com/Runfusion/Fusion#readme",


### PR DESCRIPTION
This PR was created by the [Changesets release](https://github.com/changesets/action) GitHub action (manually re-created because GitHub Actions lacks PR-create permission on this repo). When merged, `version.yml` will publish `@runfusion/fusion` to npm and push a version tag that triggers `release.yml` to build signed platform binaries.

# Releases
## @runfusion/fusion@0.1.1

### Patch Changes

- 39f7709: Dashboard TUI now surfaces engine log output in the Logs tab.
- 585e480: Keyboard navigation and inspection for the Dashboard TUI Logs tab.
- 86fd24e: `fn dashboard` TTY mode now opens on the System tab first.
- 585e480: Fix Dashboard TUI log navigation (Home/End, Space/e expand, wrap).
- 7d31b21: Fix iOS terminal typing in the dashboard (gesture-focus handler now no-ops on touch-primary devices so typed keys reach xterm).
- ff5df16: Fix executor model resolution precedence across execute/hot-swap/step-session.
- df2836c: Fix dashboard TUI log navigation reach + buffer streamed merge output.
- bbdd11a: Guard SQLite FTS5 usage so Fusion starts on Node builds without FTS5.
- 0bb0100: Update dashboard TUI header branding from "fn board" to "fusion".

🤖 Generated with [Claude Code](https://claude.com/claude-code)