### PR TITLE
fix: skip blocked todo tasks during self-owned reclaim

### DIFF
--- a/.changeset/blocked-todo-reclaim.md
+++ b/.changeset/blocked-todo-reclaim.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Skip self-owned branch reclaim for dependency-blocked todo tasks so repaired queued work is not repeatedly resumed before its blocker clears.

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -7722,6 +7722,20 @@ describe("SelfHealingManager reclaimSelfOwnedBranchConflicts", () => {
     expect(store.updateTask).toHaveBeenCalledWith("FN-500", expect.objectContaining({ worktree: "/tmp/fn-500", branch: "fusion/fn-500", status: null, paused: false }));
   });
 
+  it("skips blocked todo tasks with preserved branches", async () => {
+    (store.listTasks as any)
+      .mockResolvedValueOnce([{ id: "FN-516", column: "todo", blockedBy: "FN-216", checkedOutBy: null, branch: "fusion/fn-516", worktree: "/tmp/fn-516" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    const inspectSpy = vi.spyOn(branchConflictModule, "inspectBranchConflict");
+
+    const recovered = await manager.reclaimSelfOwnedBranchConflicts();
+
+    expect(recovered).toBe(0);
+    expect(inspectSpy).not.toHaveBeenCalled();
+    expect(store.updateTask).not.toHaveBeenCalled();
+  });
+
   it("skips checked out tasks", async () => {
     (store.listTasks as any)
       .mockResolvedValueOnce([{ id: "FN-501", checkedOutBy: "agent-1", branch: "fusion/fn-501", worktree: "/tmp/fn-501" }])

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -2083,6 +2083,10 @@ export class SelfHealingManager {
       for (const task of candidates) {
         if (task.checkedOutBy || activeTaskIds.has(task.id.toUpperCase()) || !task.branch || !task.worktree) continue;
         if (task.userPaused) continue;
+        if (task.column === "todo" && task.blockedBy) {
+          log.log(`[self-healing] skipping blocked todo task ${task.id} during self-owned branch reclaim (blockedBy=${task.blockedBy})`);
+          continue;
+        }
         if (task.pausedReason === "worktrunk_operation_failed") {
           log.log(`[self-healing] skipping worktrunk-paused task ${task.id}`);
           continue;


### PR DESCRIPTION
## Summary
- Skip self-owned branch reclaim for tasks that are already back in `todo` and dependency-blocked via `blockedBy`.
- Add a regression test that ensures blocked queued tasks with preserved branches are not inspected/reclaimed.
- Add a patch changeset for the published CLI bundle.

## Why
A manually repaired task can legitimately sit in `todo`/queued while waiting on an unmet dependency. The self-owned reclaim startup path was still treating that preserved branch/worktree as reclaimable, causing repeated recovery/resume churn even though the task could not safely execute until the blocker cleared.

## Test Plan
- `corepack pnpm --filter @fusion/engine test -- self-healing.test.ts -t 'skips blocked todo tasks|reclaimSelfOwnedBranchConflicts'`
- `corepack pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where queued tasks with unmet dependencies would be repeatedly resumed before their dependency blockers were cleared.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/1202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->