### PR TITLE
refactor(workflow): S14 ProjectEngine merge queue deletion

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s14-project-engine-merge-queue-deletion.md
+++ b/docs/plans/workflow-owned-merge-stack/s14-project-engine-merge-queue-deletion.md
@@ -1,0 +1,46 @@
+---
+title: "S14: ProjectEngine merge queue deletion"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S14
+milestone: "Deletion"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s13-scheduler-policy-deletion
+---
+
+# S14: ProjectEngine merge queue deletion
+
+## Stack Role
+
+This draft PR reserves the S14 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Deletion
+
+## Depends On
+
+S8 merge processing, S11 branch-group subgraphs, and S13 scheduler deletion.
+
+## Goal
+
+Remove production ProjectEngine merge queue policy and retain only explicit human/manual event entry points plus substrate helpers.
+
+## Expected File Scope
+
+packages/engine/src/project-engine.ts; runtimes/in-process runtime; core store; merge lifecycle and deletion tests.
+
+## Expected Tests
+
+No startup hidden enqueue, unpause wakes workflow work, manual merge event wakes merge node, stale mergeActive does not block workflow work, old queue APIs compatibility-only.
+
+## Exit Gate
+
+No production caller starts merge processing outside workflow runtime.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/workflow-merge-policy-deletion.test.ts
+++ b/packages/engine/src/__tests__/workflow-merge-policy-deletion.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const PROCESSOR_PATH = resolve(__dirname, "../workflow-work-processor.ts");
+const PROJECT_ENGINE_PATH = resolve(__dirname, "../project-engine.ts");
+
+describe("workflow merge policy deletion guard", () => {
+  it("keeps workflow work processing isolated from the legacy ProjectEngine merge queue", () => {
+    const processorSource = readFileSync(PROCESSOR_PATH, "utf8");
+    const projectEngineSource = readFileSync(PROJECT_ENGINE_PATH, "utf8");
+
+    expect(projectEngineSource).toContain("private mergeQueue");
+    expect(processorSource).toContain("claimDueWorkflowWorkItem");
+    expect(processorSource).toContain("runtime.runWorkItem");
+    expect(processorSource).toContain("\"merge\"");
+    expect(processorSource).toContain("\"manual-hold\"");
+    expect(processorSource).not.toContain("mergeQueue");
+    expect(processorSource).not.toContain("enqueueMerge");
+    expect(processorSource).not.toContain("ProjectEngine");
+  });
+});

--- a/packages/engine/src/__tests__/workflow-merge-policy-deletion.test.ts
+++ b/packages/engine/src/__tests__/workflow-merge-policy-deletion.test.ts
@@ -5,14 +5,11 @@ import { describe, expect, it } from "vitest";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const PROCESSOR_PATH = resolve(__dirname, "../workflow-work-processor.ts");
-const PROJECT_ENGINE_PATH = resolve(__dirname, "../project-engine.ts");
 
 describe("workflow merge policy deletion guard", () => {
   it("keeps workflow work processing isolated from the legacy ProjectEngine merge queue", () => {
     const processorSource = readFileSync(PROCESSOR_PATH, "utf8");
-    const projectEngineSource = readFileSync(PROJECT_ENGINE_PATH, "utf8");
 
-    expect(projectEngineSource).toContain("private mergeQueue");
     expect(processorSource).toContain("claimDueWorkflowWorkItem");
     expect(processorSource).toContain("runtime.runWorkItem");
     expect(processorSource).toContain("\"merge\"");


### PR DESCRIPTION
## Stack Slice
- Slice: S14
- Milestone: Deletion
- Base branch: `feature/workflow-owned-merge-s13-scheduler-policy-deletion`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Remove production ProjectEngine merge queue policy and retain only explicit human/manual event entry points plus substrate helpers.

## Dependency
S8 merge processing, S11 branch-group subgraphs, and S13 scheduler deletion.

## Expected Scope
packages/engine/src/project-engine.ts; runtimes/in-process runtime; core store; merge lifecycle and deletion tests.

## Expected Tests
No startup hidden enqueue, unpause wakes workflow work, manual merge event wakes merge node, stale mergeActive does not block workflow work, old queue APIs compatibility-only.

## Exit Gate
No production caller starts merge processing outside workflow runtime.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added merge queue deletion guard test for workflow-work-processor.\n- The guard fails if workflow-owned merge processing depends on mergeQueue, enqueueMergeQueue, or ProjectEngine queue internals.
