### PR TITLE
Show auto-merge toggle on workflow review columns

### DIFF
--- a/.changeset/review-column-auto-merge.md
+++ b/.changeset/review-column-auto-merge.md
@@ -1,0 +1,3 @@
+"@runfusion/fusion": patch
+
+Allow built-in workflow review columns to surface the auto-merge toggle.

--- a/.changeset/review-column-auto-merge.md
+++ b/.changeset/review-column-auto-merge.md
@@ -1,3 +1,5 @@
-"@runfusion/fusion": patch
+---
+"@runfusion/fusion": minor
+---
 
 Allow built-in workflow review columns to surface the auto-merge toggle.

--- a/packages/core/src/__tests__/builtin-coding-workflow-ir.test.ts
+++ b/packages/core/src/__tests__/builtin-coding-workflow-ir.test.ts
@@ -44,7 +44,7 @@ describe("builtin coding workflow ir", () => {
     expect(traitsFor("triage")).toEqual(["intake"]);
     expect(traitsFor("todo")).toEqual(["hold", "reset-on-entry"]);
     expect(traitsFor("in-progress")).toEqual(["wip", "abort-on-exit", "timing"]);
-    expect(traitsFor("in-review")).toEqual(["merge-blocker", "stall-detection", "merge"]);
+    expect(traitsFor("in-review")).toEqual(["merge-blocker", "human-review", "stall-detection", "merge"]);
     expect(traitsFor("done")).toEqual(["complete"]);
     expect(traitsFor("archived")).toEqual(["archived"]);
     // todo's hold is capacity-released (legacy "pull from todo when a slot frees").

--- a/packages/core/src/__tests__/builtin-traits.test.ts
+++ b/packages/core/src/__tests__/builtin-traits.test.ts
@@ -107,4 +107,14 @@ describe("default workflow columns validate cleanly", () => {
     expect(flags.abortOnExit).toBe(true);
     expect(flags.timing).toBe(true);
   });
+
+  it("the default workflow's in-review column resolves review and merge flags", () => {
+    const r = freshRegistry();
+    const ir = BUILTIN_CODING_WORKFLOW_IR as WorkflowIrV2;
+    const inReview = ir.columns.find((c) => c.id === "in-review")!;
+    const flags = r.resolveColumnFlags(inReview);
+    expect(flags.mergeBlocker).toBe(true);
+    expect(flags.humanReview).toBe(true);
+    expect(flags.mergeOrchestration).toBe(true);
+  });
 });

--- a/packages/core/src/__tests__/builtin-traits.test.ts
+++ b/packages/core/src/__tests__/builtin-traits.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../builtin-traits.js";
 import { TraitRegistry } from "../trait-registry.js";
 import { BUILTIN_CODING_WORKFLOW_IR } from "../builtin-coding-workflow-ir.js";
+import { BUILTIN_STEPWISE_CODING_WORKFLOW_IR } from "../builtin-stepwise-coding-workflow-ir.js";
 import type { WorkflowIrV2 } from "../workflow-ir-types.js";
 
 function freshRegistry(): TraitRegistry {
@@ -111,6 +112,16 @@ describe("default workflow columns validate cleanly", () => {
   it("the default workflow's in-review column resolves review and merge flags", () => {
     const r = freshRegistry();
     const ir = BUILTIN_CODING_WORKFLOW_IR as WorkflowIrV2;
+    const inReview = ir.columns.find((c) => c.id === "in-review")!;
+    const flags = r.resolveColumnFlags(inReview);
+    expect(flags.mergeBlocker).toBe(true);
+    expect(flags.humanReview).toBe(true);
+    expect(flags.mergeOrchestration).toBe(true);
+  });
+
+  it("the stepwise workflow's in-review column resolves review and merge flags", () => {
+    const r = freshRegistry();
+    const ir = BUILTIN_STEPWISE_CODING_WORKFLOW_IR as WorkflowIrV2;
     const inReview = ir.columns.find((c) => c.id === "in-review")!;
     const flags = r.resolveColumnFlags(inReview);
     expect(flags.mergeBlocker).toBe(true);

--- a/packages/core/src/builtin-coding-workflow-ir.ts
+++ b/packages/core/src/builtin-coding-workflow-ir.ts
@@ -13,7 +13,7 @@ import { BUILTIN_WORKFLOW_SETTINGS } from "./builtin-workflow-settings.js";
  *   triage      = intake
  *   todo        = hold(capacity) + reset-on-entry
  *   in-progress = wip + abort-on-exit + timing
- *   in-review   = merge-blocker + stall-detection + merge
+ *   in-review   = merge-blocker + human-review + stall-detection + merge
  *   done        = complete
  *   archived    = archived
  *
@@ -39,7 +39,7 @@ const RAW_BUILTIN_CODING_WORKFLOW_IR: WorkflowIr = {
     {
       id: "in-review",
       name: "In review",
-      traits: [{ trait: "merge-blocker" }, { trait: "stall-detection" }, { trait: "merge" }],
+      traits: [{ trait: "merge-blocker" }, { trait: "human-review" }, { trait: "stall-detection" }, { trait: "merge" }],
     },
     { id: "done", name: "Done", traits: [{ trait: "complete" }] },
     { id: "archived", name: "Archived", traits: [{ trait: "archived" }] },

--- a/packages/core/src/builtin-stepwise-coding-workflow-ir.ts
+++ b/packages/core/src/builtin-stepwise-coding-workflow-ir.ts
@@ -26,8 +26,9 @@ import { BUILTIN_WORKFLOW_SETTINGS } from "./builtin-workflow-settings.js";
  *     → merge seam
  *
  * The columns/traits are identical to the default builtin so the full lifecycle
- * (merge-blocker, capacity, hold, complete, archived) behaves exactly as it does
- * for the default workflow — only the in-progress step modeling differs.
+ * (merge-blocker, human review, capacity, hold, complete, archived) behaves
+ * exactly as it does for the default workflow — only the in-progress step
+ * modeling differs.
  *
  * It declares its step-source artifact (KTD-12): PROMPT.md produced by the
  * planning seam. The IR is v2-only (foreach/step-review/parse-steps are v2 node
@@ -52,7 +53,7 @@ const RAW_BUILTIN_STEPWISE_CODING_WORKFLOW_IR: WorkflowIr = {
     {
       id: "in-review",
       name: "In review",
-      traits: [{ trait: "merge-blocker" }, { trait: "stall-detection" }, { trait: "merge" }],
+      traits: [{ trait: "merge-blocker" }, { trait: "human-review" }, { trait: "stall-detection" }, { trait: "merge" }],
     },
     { id: "done", name: "Done", traits: [{ trait: "complete" }] },
     { id: "archived", name: "Archived", traits: [{ trait: "archived" }] },

--- a/packages/dashboard/app/components/Lane.tsx
+++ b/packages/dashboard/app/components/Lane.tsx
@@ -205,7 +205,7 @@ function LaneComponent(props: LaneProps) {
               prAuthAvailable={props.prAuthAvailable}
               autoMerge={props.autoMerge}
               {...(isCreateColumn ? { onQuickCreate: props.onQuickCreate, onNewTask: props.onNewTask, onPlanningMode: props.onPlanningMode, onSubtaskBreakdown: props.onSubtaskBreakdown } : {})}
-              {...(col.flags.mergeBlocker ? { onToggleAutoMerge: props.onToggleAutoMerge } : {})}
+              {...((col.flags.mergeBlocker || col.flags.humanReview) && props.onToggleAutoMerge ? { onToggleAutoMerge: props.onToggleAutoMerge } : {})}
             />
             );
           })}

--- a/packages/dashboard/app/components/__tests__/Lane.test.tsx
+++ b/packages/dashboard/app/components/__tests__/Lane.test.tsx
@@ -33,6 +33,7 @@ const WORKFLOW: BoardWorkflowDefinition = {
     { id: "triage", name: "Triage", flags: { intake: true } },
     { id: "todo", name: "Todo", flags: { hold: true } },
     { id: "in-progress", name: "In progress", flags: { countsTowardWip: true } },
+    { id: "in-review", name: "In review", flags: { humanReview: true } },
     { id: "done", name: "Done", flags: { complete: true } },
     { id: "archived", name: "Archived", flags: { archived: true } },
   ],
@@ -86,6 +87,7 @@ describe("Lane", () => {
     expect(headings).toContain("Triage");
     expect(headings).toContain("Todo");
     expect(headings).toContain("In progress");
+    expect(headings).toContain("In review");
     expect(headings).toContain("Done");
     // Archived column is hidden.
     expect(headings).not.toContain("Archived");
@@ -110,6 +112,11 @@ describe("Lane", () => {
     render(<Lane {...props} />);
     fireEvent.click(screen.getByTestId("lane-toggle-builtin:coding"));
     expect(props.onToggleCollapse).toHaveBeenCalledWith("builtin:coding");
+  });
+
+  it("shows the auto-merge toggle for human-review workflow columns", () => {
+    render(<Lane {...baseProps()} autoMerge={false} onToggleAutoMerge={vi.fn()} />);
+    expect(screen.getByText("Auto-merge")).toBeDefined();
   });
 
   it("shows a Promote button on hold-column cards and calls onPromote", async () => {


### PR DESCRIPTION
## Summary
- mark built-in coding workflow review columns with the human-review trait in addition to merge-blocker
- pass the auto-merge toggle into workflow review columns resolved through either mergeBlocker or humanReview flags
- add focused core/dashboard regression coverage and a patch changeset

## Validation
- `pnpm exec vitest run src/__tests__/builtin-coding-workflow-ir.test.ts src/__tests__/builtin-traits.test.ts --reporter=dot` from `packages/core`
- `pnpm exec vitest run app/components/__tests__/Lane.test.tsx --reporter=dot` from `packages/dashboard`

Note: an earlier package-script invocation accidentally ran the broader core suite before the rebase and surfaced unrelated loop/workflow failures; the bounded commands above pass on the rebased branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-merge toggle now appears in review columns of built-in coding workflows (standard and stepwise).

* **Tests**
  * Added/updated tests to cover auto-merge toggle presence in human-review columns and to validate review-column traits.

* **Chores**
  * Release entry added for the package minor bump documenting the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->