### PR TITLE
fix(cli): add missing dockerode dependency to published package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@mariozechner/pi-ai": "^0.72.1",
     "@mariozechner/pi-coding-agent": "^0.72.1",
+    "dockerode": "^4.0.2",
     "express": "^5.1.0",
     "ink": "^6.8.0",
     "ink-spinner": "^5.0.0",


### PR DESCRIPTION
## Summary

- Adds `dockerode` (`^4.0.2`) to `@runfusion/fusion`'s `dependencies` so the published package can resolve the externalized import at runtime.

## Problem

`npx runfusion.ai` fails immediately:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dockerode'
```

`@fusion/core` imports `dockerode` and is bundled into the CLI via tsup `noExternal`, but `dockerode` itself is marked `external` in `tsup.config.ts` (line 46). The dependency was only declared in the private `@fusion/core` workspace package — invisible after publish.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI package with Docker runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->