### PR TITLE
refactor(workflow): S16 legacy retry field demotion

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/s16-legacy-retry-field-demotion.md
+++ b/docs/plans/workflow-owned-merge-stack/s16-legacy-retry-field-demotion.md
@@ -1,0 +1,46 @@
+---
+title: "S16: legacy retry field demotion"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S16
+milestone: "Deletion"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s15-self-healing-policy-deletion
+---
+
+# S16: legacy retry field demotion
+
+## Stack Role
+
+This draft PR reserves the S16 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Deletion
+
+## Depends On
+
+S9 retry state, S12 projections, and S15 self-healing policy deletion.
+
+## Goal
+
+Demote task-level retry/merge counters to projections and remove policy reads that still treat them as authority.
+
+## Expected File Scope
+
+core types, retry summary, manual retry reset, core store, project engine, self-healing, retry tests.
+
+## Expected Tests
+
+Retry summaries derive from workflow state, manual retry emits workflow wake, task field changes alone cannot cause scheduler/recovery/merge action.
+
+## Exit Gate
+
+Task retry fields are display-only compatibility data.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/packages/core/src/__tests__/workflow-work-projection.test.ts
+++ b/packages/core/src/__tests__/workflow-work-projection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { projectWorkflowWorkStatus } from "../workflow-work-projection.js";
+import { hasAuthoritativeWorkflowWork, projectWorkflowWorkStatus } from "../workflow-work-projection.js";
 import type { Task, WorkflowWorkItem } from "../types.js";
 
 const task = { id: "FN-PROJECT", mergeRetries: 4, status: "legacy status" } as Task;
@@ -75,6 +75,20 @@ describe("workflow work projection", () => {
     expect(projectWorkflowWorkStatus({ ...task, mergeRetries: 0, mergeTransientRetryCount: 2 }, [])).toEqual(expect.objectContaining({
       source: "legacy",
       attempt: 0,
+    }));
+  });
+
+  it("treats legacy retry counters as display-only when workflow work exists", () => {
+    const workflowItems = [
+      item({ id: "work-1", kind: "retry", state: "retrying", attempt: 1, retryAfter: "2026-06-09T00:05:00.000Z" }),
+    ];
+
+    expect(hasAuthoritativeWorkflowWork(workflowItems)).toBe(true);
+    expect(projectWorkflowWorkStatus({ ...task, mergeRetries: 99 }, workflowItems)).toEqual(expect.objectContaining({
+      source: "workflow",
+      status: "retrying",
+      attempt: 1,
+      retryAfter: "2026-06-09T00:05:00.000Z",
     }));
   });
 });

--- a/packages/core/src/__tests__/workflow-work-projection.test.ts
+++ b/packages/core/src/__tests__/workflow-work-projection.test.ts
@@ -91,4 +91,20 @@ describe("workflow work projection", () => {
       retryAfter: "2026-06-09T00:05:00.000Z",
     }));
   });
+
+  it("keeps authoritative gate aligned with projection source selection", () => {
+    expect(hasAuthoritativeWorkflowWork([
+      item({ id: "cancelled", kind: "merge", state: "cancelled" }),
+    ])).toBe(false);
+    expect(projectWorkflowWorkStatus(task, [
+      item({ id: "cancelled", kind: "merge", state: "cancelled" }),
+    ])).toEqual(expect.objectContaining({ source: "legacy" }));
+
+    expect(hasAuthoritativeWorkflowWork([
+      item({ id: "task-work", kind: "task", state: "runnable" }),
+    ])).toBe(true);
+    expect(projectWorkflowWorkStatus(task, [
+      item({ id: "task-work", kind: "task", state: "runnable" }),
+    ])).toEqual(expect.objectContaining({ source: "workflow", workItemId: "task-work" }));
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,7 @@ export {
   GitRepositoryInitializationError,
 } from "./git-repository.js";
 export {
+  hasAuthoritativeWorkflowWork,
   projectWorkflowWorkStatus,
   type WorkflowWorkProjection,
   type WorkflowWorkProjectionStatus,

--- a/packages/core/src/workflow-work-projection.ts
+++ b/packages/core/src/workflow-work-projection.ts
@@ -59,6 +59,10 @@ export function projectWorkflowWorkStatus(
   return workflowProjection(active, "merge-queued");
 }
 
+export function hasAuthoritativeWorkflowWork(workItems: WorkflowWorkItem[]): boolean {
+  return workItems.some((item) => item.kind === "merge" || item.kind === "retry" || item.kind === "manual-hold" || item.kind === "recovery");
+}
+
 function workflowProjection(item: WorkflowWorkItem, status: WorkflowWorkProjectionStatus): WorkflowWorkProjection {
   return {
     status,

--- a/packages/core/src/workflow-work-projection.ts
+++ b/packages/core/src/workflow-work-projection.ts
@@ -60,7 +60,7 @@ export function projectWorkflowWorkStatus(
 }
 
 export function hasAuthoritativeWorkflowWork(workItems: WorkflowWorkItem[]): boolean {
-  return workItems.some((item) => item.kind === "merge" || item.kind === "retry" || item.kind === "manual-hold" || item.kind === "recovery");
+  return workItems.some((item) => item.state !== "cancelled");
 }
 
 function workflowProjection(item: WorkflowWorkItem, status: WorkflowWorkProjectionStatus): WorkflowWorkProjection {


### PR DESCRIPTION
## Stack Slice
- Slice: S16
- Milestone: Deletion
- Base branch: `feature/workflow-owned-merge-s15-self-healing-policy-deletion`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Demote task-level retry/merge counters to projections and remove policy reads that still treat them as authority.

## Dependency
S9 retry state, S12 projections, and S15 self-healing policy deletion.

## Expected Scope
core types, retry summary, manual retry reset, core store, project engine, self-healing, retry tests.

## Expected Tests
Retry summaries derive from workflow state, manual retry emits workflow wake, task field changes alone cannot cause scheduler/recovery/merge action.

## Exit Gate
Task retry fields are display-only compatibility data.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added hasAuthoritativeWorkflowWork and extended projection tests so workflow work beats legacy retry counters.\n- Legacy retry fields are now explicitly display-only fallback data in projection.
