### PR TITLE
fix(desktop): include ms in packaged runtime

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@fusion/core": "workspace:*",
     "@fusion/dashboard": "workspace:*",
-    "electron-updater": "^6.6.0"
+    "electron-updater": "^6.6.0",
+    "ms": "^2.1.3"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/packages/desktop/src/__tests__/electron-builder-config.test.ts
+++ b/packages/desktop/src/__tests__/electron-builder-config.test.ts
@@ -107,6 +107,35 @@ describe("electron-builder desktop config", () => {
     expect(linuxArchByTarget.get("tar.gz")).toEqual(["arm64", "x64"]);
   });
 
+  it("packages @fusion/core runtime dependencies used during desktop startup", async () => {
+    const builderConfig = await readDesktopFile("electron-builder.yml");
+    const requiredRuntimeDependencyGlobs = [
+      "node_modules/debug/**/*",
+      "node_modules/ms/**/*",
+      "node_modules/extract-zip/**/*",
+      "node_modules/get-stream/**/*",
+      "node_modules/pump/**/*",
+      "node_modules/end-of-stream/**/*",
+      "node_modules/once/**/*",
+      "node_modules/wrappy/**/*",
+      "node_modules/yauzl/**/*",
+      "node_modules/fd-slicer/**/*",
+      "node_modules/pend/**/*",
+      "node_modules/buffer-crc32/**/*",
+      "node_modules/tar/**/*",
+      "node_modules/@isaacs/fs-minipass/**/*",
+      "node_modules/chownr/**/*",
+      "node_modules/minipass/**/*",
+      "node_modules/minizlib/**/*",
+      "node_modules/yallist/**/*",
+      "node_modules/yaml/**/*",
+    ];
+
+    for (const dependencyGlob of requiredRuntimeDependencyGlobs) {
+      expect(builderConfig).toContain(`- ${dependencyGlob}`);
+    }
+  });
+
   it("locks mac signing and notarization configuration", async () => {
     const builderConfig = await readDesktopFile("electron-builder.yml");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
       electron-updater:
         specifier: ^6.6.0
         version: 6.8.3
+      ms:
+        specifier: ^2.1.3
+        version: 2.1.3
     devDependencies:
       '@testing-library/react':
         specifier: ^16.3.2


### PR DESCRIPTION
## Summary
Linux desktop builds can no longer ship without the `ms` module required by `debug` during `extract-zip` startup. The previous packaging config listed `node_modules/ms/**/*`, but `ms` was only present through pnpm's virtual store and was not actually copied into the generated `app.asar`; making it a desktop runtime dependency gives electron-builder a real package entry to include.

This also adds a desktop config regression test that keeps the startup/archive dependency globs in place for future package changes.

Refs Runfusion/Fusion#1472.

## Verification
- `pnpm --filter @fusion/desktop exec vitest run src/__tests__/electron-builder-config.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/core exec vitest run src/__tests__/agent-companies-parser.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/desktop run pack`
- Inspected generated `packages/desktop/dist-electron/mac-arm64/Fusion.app/Contents/Resources/app.asar` and confirmed it contains `/node_modules/ms/index.js`, plus `debug`, `extract-zip`, and `tar`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation test for desktop build configuration to ensure runtime dependencies are properly included in the packaging setup
  * Updated desktop package dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->