### PR TITLE
fix: treat origin/main commits as integrated in contamination checks

### DIFF
--- a/.changeset/remote-integration-contamination.md
+++ b/.changeset/remote-integration-contamination.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Treat foreign-attributed commits reachable from origin/main as already integrated during branch contamination checks to avoid false-positive recovery loops when local main is stale.

--- a/packages/engine/src/__tests__/branch-conflicts.test.ts
+++ b/packages/engine/src/__tests__/branch-conflicts.test.ts
@@ -467,8 +467,8 @@ describe("branch-conflicts", () => {
   });
 
   // FN-5475 / option-2 promotion check: a commit attributed to another
-  // task that's already reachable from local `main` was integrated via
-  // fast-forward and shouldn't be treated as contamination on a
+  // task that's already reachable from the integration target was integrated
+  // via fast-forward and shouldn't be treated as contamination on a
   // downstream branch that briefly inherited it.
   it("assertCleanBranchAtBase treats foreign-attributed commits that are ancestors of main as promoted", async () => {
     mockedExecSync.mockImplementation((cmd: string | string[]) => {
@@ -477,7 +477,7 @@ describe("branch-conflicts", () => {
         return Buffer.from("bbb222feat(FN-4386): foreignFusion-Task-Id: FN-4386\n");
       }
       if (command.includes("git merge-base --is-ancestor 'bbb222' 'main'")) {
-        // Simulate the FN-5475 case: foreign commit is already on main.
+        // Simulate the FN-5475 case: foreign commit is already on local main.
         return Buffer.from("");
       }
       throw new Error(`Unexpected command: ${command}`);
@@ -488,14 +488,38 @@ describe("branch-conflicts", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("assertCleanBranchAtBase still throws when foreign-attributed commits are NOT on main", async () => {
+  it("assertCleanBranchAtBase treats foreign-attributed commits that are only ancestors of origin/main as promoted", async () => {
+    mockedExecSync.mockImplementation((cmd: string | string[]) => {
+      const command = typeof cmd === "string" ? cmd : cmd[0];
+      if (command.includes("git log --format=%H%x1f%s%x1f%b 'main..fusion/fn-4068'")) {
+        return Buffer.from("bbb222feat(FN-4386): foreignFusion-Task-Id: FN-4386\n");
+      }
+      if (command.includes("git merge-base --is-ancestor 'bbb222' 'main'")) {
+        // Local main is stale and does not yet contain the promoted dependency.
+        const err = new Error("not an ancestor") as Error & { stderr?: string };
+        err.stderr = "";
+        throw err;
+      }
+      if (command.includes("git merge-base --is-ancestor 'bbb222' 'origin/main'")) {
+        // Remote-tracking integration branch already contains it.
+        return Buffer.from("");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(
+      assertCleanBranchAtBase("/tmp/repo", "fusion/fn-4068", "main", "FN-4068"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("assertCleanBranchAtBase still throws when foreign-attributed commits are NOT on any integration ref", async () => {
     mockedExecSync.mockImplementation((cmd: string | string[]) => {
       const command = typeof cmd === "string" ? cmd : cmd[0];
       if (command.includes("git log --format=%H%x1f%s%x1f%b 'main..fusion/fn-4068'")) {
         return Buffer.from("bbb222feat(FN-4386): foreignFusion-Task-Id: FN-4386\n");
       }
       if (command.includes("git merge-base --is-ancestor")) {
-        // Not on main — exits non-zero.
+        // Not on any integration ref — exits non-zero.
         const err = new Error("not an ancestor") as Error & { stderr?: string };
         err.stderr = "";
         throw err;

--- a/packages/engine/src/branch-conflicts.ts
+++ b/packages/engine/src/branch-conflicts.ts
@@ -447,14 +447,23 @@ export async function assertCleanBranchAtBase(
 
   if (candidateForeign.length === 0) return;
 
-  // FN-5475: a commit attributed to another task that's already reachable
-  // from local `main` was promoted through integration. Treat it as
-  // ancestral, not contamination. This closes the race where a sibling
-  // task's commit briefly sat at local-main's tip while a downstream
-  // worktree was created (cross-task tip absorption).
+  // FN-5475/FN-219: a commit attributed to another task that's already
+  // reachable from the integration target was promoted through integration.
+  // Treat it as ancestral, not contamination. Check both local `main` and
+  // `origin/main`: long-running dashboards can have stale local main while
+  // the remote-tracking branch already contains the promoted dependency, and
+  // using only local main produces false branch-cross-contamination loops.
+  const integratedRefs = ["main", "origin/main"];
   const foreignCommits: BranchCrossContaminationCommit[] = [];
   for (const commit of candidateForeign) {
-    if (await isAncestorOf(repoDir, commit.sha, "main")) continue;
+    let alreadyIntegrated = false;
+    for (const ref of integratedRefs) {
+      if (await isAncestorOf(repoDir, commit.sha, ref)) {
+        alreadyIntegrated = true;
+        break;
+      }
+    }
+    if (alreadyIntegrated) continue;
     foreignCommits.push(commit);
   }
 


### PR DESCRIPTION
## Summary
- treat foreign-task commits reachable from either `main` or `origin/main` as already integrated during branch contamination checks
- add a regression for stale local `main` where `origin/main` already contains the promoted dependency commit
- add a patch changeset for the published Fusion package

## Why
Long-running dashboards can have a stale local `main` while `origin/main` already contains dependency commits. The contamination checker only considered local `main`, so downstream task branches could be falsely paused in a branch-cross-contamination recovery loop even though the foreign-attributed commits were already integrated upstream.

## Testing
- `corepack pnpm --filter @fusion/engine test -- branch-conflicts.test.ts -t 'assertCleanBranchAtBase'`
- `corepack pnpm build`
- `corepack pnpm lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed false-positive contamination detection when local tracking branch is stale compared to remote, preventing unnecessary recovery loops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Runfusion/Fusion/pull/1203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->