### PR TITLE
fix(engine): requeue incomplete stuck-loop exhaustion

### DIFF
--- a/.changeset/quiet-lions-park.md
+++ b/.changeset/quiet-lions-park.md
@@ -2,4 +2,4 @@
 "@runfusion/fusion": patch
 ---
 
-Park incomplete stuck-loop exhausted tasks in todo instead of routing them through review or merge.
+Requeue incomplete stuck-loop exhausted tasks in todo with progress preserved instead of routing them through review/merge or requiring manual unpause.

--- a/packages/engine/src/__tests__/reliability-interactions/non-progress-churn.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/non-progress-churn.test.ts
@@ -189,7 +189,7 @@ describe("reliability interactions: non-progress churn", () => {
     manager.stop();
   });
 
-  it("parks incomplete STUCK_LOOP_EXHAUSTED tasks in todo when the churn signal does not fire", async () => {
+  it("re-queues incomplete STUCK_LOOP_EXHAUSTED tasks in todo when the churn signal does not fire", async () => {
     const task = baseTask({ id: "FN-5168-LOOP", stuckKillCount: 6 });
     const store = createStore(task);
     const manager = new SelfHealingManager(store, { rootDir: "/tmp/repo" });
@@ -210,11 +210,11 @@ describe("reliability interactions: non-progress churn", () => {
     await detector.killAndRetry(task.id, 60_000);
 
     expect(task.error).toBeNull();
-    expect(task.status).toBeNull();
+    expect(task.status).toBe("queued");
     expect(task.column).toBe("todo");
-    expect(task.paused).toBe(true);
-    expect(task.userPaused).toBe(true);
-    expect(task.pausedReason).toBe("stuck-loop-exhausted-incomplete-steps");
+    expect(task.paused).toBe(false);
+    expect(task.userPaused).toBe(false);
+    expect(task.pausedReason).toBeNull();
     expect(task.stuckKillCount).toBe(7);
     expect(task.steps).toEqual([{ name: "Implement", status: "in-progress" }]);
     expect(task.log?.some((entry) => entry.action.includes("incomplete task exhausted stuck kill budget"))).toBe(true);

--- a/packages/engine/src/__tests__/reliability-interactions/non-progress-churn.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/non-progress-churn.test.ts
@@ -4,6 +4,7 @@ import "../executor-test-helpers.js";
 import type { Task, TaskStore } from "@fusion/core";
 import { TaskExecutor } from "../../executor.js";
 import { SelfHealingManager } from "../../self-healing.js";
+import { isRunnableQueuedOverlapCandidate } from "../../scheduler.js";
 import { StuckTaskDetector } from "../../stuck-task-detector.js";
 
 type MockTaskStore = TaskStore & EventEmitter & {
@@ -219,6 +220,7 @@ describe("reliability interactions: non-progress churn", () => {
     expect(task.steps).toEqual([{ name: "Implement", status: "in-progress" }]);
     expect(task.log?.some((entry) => entry.action.includes("incomplete task exhausted stuck kill budget"))).toBe(true);
     expect(store.handoffToReview).not.toHaveBeenCalled();
+    expect(isRunnableQueuedOverlapCandidate(task, [task])).toBe(true);
 
     manager.stop();
   });

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -440,14 +440,11 @@ describe("SelfHealingManager", () => {
       const result = await manager.checkStuckBudget("FN-001", "loop");
 
       expect(result).toBe(false);
-      expect(store.updateTask).toHaveBeenCalledWith("FN-001", expect.objectContaining({
-        stuckKillCount: 7,
-        paused: false,
-        userPaused: false,
-        pausedReason: null,
-        status: "queued",
-      }));
-      expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", { preserveProgress: true });
+      expect(store.updateTask).toHaveBeenCalledWith("FN-001", { stuckKillCount: 7 });
+      expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", {
+        preserveProgress: true,
+        preserveStatus: true,
+      });
       expect(store.updateTask).toHaveBeenLastCalledWith("FN-001", expect.objectContaining({
         stuckKillCount: 7,
         paused: false,
@@ -462,7 +459,7 @@ describe("SelfHealingManager", () => {
       );
     });
 
-    it("leaves incomplete stuck-loop exhaustion unpaused when todo parking fails", async () => {
+    it("falls back to executor requeue when todo parking fails", async () => {
       (store.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: "FN-001",
         column: "in-progress",
@@ -478,19 +475,22 @@ describe("SelfHealingManager", () => {
 
       const result = await manager.checkStuckBudget("FN-001", "loop");
 
-      expect(result).toBe(false);
-      expect(store.updateTask).toHaveBeenCalledWith("FN-001", expect.objectContaining({
-        stuckKillCount: 7,
+      expect(result).toBe(true);
+      expect(store.updateTask).toHaveBeenCalledWith("FN-001", { stuckKillCount: 7 });
+      expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", {
+        preserveProgress: true,
+        preserveStatus: true,
+      });
+      expect(store.updateTask).not.toHaveBeenCalledWith("FN-001", expect.objectContaining({
         paused: false,
         userPaused: false,
         pausedReason: null,
         status: "queued",
       }));
-      expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", { preserveProgress: true });
       expect(store.handoffToReview).not.toHaveBeenCalled();
       expect(store.logEntry).toHaveBeenCalledWith(
         "FN-001",
-        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Failed to move task to todo (database is busy); task remains unpaused for scheduler retry.",
+        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Failed to move task to todo (database is busy); falling back to executor stuck-kill requeue.",
       );
     });
 

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -424,7 +424,7 @@ describe("SelfHealingManager", () => {
       );
     });
 
-    it("parks incomplete stuck-loop exhaustion in todo without review handoff", async () => {
+    it("re-queues incomplete stuck-loop exhaustion in todo without review handoff", async () => {
       (store.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: "FN-001",
         column: "in-progress",
@@ -442,25 +442,27 @@ describe("SelfHealingManager", () => {
       expect(result).toBe(false);
       expect(store.updateTask).toHaveBeenCalledWith("FN-001", expect.objectContaining({
         stuckKillCount: 7,
-        paused: true,
-        userPaused: true,
-        pausedReason: "stuck-loop-exhausted-incomplete-steps",
+        paused: false,
+        userPaused: false,
+        pausedReason: null,
+        status: "queued",
       }));
       expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", { preserveProgress: true });
       expect(store.updateTask).toHaveBeenLastCalledWith("FN-001", expect.objectContaining({
         stuckKillCount: 7,
-        paused: true,
-        userPaused: true,
-        pausedReason: "stuck-loop-exhausted-incomplete-steps",
+        paused: false,
+        userPaused: false,
+        pausedReason: null,
+        status: "queued",
       }));
       expect(store.handoffToReview).not.toHaveBeenCalled();
       expect(store.logEntry).toHaveBeenCalledWith(
         "FN-001",
-        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Parked in todo with progress preserved; manual review/resume required before retry.",
+        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Re-queued in todo with progress preserved; scheduler may retry without manual unpause.",
       );
     });
 
-    it("leaves incomplete stuck-loop exhaustion paused when todo parking fails", async () => {
+    it("leaves incomplete stuck-loop exhaustion unpaused when todo parking fails", async () => {
       (store.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: "FN-001",
         column: "in-progress",
@@ -479,15 +481,16 @@ describe("SelfHealingManager", () => {
       expect(result).toBe(false);
       expect(store.updateTask).toHaveBeenCalledWith("FN-001", expect.objectContaining({
         stuckKillCount: 7,
-        paused: true,
-        userPaused: true,
-        pausedReason: "stuck-loop-exhausted-incomplete-steps",
+        paused: false,
+        userPaused: false,
+        pausedReason: null,
+        status: "queued",
       }));
       expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", { preserveProgress: true });
       expect(store.handoffToReview).not.toHaveBeenCalled();
       expect(store.logEntry).toHaveBeenCalledWith(
         "FN-001",
-        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Failed to move task to todo (database is busy); task remains paused for manual intervention.",
+        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Failed to move task to todo (database is busy); task remains unpaused for scheduler retry.",
       );
     });
 

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -494,6 +494,40 @@ describe("SelfHealingManager", () => {
       );
     });
 
+    it("logs post-move requeue patch failures without executor fallback", async () => {
+      (store.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: "FN-001",
+        column: "in-progress",
+        stuckKillCount: 6,
+        steps: [
+          { name: "Preflight", status: "done" },
+          { name: "Delivery", status: "in-progress" },
+        ],
+      } as unknown as Task);
+      (store.updateTask as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({} as Task)
+        .mockRejectedValueOnce(new Error("write conflict"));
+
+      manager.start();
+
+      const result = await manager.checkStuckBudget("FN-001", "loop");
+
+      expect(result).toBe(false);
+      expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", {
+        preserveProgress: true,
+        preserveStatus: true,
+      });
+      expect(store.logEntry).toHaveBeenCalledWith(
+        "FN-001",
+        "STUCK_LOOP_EXHAUSTED: incomplete task moved to todo with progress preserved, but post-move requeue patch failed (write conflict); scheduler retry may wait for the next state repair pass.",
+      );
+      expect(store.logEntry).toHaveBeenCalledWith(
+        "FN-001",
+        "STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (7/6), last reason=loop. Re-queued in todo with progress preserved; scheduler may retry without manual unpause.",
+      );
+      expect(store.handoffToReview).not.toHaveBeenCalled();
+    });
+
     it("terminalizes no-progress churn without incrementing stuck kill budget", async () => {
       (store.getTask as ReturnType<typeof vi.fn>).mockResolvedValue({
         id: "FN-001",

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -1073,34 +1073,32 @@ export class SelfHealingManager {
 
         if (hasIncompleteSteps) {
           log.warn(`${taskId} exceeded stuck kill budget (${newCount}/${maxKills}, reason=${reason}) with incomplete steps — re-queueing in todo with progress preserved`);
-          await this.store.updateTask(taskId, {
-            stuckKillCount: newCount,
-            paused: false,
-            userPaused: false,
-            pausedReason: null,
-            status: "queued",
-          } as unknown as Partial<Task> & { userPaused: boolean });
-          let parkedInTodo = true;
-          let moveErrMessage = "";
+          await this.store.updateTask(taskId, { stuckKillCount: newCount });
           try {
-            await this.store.moveTask(taskId, "todo", { preserveProgress: true });
-            await this.store.updateTask(taskId, {
+            await this.store.moveTask(taskId, "todo", {
+              preserveProgress: true,
+              preserveStatus: true,
+            });
+            const requeueUpdate = {
               stuckKillCount: newCount,
               paused: false,
               userPaused: false,
               pausedReason: null,
               status: "queued",
-            } as unknown as Partial<Task> & { userPaused: boolean });
+            } satisfies Parameters<typeof this.store.updateTask>[1] & { userPaused: boolean };
+            await this.store.updateTask(taskId, requeueUpdate);
           } catch (moveErr: unknown) {
-            parkedInTodo = false;
-            moveErrMessage = moveErr instanceof Error ? moveErr.message : String(moveErr);
-            log.warn(`${taskId} moveTask(todo) failed (${moveErrMessage}) after incomplete STUCK_LOOP_EXHAUSTED terminalization — task remains queued for scheduler retry`);
+            const moveErrMessage = moveErr instanceof Error ? moveErr.message : String(moveErr);
+            log.warn(`${taskId} moveTask(todo) failed (${moveErrMessage}) after incomplete STUCK_LOOP_EXHAUSTED terminalization — falling back to executor stuck-kill requeue`);
+            await this.store.logEntry(
+              taskId,
+              `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Failed to move task to todo (${moveErrMessage}); falling back to executor stuck-kill requeue.`,
+            );
+            return true;
           }
           await this.store.logEntry(
             taskId,
-            parkedInTodo
-              ? `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Re-queued in todo with progress preserved; scheduler may retry without manual unpause.`
-              : `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Failed to move task to todo (${moveErrMessage}); task remains unpaused for scheduler retry.`,
+            `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Re-queued in todo with progress preserved; scheduler may retry without manual unpause.`,
           );
           return false;
         }

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -1079,14 +1079,6 @@ export class SelfHealingManager {
               preserveProgress: true,
               preserveStatus: true,
             });
-            const requeueUpdate = {
-              stuckKillCount: newCount,
-              paused: false,
-              userPaused: false,
-              pausedReason: null,
-              status: "queued",
-            } satisfies Parameters<typeof this.store.updateTask>[1] & { userPaused: boolean };
-            await this.store.updateTask(taskId, requeueUpdate);
           } catch (moveErr: unknown) {
             const moveErrMessage = moveErr instanceof Error ? moveErr.message : String(moveErr);
             log.warn(`${taskId} moveTask(todo) failed (${moveErrMessage}) after incomplete STUCK_LOOP_EXHAUSTED terminalization — falling back to executor stuck-kill requeue`);
@@ -1095,6 +1087,24 @@ export class SelfHealingManager {
               `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Failed to move task to todo (${moveErrMessage}); falling back to executor stuck-kill requeue.`,
             );
             return true;
+          }
+
+          const requeueUpdate = {
+            stuckKillCount: newCount,
+            paused: false,
+            userPaused: false,
+            pausedReason: null,
+            status: "queued",
+          } satisfies Parameters<typeof this.store.updateTask>[1] & { userPaused: boolean };
+          try {
+            await this.store.updateTask(taskId, requeueUpdate);
+          } catch (patchErr: unknown) {
+            const patchErrMessage = patchErr instanceof Error ? patchErr.message : String(patchErr);
+            log.warn(`${taskId} post-move requeue patch failed after incomplete STUCK_LOOP_EXHAUSTED terminalization: ${patchErrMessage}`);
+            await this.store.logEntry(
+              taskId,
+              `STUCK_LOOP_EXHAUSTED: incomplete task moved to todo with progress preserved, but post-move requeue patch failed (${patchErrMessage}); scheduler retry may wait for the next state repair pass.`,
+            );
           }
           await this.store.logEntry(
             taskId,

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -1072,33 +1072,35 @@ export class SelfHealingManager {
         const hasIncompleteSteps = !!task.steps?.some((step) => NON_TERMINAL_STEP_STATUSES.has(step.status));
 
         if (hasIncompleteSteps) {
-          log.warn(`${taskId} exceeded stuck kill budget (${newCount}/${maxKills}, reason=${reason}) with incomplete steps — parking in todo`);
+          log.warn(`${taskId} exceeded stuck kill budget (${newCount}/${maxKills}, reason=${reason}) with incomplete steps — re-queueing in todo with progress preserved`);
           await this.store.updateTask(taskId, {
             stuckKillCount: newCount,
-            paused: true,
-            userPaused: true,
-            pausedReason: "stuck-loop-exhausted-incomplete-steps",
-          } as Partial<Task> & { userPaused: boolean });
+            paused: false,
+            userPaused: false,
+            pausedReason: null,
+            status: "queued",
+          } as unknown as Partial<Task> & { userPaused: boolean });
           let parkedInTodo = true;
           let moveErrMessage = "";
           try {
             await this.store.moveTask(taskId, "todo", { preserveProgress: true });
             await this.store.updateTask(taskId, {
               stuckKillCount: newCount,
-              paused: true,
-              userPaused: true,
-              pausedReason: "stuck-loop-exhausted-incomplete-steps",
-            } as Partial<Task> & { userPaused: boolean });
+              paused: false,
+              userPaused: false,
+              pausedReason: null,
+              status: "queued",
+            } as unknown as Partial<Task> & { userPaused: boolean });
           } catch (moveErr: unknown) {
             parkedInTodo = false;
             moveErrMessage = moveErr instanceof Error ? moveErr.message : String(moveErr);
-            log.warn(`${taskId} moveTask(todo) failed (${moveErrMessage}) after incomplete STUCK_LOOP_EXHAUSTED terminalization — task remains paused for manual intervention`);
+            log.warn(`${taskId} moveTask(todo) failed (${moveErrMessage}) after incomplete STUCK_LOOP_EXHAUSTED terminalization — task remains queued for scheduler retry`);
           }
           await this.store.logEntry(
             taskId,
             parkedInTodo
-              ? `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Parked in todo with progress preserved; manual review/resume required before retry.`
-              : `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Failed to move task to todo (${moveErrMessage}); task remains paused for manual intervention.`,
+              ? `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Re-queued in todo with progress preserved; scheduler may retry without manual unpause.`
+              : `STUCK_LOOP_EXHAUSTED: incomplete task exhausted stuck kill budget (${newCount}/${maxKills}), last reason=${reason}. Failed to move task to todo (${moveErrMessage}); task remains unpaused for scheduler retry.`,
           );
           return false;
         }


### PR DESCRIPTION
## Summary

- keep incomplete stuck-loop exhausted tasks out of review/merge
- requeue preserved-progress tasks in Todo without setting manual/user pause flags
- skip stale-spec replanning for already-started preserved-progress work

## Why

Atlas Notes exposed a bad steady state: retry-heavy tasks that had already made progress were being moved back to Todo with `paused=true`/`userPaused=true`, which made manual unpause a normal part of the system. A healthy Fusion board should keep flowing after preserving progress; pauses should be explicit operator decisions, not the default terminalization path.

## Verification

- `CI=true corepack pnpm --filter @fusion/engine exec vitest run src/__tests__/self-healing.test.ts src/__tests__/spec-staleness.test.ts src/__tests__/executor-recovery.test.ts src/__tests__/reliability-interactions/non-progress-churn.test.ts --silent=false --reporter=dot`
- `CI=true corepack pnpm --filter @fusion/engine typecheck`
- `CI=true corepack pnpm --filter @runfusion/fusion build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks that exhaust their stuck-kill budget are now automatically re-queued into the todo queue with progress preserved, left unpaused/queued, and not routed through review/merge or requiring manual unpause.

* **Tests**
  * Updated tests to expect the re-queue/unpaused behavior and added coverage for fallback when todo requeue fails.

* **Documentation**
  * Clarified change descriptions and logs to reflect scheduler-retry semantics for exhausted tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->