### PR TITLE
refactor(workflow): S09 workflow-owned retry state

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s09-workflow-owned-retry-state.md
+++ b/docs/plans/workflow-owned-merge-stack/s09-workflow-owned-retry-state.md
@@ -1,0 +1,46 @@
+---
+title: "S09: workflow-owned retry state"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S09
+milestone: "Retry"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s08-workflow-owned-merge-processing
+---
+
+# S09: workflow-owned retry state
+
+## Stack Role
+
+This draft PR reserves the S09 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Retry
+
+## Depends On
+
+S5 runtime driver and S8 workflow-owned merge processing.
+
+## Goal
+
+Move retry attempts, budgets, backoff, retry-after, exhaustion, and manual retry reset into workflow node/work-item state.
+
+## Expected File Scope
+
+workflow graph executor, node handlers, retry/backoff helpers, retry summary/manual retry files, retry policy tests.
+
+## Expected Tests
+
+Implementation retry budget, merge retry isolation, due-time persistence, exhaustion routing, targeted manual retry clear, restart persistence.
+
+## Exit Gate
+
+No retry branch is controlled solely by task counters.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/workflow-node-retry-policy.test.ts
+++ b/packages/engine/src/__tests__/workflow-node-retry-policy.test.ts
@@ -95,4 +95,28 @@ describe("workflow node retry policy", () => {
     });
     expect(result.contextPatch).not.toHaveProperty("workflow:retry:execute:attempt");
   });
+
+  it("honors configured retry base delay in the node handler", async () => {
+    const handlers = createDefaultNodeHandlers(createNoopLegacySeams());
+    const result = await handlers["retry-backoff"](
+      { id: "merge-retry", kind: "retry-backoff", config: { maxAttempts: 3, baseDelayMs: 5_000 } },
+      {
+        task: { id: "FN-RETRY", description: "retry" } as any,
+        settings: { experimentalFeatures: {} },
+        context: {
+          "workflow:run-id": "run-1",
+          "workflow:now": "2026-06-09T00:00:00.000Z",
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      outcome: "success",
+      value: "retry-scheduled",
+      contextPatch: {
+        "workflow:retry:merge-retry:attempt": 1,
+        "workflow:retry:merge-retry:retryAfter": "2026-06-09T00:00:05.000Z",
+      },
+    });
+  });
 });

--- a/packages/engine/src/__tests__/workflow-node-retry-policy.test.ts
+++ b/packages/engine/src/__tests__/workflow-node-retry-policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultNodeHandlers, createNoopLegacySeams } from "../workflow-node-handlers.js";
+import { nextWorkflowRetryState, workflowRetryContextPatch } from "../workflow-node-retry-policy.js";
+
+describe("workflow node retry policy", () => {
+  it("computes node-scoped retry attempts and retry-after timestamps", () => {
+    const retry = nextWorkflowRetryState({
+      runId: "run-1",
+      taskId: "FN-RETRY",
+      nodeId: "merge-retry",
+      attempt: 1,
+      maxAttempts: 4,
+      baseDelayMs: 1_000,
+      now: "2026-06-09T00:00:00.000Z",
+      lastError: "socket hang up",
+    });
+
+    expect(retry).toEqual({
+      runId: "run-1",
+      taskId: "FN-RETRY",
+      nodeId: "merge-retry",
+      attempt: 2,
+      maxAttempts: 4,
+      retryAfter: "2026-06-09T00:00:02.000Z",
+      exhausted: false,
+      lastError: "socket hang up",
+    });
+    expect(workflowRetryContextPatch(retry)).toMatchObject({
+      "workflow:retry:merge-retry:attempt": 2,
+      "workflow:retry:merge-retry:retryAfter": "2026-06-09T00:00:02.000Z",
+      "workflow:retry:merge-retry:exhausted": false,
+    });
+  });
+
+  it("caps exponential retry delay to keep retry-after timestamps valid", () => {
+    const retry = nextWorkflowRetryState({
+      runId: "run-1",
+      taskId: "FN-RETRY",
+      nodeId: "merge-retry",
+      attempt: 42,
+      maxAttempts: 100,
+      baseDelayMs: 30_000,
+      now: "2026-06-09T00:00:00.000Z",
+    });
+
+    expect(retry).toMatchObject({
+      attempt: 43,
+      exhausted: false,
+      retryAfter: "2026-06-10T00:00:00.000Z",
+    });
+  });
+
+  it("routes exhausted retry state to failure without resetting other nodes", async () => {
+    const handlers = createDefaultNodeHandlers(createNoopLegacySeams());
+    const result = await handlers["retry-backoff"](
+      { id: "merge-retry", kind: "retry-backoff", config: { maxAttempts: 2 } },
+      {
+        task: { id: "FN-RETRY", description: "retry" } as any,
+        settings: { experimentalFeatures: {} },
+        context: {
+          "workflow:run-id": "run-1",
+          "workflow:now": "2026-06-09T00:00:00.000Z",
+          "workflow:retry:merge-retry:attempt": 1,
+          "workflow:retry:execute:attempt": 1,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      outcome: "failure",
+      value: "retry-exhausted",
+      contextPatch: {
+        "workflow:retry:merge-retry:attempt": 2,
+        "workflow:retry:merge-retry:exhausted": true,
+      },
+    });
+    expect(result.contextPatch).not.toHaveProperty("workflow:retry:execute:attempt");
+  });
+});

--- a/packages/engine/src/__tests__/workflow-node-retry-policy.test.ts
+++ b/packages/engine/src/__tests__/workflow-node-retry-policy.test.ts
@@ -50,6 +50,25 @@ describe("workflow node retry policy", () => {
     });
   });
 
+  it("falls back when retry context carries a malformed now timestamp", () => {
+    const retry = nextWorkflowRetryState({
+      runId: "run-1",
+      taskId: "FN-RETRY",
+      nodeId: "merge-retry",
+      attempt: 0,
+      maxAttempts: 3,
+      baseDelayMs: 1_000,
+      now: "not-a-date",
+      fallbackNowMs: Date.parse("2026-06-09T00:00:00.000Z"),
+    });
+
+    expect(retry).toMatchObject({
+      attempt: 1,
+      exhausted: false,
+      retryAfter: "2026-06-09T00:00:01.000Z",
+    });
+  });
+
   it("routes exhausted retry state to failure without resetting other nodes", async () => {
     const handlers = createDefaultNodeHandlers(createNoopLegacySeams());
     const result = await handlers["retry-backoff"](

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -158,6 +158,12 @@ export {
   type WorkflowWorkProcessorOptions,
   type WorkflowWorkProcessorResult,
 } from "./workflow-work-processor.js";
+export {
+  nextWorkflowRetryState,
+  workflowRetryContextPatch,
+  type WorkflowRetryPolicyInput,
+  type WorkflowRetryState,
+} from "./workflow-node-retry-policy.js";
 export { MeshLeaseManager, type MeshLeaseManagerOptions, type LeaseRecoveryContext } from "./mesh-lease-manager.js";
 export { MissionAutopilot, type MissionAutopilotOptions } from "./mission-autopilot.js";
 export { MissionExecutionLoop, type MissionExecutionLoopOptions, type ValidationResult, loopLog } from "./mission-execution-loop.js";

--- a/packages/engine/src/workflow-node-handlers.ts
+++ b/packages/engine/src/workflow-node-handlers.ts
@@ -956,6 +956,7 @@ export function createDefaultNodeHandlers(
           ? ctx.context[`workflow:retry:${node.id}:attempt`] as number
           : 0,
         maxAttempts: typeof node.config?.maxAttempts === "number" ? node.config.maxAttempts : 3,
+        baseDelayMs: typeof node.config?.baseDelayMs === "number" ? node.config.baseDelayMs : undefined,
         now: typeof ctx.context["workflow:now"] === "string" ? ctx.context["workflow:now"] : undefined,
         lastError: typeof ctx.context["workflow:last-error"] === "string" ? ctx.context["workflow:last-error"] : null,
       });

--- a/packages/engine/src/workflow-node-handlers.ts
+++ b/packages/engine/src/workflow-node-handlers.ts
@@ -10,6 +10,7 @@ import {
   type WorkflowRuntimePrimitives,
 } from "./runtime-primitives.js";
 import { runWorkflowMergeAttemptNode } from "./workflow-merge-nodes.js";
+import { nextWorkflowRetryState, workflowRetryContextPatch } from "./workflow-node-retry-policy.js";
 
 export type WorkflowSeamName =
   | "planning"
@@ -946,7 +947,24 @@ export function createDefaultNodeHandlers(
       );
     },
     "manual-merge-hold": async () => ({ outcome: "failure", value: "manual-required" }),
-    "retry-backoff": async () => ({ outcome: "success" }),
+    "retry-backoff": async (node, ctx) => {
+      const retry = nextWorkflowRetryState({
+        runId: typeof ctx.context["workflow:run-id"] === "string" ? ctx.context["workflow:run-id"] : ctx.task.id,
+        taskId: ctx.task.id,
+        nodeId: node.id,
+        attempt: typeof ctx.context[`workflow:retry:${node.id}:attempt`] === "number"
+          ? ctx.context[`workflow:retry:${node.id}:attempt`] as number
+          : 0,
+        maxAttempts: typeof node.config?.maxAttempts === "number" ? node.config.maxAttempts : 3,
+        now: typeof ctx.context["workflow:now"] === "string" ? ctx.context["workflow:now"] : undefined,
+        lastError: typeof ctx.context["workflow:last-error"] === "string" ? ctx.context["workflow:last-error"] : null,
+      });
+      return {
+        outcome: retry.exhausted ? "failure" : "success",
+        value: retry.exhausted ? "retry-exhausted" : "retry-scheduled",
+        contextPatch: workflowRetryContextPatch(retry),
+      };
+    },
     "recovery-router": async (_node, ctx) => ({
       outcome: "success",
       value: typeof ctx.context.recoveryOutcome === "string" ? ctx.context.recoveryOutcome : "wake-merge",

--- a/packages/engine/src/workflow-node-retry-policy.ts
+++ b/packages/engine/src/workflow-node-retry-policy.ts
@@ -1,0 +1,52 @@
+export interface WorkflowRetryState {
+  runId: string;
+  taskId: string;
+  nodeId: string;
+  attempt: number;
+  maxAttempts: number;
+  retryAfter: string | null;
+  exhausted: boolean;
+  lastError: string | null;
+}
+
+export interface WorkflowRetryPolicyInput {
+  runId: string;
+  taskId: string;
+  nodeId: string;
+  attempt?: number;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  now?: string;
+  lastError?: string | null;
+}
+
+export function nextWorkflowRetryState(input: WorkflowRetryPolicyInput): WorkflowRetryState {
+  const attempt = Math.max(0, Math.floor(input.attempt ?? 0)) + 1;
+  const maxAttempts = Math.max(1, Math.floor(input.maxAttempts ?? 3));
+  const exhausted = attempt >= maxAttempts;
+  const nowMs = Date.parse(input.now ?? new Date().toISOString());
+  const baseDelayMs = Math.max(1_000, Math.floor(input.baseDelayMs ?? 30_000));
+  const maxDelayMs = 24 * 60 * 60_000;
+  const delayMs = Math.min(baseDelayMs * 2 ** Math.max(0, attempt - 1), maxDelayMs);
+
+  return {
+    runId: input.runId,
+    taskId: input.taskId,
+    nodeId: input.nodeId,
+    attempt,
+    maxAttempts,
+    retryAfter: exhausted ? null : new Date(nowMs + delayMs).toISOString(),
+    exhausted,
+    lastError: input.lastError ?? null,
+  };
+}
+
+export function workflowRetryContextPatch(state: WorkflowRetryState): Record<string, unknown> {
+  return {
+    [`workflow:retry:${state.nodeId}:attempt`]: state.attempt,
+    [`workflow:retry:${state.nodeId}:maxAttempts`]: state.maxAttempts,
+    [`workflow:retry:${state.nodeId}:retryAfter`]: state.retryAfter,
+    [`workflow:retry:${state.nodeId}:exhausted`]: state.exhausted,
+    [`workflow:retry:${state.nodeId}:lastError`]: state.lastError,
+  };
+}

--- a/packages/engine/src/workflow-node-retry-policy.ts
+++ b/packages/engine/src/workflow-node-retry-policy.ts
@@ -17,6 +17,7 @@ export interface WorkflowRetryPolicyInput {
   maxAttempts?: number;
   baseDelayMs?: number;
   now?: string;
+  fallbackNowMs?: number;
   lastError?: string | null;
 }
 
@@ -24,7 +25,8 @@ export function nextWorkflowRetryState(input: WorkflowRetryPolicyInput): Workflo
   const attempt = Math.max(0, Math.floor(input.attempt ?? 0)) + 1;
   const maxAttempts = Math.max(1, Math.floor(input.maxAttempts ?? 3));
   const exhausted = attempt >= maxAttempts;
-  const nowMs = Date.parse(input.now ?? new Date().toISOString());
+  const parsedNowMs = Date.parse(input.now ?? new Date().toISOString());
+  const nowMs = Number.isFinite(parsedNowMs) ? parsedNowMs : input.fallbackNowMs ?? Date.now();
   const baseDelayMs = Math.max(1_000, Math.floor(input.baseDelayMs ?? 30_000));
   const maxDelayMs = 24 * 60 * 60_000;
   const delayMs = Math.min(baseDelayMs * 2 ** Math.max(0, attempt - 1), maxDelayMs);


### PR DESCRIPTION
## Stack Slice
- Slice: S09
- Milestone: Retry
- Base branch: `feature/workflow-owned-merge-s08-workflow-owned-merge-processing`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Move retry attempts, budgets, backoff, retry-after, exhaustion, and manual retry reset into workflow node/work-item state.

## Dependency
S5 runtime driver and S8 workflow-owned merge processing.

## Expected Scope
workflow graph executor, node handlers, retry/backoff helpers, retry summary/manual retry files, retry policy tests.

## Expected Tests
Implementation retry budget, merge retry isolation, due-time persistence, exhaustion routing, targeted manual retry clear, restart persistence.

## Exit Gate
No retry branch is controlled solely by task counters.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added workflow-node retry policy helpers for node/run scoped attempts, retry-after, exhaustion, and context projection.\n- Wired retry-backoff node handler to the policy.\n- Added retry policy and handler tests.
