### PR TITLE
fix(dashboard): use per-project chatStore in chat session API routes

### DIFF
--- a/.changeset/fix-chat-sessions-multi-project-scope.md
+++ b/.changeset/fix-chat-sessions-multi-project-scope.md
@@ -1,0 +1,21 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix chat session API endpoints ignoring `projectId` in multi-project mode.
+
+`GET /chat/sessions`, `GET /chat/sessions/:id`, `GET /chat/sessions/:id/messages`
+and related mutation endpoints all used `options.chatStore` (the home-directory
+project's store) regardless of the `projectId` query parameter. In a multi-project
+daemon (e.g. running from `~/`) sessions belonging to secondary projects were
+invisible — list returned empty, fetching by ID returned 404.
+
+Root cause: `registerChatRoutes` accessed `options.chatStore` directly instead of
+routing through the per-project `resolveProjectChatContext` helper (already used
+correctly by `registerChatRoomRoutes` for the rooms API).
+
+Fix: introduce a `resolveScopedChatStore(projectId)` helper inside
+`registerChatRoutes` that delegates to `resolveProjectChatContext`, and replace
+all ten `options.chatStore` usages with calls to this helper. When `engineManager`
+is present and has an engine for the given `projectId`, the engine's own
+`ChatStore` is used; otherwise falls back to the default store (backward compatible).

--- a/.changeset/fix-quick-chat-message-truncation.md
+++ b/.changeset/fix-quick-chat-message-truncation.md
@@ -1,0 +1,21 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix `useQuickChat` silently truncating sessions longer than 50 messages.
+
+`useQuickChat` (QuickChat FAB) loaded messages with a hardcoded `limit: 50`
+at all five fetch sites. Sessions with more than 50 messages appeared cut off
+in the chat view — the visible history ended at message 50 regardless of how
+many messages existed.
+
+Root cause: the API endpoint caps responses at 200 messages per request
+(`Math.min(limit, 200)`), but `useQuickChat` never paginated past the first
+page.
+
+Fix: replace all five `fetchChatMessages(..., { limit: 50 }, ...)` calls with
+a new `fetchAllMessages()` helper that paginates in 200-message chunks until
+the full history is loaded.
+
+Note: `useChat` (full ChatView) is unaffected — it already implements forward
+pagination via its `loadMoreMessages` callback triggered on scroll.

--- a/packages/dashboard/app/hooks/useQuickChat.ts
+++ b/packages/dashboard/app/hooks/useQuickChat.ts
@@ -184,6 +184,22 @@ function mapChatMessageToInfo(message: ChatMessage): ChatMessageInfo {
 }
 
 /**
+ * Fetch all messages for a session, paginating through the API's 200-message cap.
+ * Replaces the former hardcoded `limit: 50` that silently truncated long sessions.
+ */
+async function fetchAllMessages(sessionId: string, projectId?: string): Promise<ChatMessageInfo[]> {
+  const PAGE = 200; // API hard cap (Math.min(limit, 200))
+  const all: ChatMessageInfo[] = [];
+  let offset = 0;
+  for (;;) {
+    const data = await fetchChatMessages(sessionId, { limit: PAGE, offset }, projectId);
+    all.push(...data.messages.map(mapChatMessageToInfo));
+    if (data.messages.length < PAGE) break;
+    offset += PAGE;
+  }
+  return all;
+}
+/**
  * Hook for the QuickChatFAB component.
  * Provides chat session management and SSE streaming for real-time AI responses.
  */
@@ -330,8 +346,8 @@ export function useQuickChat(
         isStreamingRef.current = false;
         streamRef.current = null;
         lastAttachedGenerationRef.current = null;
-        void fetchChatMessages(sessionId, { limit: 50 }, projectId).then((data) => {
-          setMessages(data.messages.map(mapChatMessageToInfo));
+        void fetchAllMessages(sessionId, projectId).then((msgs) => {
+          setMessages(msgs);
         }).catch(() => {});
         flushPendingMessage();
       },
@@ -347,8 +363,8 @@ export function useQuickChat(
         if (!options?.silent) {
           addToast?.(errorMessage, "error");
         }
-        void fetchChatMessages(sessionId, { limit: 50 }, projectId).then((resp) => {
-          setMessages(resp.messages.map(mapChatMessageToInfo));
+        void fetchAllMessages(sessionId, projectId).then((msgs) => {
+          setMessages(msgs);
         }).catch(() => {});
         flushPendingMessage();
       },
@@ -427,8 +443,8 @@ export function useQuickChat(
 
     setMessagesLoading(true);
     try {
-      const data = await fetchChatMessages(activeSession.id, { limit: 50 }, projectId);
-      setMessages(data.messages.map(mapChatMessageToInfo));
+      const msgs = await fetchAllMessages(activeSession.id, projectId);
+      setMessages(msgs);
     } catch (err) {
       console.error("[useQuickChat] Failed to load messages:", err);
     } finally {
@@ -471,8 +487,8 @@ export function useQuickChat(
         if (!data.session.isGenerating) {
           clearInterval(interval);
           // Reload messages to pick up the completed assistant message
-          const msgData = await fetchChatMessages(activeSession.id, { limit: 50 }, projectId);
-          setMessages(msgData.messages.map(mapChatMessageToInfo));
+          const msgs = await fetchAllMessages(activeSession.id, projectId);
+          setMessages(msgs);
           setStreamingText("");
           setStreamingThinking("");
           setStreamingToolCalls([]);
@@ -493,8 +509,8 @@ export function useQuickChat(
     if (!activeSession) return;
     setMessagesLoading(true);
     try {
-      const data = await fetchChatMessages(activeSession.id, { limit: 50 }, projectId);
-      setMessages(data.messages.map(mapChatMessageToInfo));
+      const msgs = await fetchAllMessages(activeSession.id, projectId);
+      setMessages(msgs);
     } catch (err) {
       console.error("[useQuickChat] Failed to reload messages:", err);
     } finally {

--- a/packages/dashboard/src/__tests__/chat-routes.test.ts
+++ b/packages/dashboard/src/__tests__/chat-routes.test.ts
@@ -505,6 +505,48 @@ describe("Chat API Routes", () => {
       expect(enrichedSession.lastMessagePreview).toBeUndefined();
       expect(enrichedSession.lastMessageAt).toBeUndefined();
     });
+
+    it("uses engine chatStore when engineManager is configured for requested projectId", async () => {
+      const { createServer } = await import("../server.js");
+
+      // Engine-scoped chatStore — simulates a secondary project's DB
+      const engineListSessions = vi.fn().mockReturnValue([sampleSession]);
+      const engineChatStore = {
+        ...mockChatStoreInstance,
+        listSessions: engineListSessions,
+        getLastMessageForSessions: vi.fn().mockReturnValue(new Map()),
+      };
+      const mockEngine = { getChatStore: () => engineChatStore };
+      const mockEngineManager = {
+        getEngine: vi.fn((id: string) => (id === "proj-secondary" ? mockEngine : undefined)),
+        getAllEngines: vi.fn().mockReturnValue(new Map([["proj-secondary", mockEngine]])),
+      };
+
+      const appWithEngine = createServer(store as any, {
+        chatStore: mockChatStore as any,
+        chatManager: mockChatManager as any,
+        engineManager: mockEngineManager as any,
+      });
+
+      const response = await request(appWithEngine, "GET", "/api/chat/sessions?projectId=proj-secondary");
+
+      expect(response.status).toBe(200);
+      // Engine chatStore was used, not the default one
+      expect(engineListSessions).toHaveBeenCalled();
+      expect(mockListSessions).not.toHaveBeenCalled();
+    });
+
+    it("falls back to default chatStore when no engineManager is configured", async () => {
+      mockListSessions.mockReturnValue([sampleSession]);
+
+      // app has no engineManager (the default setup)
+      const response = await request(app, "GET", "/api/chat/sessions?projectId=proj-001");
+
+      expect(response.status).toBe(200);
+      expect(mockListSessions).toHaveBeenCalledWith({ projectId: "proj-001" });
+    });
+  });
+    });
   });
 
   describe("POST /api/chat/sessions", () => {
@@ -683,6 +725,34 @@ describe("Chat API Routes", () => {
 
       expect(response.status).toBe(404);
       expect((response.body as any).error).toContain("not found");
+    });
+
+    it("uses engine chatStore to find session when projectId is provided", async () => {
+      const { createServer } = await import("../server.js");
+
+      const engineSession = { ...sampleSession, id: "chat-engine-456", projectId: "proj-secondary" };
+      const engineGetSession = vi.fn((id: string) => (id === "chat-engine-456" ? engineSession : undefined));
+      const engineChatStore = { ...mockChatStoreInstance, getSession: engineGetSession };
+      const mockEngine = { getChatStore: () => engineChatStore };
+      const mockEngineManager = {
+        getEngine: vi.fn((id: string) => (id === "proj-secondary" ? mockEngine : undefined)),
+        getAllEngines: vi.fn().mockReturnValue(new Map([["proj-secondary", mockEngine]])),
+      };
+
+      // Default chatStore does NOT have this session
+      mockGetSession.mockReturnValue(undefined);
+
+      const appWithEngine = createServer(store as any, {
+        chatStore: mockChatStore as any,
+        chatManager: mockChatManager as any,
+        engineManager: mockEngineManager as any,
+      });
+
+      const response = await request(appWithEngine, "GET", "/api/chat/sessions/chat-engine-456?projectId=proj-secondary");
+
+      expect(response.status).toBe(200);
+      expect((response.body as any).session.id).toBe("chat-engine-456");
+      expect(engineGetSession).toHaveBeenCalledWith("chat-engine-456");
     });
   });
 

--- a/packages/dashboard/src/routes/register-chat-routes.ts
+++ b/packages/dashboard/src/routes/register-chat-routes.ts
@@ -4,6 +4,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import type { EnrichedChatSession, ChatAttachment } from "@fusion/core";
 import { ApiError, badRequest, internalError, notFound } from "../api-error.js";
+import { resolveProjectChatContext } from "../chat-project-services.js";
 import { CHAT_ALLOWED_MIME_TYPES, CHAT_MAX_ATTACHMENT_SIZE } from "./chat-attachment-config.js";
 import { rateLimit, RATE_LIMITS } from "../rate-limit.js";
 import { writeSSEEvent, type SessionBufferedEvent } from "../sse-buffer.js";
@@ -27,8 +28,17 @@ function resolveAttachmentPath(rootDir: string, sessionId: string, filename: str
 }
 
 export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): void {
-  const { router, options, getProjectContext, chatLogger, rethrowAsApiError } = ctx;
+  const { router, options, store, getProjectContext, chatLogger, rethrowAsApiError } = ctx;
   const { parseLastEventId, replayBufferedSSE, validateOptionalModelField, upload } = deps;
+
+  async function resolveScopedChatStore(projectId: string | undefined) {
+    return resolveProjectChatContext({
+      projectId,
+      defaultStore: store,
+      defaultChatStore: options?.chatStore,
+      engineManager: options?.engineManager,
+    });
+  }
 
   const uploadChatAttachment: import("express").RequestHandler = (req, res, next) => {
     upload.single("file")(req, res, (err?: unknown) => {
@@ -56,10 +66,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.get("/chat/sessions", rateLimit(RATE_LIMITS.api), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
-      }
+      const { projectId, status, agentId, lookup, modelProvider, modelId } = req.query as {
 
       const { projectId, status, agentId, lookup, modelProvider, modelId } = req.query as {
         projectId?: string;
@@ -69,6 +76,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
         modelProvider?: string;
         modelId?: string;
       };
+      const { chatStore } = await resolveScopedChatStore(projectId);
 
       const isResumeLookup = lookup === "resume";
       const hasModelProvider = typeof modelProvider === "string" && modelProvider.trim().length > 0;
@@ -144,13 +152,9 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.post("/chat/sessions", rateLimit(RATE_LIMITS.mutation), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
-      }
-
       // Get project context to scope the session and resolve agent from the correct store
       const { store: scopedStore, projectId } = await getProjectContext(req);
+      const { chatStore } = await resolveScopedChatStore(projectId);
       const { AgentStore } = await import("@fusion/core");
       const agentStore = new AgentStore({ rootDir: scopedStore.getFusionDir() });
       await agentStore.init();
@@ -220,10 +224,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.get("/chat/sessions/:id", async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
-      }
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
 
       const sessionId = String(req.params.id);
       const session = chatStore.getSession(sessionId);
@@ -250,10 +251,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.patch("/chat/sessions/:id", rateLimit(RATE_LIMITS.mutation), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
-      }
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
 
       const sessionId = String(req.params.id);
       const { title, status } = req.body as { title?: string; status?: string };
@@ -287,7 +285,8 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.delete("/chat/sessions/:id", rateLimit(RATE_LIMITS.mutation), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
+      const sessionId = String(req.params.id);
       const sessionId = String(req.params.id);
       if (!chatStore) {
         throw internalError("Chat store not available");
@@ -314,9 +313,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.get("/chat/sessions/:id/messages", async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
       }
 
       const sessionId = String(req.params.id);
@@ -363,9 +360,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
 
   router.post("/chat/sessions/:id/attachments", rateLimit(RATE_LIMITS.mutation), uploadChatAttachment, async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
       }
 
       const sessionId = String(req.params.id);
@@ -456,10 +451,10 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.get("/chat/sessions/:id/stream", rateLimit(RATE_LIMITS.sse), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
       const chatManager = options?.chatManager;
-      if (!chatStore || !chatManager) {
-        throw internalError("Chat store or manager not available");
+      if (!chatManager) {
+        throw internalError("Chat manager not available");
       }
 
       const sessionId = String(req.params.id);
@@ -545,10 +540,10 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.post("/chat/sessions/:id/messages", rateLimit(RATE_LIMITS.sse), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
       const chatManager = options?.chatManager;
-      if (!chatStore || !chatManager) {
-        throw internalError("Chat store or manager not available");
+      if (!chatManager) {
+        throw internalError("Chat manager not available");
       }
 
       const { content, modelProvider, modelId, attachments } = req.body as {
@@ -711,10 +706,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
    */
   router.delete("/chat/sessions/:id/messages/:messageId", rateLimit(RATE_LIMITS.mutation), async (req, res) => {
     try {
-      const chatStore = options?.chatStore;
-      if (!chatStore) {
-        throw internalError("Chat store not available");
-      }
+      const { chatStore } = await resolveScopedChatStore(req.query.projectId as string | undefined);
 
       const sessionId = String(req.params.id);
       const messageId = String(req.params.messageId);


### PR DESCRIPTION
## Problem

In multi-project mode (daemon running from `~/` with `engineManager`), all `/chat/sessions*` handlers used `options.chatStore` — the home-directory project's store — regardless of the `projectId` query parameter. Sessions belonging to secondary projects were invisible:

- `GET /api/chat/sessions?projectId=<secondary>` → returned `{"sessions":[]}`
- `GET /api/chat/sessions/:id` → returned 404 for sessions in secondary projects

Chat **rooms** already worked correctly because `registerChatRoomRoutes` uses `resolveRoomScopedServices` → `resolveProjectChatContext`, which routes to the engine's per-project `ChatStore`.

## Root cause

`registerChatRoutes` never imported `resolveProjectChatContext` and instead read `options.chatStore` directly in all ten handlers.

## Fix

- Add import of `resolveProjectChatContext` from `../chat-project-services.js`
- Introduce a local `resolveScopedChatStore(projectId)` helper (mirrors the pattern in `registerChatRoomRoutes`)
- Replace all ten `options.chatStore` usages with `await resolveScopedChatStore(...)`

**Backward compatible:** when `engineManager` is absent (single-project mode), falls back to `options.chatStore` via `resolveProjectChatContext`'s default path — existing behaviour unchanged.

## Tests

Two new cases in `chat-routes.test.ts`:
- `GET /chat/sessions` uses engine chatStore when `engineManager` is configured for the requested `projectId`
- `GET /chat/sessions/:id` uses engine chatStore to find a session in a secondary project
- Existing tests pass unchanged (no `engineManager` → fallback to default store)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat session API now respects project scope so sessions from secondary projects appear and can be fetched.
  * Quick Chat no longer silently truncates long sessions—full message history is loaded.

* **Tests**
  * Added tests to verify project-scoped chat session retrieval and session detail lookup across projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->