### PR TITLE
fix(engine): do not fail tasks parked for pending review

### DIFF
--- a/.changeset/pending-review-not-failed.md
+++ b/.changeset/pending-review-not-failed.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Do not mark executor sessions as failed when they are parked for pending code review.

--- a/packages/engine/src/__tests__/executor-step-session.test.ts
+++ b/packages/engine/src/__tests__/executor-step-session.test.ts
@@ -241,7 +241,7 @@ describe("Workflow Steps Execution", () => {
       await executor.execute(baseTask as any);
 
       expect(mockedCreateFnAgent).toHaveBeenCalledTimes(1);
-      expect(store.updateTask).toHaveBeenCalledWith("FN-5436-A", {
+      expect(store.updateTask).not.toHaveBeenCalledWith("FN-5436-A", {
         status: "failed",
         error: "executor-exit-while-review-pending",
       });
@@ -253,7 +253,7 @@ describe("Workflow Steps Execution", () => {
         undefined,
         expect.objectContaining({ agentId: "executor" }),
       );
-      expect(onError).toHaveBeenCalledWith(
+      expect(onError).not.toHaveBeenCalledWith(
         expect.objectContaining({ id: "FN-5436-A" }),
         expect.objectContaining({ message: "executor-exit-while-review-pending" }),
       );
@@ -291,7 +291,7 @@ describe("Workflow Steps Execution", () => {
       await executor.execute(baseTask as any);
 
       expect(mockedCreateFnAgent).toHaveBeenCalledTimes(1);
-      expect(store.updateTask).toHaveBeenCalledWith("FN-5436-B", {
+      expect(store.updateTask).not.toHaveBeenCalledWith("FN-5436-B", {
         status: "failed",
         error: "executor-exit-while-review-pending",
       });

--- a/packages/engine/src/__tests__/reliability-interactions/executor-pending-review-skip-retry.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/executor-pending-review-skip-retry.test.ts
@@ -85,7 +85,7 @@ describe("reliability interactions: FN-5436 executor pending-review skip", () =>
     const executor = new TaskExecutor(store as any, "/repo");
     await executor.execute(task);
 
-    expect(store.updateTask).toHaveBeenCalledWith("FN-5436-RI-C", {
+    expect(store.updateTask).not.toHaveBeenCalledWith("FN-5436-RI-C", {
       status: "failed",
       error: "executor-exit-while-review-pending",
     });

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -4536,12 +4536,12 @@ export class TaskExecutor {
                 this.tokenUsageBaselines.delete(task.id);
                 session.dispose();
                 await this.persistTokenUsage(task.id);
-                await this.store.updateTask(task.id, {
-                  status: "failed",
-                  error: "executor-exit-while-review-pending",
-                });
+                // A pending-review block is not an execution failure. The executor
+                // cannot continue until the reviewer decision is resolved, so park
+                // the task in review without setting status=failed; otherwise the
+                // merge/review queue deadlocks on a task that is both in-review and
+                // failed.
                 await this.handoffTaskToReview(task, "executor-exit-while-review-pending");
-                this.options.onError?.(task, new Error("executor-exit-while-review-pending"));
                 pendingReviewParked = true;
                 break;
               }


### PR DESCRIPTION
## Summary
- Treat executor pending-review parking as a review lifecycle state, not an execution failure.
- Avoid contradictory `in-review` + `failed` task state for `executor-exit-while-review-pending`.
- Prevent review/merge/self-healing deadlocks when an executor exits while a code-review decision is still outstanding.

## Test plan
- `pnpm --filter @fusion/engine exec vitest run src/__tests__/reliability-interactions/executor-pending-review-skip-retry.test.ts src/__tests__/executor-step-session.test.ts --silent=passed-only --reporter=dot`
  - Passed in existing checkout: 52 tests.
- Fresh origin/main worktree test run was blocked before execution by pnpm minimumReleaseAge lockfile policy for recently published dependencies; the branch cherry-picks cleanly onto current `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Executor sessions parked for pending code review are no longer incorrectly marked as failed. Tasks now transition to review status appropriately without triggering failure states or preventing future operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/1142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->