### PR TITLE
refactor(workflow): S13 scheduler policy deletion

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s13-scheduler-policy-deletion.md
+++ b/docs/plans/workflow-owned-merge-stack/s13-scheduler-policy-deletion.md
@@ -1,0 +1,46 @@
+---
+title: "S13: scheduler policy deletion"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S13
+milestone: "Deletion"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s12-workflow-projections
+---
+
+# S13: scheduler policy deletion
+
+## Stack Role
+
+This draft PR reserves the S13 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Deletion
+
+## Depends On
+
+S3 scheduler claim path, S7 handoff, S8 merge processing, and S12 projections.
+
+## Goal
+
+Delete scheduler branches that infer lifecycle, merge eligibility, retry routing, or in-review dependency behavior from task columns.
+
+## Expected File Scope
+
+packages/engine/src/scheduler.ts; packages/core/src/task-merge.ts; scheduler deletion tests.
+
+## Expected Tests
+
+Dependency satisfaction cannot rely on in-review alone, retry due time from work item, overlap leases from workflow work, PR monitor remains substrate.
+
+## Exit Gate
+
+Search/structure tests fail if scheduler reintroduces task-column merge/retry policy.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/workflow-scheduler-policy-deletion.test.ts
+++ b/packages/engine/src/__tests__/workflow-scheduler-policy-deletion.test.ts
@@ -14,8 +14,8 @@ describe("workflow scheduler policy deletion guard", () => {
     expect(source).toContain("acquireWorkflowWorkItemLease");
     expect(source).not.toMatch(/\bgetTask\b/);
     expect(source).not.toMatch(/\bmoveTask\b/);
-    expect(source).not.toContain("in-review");
-    expect(source).not.toContain("mergeRetries");
-    expect(source).not.toContain("retryAfter");
+    expect(source).not.toMatch(/["']in-review["']/);
+    expect(source).not.toMatch(/\bmergeRetries\b/);
+    expect(source).not.toMatch(/\bretryAfter\b/);
   });
 });

--- a/packages/engine/src/__tests__/workflow-scheduler-policy-deletion.test.ts
+++ b/packages/engine/src/__tests__/workflow-scheduler-policy-deletion.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const WORKFLOW_SCHEDULER_PATH = resolve(__dirname, "../workflow-work-scheduler.ts");
+
+describe("workflow scheduler policy deletion guard", () => {
+  it("keeps generic workflow work claiming independent of task lifecycle columns", () => {
+    const source = readFileSync(WORKFLOW_SCHEDULER_PATH, "utf8");
+
+    expect(source).toContain("listDueWorkflowWorkItems");
+    expect(source).toContain("acquireWorkflowWorkItemLease");
+    expect(source).not.toMatch(/\bgetTask\b/);
+    expect(source).not.toMatch(/\bmoveTask\b/);
+    expect(source).not.toContain("in-review");
+    expect(source).not.toContain("mergeRetries");
+    expect(source).not.toContain("retryAfter");
+  });
+});


### PR DESCRIPTION
## Stack Slice
- Slice: S13
- Milestone: Deletion
- Base branch: `feature/workflow-owned-merge-s12-workflow-projections`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Delete scheduler branches that infer lifecycle, merge eligibility, retry routing, or in-review dependency behavior from task columns.

## Dependency
S3 scheduler claim path, S7 handoff, S8 merge processing, and S12 projections.

## Expected Scope
packages/engine/src/scheduler.ts; packages/core/src/task-merge.ts; scheduler deletion tests.

## Expected Tests
Dependency satisfaction cannot rely on in-review alone, retry due time from work item, overlap leases from workflow work, PR monitor remains substrate.

## Exit Gate
Search/structure tests fail if scheduler reintroduces task-column merge/retry policy.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added scheduler policy deletion guard test for workflow-work-scheduler.\n- The guard fails if generic workflow work claiming starts reading task columns, merge retries, or moveTask.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow plan documentation for S13 scheduler policy deletion slice, including scope, milestone, dependencies, and exit criteria.

* **Tests**
  * Added automated validation tests to verify scheduler policy deletion requirements are implemented correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->