### PR TITLE
fix(dashboard): paginate all messages in useQuickChat (was truncated at 50)

### DIFF
--- a/.changeset/fix-quick-chat-message-truncation.md
+++ b/.changeset/fix-quick-chat-message-truncation.md
@@ -1,0 +1,21 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix `useQuickChat` silently truncating sessions longer than 50 messages.
+
+`useQuickChat` (QuickChat FAB) loaded messages with a hardcoded `limit: 50`
+at all five fetch sites. Sessions with more than 50 messages appeared cut off
+in the chat view — the visible history ended at message 50 regardless of how
+many messages existed.
+
+Root cause: the API endpoint caps responses at 200 messages per request
+(`Math.min(limit, 200)`), but `useQuickChat` never paginated past the first
+page.
+
+Fix: replace all five `fetchChatMessages(..., { limit: 50 }, ...)` calls with
+a new `fetchAllMessages()` helper that paginates in 200-message chunks until
+the full history is loaded.
+
+Note: `useChat` (full ChatView) is unaffected — it already implements forward
+pagination via its `loadMoreMessages` callback triggered on scroll.

--- a/packages/dashboard/app/hooks/useQuickChat.ts
+++ b/packages/dashboard/app/hooks/useQuickChat.ts
@@ -184,6 +184,22 @@ function mapChatMessageToInfo(message: ChatMessage): ChatMessageInfo {
 }
 
 /**
+ * Fetch all messages for a session, paginating through the API's 200-message cap.
+ * Replaces the former hardcoded `limit: 50` that silently truncated long sessions.
+ */
+async function fetchAllMessages(sessionId: string, projectId?: string): Promise<ChatMessageInfo[]> {
+  const PAGE = 200; // API hard cap (Math.min(limit, 200))
+  const all: ChatMessageInfo[] = [];
+  let offset = 0;
+  for (;;) {
+    const data = await fetchChatMessages(sessionId, { limit: PAGE, offset }, projectId);
+    all.push(...data.messages.map(mapChatMessageToInfo));
+    if (data.messages.length < PAGE) break;
+    offset += PAGE;
+  }
+  return all;
+}
+/**
  * Hook for the QuickChatFAB component.
  * Provides chat session management and SSE streaming for real-time AI responses.
  */
@@ -330,8 +346,8 @@ export function useQuickChat(
         isStreamingRef.current = false;
         streamRef.current = null;
         lastAttachedGenerationRef.current = null;
-        void fetchChatMessages(sessionId, { limit: 50 }, projectId).then((data) => {
-          setMessages(data.messages.map(mapChatMessageToInfo));
+        void fetchAllMessages(sessionId, projectId).then((msgs) => {
+          if (activeSessionRef.current?.id === sessionId) setMessages(msgs);
         }).catch(() => {});
         flushPendingMessage();
       },
@@ -347,8 +363,8 @@ export function useQuickChat(
         if (!options?.silent) {
           addToast?.(errorMessage, "error");
         }
-        void fetchChatMessages(sessionId, { limit: 50 }, projectId).then((resp) => {
-          setMessages(resp.messages.map(mapChatMessageToInfo));
+        void fetchAllMessages(sessionId, projectId).then((msgs) => {
+          if (activeSessionRef.current?.id === sessionId) setMessages(msgs);
         }).catch(() => {});
         flushPendingMessage();
       },
@@ -427,8 +443,9 @@ export function useQuickChat(
 
     setMessagesLoading(true);
     try {
-      const data = await fetchChatMessages(activeSession.id, { limit: 50 }, projectId);
-      setMessages(data.messages.map(mapChatMessageToInfo));
+      const sessionId = activeSession.id;
+      const msgs = await fetchAllMessages(sessionId, projectId);
+      if (activeSessionRef.current?.id === sessionId) setMessages(msgs);
     } catch (err) {
       console.error("[useQuickChat] Failed to load messages:", err);
     } finally {
@@ -471,8 +488,9 @@ export function useQuickChat(
         if (!data.session.isGenerating) {
           clearInterval(interval);
           // Reload messages to pick up the completed assistant message
-          const msgData = await fetchChatMessages(activeSession.id, { limit: 50 }, projectId);
-          setMessages(msgData.messages.map(mapChatMessageToInfo));
+          const sessionId = activeSession.id;
+          const msgs = await fetchAllMessages(sessionId, projectId);
+          if (activeSessionRef.current?.id === sessionId) setMessages(msgs);
           setStreamingText("");
           setStreamingThinking("");
           setStreamingToolCalls([]);
@@ -493,8 +511,9 @@ export function useQuickChat(
     if (!activeSession) return;
     setMessagesLoading(true);
     try {
-      const data = await fetchChatMessages(activeSession.id, { limit: 50 }, projectId);
-      setMessages(data.messages.map(mapChatMessageToInfo));
+      const sessionId = activeSession.id;
+      const msgs = await fetchAllMessages(sessionId, projectId);
+      if (activeSessionRef.current?.id === sessionId) setMessages(msgs);
     } catch (err) {
       console.error("[useQuickChat] Failed to reload messages:", err);
     } finally {


### PR DESCRIPTION
## Problem

`useQuickChat` (the QuickChat FAB) loaded messages with a hardcoded `limit: 50` at all five fetch sites and never paginated further. Sessions with more than 50 messages appeared silently cut off — the visible history ended at message 50.

Note: the API endpoint already caps responses at 200 per request (`effectiveLimit = Math.min(limit, 200)`), so even requesting more requires pagination.

## Root cause

Five `fetchChatMessages(sessionId, { limit: 50 }, projectId)` calls with no pagination loop or load-more trigger.

## Fix

Introduce a `fetchAllMessages(sessionId, projectId)` helper that paginates in 200-message chunks until the full history is loaded, and replace all five call sites.

## Scope

`useChat` (full ChatView) is **not affected** — it already implements `loadMoreMessages` forward pagination triggered on scroll to bottom. This fix is scoped to `useQuickChat` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed QuickChat message history truncation so conversations load their full history (no silent 50-message cutoff). Refreshes, stream retries, and recovery paths now reliably apply up-to-date messages and avoid showing stale content after session changes.

* **Documentation**
  * Added a release note documenting the QuickChat history fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->