### PR TITLE
fix: Plan Mission With AI modal stale data and unable to type

### DIFF
--- a/.changeset/fix-mission-interview-stale-goal-cant-type.md
+++ b/.changeset/fix-mission-interview-stale-goal-cant-type.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix Plan Mission With AI modal: stale goal text and unable to type in textarea. The persisted-goal restoration effect depended on `handleStartInterview`, which recreates on every keystroke via `missionGoal` — causing the effect to re-fire and overwrite user input with stale localStorage data on each character typed.

--- a/packages/dashboard/app/components/MissionInterviewModal.tsx
+++ b/packages/dashboard/app/components/MissionInterviewModal.tsx
@@ -345,6 +345,19 @@ export function MissionInterviewModal({
     }
   }, [isOpen, view.type]);
 
+  // Restore persisted goal from localStorage ONCE when the modal opens.
+  // Must NOT depend on handleStartInterview or missionGoal — otherwise every
+  // keystroke recreates handleStartInterview, re-triggers this effect, and
+  // overwrites what the user just typed (cursor jumps to end, can't edit).
+  useEffect(() => {
+    if (isOpen && !initialGoalProp && !resumeSessionId && !hasAutoStartedRef.current && view.type === "initial") {
+      const persisted = getMissionGoal(projectId);
+      if (persisted) {
+        setMissionGoal(persisted);
+      }
+    }
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Auto-start when initialGoal prop is provided
   useEffect(() => {
     if (isOpen && initialGoalProp && !hasAutoStartedRef.current && view.type === "initial") {
@@ -354,12 +367,6 @@ export function MissionInterviewModal({
         handleStartInterview(initialGoalProp);
       }, 0);
       return () => clearTimeout(timer);
-    } else if (isOpen && !initialGoalProp && !hasAutoStartedRef.current && view.type === "initial") {
-      // Check localStorage for persisted goal when no prop provided
-      const persisted = getMissionGoal(projectId);
-      if (persisted) {
-        setMissionGoal(persisted);
-      }
     }
   }, [isOpen, initialGoalProp, view.type, handleStartInterview]);
 

--- a/packages/dashboard/app/components/MissionInterviewModal.tsx
+++ b/packages/dashboard/app/components/MissionInterviewModal.tsx
@@ -356,7 +356,7 @@ export function MissionInterviewModal({
         setMissionGoal(persisted);
       }
     }
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isOpen]); // intentional: only re-run on open/close, not on every keystroke
 
   // Auto-start when initialGoal prop is provided
   useEffect(() => {

--- a/packages/dashboard/app/components/MissionInterviewModal.tsx
+++ b/packages/dashboard/app/components/MissionInterviewModal.tsx
@@ -356,7 +356,7 @@ export function MissionInterviewModal({
         setMissionGoal(persisted);
       }
     }
-  }, [isOpen]); // intentional: only re-run on open/close, not on every keystroke
+  }, [isOpen]);
 
   // Auto-start when initialGoal prop is provided
   useEffect(() => {

--- a/packages/dashboard/app/components/__tests__/MissionInterviewModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/MissionInterviewModal.test.tsx
@@ -30,9 +30,11 @@ vi.mock("../../api", () => ({
   fetchModels: (...args: any[]) => mockFetchModels(...args),
 }));
 
+const mockGetMissionGoal = vi.fn(() => "");
+
 vi.mock("../../hooks/modalPersistence", () => ({
   saveMissionGoal: vi.fn(),
-  getMissionGoal: vi.fn(() => ""),
+  getMissionGoal: (...args: any[]) => mockGetMissionGoal(...args),
   clearMissionGoal: vi.fn(),
 }));
 
@@ -323,5 +325,38 @@ describe("MissionInterviewModal", () => {
         expect.any(String),
       );
     });
+  });
+
+  it("restores persisted goal from localStorage on open", () => {
+    mockGetMissionGoal.mockReturnValue("Previous mission goal");
+
+    renderModal();
+
+    const textarea = screen.getByLabelText("What do you want to build?");
+    expect(textarea).toHaveValue("Previous mission goal");
+  });
+
+  it("allows typing in textarea without resetting to stale persisted goal", async () => {
+    // Simulate a stale persisted goal from a previous session
+    mockGetMissionGoal.mockReturnValue("Old stale goal");
+
+    renderModal();
+
+    const textarea = screen.getByLabelText("What do you want to build?");
+    expect(textarea).toHaveValue("Old stale goal");
+
+    // User starts typing a new goal
+    fireEvent.change(textarea, { target: { value: "New mission" } });
+    expect(textarea).toHaveValue("New mission");
+
+    // Type more characters — the stale value should NOT overwrite
+    fireEvent.change(textarea, { target: { value: "New mission idea" } });
+    expect(textarea).toHaveValue("New mission idea");
+
+    // Even after a re-render cycle, user input should persist
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(textarea).toHaveValue("New mission idea");
   });
 });


### PR DESCRIPTION
## Fix for #36

The "Plan Mission With AI" modal had two related bugs:
1. **Stale data** — textarea showed the goal from the last planned mission
2. **Can't type** — each keystroke was overwritten, cursor jumped to end

### Root cause

A single `useEffect` handled both auto-start and persisted-goal restoration, but depended on `handleStartInterview` (which recreates on every `missionGoal` change). This created a cycle: keystroke → effect re-fires → overwrites input with stale localStorage value.

### Fix

Split into two separate effects:
- **Goal restoration** — depends only on `[isOpen]`, runs once on modal open
- **Auto-start** — keeps `handleStartInterview` dep for `initialGoalProp` flow only

### Tests

- ✅ "restores persisted goal from localStorage on open" — confirms draft restoration still works
- ✅ "allows typing in textarea without resetting to stale persisted goal" — regression test

All 9 tests pass.

Closes #36

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Fix Plan Mission With AI" modal so the goal textarea no longer gets overwritten by stale persisted data and reliably accepts user typing when opened.

* **Tests**
  * Added tests confirming persisted mission goals restore on modal open and that user edits are preserved (not overwritten by stale persistence).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->