### PR TITLE
fix(compound-engineering): include dashboard CSS in build

### DIFF
--- a/.changeset/fix-compound-engineering-css-build.md
+++ b/.changeset/fix-compound-engineering-css-build.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix the bundled Compound Engineering dashboard plugin build so its CSS is included in `dist`.

--- a/plugins/fusion-plugin-compound-engineering/package.json
+++ b/plugins/fusion-plugin-compound-engineering/package.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-css.mjs",
     "test": "vitest run --silent=passed-only --reporter=dot"
   },
   "dependencies": {

--- a/plugins/fusion-plugin-compound-engineering/scripts/copy-css.mjs
+++ b/plugins/fusion-plugin-compound-engineering/scripts/copy-css.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Copies every .css file under src/ to the mirrored path under dist/.
+import { cp, mkdir, readdir } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url)) + "/..";
+const srcDir = join(root, "src");
+const distDir = join(root, "dist");
+
+async function* cssFiles(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* cssFiles(full);
+    else if (entry.isFile() && entry.name.endsWith(".css")) yield full;
+  }
+}
+
+for await (const file of cssFiles(srcDir)) {
+  const dest = join(distDir, relative(srcDir, file));
+  await mkdir(dirname(dest), { recursive: true });
+  await cp(file, dest);
+}

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/manifest.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import manifest from "../../manifest.json";
+import packageJson from "../../package.json";
 import plugin from "../index.js";
 import { COMPOUND_ENGINEERING_SKILLS } from "../skills.js";
 import { settingsSchema } from "../settings.js";
@@ -73,6 +74,11 @@ describe("compound engineering plugin manifest", () => {
 
   it("registers an onLoad hook that installs bundled skills (U2)", () => {
     expect(typeof plugin.hooks?.onLoad).toBe("function");
+  });
+
+  it("copies dashboard CSS into dist during build", () => {
+    expect(packageJson.scripts.build).toContain("tsc");
+    expect(packageJson.scripts.build).toContain("node scripts/copy-css.mjs");
   });
 
   it("wires the settings schema onto the runtime manifest and manifest.json (U9)", () => {


### PR DESCRIPTION
## Summary
The Compound Engineering plugin dashboard can now load from a built plugin package because its stylesheet is mirrored into `dist` alongside the compiled dashboard module. This fixes enablement failures where `CompoundEngineeringView.js` resolved but its `./CompoundEngineeringView.css` import pointed at a missing build artifact.

The build now copies CSS assets after TypeScript compilation, matching the existing bundled plugin pattern, and a manifest-level regression test keeps the build contract in place.

## Tests
- `pnpm --filter @fusion-plugin-examples/compound-engineering test -- src/__tests__/manifest.test.ts`
- `pnpm --filter @fusion-plugin-examples/compound-engineering build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where Compound Engineering dashboard plugin CSS styles were not being included in the production build, ensuring the plugin appears with proper styling in deployed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->