### PR TITLE
refactor(workflow): S10 self-healing recovery events

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s10-self-healing-recovery-events.md
+++ b/docs/plans/workflow-owned-merge-stack/s10-self-healing-recovery-events.md
@@ -1,0 +1,46 @@
+---
+title: "S10: self-healing recovery events"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S10
+milestone: "Gate C"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s09-workflow-owned-retry-state
+---
+
+# S10: self-healing recovery events
+
+## Stack Role
+
+This draft PR reserves the S10 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Gate C
+
+## Depends On
+
+S5 runtime driver, S8 merge processing, and S9 retry state.
+
+## Goal
+
+Convert self-healing merge/retry lifecycle mutations into typed workflow recovery events and node wakes.
+
+## Expected File Scope
+
+packages/engine/src/self-healing.ts; restart recovery coordinator; recovery policy; workflow runtime; recovery tests.
+
+## Expected Tests
+
+Mergeable in-review recovery event, stale merge status event, transient merge retry event, already-landed finalize event, autoMerge false terminal behavior, dedupe.
+
+## Exit Gate
+
+Self-healing no longer directly requeues, pauses, fails, unpauses, or moves merge/retry tasks except through guarded workflow primitives.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/workflow-recovery-events.test.ts
+++ b/packages/engine/src/__tests__/workflow-recovery-events.test.ts
@@ -70,42 +70,49 @@ describe("workflow recovery events", () => {
     ]);
   });
 
-  it("publishes a fresh recovery work item when the previous event is terminal", async () => {
-    const task = await store.createTask({ description: "recurring recovery" });
+  it.each(["succeeded", "failed", "cancelled", "exhausted"] as const)(
+    "publishes a fresh recovery work item when the previous event is terminal (%s)",
+    async (terminalState) => {
+      const task = await store.createTask({ description: `recurring recovery (${terminalState})` });
 
-    const first = publishWorkflowRecoveryEvent(store, {
-      taskId: task.id,
-      kind: "transient-merge-failure",
-      source: "self-healing",
-      reason: "socket hang up",
-      now: "2026-06-09T00:00:00.000Z",
-    });
-    store.transitionWorkflowWorkItem(first.id, "succeeded", {
-      now: "2026-06-09T00:00:01.000Z",
-      leaseOwner: null,
-      leaseExpiresAt: null,
-    });
+      const first = publishWorkflowRecoveryEvent(store, {
+        taskId: task.id,
+        kind: "transient-merge-failure",
+        source: "self-healing",
+        reason: "socket hang up",
+        now: "2026-06-09T00:00:00.000Z",
+      });
+      store.transitionWorkflowWorkItem(first.id, terminalState, {
+        now: "2026-06-09T00:00:01.000Z",
+        leaseOwner: null,
+        leaseExpiresAt: null,
+      });
 
-    const second = publishWorkflowRecoveryEvent(store, {
-      taskId: task.id,
-      kind: "transient-merge-failure",
-      source: "self-healing",
-      reason: "socket hang up again",
-      now: "2026-06-09T00:00:02.000Z",
-    });
+      const second = publishWorkflowRecoveryEvent(store, {
+        taskId: task.id,
+        kind: "transient-merge-failure",
+        source: "self-healing",
+        reason: "socket hang up again",
+        now: "2026-06-09T00:00:02.000Z",
+      });
 
-    expect(second.id).not.toBe(first.id);
-    expect(second.runId).toMatch(new RegExp(`^recovery:transient-merge-failure:${task.id}:`));
-    expect(store.listWorkflowWorkItemsForTask(task.id, { kinds: ["recovery"] })).toEqual([
-      expect.objectContaining({
-        id: first.id,
-        state: "succeeded",
-      }),
-      expect.objectContaining({
-        id: second.id,
-        state: "runnable",
-        lastError: "socket hang up again",
-      }),
-    ]);
-  });
+      expect(second.id).not.toBe(first.id);
+      expect(second.runId).toMatch(new RegExp(`^recovery:transient-merge-failure:${task.id}:`));
+      const items = store.listWorkflowWorkItemsForTask(task.id, { kinds: ["recovery"] });
+      expect(items).toHaveLength(2);
+      expect(items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: first.id,
+            state: terminalState,
+          }),
+          expect.objectContaining({
+            id: second.id,
+            state: "runnable",
+            lastError: "socket hang up again",
+          }),
+        ]),
+      );
+    },
+  );
 });

--- a/packages/engine/src/__tests__/workflow-recovery-events.test.ts
+++ b/packages/engine/src/__tests__/workflow-recovery-events.test.ts
@@ -69,4 +69,43 @@ describe("workflow recovery events", () => {
       }),
     ]);
   });
+
+  it("publishes a fresh recovery work item when the previous event is terminal", async () => {
+    const task = await store.createTask({ description: "recurring recovery" });
+
+    const first = publishWorkflowRecoveryEvent(store, {
+      taskId: task.id,
+      kind: "transient-merge-failure",
+      source: "self-healing",
+      reason: "socket hang up",
+      now: "2026-06-09T00:00:00.000Z",
+    });
+    store.transitionWorkflowWorkItem(first.id, "succeeded", {
+      now: "2026-06-09T00:00:01.000Z",
+      leaseOwner: null,
+      leaseExpiresAt: null,
+    });
+
+    const second = publishWorkflowRecoveryEvent(store, {
+      taskId: task.id,
+      kind: "transient-merge-failure",
+      source: "self-healing",
+      reason: "socket hang up again",
+      now: "2026-06-09T00:00:02.000Z",
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.runId).toMatch(new RegExp(`^recovery:transient-merge-failure:${task.id}:`));
+    expect(store.listWorkflowWorkItemsForTask(task.id, { kinds: ["recovery"] })).toEqual([
+      expect.objectContaining({
+        id: first.id,
+        state: "succeeded",
+      }),
+      expect.objectContaining({
+        id: second.id,
+        state: "runnable",
+        lastError: "socket hang up again",
+      }),
+    ]);
+  });
 });

--- a/packages/engine/src/__tests__/workflow-recovery-events.test.ts
+++ b/packages/engine/src/__tests__/workflow-recovery-events.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { TaskStore } from "@fusion/core";
+import { publishWorkflowRecoveryEvent } from "../workflow-recovery-events.js";
+
+describe("workflow recovery events", () => {
+  let rootDir: string;
+  let store: TaskStore;
+
+  beforeEach(async () => {
+    rootDir = mkdtempSync(join(tmpdir(), "kb-workflow-recovery-events-"));
+    store = new TaskStore(rootDir, join(rootDir, ".fusion-global"));
+    await store.init();
+  });
+
+  afterEach(async () => {
+    store.close();
+    await rm(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  });
+
+  it("publishes typed recovery facts as runnable recovery work", async () => {
+    const task = await store.createTask({ description: "recovery task" });
+
+    const event = publishWorkflowRecoveryEvent(store, {
+      taskId: task.id,
+      kind: "transient-merge-failure",
+      source: "self-healing",
+      reason: "socket hang up",
+      now: "2026-06-09T00:00:00.000Z",
+    });
+    const duplicate = publishWorkflowRecoveryEvent(store, {
+      taskId: task.id,
+      kind: "transient-merge-failure",
+      source: "self-healing",
+      reason: "socket hang up",
+      now: "2026-06-09T00:00:01.000Z",
+    });
+
+    expect(duplicate.id).toBe(event.id);
+    expect(store.listWorkflowWorkItemsForTask(task.id, { kinds: ["recovery"] })).toEqual([
+      expect.objectContaining({
+        runId: `recovery:transient-merge-failure:${task.id}`,
+        nodeId: "recovery-router",
+        kind: "recovery",
+        state: "runnable",
+        blockedReason: "transient-merge-failure",
+        lastError: "socket hang up",
+      }),
+    ]);
+  });
+
+  it("leaves lastError empty for informational recovery events without a reason", async () => {
+    const task = await store.createTask({ description: "already landed" });
+
+    publishWorkflowRecoveryEvent(store, {
+      taskId: task.id,
+      kind: "already-landed",
+      source: "self-healing",
+      now: "2026-06-09T00:00:00.000Z",
+    });
+
+    expect(store.listWorkflowWorkItemsForTask(task.id, { kinds: ["recovery"] })).toEqual([
+      expect.objectContaining({
+        blockedReason: "already-landed",
+        lastError: null,
+      }),
+    ]);
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -164,6 +164,12 @@ export {
   type WorkflowRetryPolicyInput,
   type WorkflowRetryState,
 } from "./workflow-node-retry-policy.js";
+export {
+  publishWorkflowRecoveryEvent,
+  type WorkflowRecoveryEventInput,
+  type WorkflowRecoveryEventKind,
+  type WorkflowRecoveryEventStore,
+} from "./workflow-recovery-events.js";
 export { MeshLeaseManager, type MeshLeaseManagerOptions, type LeaseRecoveryContext } from "./mesh-lease-manager.js";
 export { MissionAutopilot, type MissionAutopilotOptions } from "./mission-autopilot.js";
 export { MissionExecutionLoop, type MissionExecutionLoopOptions, type ValidationResult, loopLog } from "./mission-execution-loop.js";

--- a/packages/engine/src/workflow-recovery-events.ts
+++ b/packages/engine/src/workflow-recovery-events.ts
@@ -18,7 +18,7 @@ export interface WorkflowRecoveryEventInput {
 }
 
 export interface WorkflowRecoveryEventStore {
-  listWorkflowWorkItemsForTask?: (taskId: string, opts?: { kinds?: ["recovery"] }) => WorkflowWorkItem[];
+  listWorkflowWorkItemsForTask: (taskId: string, opts?: { kinds?: ["recovery"] }) => WorkflowWorkItem[];
   upsertWorkflowWorkItem(input: {
     runId: string;
     taskId: string;
@@ -50,7 +50,7 @@ export function publishWorkflowRecoveryEvent(
 }
 
 function recoveryRunIdForPublish(store: WorkflowRecoveryEventStore, taskId: string, baseRunId: string): string {
-  const existing = store.listWorkflowWorkItemsForTask?.(taskId, { kinds: ["recovery"] })
+  const existing = store.listWorkflowWorkItemsForTask(taskId, { kinds: ["recovery"] })
     .find((item) => item.runId === baseRunId && item.nodeId === "recovery-router" && item.kind === "recovery");
   if (!existing) return baseRunId;
   if (existing.state === "succeeded" || existing.state === "failed" || existing.state === "cancelled" || existing.state === "exhausted") {

--- a/packages/engine/src/workflow-recovery-events.ts
+++ b/packages/engine/src/workflow-recovery-events.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { WorkflowWorkItem } from "@fusion/core";
 
 export type WorkflowRecoveryEventKind =
@@ -17,6 +18,7 @@ export interface WorkflowRecoveryEventInput {
 }
 
 export interface WorkflowRecoveryEventStore {
+  listWorkflowWorkItemsForTask?: (taskId: string, opts?: { kinds?: ["recovery"] }) => WorkflowWorkItem[];
   upsertWorkflowWorkItem(input: {
     runId: string;
     taskId: string;
@@ -33,7 +35,8 @@ export function publishWorkflowRecoveryEvent(
   store: WorkflowRecoveryEventStore,
   input: WorkflowRecoveryEventInput,
 ): WorkflowWorkItem {
-  const runId = input.runId ?? `recovery:${input.kind}:${input.taskId}`;
+  const baseRunId = input.runId ?? `recovery:${input.kind}:${input.taskId}`;
+  const runId = input.runId ? baseRunId : recoveryRunIdForPublish(store, input.taskId, baseRunId);
   return store.upsertWorkflowWorkItem({
     runId,
     taskId: input.taskId,
@@ -44,4 +47,14 @@ export function publishWorkflowRecoveryEvent(
     lastError: input.reason ?? null,
     now: input.now,
   });
+}
+
+function recoveryRunIdForPublish(store: WorkflowRecoveryEventStore, taskId: string, baseRunId: string): string {
+  const existing = store.listWorkflowWorkItemsForTask?.(taskId, { kinds: ["recovery"] })
+    .find((item) => item.runId === baseRunId && item.nodeId === "recovery-router" && item.kind === "recovery");
+  if (!existing) return baseRunId;
+  if (existing.state === "succeeded" || existing.state === "failed" || existing.state === "cancelled" || existing.state === "exhausted") {
+    return `${baseRunId}:${randomUUID()}`;
+  }
+  return baseRunId;
 }

--- a/packages/engine/src/workflow-recovery-events.ts
+++ b/packages/engine/src/workflow-recovery-events.ts
@@ -1,0 +1,47 @@
+import type { WorkflowWorkItem } from "@fusion/core";
+
+export type WorkflowRecoveryEventKind =
+  | "mergeable-in-review"
+  | "stale-merge-status"
+  | "transient-merge-failure"
+  | "already-landed"
+  | "completion-handoff-limbo";
+
+export interface WorkflowRecoveryEventInput {
+  taskId: string;
+  runId?: string;
+  kind: WorkflowRecoveryEventKind;
+  source: string;
+  reason?: string;
+  now?: string;
+}
+
+export interface WorkflowRecoveryEventStore {
+  upsertWorkflowWorkItem(input: {
+    runId: string;
+    taskId: string;
+    nodeId: string;
+    kind: "recovery";
+    state: "runnable";
+    blockedReason?: string | null;
+    lastError?: string | null;
+    now?: string;
+  }): WorkflowWorkItem;
+}
+
+export function publishWorkflowRecoveryEvent(
+  store: WorkflowRecoveryEventStore,
+  input: WorkflowRecoveryEventInput,
+): WorkflowWorkItem {
+  const runId = input.runId ?? `recovery:${input.kind}:${input.taskId}`;
+  return store.upsertWorkflowWorkItem({
+    runId,
+    taskId: input.taskId,
+    nodeId: "recovery-router",
+    kind: "recovery",
+    state: "runnable",
+    blockedReason: input.kind,
+    lastError: input.reason ?? null,
+    now: input.now,
+  });
+}


### PR DESCRIPTION
## Stack Slice
- Slice: S10
- Milestone: Gate C
- Base branch: `feature/workflow-owned-merge-s09-workflow-owned-retry-state`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Convert self-healing merge/retry lifecycle mutations into typed workflow recovery events and node wakes.

## Dependency
S5 runtime driver, S8 merge processing, and S9 retry state.

## Expected Scope
packages/engine/src/self-healing.ts; restart recovery coordinator; recovery policy; workflow runtime; recovery tests.

## Expected Tests
Mergeable in-review recovery event, stale merge status event, transient merge retry event, already-landed finalize event, autoMerge false terminal behavior, dedupe.

## Exit Gate
Self-healing no longer directly requeues, pauses, fails, unpauses, or moves merge/retry tasks except through guarded workflow primitives.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added typed workflow recovery event publisher that wakes recovery-router work items.\n- Added TaskStore-backed tests for deduped runnable recovery work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workflow recovery events to support self-healing capabilities for failed or blocked workflow executions.
  * Recovery events automatically create new recovery attempts when previous attempts reach terminal states.

* **Documentation**
  * Added planning documentation for self-healing recovery events functionality.

* **Tests**
  * Added comprehensive test coverage for recovery event publishing and handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->