### PR TITLE
refactor(workflow): S15 self-healing policy deletion

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s15-self-healing-policy-deletion.md
+++ b/docs/plans/workflow-owned-merge-stack/s15-self-healing-policy-deletion.md
@@ -1,0 +1,46 @@
+---
+title: "S15: self-healing policy deletion"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S15
+milestone: "Deletion"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s14-project-engine-merge-queue-deletion
+---
+
+# S15: self-healing policy deletion
+
+## Stack Role
+
+This draft PR reserves the S15 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Deletion
+
+## Depends On
+
+S10 recovery events, S11 branch-group subgraphs, and S14 merge queue deletion.
+
+## Goal
+
+Delete self-healing direct lifecycle mutations for merge/retry tasks after recovery events cover all cases.
+
+## Expected File Scope
+
+packages/engine/src/self-healing.ts; self-healing audit docs; recovery event and deletion tests.
+
+## Expected Tests
+
+Direct move/pause/requeue/retry-reset patterns absent for merge/retry surfaces, valid held states no-op, recovery facts include audit context.
+
+## Exit Gate
+
+Search tests fail on direct self-healing merge/retry lifecycle mutation patterns.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -1942,6 +1942,38 @@ describe("SelfHealingManager", () => {
       mgr.stop();
     });
 
+    it("still re-enqueues when workflow recovery event publication fails", async () => {
+      const transientStore = setupTransientRecoveryStore({
+        tasks: [
+          {
+            id: "FN-5629",
+            column: "in-review",
+            paused: false,
+            status: "failed",
+            mergeRetries: 3,
+            error: "Merge handoff refused (lease-handoff-failed): target-not-queued",
+            mergeDetails: undefined,
+          },
+        ],
+      });
+      Object.assign(transientStore, {
+        upsertWorkflowWorkItem: vi.fn(() => {
+          throw new Error("terminal recovery item");
+        }),
+      });
+      const requeueForAutoMerge = vi.fn();
+      const mgr = new SelfHealingManager(transientStore, {
+        rootDir: "/tmp/test-project",
+        requeueForAutoMerge,
+      });
+
+      const recovered = await mgr.recoverTransientMergeFailures();
+
+      expect(recovered).toBe(1);
+      expect(requeueForAutoMerge).toHaveBeenCalledWith("FN-5629");
+      mgr.stop();
+    });
+
     it("recovers same-SHA spurious concurrent-advance failures (pre-FN-5627 legacy)", async () => {
       const transientStore = setupTransientRecoveryStore({
         tasks: [

--- a/packages/engine/src/__tests__/workflow-self-healing-policy-deletion.test.ts
+++ b/packages/engine/src/__tests__/workflow-self-healing-policy-deletion.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const RECOVERY_EVENTS_PATH = resolve(__dirname, "../workflow-recovery-events.ts");
+const SELF_HEALING_PATH = resolve(__dirname, "../self-healing.ts");
+
+describe("workflow self-healing policy deletion guard", () => {
+  it("records recovery facts as workflow work while keeping event publication mutation-free", () => {
+    const recoveryEventsSource = readFileSync(RECOVERY_EVENTS_PATH, "utf8");
+    const selfHealingSource = readFileSync(SELF_HEALING_PATH, "utf8");
+
+    expect(selfHealingSource).toContain("publishWorkflowRecoveryEvent");
+    expect(selfHealingSource).toContain("\"transient-merge-failure\"");
+    expect(selfHealingSource).toContain("\"completion-handoff-limbo\"");
+    expect(recoveryEventsSource).toContain("upsertWorkflowWorkItem");
+    expect(recoveryEventsSource).toContain("recovery-router");
+    expect(recoveryEventsSource).not.toContain("moveTask");
+    expect(recoveryEventsSource).not.toContain("updateTask");
+    expect(recoveryEventsSource).not.toContain("enqueueMerge");
+    expect(recoveryEventsSource).not.toContain("transitionMergeRequestState");
+  });
+});

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -31,6 +31,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, allowsAutoMergeProcessing, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkflowColumnsEnabled, isSharedBranchGroupMemberIntegration, parseExplicitDuplicateMarker, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult } from "@fusion/core";
 import type { MeshLeaseManager } from "./mesh-lease-manager.js";
 import { createLogger, schedulerLog } from "./logger.js";
+import { publishWorkflowRecoveryEvent } from "./workflow-recovery-events.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { RemovalReason, classifyTaskWorktree, getRegisteredWorktreeBranchMap, getRegisteredWorktreePaths, isUsableTaskWorktree, removeWorktree, resolveWorktreeBackend, scanIdleWorktrees, scanOrphanedBranches } from "./worktree-pool.js";
 import {
@@ -5906,6 +5907,12 @@ export class SelfHealingManager {
             transientRecoveryCount: nextCount,
           },
         });
+        publishWorkflowRecoveryEvent(this.store, {
+          taskId: task.id,
+          kind: "transient-merge-failure",
+          source: "self-healing",
+          reason: errorSnippet,
+        });
         try {
           await audit.database({
             type: "merger:transient-failure-auto-recovered",
@@ -7064,6 +7071,12 @@ export class SelfHealingManager {
 
       await this.store.updateTask(task.id, {
         completionHandoffLimboRecoveryCount: currentCount + 1,
+      });
+      publishWorkflowRecoveryEvent(this.store, {
+        taskId: task.id,
+        kind: "completion-handoff-limbo",
+        source: "self-healing",
+        reason: `ageMs=${ageMs}; attempts=${currentCount + 1}`,
       });
 
       const audit = createRunAuditor(this.store, {

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -5907,12 +5907,20 @@ export class SelfHealingManager {
             transientRecoveryCount: nextCount,
           },
         });
-        publishWorkflowRecoveryEvent(this.store, {
-          taskId: task.id,
-          kind: "transient-merge-failure",
-          source: "self-healing",
-          reason: errorSnippet,
-        });
+        try {
+          publishWorkflowRecoveryEvent(this.store, {
+            taskId: task.id,
+            kind: "transient-merge-failure",
+            source: "self-healing",
+            reason: errorSnippet,
+          });
+        } catch (eventErr) {
+          log.warn(
+            `recoverTransientMergeFailures: workflow recovery event publish failed for ${task.id}: ${
+              eventErr instanceof Error ? eventErr.message : String(eventErr)
+            }`,
+          );
+        }
         try {
           await audit.database({
             type: "merger:transient-failure-auto-recovered",
@@ -7072,12 +7080,20 @@ export class SelfHealingManager {
       await this.store.updateTask(task.id, {
         completionHandoffLimboRecoveryCount: currentCount + 1,
       });
-      publishWorkflowRecoveryEvent(this.store, {
-        taskId: task.id,
-        kind: "completion-handoff-limbo",
-        source: "self-healing",
-        reason: `ageMs=${ageMs}; attempts=${currentCount + 1}`,
-      });
+      try {
+        publishWorkflowRecoveryEvent(this.store, {
+          taskId: task.id,
+          kind: "completion-handoff-limbo",
+          source: "self-healing",
+          reason: `ageMs=${ageMs}; attempts=${currentCount + 1}`,
+        });
+      } catch (eventErr) {
+        log.warn(
+          `recoverCompletionHandoffLimbo: workflow recovery event publish failed for ${task.id}: ${
+            eventErr instanceof Error ? eventErr.message : String(eventErr)
+          }`,
+        );
+      }
 
       const audit = createRunAuditor(this.store, {
         runId: generateSyntheticRunId("self-heal", task.id),


### PR DESCRIPTION
## Stack Slice
- Slice: S15
- Milestone: Deletion
- Base branch: `feature/workflow-owned-merge-s14-project-engine-merge-queue-deletion`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Delete self-healing direct lifecycle mutations for merge/retry tasks after recovery events cover all cases.

## Dependency
S10 recovery events, S11 branch-group subgraphs, and S14 merge queue deletion.

## Expected Scope
packages/engine/src/self-healing.ts; self-healing audit docs; recovery event and deletion tests.

## Expected Tests
Direct move/pause/requeue/retry-reset patterns absent for merge/retry surfaces, valid held states no-op, recovery facts include audit context.

## Exit Gate
Search tests fail on direct self-healing merge/retry lifecycle mutation patterns.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added self-healing policy deletion guard test for workflow-recovery-events.\n- The guard fails if recovery fact publishing directly moves/updates tasks, enqueues merge, or mutates merge request state.
