### PR TITLE
fix(engine): default mergeStrategy to pull-request + subject-only landed commit search

### DIFF
--- a/.changeset/fix-landed-commit-subject-only-grep.md
+++ b/.changeset/fix-landed-commit-subject-only-grep.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix auto-merge recovery to search commit subjects only, preventing false matches from commit bodies that mention unrelated task IDs.

--- a/packages/cli/src/commands/settings.ts
+++ b/packages/cli/src/commands/settings.ts
@@ -17,6 +17,11 @@ export const VALID_SETTINGS = [
   "maxParallelSteps",
   "defaultNodeId",
   "unavailableNodePolicy",
+  "mergeStrategy",
+  "requirePrApproval",
+  "autoMerge",
+  "pushAfterMerge",
+  "pushRemote",
 ] as const;
 
 const GLOBAL_ONLY_SETTINGS = ["ntfyEnabled", "ntfyTopic", "defaultModel"] as const;

--- a/packages/core/src/__tests__/store-settings.test.ts
+++ b/packages/core/src/__tests__/store-settings.test.ts
@@ -51,9 +51,9 @@ describe("TaskStore", () => {
   });
 
   describe("mergeStrategy setting", () => {
-    it("defaults mergeStrategy to direct for backward compatibility", async () => {
+    it("defaults mergeStrategy to pull-request", async () => {
       const settings = await harness.store().getSettings();
-      expect(settings.mergeStrategy).toBe("direct");
+      expect(settings.mergeStrategy).toBe("pull-request");
     });
 
     it("persists mergeStrategy and returns it via getSettings", async () => {

--- a/packages/core/src/settings-schema.ts
+++ b/packages/core/src/settings-schema.ts
@@ -168,7 +168,7 @@ export const DEFAULT_PROJECT_SETTINGS = {
   groupOverlappingFiles: true,
   overlapIgnorePaths: [],
   autoMerge: true,
-  mergeStrategy: "direct",
+  mergeStrategy: "pull-request",
   requirePrApproval: false,
   pushAfterMerge: false,
   pushRemote: "origin",

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -673,8 +673,51 @@ export class SelfHealingManager {
     }
 
     // (4) Subject grep fallback (legacy commits).
+    // git log --grep searches both subject and body; to avoid false
+    // matches from commit bodies mentioning unrelated task IDs, we
+    // pipe git log --format='%H%x1f%s' through grep on the subject only.
     if (!stdout.trim()) {
-      stdout = await search(shellQuote(task.id), true);
+      const range = task.baseCommitSha ? `${task.baseCommitSha}..HEAD` : "HEAD";
+      const subjectOnlyCommand = [
+        "git log",
+        shellQuote(range),
+        "--format=%H%x1f%s",
+        "--max-count=20",
+        ...(options?.preferEarliestOwnedCommit ? ["--reverse"] : []),
+        "|",
+        "grep",
+        "-F",
+        shellQuote(task.id),
+      ].join(" ");
+      try {
+        const r = await execAsync(subjectOnlyCommand, {
+          cwd: this.options.rootDir,
+          maxBuffer: 1024 * 1024,
+        });
+        stdout = r.stdout;
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.warn(
+          `Failed to read git log for subject-only landed commit lookup (${task.id}): ${errorMessage}`,
+        );
+        stdout = "";
+      }
+      // Bounded range may exclude the landed commit; re-scan all of HEAD if empty.
+      if (!stdout.trim() && task.baseCommitSha) {
+        const headCommand = subjectOnlyCommand.replace(
+          shellQuote(`${task.baseCommitSha}..HEAD`),
+          "HEAD",
+        );
+        try {
+          const r = await execAsync(headCommand, {
+            cwd: this.options.rootDir,
+            maxBuffer: 1024 * 1024,
+          });
+          stdout = r.stdout;
+        } catch {
+          stdout = "";
+        }
+      }
     }
 
     const firstLine = stdout.trim().split("\n").find(Boolean);


### PR DESCRIPTION
Two fixes to prevent tasks being falsely marked as merged without a proper PR:

## Problem
Tasks could be marked 'Done' with 'Merged successfully' without an actual PR being raised. Auto-merge could fail silently, then self-healing falsely detected unrelated commits that merely mentioned the task ID in their body.

## Fix 1: Default mergeStrategy to pull-request
- Changed default from 'direct' to 'pull-request' in settings-schema.ts
- Updated corresponding test
- This ensures tasks always raise a PR instead of attempting AI squash merge

## Fix 2: Subject-only landed commit search
- Changed self-healing.ts to pipe git log through grep instead of using --grep
- git log --grep searches both subject and body, causing false matches
- New approach searches only subject lines

With these changes, tasks will create PRs that humans or approved auto-merge can properly merge via GitHub.