### PR TITLE
refactor(workflow): S12 dashboard API CLI workflow projection

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s12-workflow-projections.md
+++ b/docs/plans/workflow-owned-merge-stack/s12-workflow-projections.md
@@ -1,0 +1,46 @@
+---
+title: "S12: dashboard API CLI workflow projection"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S12
+milestone: "Gate D"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s11-branch-group-subgraphs
+---
+
+# S12: dashboard API CLI workflow projection
+
+## Stack Role
+
+This draft PR reserves the S12 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Gate D
+
+## Depends On
+
+S1/S2 state foundations, S7 merge work handoff, S9 retry state, and S10 recovery events.
+
+## Goal
+
+Surface workflow-native queued, retrying, merging, manual-hold, failed, stalled, and recovered reasons across inspection surfaces.
+
+## Expected File Scope
+
+dashboard TaskCard/detail/API/CLI output files, retry summary, task merge projection files, dashboard/API tests.
+
+## Expected Tests
+
+Workflow-first merge queued, retry due time, manual hold, recovery reason, stale badge hiding, branch-group target identity.
+
+## Exit Gate
+
+UI/API/CLI tests prove workflow state is the first projection source.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/core/src/__tests__/workflow-work-projection.test.ts
+++ b/packages/core/src/__tests__/workflow-work-projection.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "vitest";
 import { projectWorkflowWorkStatus } from "../workflow-work-projection.js";
 import type { Task, WorkflowWorkItem } from "../types.js";
 
+/*
+FNXC:WorkflowProjections 2026-06-17-08:42:
+These tests pin the user-facing workflow status surfaced for a task by projectWorkflowWorkStatus, which
+dashboard, API, and CLI all read. Requirements encoded here:
+- A single workflow status is derived from a task's work items by priority (recovery > manual-hold >
+  running > retrying > merge > other), so the most operator-relevant state wins when several items coexist.
+- When no item is still active, the task projects as "complete" from the deterministic earliest succeeded
+  item; if there is no workflow item at all it falls back to the "legacy" task status.
+- The projected workItemId must be stable for identical logical state regardless of work-item array order,
+  so the same task never flips between ids across callers.
+*/
+
 const task = { id: "FN-PROJECT", mergeRetries: 4, status: "legacy status" } as Task;
 
 function item(input: Partial<WorkflowWorkItem> & Pick<WorkflowWorkItem, "id" | "kind" | "state">): WorkflowWorkItem {

--- a/packages/core/src/__tests__/workflow-work-projection.test.ts
+++ b/packages/core/src/__tests__/workflow-work-projection.test.ts
@@ -50,6 +50,17 @@ describe("workflow work projection", () => {
     }));
   });
 
+  it("keeps projection dispatch aligned with manual-hold sort priority", () => {
+    expect(projectWorkflowWorkStatus(task, [
+      item({ id: "work-running", kind: "merge", state: "running" }),
+      item({ id: "work-manual", kind: "manual-hold", state: "retrying", blockedReason: "autoMerge:false" }),
+    ])).toEqual(expect.objectContaining({
+      status: "manual-hold",
+      workItemId: "work-manual",
+      reason: "autoMerge:false",
+    }));
+  });
+
   it("falls back to legacy task fields only when no workflow work exists", () => {
     expect(projectWorkflowWorkStatus(task, [])).toEqual({
       status: "legacy",

--- a/packages/core/src/__tests__/workflow-work-projection.test.ts
+++ b/packages/core/src/__tests__/workflow-work-projection.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { projectWorkflowWorkStatus } from "../workflow-work-projection.js";
+import type { Task, WorkflowWorkItem } from "../types.js";
+
+const task = { id: "FN-PROJECT", mergeRetries: 4, status: "legacy status" } as Task;
+
+function item(input: Partial<WorkflowWorkItem> & Pick<WorkflowWorkItem, "id" | "kind" | "state">): WorkflowWorkItem {
+  return {
+    runId: "run-1",
+    taskId: task.id,
+    nodeId: "merge-gate",
+    attempt: 0,
+    retryAfter: null,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    lastError: null,
+    blockedReason: null,
+    createdAt: "2026-06-09T00:00:00.000Z",
+    updatedAt: "2026-06-09T00:00:00.000Z",
+    ...input,
+  };
+}
+
+describe("workflow work projection", () => {
+  it("uses workflow merge work before legacy task retry fields", () => {
+    expect(projectWorkflowWorkStatus(task, [
+      item({ id: "work-1", kind: "merge", state: "runnable" }),
+    ])).toEqual(expect.objectContaining({
+      source: "workflow",
+      status: "merge-queued",
+      workItemId: "work-1",
+      attempt: 0,
+    }));
+  });
+
+  it("surfaces manual hold and recovery reasons", () => {
+    expect(projectWorkflowWorkStatus(task, [
+      item({ id: "work-1", kind: "merge", state: "runnable" }),
+      item({ id: "work-2", kind: "manual-hold", state: "manual-required", blockedReason: "autoMerge:false" }),
+    ])).toEqual(expect.objectContaining({
+      status: "manual-hold",
+      reason: "autoMerge:false",
+    }));
+
+    expect(projectWorkflowWorkStatus(task, [
+      item({ id: "work-3", kind: "recovery", state: "runnable", blockedReason: "already-landed" }),
+    ])).toEqual(expect.objectContaining({
+      status: "recovery",
+      reason: "already-landed",
+    }));
+  });
+
+  it("falls back to legacy task fields only when no workflow work exists", () => {
+    expect(projectWorkflowWorkStatus(task, [])).toEqual({
+      status: "legacy",
+      source: "legacy",
+      taskId: task.id,
+      reason: "legacy status",
+      attempt: 4,
+    });
+  });
+
+  it("preserves zero legacy retry attempts in fallback projection", () => {
+    expect(projectWorkflowWorkStatus({ ...task, mergeRetries: 0, mergeTransientRetryCount: 2 }, [])).toEqual(expect.objectContaining({
+      source: "legacy",
+      attempt: 0,
+    }));
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,6 +118,11 @@ export {
   ensureGitRepositoryForProjectPath,
   GitRepositoryInitializationError,
 } from "./git-repository.js";
+export {
+  projectWorkflowWorkStatus,
+  type WorkflowWorkProjection,
+  type WorkflowWorkProjectionStatus,
+} from "./workflow-work-projection.js";
 export type {
   GitRepositoryCommandResult,
   GitRepositoryCommandRunner,

--- a/packages/core/src/workflow-work-projection.ts
+++ b/packages/core/src/workflow-work-projection.ts
@@ -28,7 +28,17 @@ export function projectWorkflowWorkStatus(
     item.state !== "succeeded" && item.state !== "cancelled",
   );
   if (!active) {
-    const completed = workItems.find((item) => item.state === "succeeded");
+    /*
+    FNXC:WorkflowProjections 2026-06-17-08:42:
+    When no work item is still active, the projection must report a stable "complete" status for the task.
+    If several succeeded items exist for the same task, the chosen workItemId must be deterministic so the
+    same logical state always projects to the same id regardless of incoming array order (otherwise dashboard,
+    API, and CLI callers can disagree on which work item represents completion). Order succeeded items by
+    createdAt ascending — matching the tiebreaker in compareWorkItemsForProjection — and take the earliest.
+    */
+    const completed = [...workItems]
+      .filter((item) => item.state === "succeeded")
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0];
     if (completed) {
       return { status: "complete", source: "workflow", taskId: task.id, workItemId: completed.id };
     }

--- a/packages/core/src/workflow-work-projection.ts
+++ b/packages/core/src/workflow-work-projection.ts
@@ -44,11 +44,11 @@ export function projectWorkflowWorkStatus(
   if (active.kind === "recovery") {
     return workflowProjection(active, "recovery");
   }
-  if (active.state === "retrying") {
-    return workflowProjection(active, "retrying");
-  }
   if (active.kind === "manual-hold" || active.state === "manual-required" || active.state === "held") {
     return workflowProjection(active, "manual-hold");
+  }
+  if (active.state === "retrying") {
+    return workflowProjection(active, "retrying");
   }
   if (active.state === "running") {
     return workflowProjection(active, "merge-running");

--- a/packages/core/src/workflow-work-projection.ts
+++ b/packages/core/src/workflow-work-projection.ts
@@ -1,0 +1,84 @@
+import type { Task, WorkflowWorkItem } from "./types.js";
+
+export type WorkflowWorkProjectionStatus =
+  | "merge-queued"
+  | "merge-running"
+  | "retrying"
+  | "manual-hold"
+  | "recovery"
+  | "failed"
+  | "complete"
+  | "legacy";
+
+export interface WorkflowWorkProjection {
+  status: WorkflowWorkProjectionStatus;
+  source: "workflow" | "legacy";
+  taskId: string;
+  workItemId?: string;
+  reason?: string | null;
+  retryAfter?: string | null;
+  attempt?: number;
+}
+
+export function projectWorkflowWorkStatus(
+  task: Pick<Task, "id" | "mergeRetries" | "mergeTransientRetryCount" | "status">,
+  workItems: WorkflowWorkItem[],
+): WorkflowWorkProjection {
+  const active = [...workItems].sort(compareWorkItemsForProjection).find((item) =>
+    item.state !== "succeeded" && item.state !== "cancelled",
+  );
+  if (!active) {
+    const completed = workItems.find((item) => item.state === "succeeded");
+    if (completed) {
+      return { status: "complete", source: "workflow", taskId: task.id, workItemId: completed.id };
+    }
+    return {
+      status: "legacy",
+      source: "legacy",
+      taskId: task.id,
+      reason: task.status ?? null,
+      attempt: task.mergeRetries ?? task.mergeTransientRetryCount ?? undefined,
+    };
+  }
+
+  if (active.kind === "recovery") {
+    return workflowProjection(active, "recovery");
+  }
+  if (active.state === "retrying") {
+    return workflowProjection(active, "retrying");
+  }
+  if (active.kind === "manual-hold" || active.state === "manual-required" || active.state === "held") {
+    return workflowProjection(active, "manual-hold");
+  }
+  if (active.state === "running") {
+    return workflowProjection(active, "merge-running");
+  }
+  if (active.state === "failed" || active.state === "exhausted") {
+    return workflowProjection(active, "failed");
+  }
+  return workflowProjection(active, "merge-queued");
+}
+
+function workflowProjection(item: WorkflowWorkItem, status: WorkflowWorkProjectionStatus): WorkflowWorkProjection {
+  return {
+    status,
+    source: "workflow",
+    taskId: item.taskId,
+    workItemId: item.id,
+    reason: item.blockedReason ?? item.lastError,
+    retryAfter: item.retryAfter,
+    attempt: item.attempt,
+  };
+}
+
+function compareWorkItemsForProjection(a: WorkflowWorkItem, b: WorkflowWorkItem): number {
+  const priority = (item: WorkflowWorkItem): number => {
+    if (item.kind === "recovery") return 0;
+    if (item.kind === "manual-hold" || item.state === "manual-required" || item.state === "held") return 1;
+    if (item.state === "running") return 2;
+    if (item.state === "retrying") return 3;
+    if (item.kind === "merge") return 4;
+    return 5;
+  };
+  return priority(a) - priority(b) || a.createdAt.localeCompare(b.createdAt);
+}


### PR DESCRIPTION
## Stack Slice
- Slice: S12
- Milestone: Gate D
- Base branch: `feature/workflow-owned-merge-s11-branch-group-subgraphs`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Surface workflow-native queued, retrying, merging, manual-hold, failed, stalled, and recovered reasons across inspection surfaces.

## Dependency
S1/S2 state foundations, S7 merge work handoff, S9 retry state, and S10 recovery events.

## Expected Scope
dashboard TaskCard/detail/API/CLI output files, retry summary, task merge projection files, dashboard/API tests.

## Expected Tests
Workflow-first merge queued, retry due time, manual hold, recovery reason, stale badge hiding, branch-group target identity.

## Exit Gate
UI/API/CLI tests prove workflow state is the first projection source.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added workflow-first status projection helper in @fusion/core for merge, retry, manual hold, recovery, failed, complete, and legacy fallback states.\n- Added projection tests for workflow precedence and legacy fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new public API for normalizing and projecting workflow work-item states with support for merge, retry, manual-hold, recovery, and fallback modes.

* **Documentation**
  * Added planning documentation detailing the workflow-owned merge stack migration roadmap and implementation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->