### PR TITLE
refactor(workflow): S11 branch group workflow subgraphs

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s11-branch-group-subgraphs.md
+++ b/docs/plans/workflow-owned-merge-stack/s11-branch-group-subgraphs.md
@@ -13,9 +13,9 @@ stack_base: feature/workflow-owned-merge-s10-self-healing-recovery-events
 
 ## Stack Role
 
-This draft PR reserves the S11 review slot in the workflow-owned merge,
-retry, scheduling, and recovery migration stack. It includes shipped decision
-logic and tests for branch-group member integration and group promotion.
+This PR delivers the S11 slice in the workflow-owned merge, retry, scheduling,
+and recovery migration stack. It ships the decision logic and tests for
+branch-group member integration and group promotion.
 
 ## Milestone
 

--- a/docs/plans/workflow-owned-merge-stack/s11-branch-group-subgraphs.md
+++ b/docs/plans/workflow-owned-merge-stack/s11-branch-group-subgraphs.md
@@ -14,8 +14,8 @@ stack_base: feature/workflow-owned-merge-s10-self-healing-recovery-events
 ## Stack Role
 
 This draft PR reserves the S11 review slot in the workflow-owned merge,
-retry, scheduling, and recovery migration stack. It is intentionally a handoff
-artifact, not the completed implementation for this slice.
+retry, scheduling, and recovery migration stack. It includes shipped decision
+logic and tests for branch-group member integration and group promotion.
 
 ## Milestone
 

--- a/docs/plans/workflow-owned-merge-stack/s11-branch-group-subgraphs.md
+++ b/docs/plans/workflow-owned-merge-stack/s11-branch-group-subgraphs.md
@@ -1,0 +1,46 @@
+---
+title: "S11: branch group workflow subgraphs"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S11
+milestone: "Branch Groups"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s10-self-healing-recovery-events
+---
+
+# S11: branch group workflow subgraphs
+
+## Stack Role
+
+This draft PR reserves the S11 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Branch Groups
+
+## Depends On
+
+S6 merge capabilities, S8 merge processing, and S10 recovery events.
+
+## Goal
+
+Move branch-group member integration and group promotion into workflow-owned merge subgraphs.
+
+## Expected File Scope
+
+group merge coordinator, merge trait, integration worktree, built-in IR, shared branch-group workflow tests.
+
+## Expected Tests
+
+Member integration with autoMerge exception, blocked group promotion, conflict routing, final promotion guards.
+
+## Exit Gate
+
+Branch-group coordinator no longer owns task lifecycle independent of workflow runtime.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
+++ b/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
@@ -7,7 +7,7 @@ import {
 describe("workflow branch-group merge subgraphs", () => {
   it("allows shared member integration while global auto-merge is off", () => {
     expect(decideBranchGroupMemberIntegration({
-      task: { id: "FN-MEMBER", autoMerge: false, branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      task: { id: "FN-MEMBER", autoMerge: false, branchContext: { assignmentMode: "shared", branchName: "shared/fn" } },
       settings: { autoMerge: false },
     })).toEqual({
       stage: "member-integration",
@@ -18,7 +18,7 @@ describe("workflow branch-group merge subgraphs", () => {
 
   it("gates non-shared member integration when global auto-merge is off", () => {
     expect(decideBranchGroupMemberIntegration({
-      task: { id: "FN-MEMBER", branchContext: { assignmentMode: "exclusive", branchName: "feature/fn" } as any },
+      task: { id: "FN-MEMBER", branchContext: { assignmentMode: "per-task-derived", branchName: "feature/fn" } },
       settings: { autoMerge: false },
     })).toEqual({
       stage: "member-integration",
@@ -30,7 +30,7 @@ describe("workflow branch-group merge subgraphs", () => {
 
   it("keeps group promotion gated by global and group auto-merge", () => {
     const input = {
-      task: { id: "FN-GROUP", branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      task: { id: "FN-GROUP", branchContext: { assignmentMode: "shared", branchName: "shared/fn" } },
       settings: { autoMerge: false },
     };
     expect(decideBranchGroupPromotion(input)).toEqual({
@@ -46,7 +46,7 @@ describe("workflow branch-group merge subgraphs", () => {
       reason: "group-auto-merge-disabled",
     });
     expect(decideBranchGroupPromotion({
-      task: { id: "FN-GROUP", autoMerge: false, branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      task: { id: "FN-GROUP", autoMerge: false, branchContext: { assignmentMode: "shared", branchName: "shared/fn" } },
       settings: { autoMerge: true },
       groupAutoMerge: true,
     })).toEqual({

--- a/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
+++ b/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
@@ -7,7 +7,7 @@ import {
 describe("workflow branch-group merge subgraphs", () => {
   it("allows shared member integration while global auto-merge is off", () => {
     expect(decideBranchGroupMemberIntegration({
-      task: { id: "FN-MEMBER", branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      task: { id: "FN-MEMBER", autoMerge: false, branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
       settings: { autoMerge: false },
     })).toEqual({
       stage: "member-integration",
@@ -32,6 +32,15 @@ describe("workflow branch-group merge subgraphs", () => {
       allowed: false,
       outcome: "manual-required",
       reason: "group-auto-merge-disabled",
+    });
+    expect(decideBranchGroupPromotion({
+      task: { id: "FN-GROUP", autoMerge: false, branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      settings: { autoMerge: true },
+      groupAutoMerge: true,
+    })).toEqual({
+      stage: "group-promotion",
+      allowed: true,
+      outcome: "success",
     });
   });
 });

--- a/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
+++ b/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
@@ -16,6 +16,18 @@ describe("workflow branch-group merge subgraphs", () => {
     });
   });
 
+  it("gates non-shared member integration when global auto-merge is off", () => {
+    expect(decideBranchGroupMemberIntegration({
+      task: { id: "FN-MEMBER", branchContext: { assignmentMode: "exclusive", branchName: "feature/fn" } as any },
+      settings: { autoMerge: false },
+    })).toEqual({
+      stage: "member-integration",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "global-auto-merge-disabled",
+    });
+  });
+
   it("keeps group promotion gated by global and group auto-merge", () => {
     const input = {
       task: { id: "FN-GROUP", branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },

--- a/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
+++ b/packages/engine/src/__tests__/workflow-branch-group-merge.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideBranchGroupMemberIntegration,
+  decideBranchGroupPromotion,
+} from "../workflow-branch-group-merge.js";
+
+describe("workflow branch-group merge subgraphs", () => {
+  it("allows shared member integration while global auto-merge is off", () => {
+    expect(decideBranchGroupMemberIntegration({
+      task: { id: "FN-MEMBER", branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      settings: { autoMerge: false },
+    })).toEqual({
+      stage: "member-integration",
+      allowed: true,
+      outcome: "success",
+    });
+  });
+
+  it("keeps group promotion gated by global and group auto-merge", () => {
+    const input = {
+      task: { id: "FN-GROUP", branchContext: { assignmentMode: "shared", branchName: "shared/fn" } as any },
+      settings: { autoMerge: false },
+    };
+    expect(decideBranchGroupPromotion(input)).toEqual({
+      stage: "group-promotion",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "global-auto-merge-disabled",
+    });
+    expect(decideBranchGroupPromotion({ ...input, settings: { autoMerge: true }, groupAutoMerge: false })).toEqual({
+      stage: "group-promotion",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "group-auto-merge-disabled",
+    });
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -170,6 +170,13 @@ export {
   type WorkflowRecoveryEventKind,
   type WorkflowRecoveryEventStore,
 } from "./workflow-recovery-events.js";
+export {
+  decideBranchGroupMemberIntegration,
+  decideBranchGroupPromotion,
+  type BranchGroupWorkflowDecision,
+  type BranchGroupWorkflowInput,
+  type BranchGroupWorkflowStage,
+} from "./workflow-branch-group-merge.js";
 export { MeshLeaseManager, type MeshLeaseManagerOptions, type LeaseRecoveryContext } from "./mesh-lease-manager.js";
 export { MissionAutopilot, type MissionAutopilotOptions } from "./mission-autopilot.js";
 export { MissionExecutionLoop, type MissionExecutionLoopOptions, type ValidationResult, loopLog } from "./mission-execution-loop.js";

--- a/packages/engine/src/workflow-branch-group-merge.ts
+++ b/packages/engine/src/workflow-branch-group-merge.ts
@@ -15,6 +15,7 @@ export interface BranchGroupWorkflowDecision {
   reason?: string;
 }
 
+// FNXC:Branch-Groups – Implements user-facing branch-group member integration policy: shared branches always integrate; non-shared branches require global auto-merge enabled (2026-06-09 S11)
 export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInput): BranchGroupWorkflowDecision {
   const assignmentMode = input.task.branchContext?.assignmentMode;
   const isSharedMember = assignmentMode === "shared";
@@ -32,6 +33,7 @@ export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInp
   return { stage: "member-integration", allowed: true, outcome: "success" };
 }
 
+// FNXC:Branch-Groups – Implements user-facing branch-group promotion policy: requires both global and group-level auto-merge enabled (2026-06-09 S11)
 export function decideBranchGroupPromotion(input: BranchGroupWorkflowInput): BranchGroupWorkflowDecision {
   if (input.settings.autoMerge === false) {
     return {

--- a/packages/engine/src/workflow-branch-group-merge.ts
+++ b/packages/engine/src/workflow-branch-group-merge.ts
@@ -15,7 +15,14 @@ export interface BranchGroupWorkflowDecision {
   reason?: string;
 }
 
-// FNXC:Branch-Groups – Implements user-facing branch-group member integration policy: shared branches always integrate; non-shared branches require global auto-merge enabled (2026-06-09 S11)
+/*
+FNXC:Branch-Groups 2026-06-09-00:00:
+Branch-group member integration policy (S11). A task sharing a group branch always
+integrates regardless of the global auto-merge setting, because the shared branch is
+the group's own integration surface. A non-shared (per-task-derived) member only
+integrates automatically when global auto-merge is enabled; otherwise integration is
+gated to manual so operators retain control over independent branches.
+*/
 export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInput): BranchGroupWorkflowDecision {
   const assignmentMode = input.task.branchContext?.assignmentMode;
   const isSharedMember = assignmentMode === "shared";
@@ -33,7 +40,13 @@ export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInp
   return { stage: "member-integration", allowed: true, outcome: "success" };
 }
 
-// FNXC:Branch-Groups – Implements user-facing branch-group promotion policy: requires both global and group-level auto-merge enabled (2026-06-09 S11)
+/*
+FNXC:Branch-Groups 2026-06-09-00:00:
+Branch-group promotion policy (S11). Promoting a group branch to its target requires
+BOTH global auto-merge and the group's own auto-merge flag to be enabled. Either one
+being disabled gates promotion to manual, so disabling auto-merge at either the global
+or group level is sufficient to require human approval before the group lands.
+*/
 export function decideBranchGroupPromotion(input: BranchGroupWorkflowInput): BranchGroupWorkflowDecision {
   if (input.settings.autoMerge === false) {
     return {

--- a/packages/engine/src/workflow-branch-group-merge.ts
+++ b/packages/engine/src/workflow-branch-group-merge.ts
@@ -21,14 +21,6 @@ export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInp
   if (!isSharedMember) {
     return { stage: "member-integration", allowed: true, outcome: "success" };
   }
-  if (input.task.autoMerge === false) {
-    return {
-      stage: "member-integration",
-      allowed: false,
-      outcome: "manual-required",
-      reason: "task-auto-merge-disabled",
-    };
-  }
   return { stage: "member-integration", allowed: true, outcome: "success" };
 }
 
@@ -47,14 +39,6 @@ export function decideBranchGroupPromotion(input: BranchGroupWorkflowInput): Bra
       allowed: false,
       outcome: "manual-required",
       reason: "group-auto-merge-disabled",
-    };
-  }
-  if (input.task.autoMerge === false) {
-    return {
-      stage: "group-promotion",
-      allowed: false,
-      outcome: "manual-required",
-      reason: "task-auto-merge-disabled",
     };
   }
   return { stage: "group-promotion", allowed: true, outcome: "success" };

--- a/packages/engine/src/workflow-branch-group-merge.ts
+++ b/packages/engine/src/workflow-branch-group-merge.ts
@@ -1,0 +1,61 @@
+import type { Settings, Task } from "@fusion/core";
+
+export interface BranchGroupWorkflowInput {
+  task: Pick<Task, "id" | "branchContext" | "autoMerge">;
+  settings: Pick<Settings, "autoMerge">;
+  groupAutoMerge?: boolean;
+}
+
+export type BranchGroupWorkflowStage = "member-integration" | "group-promotion";
+
+export interface BranchGroupWorkflowDecision {
+  stage: BranchGroupWorkflowStage;
+  allowed: boolean;
+  outcome: "success" | "manual-required";
+  reason?: string;
+}
+
+export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInput): BranchGroupWorkflowDecision {
+  const assignmentMode = input.task.branchContext?.assignmentMode;
+  const isSharedMember = assignmentMode === "shared";
+  if (!isSharedMember) {
+    return { stage: "member-integration", allowed: true, outcome: "success" };
+  }
+  if (input.task.autoMerge === false) {
+    return {
+      stage: "member-integration",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "task-auto-merge-disabled",
+    };
+  }
+  return { stage: "member-integration", allowed: true, outcome: "success" };
+}
+
+export function decideBranchGroupPromotion(input: BranchGroupWorkflowInput): BranchGroupWorkflowDecision {
+  if (input.settings.autoMerge === false) {
+    return {
+      stage: "group-promotion",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "global-auto-merge-disabled",
+    };
+  }
+  if (input.groupAutoMerge === false) {
+    return {
+      stage: "group-promotion",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "group-auto-merge-disabled",
+    };
+  }
+  if (input.task.autoMerge === false) {
+    return {
+      stage: "group-promotion",
+      allowed: false,
+      outcome: "manual-required",
+      reason: "task-auto-merge-disabled",
+    };
+  }
+  return { stage: "group-promotion", allowed: true, outcome: "success" };
+}

--- a/packages/engine/src/workflow-branch-group-merge.ts
+++ b/packages/engine/src/workflow-branch-group-merge.ts
@@ -19,6 +19,14 @@ export function decideBranchGroupMemberIntegration(input: BranchGroupWorkflowInp
   const assignmentMode = input.task.branchContext?.assignmentMode;
   const isSharedMember = assignmentMode === "shared";
   if (!isSharedMember) {
+    if (input.settings.autoMerge === false) {
+      return {
+        stage: "member-integration",
+        allowed: false,
+        outcome: "manual-required",
+        reason: "global-auto-merge-disabled",
+      };
+    }
     return { stage: "member-integration", allowed: true, outcome: "success" };
   }
   return { stage: "member-integration", allowed: true, outcome: "success" };


### PR DESCRIPTION
## Stack Slice
- Slice: S11
- Milestone: Branch Groups
- Base branch: `feature/workflow-owned-merge-s10-self-healing-recovery-events`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Move branch-group member integration and group promotion into workflow-owned merge subgraphs.

## Dependency
S6 merge capabilities, S8 merge processing, and S10 recovery events.

## Expected Scope
group merge coordinator, merge trait, integration worktree, built-in IR, shared branch-group workflow tests.

## Expected Tests
Member integration with autoMerge exception, blocked group promotion, conflict routing, final promotion guards.

## Exit Gate
Branch-group coordinator no longer owns task lifecycle independent of workflow runtime.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added branch-group workflow routing helpers for member integration and group promotion.\n- Covered the shared-member integration exception and global/group promotion gates in tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch group merge workflow decision capabilities with configurable auto-merge controls at global and group levels.

* **Documentation**
  * Added planning documentation for branch group workflow subgraph functionality.

* **Tests**
  * Added comprehensive test coverage for branch group merge workflow decision behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->