### PR TITLE
fix(FN-31): resolve per-project HeartbeatMonitor in multi-project setups

### DIFF
--- a/packages/dashboard/src/routes.ts
+++ b/packages/dashboard/src/routes.ts
@@ -980,6 +980,30 @@ export function createApiRoutes(store: TaskStore, options?: ServerOptions): Rout
   }
 
   /**
+   * Resolve the HeartbeatMonitor for the engine that owns the given scopedStore.
+   *
+   * In multi-project setups each ProjectEngine has its own HeartbeatMonitor.
+   * This function walks all engines in the engineManager and returns the one
+   * whose working directory matches the scopedStore's root.
+   * Returns undefined when no matching engine is found.
+   */
+  function resolveHeartbeatMonitor(scopedStore: TaskStore): ServerOptions["heartbeatMonitor"] {
+    const engineManager = options?.engineManager;
+    if (!engineManager) return undefined;
+    try {
+      const storeRoot = resolve(scopedStore.getRootDir());
+      for (const engine of engineManager.getAllEngines().values()) {
+        if (resolve(engine.getWorkingDirectory()) === storeRoot) {
+          return engine.getHeartbeatMonitor() ?? undefined;
+        }
+      }
+    } catch {
+      // path resolution failure — fall through
+    }
+    return undefined;
+  }
+
+  /**
    * Trigger a heartbeat wake for an assigned agent based on a comment event.
    *
    * UTILITY PATH: This function is on the heartbeat control-plane lane and is
@@ -1007,9 +1031,14 @@ export function createApiRoutes(store: TaskStore, options?: ServerOptions): Rout
       return;
     }
 
-    // Guard: heartbeatMonitor is bound to a specific project root directory.
-    // Skip the wake when the scoped store belongs to a different project.
-    if (!isHeartbeatMonitorForProject(scopedStore)) {
+    // Resolve the correct HeartbeatMonitor for this project.
+    const resolvedMonitor =
+      isHeartbeatMonitorForProject(scopedStore)
+        ? heartbeatMonitor
+        : resolveHeartbeatMonitor(scopedStore);
+
+    // Skip: no heartbeat executor available for this project
+    if (!resolvedMonitor) {
       return;
     }
 
@@ -1044,7 +1073,7 @@ export function createApiRoutes(store: TaskStore, options?: ServerOptions): Rout
       triggeringCommentType: wake.triggeringCommentType,
     };
 
-    await heartbeatMonitor.executeHeartbeat({
+    await resolvedMonitor.executeHeartbeat({
       agentId: assignedAgent.id,
       source: "on_demand",
       triggerDetail: wake.triggerDetail,
@@ -2966,6 +2995,7 @@ export function createApiRoutes(store: TaskStore, options?: ServerOptions): Rout
     hasHeartbeatExecutor,
     heartbeatMonitor,
     isHeartbeatMonitorForProject,
+    resolveHeartbeatMonitor,
     runExcerptToAgentLogs,
     parseRunAuditFilters,
     normalizeRunAuditEvent,

--- a/packages/dashboard/src/routes/register-agent-runtime-routes.ts
+++ b/packages/dashboard/src/routes/register-agent-runtime-routes.ts
@@ -16,6 +16,10 @@ interface AgentRuntimeRouteDeps {
   hasHeartbeatExecutor: boolean;
   heartbeatMonitor: import("../server.js").ServerOptions["heartbeatMonitor"];
   isHeartbeatMonitorForProject: (scopedStore: import("@fusion/core").TaskStore) => boolean;
+  /** Resolve the HeartbeatMonitor for the engine backing a scoped store.
+   *  Used for multi-project setups where each engine has its own monitor.
+   *  Returns undefined when no matching engine is found. */
+  resolveHeartbeatMonitor: (scopedStore: import("@fusion/core").TaskStore) => import("../server.js").ServerOptions["heartbeatMonitor"];
   runExcerptToAgentLogs: (run: import("@fusion/core").AgentHeartbeatRun) => import("@fusion/core").AgentLogEntry[];
   parseRunAuditFilters: (query: Record<string, unknown>) => {
     taskId?: string;
@@ -42,6 +46,7 @@ export function registerAgentRuntimeRoutes(ctx: ApiRoutesContext, deps: AgentRun
     hasHeartbeatExecutor,
     heartbeatMonitor,
     isHeartbeatMonitorForProject,
+    resolveHeartbeatMonitor,
     runExcerptToAgentLogs,
     parseRunAuditFilters,
     normalizeRunAuditEvent,
@@ -794,16 +799,22 @@ export function registerAgentRuntimeRoutes(ctx: ApiRoutesContext, deps: AgentRun
 
       // Optionally trigger execution
       let run: import("@fusion/core").AgentHeartbeatRun | undefined;
-      if (triggerExecution && hasHeartbeatExecutor && heartbeatMonitor && isHeartbeatMonitorForProject(scopedStore)) {
-        run = await heartbeatMonitor.executeHeartbeat({
-          agentId: req.params.id,
-          source: "on_demand",
-          triggerDetail: "Triggered from heartbeat",
-          contextSnapshot: {
-            wakeReason: "on_demand",
+      if (triggerExecution && hasHeartbeatExecutor && heartbeatMonitor) {
+        const resolvedMonitor =
+          isHeartbeatMonitorForProject(scopedStore)
+            ? heartbeatMonitor
+            : resolveHeartbeatMonitor(scopedStore);
+        if (resolvedMonitor) {
+          run = await resolvedMonitor.executeHeartbeat({
+            agentId: req.params.id,
+            source: "on_demand",
             triggerDetail: "Triggered from heartbeat",
-          },
-        });
+            contextSnapshot: {
+              wakeReason: "on_demand",
+              triggerDetail: "Triggered from heartbeat",
+            },
+          });
+        }
       }
 
       res.json(run ? { event, run } : event);
@@ -939,10 +950,15 @@ export function registerAgentRuntimeRoutes(ctx: ApiRoutesContext, deps: AgentRun
         // Check for existing active run
         const { store: scopedStore } = await getProjectContext(req);
 
-        // Guard: heartbeatMonitor is bound to a specific project root directory.
-        // Reject when the scoped store belongs to a different project.
-        if (!isHeartbeatMonitorForProject(scopedStore)) {
-          throw new ApiError(400, "Agent execution is only available for the server's primary project. The heartbeat monitor is not bound to this project.");
+        // Resolve the correct HeartbeatMonitor for this project.
+        // In multi-project setups, each engine has its own monitor.
+        const resolvedMonitor =
+          isHeartbeatMonitorForProject(scopedStore)
+            ? heartbeatMonitor
+            : resolveHeartbeatMonitor(scopedStore);
+
+        if (!resolvedMonitor) {
+          throw new ApiError(400, "No heartbeat executor available for this project.");
         }
 
         const { AgentStore: AgentStoreClass } = await import("@fusion/core");
@@ -960,7 +976,7 @@ export function registerAgentRuntimeRoutes(ctx: ApiRoutesContext, deps: AgentRun
         }
 
         // Execute heartbeat end-to-end (single run record, no duplicate startRun call)
-        const run = await heartbeatMonitor.executeHeartbeat({
+        const run = await resolvedMonitor.executeHeartbeat({
           agentId: req.params.id,
           source: invocationSource,
           triggerDetail: trigger,
@@ -1033,8 +1049,32 @@ export function registerAgentRuntimeRoutes(ctx: ApiRoutesContext, deps: AgentRun
         return;
       }
 
-      if (hasHeartbeatExecutor && heartbeatMonitor && isHeartbeatMonitorForProject(scopedStore)) {
-        await heartbeatMonitor.stopRun(req.params.id);
+      if (hasHeartbeatExecutor && heartbeatMonitor) {
+        const resolvedMonitor =
+          isHeartbeatMonitorForProject(scopedStore)
+            ? heartbeatMonitor
+            : resolveHeartbeatMonitor(scopedStore);
+        if (resolvedMonitor) {
+          await resolvedMonitor.stopRun(req.params.id);
+        } else {
+          const existingRun = await agentStore.getRunDetail(req.params.id, activeRun.id);
+          if (existingRun) {
+            await agentStore.saveRun({
+              ...existingRun,
+              endedAt: new Date().toISOString(),
+              status: "terminated",
+              stderrExcerpt: existingRun.stderrExcerpt ?? "Run stopped by user",
+            });
+          }
+
+          await agentStore.endHeartbeatRun(activeRun.id, "terminated");
+
+          try {
+            await agentStore.updateAgentState(req.params.id, "active");
+          } catch {
+            // Best effort to restore an idle/active state for follow-up runs.
+          }
+        }
       } else {
         const existingRun = await agentStore.getRunDetail(req.params.id, activeRun.id);
         if (existingRun) {


### PR DESCRIPTION
## Summary

- Fixes zombie heartbeat runs that silently never execute when agents belong to non-primary projects in multi-project setups
- Adds `resolveHeartbeatMonitor()` to look up the correct engine's HeartbeatMonitor via `engineManager` by matching root directory
- Updates 4 code paths: `POST /agents/:id/runs`, `POST /agents/:id/heartbeat`, `POST /agents/:id/runs/stop`, and `triggerCommentWakeForAssignedAgent`

## Root Cause

The dashboard routes used a single `HeartbeatMonitor` bound to whichever project initialized first. For agents in other projects, `isHeartbeatMonitorForProject()` returned `false`, causing either a 400 error or a fallback to `agentStore.startHeartbeatRun()` which only creates a run record without executing — producing zombie runs with `status: "active"`, no logs, no system prompt, no execution prompt.

## Fix

Instead of throwing a 400 when `isHeartbeatMonitorForProject()` returns false, the fix resolves the correct engine's HeartbeatMonitor via `engineManager.getAllEngines()` by matching `engine.getWorkingDirectory()` against the scoped store's root. Each `ProjectEngine` already has its own `HeartbeatMonitor` — we just needed to use it.

This approach avoids IPC protocol changes since each engine's HeartbeatMonitor is already in-process and accessible.

### Files Changed

| File | Change |
|------|--------|
| `packages/dashboard/src/routes.ts` | Add `resolveHeartbeatMonitor()`, update `triggerCommentWakeForAssignedAgent`, pass new dep |
| `packages/dashboard/src/routes/register-agent-runtime-routes.ts` | Add `resolveHeartbeatMonitor` dep, update 3 route handlers to resolve per-project monitor |

## Test Plan

- [ ] Verify single-project setups work unchanged (primary monitor path still used)
- [ ] Register two projects, trigger on-demand run for agent in second project — should execute with correct monitor
- [ ] Stop a run for agent in second project — should route to correct engine's monitor
- [ ] Trigger comment wake for agent in second project — should execute heartbeat
- [ ] Verify zombie runs no longer created when no matching engine is found (400 returned instead)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heartbeat monitoring reliability in multi-project environments to correctly identify and use the appropriate monitor for each project.
  * Enhanced workflow comment wake-up logic to ensure proper agent run management across multiple project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->