### PR TITLE
refactor(workflow): S03 generic scheduler claim path

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s03-generic-scheduler-claim.md
+++ b/docs/plans/workflow-owned-merge-stack/s03-generic-scheduler-claim.md
@@ -1,0 +1,46 @@
+---
+title: "S03: generic scheduler claim path"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S03
+milestone: "Foundation"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s02-merge-request-projection
+---
+
+# S03: generic scheduler claim path
+
+## Stack Role
+
+This draft PR reserves the S03 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Foundation
+
+## Depends On
+
+S1 workflow work-item schema and store API.
+
+## Goal
+
+Teach Scheduler to claim due workflow work items while preserving existing task dispatch behavior.
+
+## Expected File Scope
+
+packages/engine/src/scheduler.ts; packages/engine/src/workflow-task-runtime.ts; packages/engine/src/project-engine.ts; scheduler/workflow dispatch tests.
+
+## Expected Tests
+
+Due-work claiming, retryAfter delay, capacity holds, user pause exclusion, stale lease reclaim, and remote dispatch.
+
+## Exit Gate
+
+A workflow work item can be dispatched end to end in tests without constructing a merge queue branch.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/workflow-work-engine-dispatch.test.ts
+++ b/packages/engine/src/__tests__/workflow-work-engine-dispatch.test.ts
@@ -8,9 +8,11 @@ import {
   workflowExtensionRegistryId,
   type Task,
   type TaskDetail,
+  type WorkflowWorkItem,
   type WorkflowIr,
 } from "@fusion/core";
 import { TaskExecutor } from "../executor.js";
+import { claimDueWorkflowWorkItem } from "../workflow-work-scheduler.js";
 
 describe("workflow work-engine dispatch", () => {
   afterEach(() => {
@@ -80,5 +82,73 @@ describe("workflow work-engine dispatch", () => {
       metadata: expect.objectContaining({ extensionId: extensionKey, pluginId: "engine-plugin" }),
     }));
     expect(store.updateTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("workflow work scheduler claims", () => {
+  function workItem(input: Partial<WorkflowWorkItem> & Pick<WorkflowWorkItem, "id" | "taskId" | "nodeId">): WorkflowWorkItem {
+    return {
+      runId: "run-1",
+      kind: "task",
+      state: "runnable",
+      attempt: 0,
+      retryAfter: null,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      lastError: null,
+      blockedReason: null,
+      createdAt: "2026-06-09T00:00:00.000Z",
+      updatedAt: "2026-06-09T00:00:00.000Z",
+      ...input,
+    };
+  }
+
+  it("claims the first due workflow work item without reading task columns", () => {
+    const item = workItem({ id: "work-1", taskId: "FN-1", nodeId: "node-a" });
+    const store = {
+      listDueWorkflowWorkItems: vi.fn(() => [item]),
+      acquireWorkflowWorkItemLease: vi.fn(() => ({ ...item, state: "running", leaseOwner: "scheduler-a" })),
+    };
+
+    const dispatch = claimDueWorkflowWorkItem(store, {
+      now: "2026-06-09T00:00:00.000Z",
+      leaseOwner: "scheduler-a",
+      leaseDurationMs: 60_000,
+      kinds: ["task"],
+    });
+
+    expect(store.listDueWorkflowWorkItems).toHaveBeenCalledWith({
+      now: "2026-06-09T00:00:00.000Z",
+      limit: 25,
+      kinds: ["task"],
+    });
+    expect(store.acquireWorkflowWorkItemLease).toHaveBeenCalledWith("work-1", "scheduler-a", {
+      now: "2026-06-09T00:00:00.000Z",
+      leaseDurationMs: 60_000,
+    });
+    expect(dispatch).toMatchObject({
+      runId: "run-1",
+      taskId: "FN-1",
+      nodeId: "node-a",
+      workItem: { state: "running", leaseOwner: "scheduler-a" },
+    });
+  });
+
+  it("skips contenders whose lease was already acquired", () => {
+    const first = workItem({ id: "work-1", taskId: "FN-1", nodeId: "node-a" });
+    const second = workItem({ id: "work-2", taskId: "FN-2", nodeId: "node-b" });
+    const store = {
+      listDueWorkflowWorkItems: vi.fn(() => [first, second]),
+      acquireWorkflowWorkItemLease: vi.fn((id: string) => (id === "work-2" ? { ...second, state: "running" } : null)),
+    };
+
+    const dispatch = claimDueWorkflowWorkItem(store, {
+      now: "2026-06-09T00:00:00.000Z",
+      leaseOwner: "scheduler-a",
+      leaseDurationMs: 60_000,
+    });
+
+    expect(dispatch?.workItem.id).toBe("work-2");
+    expect(store.acquireWorkflowWorkItemLease).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -141,6 +141,12 @@ export {
 } from "./workflow-task-runtime.js";
 export { collectTaskEvaluationEvidence } from "./evaluator-evidence.js";
 export { Scheduler, type SchedulerOptions } from "./scheduler.js";
+export {
+  claimDueWorkflowWorkItem,
+  type ClaimWorkflowWorkOptions,
+  type WorkflowWorkDispatch,
+  type WorkflowWorkSchedulerStore,
+} from "./workflow-work-scheduler.js";
 export { MeshLeaseManager, type MeshLeaseManagerOptions, type LeaseRecoveryContext } from "./mesh-lease-manager.js";
 export { MissionAutopilot, type MissionAutopilotOptions } from "./mission-autopilot.js";
 export { MissionExecutionLoop, type MissionExecutionLoopOptions, type ValidationResult, loopLog } from "./mission-execution-loop.js";

--- a/packages/engine/src/workflow-work-scheduler.ts
+++ b/packages/engine/src/workflow-work-scheduler.ts
@@ -1,0 +1,52 @@
+import type { WorkflowWorkItem, WorkflowWorkItemDueFilter, WorkflowWorkItemKind } from "@fusion/core";
+
+export interface WorkflowWorkSchedulerStore {
+  listDueWorkflowWorkItems(filter?: WorkflowWorkItemDueFilter): WorkflowWorkItem[];
+  acquireWorkflowWorkItemLease(
+    id: string,
+    leaseOwner: string,
+    opts: { leaseDurationMs: number; now?: string },
+  ): WorkflowWorkItem | null;
+}
+
+export interface WorkflowWorkDispatch {
+  workItem: WorkflowWorkItem;
+  runId: string;
+  taskId: string;
+  nodeId: string;
+}
+
+export interface ClaimWorkflowWorkOptions {
+  now?: string;
+  limit?: number;
+  leaseOwner: string;
+  leaseDurationMs: number;
+  kinds?: WorkflowWorkItemKind[];
+}
+
+export function claimDueWorkflowWorkItem(
+  store: WorkflowWorkSchedulerStore,
+  opts: ClaimWorkflowWorkOptions,
+): WorkflowWorkDispatch | null {
+  const due = store.listDueWorkflowWorkItems({
+    now: opts.now,
+    limit: opts.limit ?? 25,
+    kinds: opts.kinds,
+  });
+
+  for (const candidate of due) {
+    const workItem = store.acquireWorkflowWorkItemLease(candidate.id, opts.leaseOwner, {
+      now: opts.now,
+      leaseDurationMs: opts.leaseDurationMs,
+    });
+    if (!workItem) continue;
+    return {
+      workItem,
+      runId: workItem.runId,
+      taskId: workItem.taskId,
+      nodeId: workItem.nodeId,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Stack Slice
- Slice: S03
- Milestone: Foundation
- Base branch: `feature/workflow-owned-merge-s02-merge-request-projection`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Teach Scheduler to claim due workflow work items while preserving existing task dispatch behavior.

## Dependency
S1 workflow work-item schema and store API.

## Expected Scope
packages/engine/src/scheduler.ts; packages/engine/src/workflow-task-runtime.ts; packages/engine/src/project-engine.ts; scheduler/workflow dispatch tests.

## Expected Tests
Due-work claiming, retryAfter delay, capacity holds, user pause exclusion, stale lease reclaim, and remote dispatch.

## Exit Gate
A workflow work item can be dispatched end to end in tests without constructing a merge queue branch.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added workflow-work scheduler substrate helper that claims due workflow work via leases without task-column policy reads.\n- Exported scheduler helper and added dispatch/lease-race tests.
