### PR TITLE
fix: skill discovery path doubling and pattern/name matching

### DIFF
--- a/.changeset/fix-skill-name-matching.md
+++ b/.changeset/fix-skill-name-matching.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix skill name matching between Fusion's two-segment names (e.g. `web-research/SKILL.md`) and pi-coding-agent's bare directory names (e.g. `web-research`). Patterns and requested skill names now strip the `/SKILL.md` suffix before comparison, eliminating spurious "not found in discovered skills" warnings.

--- a/packages/dashboard/src/skills-adapter.ts
+++ b/packages/dashboard/src/skills-adapter.ts
@@ -264,8 +264,9 @@ export function createSkillsAdapter(options: {
         // Compute relative path for the skill.
         // Guard against baseDir being the parent of the skills directory,
         // which causes relative() to already include "skills/" in the result.
-        const _rel = relative(resource.metadata.baseDir ?? "", resource.path);
-        const skillRelativePath = _rel.startsWith("skills/") ? _rel : "skills/" + _rel;
+        const relPath = relative(resource.metadata.baseDir ?? "", resource.path)
+          .replaceAll("\\", "/");
+        const skillRelativePath = relPath.startsWith("skills/") ? relPath : `skills/${relPath}`;
 
         const skillId = computeSkillId(resource.metadata.source, skillRelativePath);
         const skillName = extractSkillName(skillRelativePath, resource.metadata.source);

--- a/packages/dashboard/src/skills-adapter.ts
+++ b/packages/dashboard/src/skills-adapter.ts
@@ -261,8 +261,11 @@ export function createSkillsAdapter(options: {
       const discoveredSkills: DiscoveredSkill[] = [];
 
       for (const resource of skillResources) {
-        // Compute relative path for the skill
-        const skillRelativePath = "skills/" + relative(resource.metadata.baseDir ?? "", resource.path);
+        // Compute relative path for the skill.
+        // Guard against baseDir being the parent of the skills directory,
+        // which causes relative() to already include "skills/" in the result.
+        const _rel = relative(resource.metadata.baseDir ?? "", resource.path);
+        const skillRelativePath = _rel.startsWith("skills/") ? _rel : "skills/" + _rel;
 
         const skillId = computeSkillId(resource.metadata.source, skillRelativePath);
         const skillName = extractSkillName(skillRelativePath, resource.metadata.source);

--- a/packages/engine/src/__tests__/skill-resolver.test.ts
+++ b/packages/engine/src/__tests__/skill-resolver.test.ts
@@ -870,5 +870,83 @@ describe("createSkillsOverrideFromSelection", () => {
       );
       expect(missingWarnings).toHaveLength(0);
     });
+
+    it("matches Fusion two-segment patterns against pi-coding-agent bare skill names", () => {
+      // Fusion's toggleExecutionSkill saves patterns like "+web-research/SKILL.md"
+      // and normalizeAgentSkills extracts "web-research/SKILL.md" from full IDs.
+      // But pi-coding-agent sets Skill.name to just the directory name: "web-research".
+      // This test verifies the cross-format matching works.
+      const dir = createMockProjectDir({
+        skills: ["+web-research/SKILL.md"],
+      });
+
+      const resolvedSkills = resolveSessionSkills({
+        projectRootDir: dir,
+        // Simulates what normalizeAgentSkills produces from "auto::skills/web-research/SKILL.md"
+        requestedSkillNames: ["web-research/SKILL.md"],
+        sessionPurpose: "triage",
+      });
+
+      const override = createSkillsOverrideFromSelection(resolvedSkills, {
+        requestedSkillNames: resolvedSkills.allowedSkillPaths.size > 0
+          ? ["web-research/SKILL.md"]
+          : undefined,
+        sessionPurpose: "triage",
+      });
+
+      // pi-coding-agent discovers skills with bare directory names
+      const base = {
+        skills: [
+          { name: "web-research", filePath: "/home/user/.pi/agent/skills/web-research/SKILL.md", description: "Web search", baseDir: "/home/user/.pi/agent/skills/web-research", sourceInfo: {} as any, disableModelInvocation: false },
+          { name: "paperclip", filePath: "/home/user/.pi/agent/skills/paperclip/SKILL.md", description: "Paperclip", baseDir: "/home/user/.pi/agent/skills/paperclip", sourceInfo: {} as any, disableModelInvocation: false },
+        ],
+        diagnostics: [],
+      };
+
+      const result = override(base);
+
+      // web-research should match despite the naming mismatch
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe("web-research");
+
+      // No spurious "not found" warnings
+      const notFoundWarnings = result.diagnostics.filter(d =>
+        d.type === "warning" && d.message.includes("not found")
+      );
+      expect(notFoundWarnings).toHaveLength(0);
+    });
+
+    it("exclusion patterns with /SKILL.md suffix correctly exclude pi-discovered skills", () => {
+      const dir = createMockProjectDir({
+        skills: ["+web-research/SKILL.md", "-paperclip/SKILL.md"],
+      });
+
+      const resolvedSkills = resolveSessionSkills({
+        projectRootDir: dir,
+      });
+
+      const override = createSkillsOverrideFromSelection(resolvedSkills, {
+        sessionPurpose: "executor",
+      });
+
+      const base = {
+        skills: [
+          { name: "web-research", filePath: "/home/user/.pi/agent/skills/web-research/SKILL.md", description: "Web search", baseDir: "", sourceInfo: {} as any, disableModelInvocation: false },
+          { name: "paperclip", filePath: "/home/user/.pi/agent/skills/paperclip/SKILL.md", description: "Paperclip", baseDir: "", sourceInfo: {} as any, disableModelInvocation: false },
+        ],
+        diagnostics: [],
+      };
+
+      const result = override(base);
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe("web-research");
+
+      // Should have a "disabled" diagnostic for paperclip (exists but excluded)
+      const disabledWarning = result.diagnostics.find(d =>
+        d.message.includes("disabled") && d.message.includes("paperclip")
+      );
+      expect(disabledWarning).toBeDefined();
+    });
   });
 });

--- a/packages/engine/src/session-skill-context.ts
+++ b/packages/engine/src/session-skill-context.ts
@@ -101,10 +101,22 @@ export function normalizeAgentSkills(
       }
     }
 
-    // Skip invalid/empty entries and deduplicate
-    if (name && name.length > 0 && !seen.has(name)) {
-      seen.add(name);
-      result.push(name);
+    // Skip invalid/empty entries and deduplicate.
+    // If the entry is a full skill ID ("source::path"), extract just the
+    // skill name (last two path segments) so it matches the discovered
+    // skill.name produced by extractSkillName().
+    if (name && name.length > 0) {
+      if (name.includes("::")) {
+        const idPath = name.split("::").pop()!;
+        const parts = idPath.replace(/\\/g, "/").split("/").filter(Boolean);
+        if (parts.length >= 2) {
+          name = parts.slice(-2).join("/");
+        }
+      }
+      if (!seen.has(name)) {
+        seen.add(name);
+        result.push(name);
+      }
     }
   }
 

--- a/packages/engine/src/skill-resolver.ts
+++ b/packages/engine/src/skill-resolver.ts
@@ -142,6 +142,24 @@ function isExclusionPattern(pattern: string): boolean {
   return pattern.startsWith("-");
 }
 
+/**
+ * Extract the bare skill name for matching purposes.
+ *
+ * Fusion conventions use two-segment names like "web-research/SKILL.md" (from
+ * extractSkillName and normalizeAgentSkills), but pi-coding-agent sets Skill.name
+ * to just the parent directory (e.g. "web-research"). This helper strips common
+ * suffixes so both sides can be compared:
+ *
+ *   "web-research/SKILL.md"           → "web-research"
+ *   "skills/web-research/SKILL.md"    → "web-research"
+ *   "web-research"                    → "web-research"
+ *   "/abs/path/skills/web-research/SKILL.md" → left unchanged (absolute paths
+ *     are matched by filePath comparison, not by this helper)
+ */
+function bareSkillName(name: string): string {
+  return name.replace(/\/SKILL\.md$/i, "");
+}
+
 // ── Main Resolution Logic ────────────────────────────────────────────────────
 
 /**
@@ -331,8 +349,13 @@ export function createSkillsOverrideFromSelection(
     // Settings patterns are relative (e.g. "web-research/SKILL.md") but
     // skill.filePath is absolute. Match against skill.name instead so
     // that patterns written by toggleExecutionSkill() actually resolve.
+    //
+    // pi-coding-agent sets Skill.name to the parent directory name
+    // (e.g. "web-research") while Fusion uses two-segment names
+    // (e.g. "web-research/SKILL.md"). bareSkillName() normalizes
+    // both sides so the comparison succeeds.
     const skillNameMatches = (skill: Skill, pattern: string): boolean =>
-      skill.name.toLowerCase() === pattern.toLowerCase()
+      bareSkillName(skill.name).toLowerCase() === bareSkillName(pattern).toLowerCase()
       || skill.filePath === pattern;
     const isExcluded = (skill: Skill): boolean => {
       for (const ep of excludedSkillPaths) {
@@ -348,10 +371,10 @@ export function createSkillsOverrideFromSelection(
     };
 
     if (hasRequestedNames) {
-      // Filter by requested names (case-insensitive match)
-      const requestedNamesLower = new Set(requestedSkillNames!.map((n) => n.toLowerCase()));
+      // Filter by requested names (case-insensitive match, normalize away /SKILL.md suffix)
+      const requestedBareNamesLower = new Set(requestedSkillNames!.map((n) => bareSkillName(n).toLowerCase()));
       filteredSkills = base.skills.filter(
-        (skill) => requestedNamesLower.has(skill.name.toLowerCase()) && !isExcluded(skill)
+        (skill) => requestedBareNamesLower.has(bareSkillName(skill.name).toLowerCase()) && !isExcluded(skill)
       );
     } else if (hasPatterns) {
       // Filter by pattern (allowed AND not excluded)
@@ -371,10 +394,13 @@ export function createSkillsOverrideFromSelection(
 
     // Check for excluded paths that DO match a discovered skill (disabled)
     const purpose = sessionPurpose ? ` [${sessionPurpose}]` : "";
-    const discoveredNames = new Set(base.skills.map((s) => s.name.toLowerCase()));
+    const discoveredBareNames = new Set(base.skills.map((s) => bareSkillName(s.name).toLowerCase()));
+    const discoveredFilePaths = new Set(base.skills.map((s) => s.filePath));
+    const hasDiscoveredMatch = (pattern: string): boolean =>
+      discoveredBareNames.has(bareSkillName(pattern).toLowerCase()) || discoveredFilePaths.has(pattern);
 
     for (const excludedPath of excludedSkillPaths) {
-      if (discoveredNames.has(excludedPath.toLowerCase())) {
+      if (hasDiscoveredMatch(excludedPath)) {
         newDiagnostics.push({
           type: "warning",
           message: `Skill at '${excludedPath}' exists but is disabled by project execution settings${purpose}`,
@@ -385,7 +411,7 @@ export function createSkillsOverrideFromSelection(
 
     // Check for configured patterns (allowed paths) that don't match any discovered skill
     for (const allowedPath of allowedSkillPaths) {
-      if (!discoveredNames.has(allowedPath.toLowerCase())) {
+      if (!hasDiscoveredMatch(allowedPath)) {
         newDiagnostics.push({
           type: "warning",
           message: `Configured skill pattern '${allowedPath}' not found in discovered skills${purpose}`,
@@ -396,10 +422,10 @@ export function createSkillsOverrideFromSelection(
 
     // Check for requested names that don't match any discovered skill
     if (requestedSkillNames) {
-      const discoveredNamesLower = new Set(base.skills.map((s) => s.name.toLowerCase()));
+      const discoveredBareNamesLower = new Set(base.skills.map((s) => bareSkillName(s.name).toLowerCase()));
       for (const requestedName of requestedSkillNames) {
         if (
-          !discoveredNamesLower.has(requestedName.toLowerCase())
+          !discoveredBareNamesLower.has(bareSkillName(requestedName).toLowerCase())
           && !isBuiltInFallbackRequest(requestedName)
         ) {
           const purpose = sessionPurpose ? ` [${sessionPurpose}]` : "";

--- a/packages/engine/src/skill-resolver.ts
+++ b/packages/engine/src/skill-resolver.ts
@@ -327,20 +327,40 @@ export function createSkillsOverrideFromSelection(
     // Skills must match the inclusion criteria AND not be in the exclusion list
     const hasExcluded = excludedSkillPaths.size > 0;
     let filteredSkills: Skill[];
+    // Build a name-based lookup for pattern/exclusion matching.
+    // Settings patterns are relative (e.g. "web-research/SKILL.md") but
+    // skill.filePath is absolute. Match against skill.name instead so
+    // that patterns written by toggleExecutionSkill() actually resolve.
+    const skillNameMatches = (skill: Skill, pattern: string): boolean =>
+      skill.name.toLowerCase() === pattern.toLowerCase()
+      || skill.filePath === pattern;
+    const isExcluded = (skill: Skill): boolean => {
+      for (const ep of excludedSkillPaths) {
+        if (skillNameMatches(skill, ep)) return true;
+      }
+      return false;
+    };
+    const isAllowed = (skill: Skill): boolean => {
+      for (const ap of allowedSkillPaths) {
+        if (skillNameMatches(skill, ap)) return true;
+      }
+      return false;
+    };
+
     if (hasRequestedNames) {
       // Filter by requested names (case-insensitive match)
       const requestedNamesLower = new Set(requestedSkillNames!.map((n) => n.toLowerCase()));
       filteredSkills = base.skills.filter(
-        (skill) => requestedNamesLower.has(skill.name.toLowerCase()) && !excludedSkillPaths.has(skill.filePath)
+        (skill) => requestedNamesLower.has(skill.name.toLowerCase()) && !isExcluded(skill)
       );
     } else if (hasPatterns) {
-      // Filter by file path (in allowed set AND not in excluded set)
+      // Filter by pattern (allowed AND not excluded)
       filteredSkills = base.skills.filter(
-        (skill) => allowedSkillPaths.has(skill.filePath) && !excludedSkillPaths.has(skill.filePath)
+        (skill) => isAllowed(skill) && !isExcluded(skill)
       );
     } else if (hasExcluded) {
       // Only exclusions set - filter out excluded skills
-      filteredSkills = base.skills.filter((skill) => !excludedSkillPaths.has(skill.filePath));
+      filteredSkills = base.skills.filter((skill) => !isExcluded(skill));
     } else {
       // No filter criteria - this shouldn't happen if filterActive is true
       filteredSkills = base.skills;
@@ -350,28 +370,22 @@ export function createSkillsOverrideFromSelection(
     const newDiagnostics: ResourceDiagnostic[] = [];
 
     // Check for excluded paths that DO match a discovered skill (disabled)
-    // These are skills that exist but were explicitly excluded by project patterns
     const purpose = sessionPurpose ? ` [${sessionPurpose}]` : "";
-    const discoveredPaths = new Set(base.skills.map((s) => s.filePath));
+    const discoveredNames = new Set(base.skills.map((s) => s.name.toLowerCase()));
 
     for (const excludedPath of excludedSkillPaths) {
-      if (discoveredPaths.has(excludedPath)) {
-        // Skill exists but was disabled by project patterns
-        // Use "warning" type since ResourceDiagnostic only supports warning|error|collision
+      if (discoveredNames.has(excludedPath.toLowerCase())) {
         newDiagnostics.push({
           type: "warning",
           message: `Skill at '${excludedPath}' exists but is disabled by project execution settings${purpose}`,
           path: excludedPath,
         });
       }
-      // If the path doesn't match any discovered skill, it's not a disabled skill - it's just not relevant
     }
 
     // Check for configured patterns (allowed paths) that don't match any discovered skill
-    // Note: At this point, we have access to base.skills for validation
     for (const allowedPath of allowedSkillPaths) {
-      if (!discoveredPaths.has(allowedPath)) {
-        // Allowed path doesn't match any discovered skill - this is a missing/invalid pattern
+      if (!discoveredNames.has(allowedPath.toLowerCase())) {
         newDiagnostics.push({
           type: "warning",
           message: `Configured skill pattern '${allowedPath}' not found in discovered skills${purpose}`,


### PR DESCRIPTION
## Problem

Three related bugs prevent agent skills from loading for heartbeat agents:

### 1. Doubled `skills/` prefix in discovery (`skills-adapter.ts`)

`discoverSkills()` unconditionally prepends `"skills/"` to the relative path, but `baseDir` points to the parent of the skills directory (e.g. `~/.fusion/agent`), so `relative()` already returns a path starting with `"skills/"`.

**Result:** Skill IDs are `auto::skills/skills/web-research/SKILL.md` instead of `auto::skills/web-research/SKILL.md`.

### 2. `normalizeAgentSkills` doesn't extract name from full ID (`session-skill-context.ts`)

The dashboard saves full skill IDs (e.g. `"auto::skills/web-research/SKILL.md"`) into agent `metadata.skills`. The runtime matches these against `skill.name` (e.g. `"web-research/SKILL.md"`) — they never match, so **agent skills silently fail to load on every heartbeat run**.

### 3. Pattern matching uses absolute `filePath` instead of skill name (`skill-resolver.ts`)

Settings patterns written by `toggleExecutionSkill()` are relative (e.g. `"web-research/SKILL.md"`), but the resolver compares them against `skill.filePath` which is absolute. Patterns can never match, producing spurious "not found in discovered skills" warnings.

## Fix

1. **skills-adapter.ts**: Only prepend `"skills/"` when the relative path doesn't already start with it
2. **session-skill-context.ts**: When an entry contains `::`, parse out the skill name (last two path segments) before matching
3. **skill-resolver.ts**: Match patterns against `skill.name` (case-insensitive) with fallback to exact `skill.filePath` for backward compat

## Reproduction

1. Create a heartbeat agent with skills assigned via the dashboard
2. Observe `metadata.skills` contains full IDs like `auto::skills/skills/web-research/SKILL.md`
3. On heartbeat run, skills fail to match — agent runs without skills
4. `.fusion/settings.json` shows `Configured skill pattern 'web-research/SKILL.md' not found` warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill path computation to avoid duplicated segments when the configured base directory is a parent of the skills directory.
  * Corrected skill ID normalization to handle special separator patterns consistently.

* **Improvements**
  * Skill filtering now matches names case-insensitively as well as by path, improving resolution and diagnostics.

* **Tests**
  * Added end-to-end tests for cross-format name matching and exclusion behavior.

* **Chore**
  * Updated release notes entry to reflect name-matching fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->