### PR TITLE
fix(core): normalize bare "user" id to dashboard alias in inbox routing

### DIFF
--- a/packages/core/src/__tests__/message-store.test.ts
+++ b/packages/core/src/__tests__/message-store.test.ts
@@ -917,4 +917,38 @@ describe("MessageStore", () => {
       expect(events[0]).toBe(message.id);
     });
   });
+
+  describe("DASHBOARD_USER_ALIASES — bare 'user' normalization", () => {
+    it("normalizeMessageParticipant('user', 'user') normalises to DASHBOARD_USER_ID", () => {
+      // Messages sent with to_id='user' (the natural human alias) must be routed to the
+      // dashboard mailbox — they should store as toId='dashboard', not 'user'.
+      const msg = store.sendMessage({
+        fromId: "agent-1",
+        fromType: "agent",
+        toId: "user",
+        toType: "user",
+        content: "Inbox test",
+        type: "agent-to-user",
+      });
+      expect(msg.toId).toBe(DASHBOARD_USER_ID);
+    });
+
+    it("getInbox('dashboard', 'user') returns messages stored with toId='user'", () => {
+      // A message stored while toId='user' was not yet in the alias set must now appear
+      // in the operator inbox — validates that the READ path covers the legacy value.
+      // We insert directly into the DB (bypassing normalizeMessageParticipant) to simulate
+      // messages created by the old code that stored toId='user' rather than 'dashboard'.
+      const legacyId = "msg-legacy-test-001";
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO messages (id, fromId, fromType, toId, toType, content, type, read, createdAt, updatedAt)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`
+      ).run(legacyId, "agent-1", "agent", "user", "user", "Legacy DM from old session", "agent-to-user", now, now);
+
+      const inbox = store.getInbox(DASHBOARD_USER_ID, "user");
+      const found = inbox.find((m) => m.id === legacyId);
+      expect(found).toBeDefined();
+      expect(found?.content).toBe("Legacy DM from old session");
+    });
+  });
 });

--- a/packages/core/src/message-store.ts
+++ b/packages/core/src/message-store.ts
@@ -220,7 +220,7 @@ export class MessageStore extends EventEmitter<MessageStoreEvents> {
 
   private getParticipantIdsForLookup(ownerId: string, ownerType: ParticipantType): string[] {
     if (ownerType === "user" && ownerId === DASHBOARD_USER_ID) {
-      return [DASHBOARD_USER_ID, "user:dashboard", "User: user:dashboard"];
+      return [DASHBOARD_USER_ID, "user", "user:dashboard", "User: user:dashboard"];
     }
     return [ownerId];
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6132,7 +6132,7 @@ export type ParticipantType = "agent" | "user" | "system";
 /** Canonical recipient ID for dashboard user mailbox routing. */
 export const DASHBOARD_USER_ID = "dashboard";
 
-const DASHBOARD_USER_ALIASES = new Set([DASHBOARD_USER_ID, "user:dashboard", "User: user:dashboard"]);
+const DASHBOARD_USER_ALIASES = new Set([DASHBOARD_USER_ID, "user", "user:dashboard", "User: user:dashboard"]);
 
 /** Normalize participant identity for durable mailbox routing. */
 export function normalizeMessageParticipant(id: string, type: ParticipantType): { id: string; type: ParticipantType } {


### PR DESCRIPTION
## Problem

Since FN-3484 (`47ae7783b`, 2026-05-05) introduced `normalizeMessageParticipant`, agents sending `fn_send_message` with `to_id: "user"` have their messages silently dropped from the operator inbox.

There are two independent gaps:

**Write path** (`packages/core/src/types.ts`): `DASHBOARD_USER_ALIASES` did not include `"user"`, so `normalizeMessageParticipant("user", "user")` returned `{ id: "user" }` unchanged instead of normalizing to `DASHBOARD_USER_ID = "dashboard"`. Messages were stored with `toId="user"` in the DB.

**Read path** (`packages/core/src/message-store.ts`): `getParticipantIdsForLookup` did not include `"user"` in its allowlist for the dashboard mailbox lookup. The inbox query used `WHERE toId IN ("dashboard","user:dashboard","User: user:dashboard")`, which never matched records stored as `toId="user"`.

Both gaps must be fixed: the write path ensures new messages are stored correctly; the read path ensures messages already stored with the legacy `"user"` value still appear in the inbox.

## Root cause

`"user"` is the natural string an agent uses for `to_id` when addressing the operator — it is the literal `ParticipantType` value and the most obvious choice. The aliases set was designed to cover `"user:dashboard"` and `"User: user:dashboard"` (older identity formats) but the plain `"user"` case was overlooked.

The chat guidance added alongside FN-3484 now says `to_id: "dashboard"` is preferred, but `"user"` must also work as a valid alias to be robust.

## Fix

**`packages/core/src/types.ts`**
```diff
-const DASHBOARD_USER_ALIASES = new Set([DASHBOARD_USER_ID, "user:dashboard", "User: user:dashboard"]);
+const DASHBOARD_USER_ALIASES = new Set([DASHBOARD_USER_ID, "user", "user:dashboard", "User: user:dashboard"]);
```

**`packages/core/src/message-store.ts`**
```diff
-return [DASHBOARD_USER_ID, "user:dashboard", "User: user:dashboard"];
+return [DASHBOARD_USER_ID, "user", "user:dashboard", "User: user:dashboard"];
```

Both changes are additive and backward-compatible.

## Tests

Two new tests in `packages/core/src/__tests__/message-store.test.ts`:

1. **Write path**: `store.sendMessage({ toId: "user" })` stores the message with `toId = DASHBOARD_USER_ID` (normalization on write).
2. **Read path / legacy**: a message inserted directly into the DB with `toId = "user"` (bypassing normalization, simulating records from before FN-3484) is returned by `store.getInbox(DASHBOARD_USER_ID, "user")`.

All 55 `message-store` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling for a specific user identity, ensuring messages are correctly stored and retrieved in the inbox.
  * Fixed compatibility with legacy messages by enabling proper inbox queries.
  * Enhanced message routing consistency for special user scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->