### PR TITLE
feat: make agent name editable in review step of creation modal

### DIFF
--- a/.changeset/editable-agent-name.md
+++ b/.changeset/editable-agent-name.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Enable editing the agent name during the review step of the New Agent dialog.

--- a/packages/dashboard/app/components/NewAgentDialog.tsx
+++ b/packages/dashboard/app/components/NewAgentDialog.tsx
@@ -736,12 +736,16 @@ export function NewAgentDialog({
                 Review your agent configuration before creating.
               </p>
               <div className="agent-dialog-summary">
-                <div className="agent-dialog-summary-row">
-                  <span className="agent-dialog-summary-row-label">Name</span>
-                  <span className="agent-dialog-summary-row-value">
-                    {icon && <span className="agent-dialog-icon-prefix">{icon}</span>}
-                    {name}
-                  </span>
+                  <div className="agent-dialog-summary-row agent-dialog-summary-row--editable">
+                  <label className="agent-dialog-summary-row-label" htmlFor="agent-review-name">Name</label>
+                  <input
+                    id="agent-review-name"
+                    type="text"
+                    className="input"
+                    placeholder="e.g. Frontend Reviewer"
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                  />
                 </div>
                 <div className="agent-dialog-summary-row agent-dialog-summary-row--editable agent-dialog-summary-row--title">
                   <label className="agent-dialog-summary-row-label" htmlFor="agent-review-title">Title</label>


### PR DESCRIPTION
This PR updates the New Agent creation wizard by making the Agent Name field editable in the final Review step (Step 2). Previously, the name was displayed as read-only, which prevented corrections. The icon prefix wrapper has also been removed to match the Title input field structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent name field in the New Agent dialog's review step is now editable, allowing you to modify the agent name during the final review before completing the agent configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/1063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->