### PR TITLE
refactor(workflow): S18 documentation settings and release notes

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -85,6 +85,9 @@ The authoritative task lifecycle runtime. It resolves a Task to workflow IR, wal
 ### Runtime Primitive
 A named, injected operation a workflow node can call to perform side effects without depending on `executor.ts` lifecycle branches. Examples include planning session, coding session, step execution/reset, review, verification, workflow step, transition, merge request, abort, and audit. Primitives are the boundary between workflow policy and engine substrate.
 
+### Workflow Work Item
+A persisted unit of workflow-owned work that a scheduler can claim and run independently of the Task's board state. It carries enough identity, lifecycle state, retry timing, ownership, and diagnostic facts to resume or observe workflow lifecycle work without re-entering legacy queues.
+
 ### Built-in Lifecycle Node
 A node in a built-in workflow that expresses default Fusion behavior, such as planning, execute, review, merge, parse-steps, step-review, or PR lifecycle actions. Built-in lifecycle nodes are the compatibility layer for existing behavior: changing default execution means changing the built-in workflow and its primitive wiring, not adding hidden imperative branches.
 
@@ -143,6 +146,9 @@ The post-merge step that rebases locally-landed merge commits onto the upstream 
 
 ### Contamination
 Foreign commits — work attributed to other Tasks — appearing on a Task's branch beyond its recorded Fork point. Contamination checks must compute their reference base fresh from the Integration branch rather than reuse the Task's stored base, since a stale stored base makes every legitimately merged commit look foreign.
+
+### Stacked PR
+A pull request whose branch intentionally bases on another open pull request branch rather than directly on the Integration branch. A Stacked PR inherits the behavioral contract of every earlier branch in the stack, so fixes to shared invariants must land on the earliest affected branch and be rebased forward through descendants.
 
 ## Chat
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,12 @@ At a high level, Fusion is split into:
 - **Mobile shell** (`@fusion/mobile`)
 - **Terminal dashboard** (part of `@runfusion/fusion` — see `packages/cli/src/commands/dashboard-tui/`)
 
+The workflow-owned merge runtime is documented in
+[`workflow-owned-merge-runtime.md`](./workflow-owned-merge-runtime.md). It covers
+the durable work-item store, merge/retry/recovery node capabilities, and cutover
+guards that keep scheduler/project-engine/self-healing policy out of the new
+workflow-owned path.
+
 Native shells expose a shared host-neutral bridge at `window.fusionShell` for first-run shell onboarding, connection profile persistence, and active shell mode/profile state. The dashboard consumes `window.fusionShell` when present and degrades cleanly in plain web/PWA mode.
 
 The dashboard also has a canonical host-context bootstrap layer (`packages/dashboard/app/shell-host.ts`) that normalizes launch metadata into one discriminated union:

--- a/docs/plans/workflow-owned-merge-stack/s18-docs-settings-release.md
+++ b/docs/plans/workflow-owned-merge-stack/s18-docs-settings-release.md
@@ -1,0 +1,46 @@
+---
+title: "S18: documentation settings and release notes"
+type: refactor
+status: draft-stack-handoff
+date: 2026-06-09
+slice: S18
+milestone: "Release"
+origin: docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md
+stack_base: feature/workflow-owned-merge-s17-cutover-matrix
+---
+
+# S18: documentation settings and release notes
+
+## Stack Role
+
+This draft PR reserves the S18 review slot in the workflow-owned merge,
+retry, scheduling, and recovery migration stack. It is intentionally a handoff
+artifact, not the completed implementation for this slice.
+
+## Milestone
+
+Release
+
+## Depends On
+
+S17 end-to-end cutover matrix.
+
+## Goal
+
+Update architecture, settings, dashboard, CLI, and testing docs for workflow-owned policy and compatibility projections.
+
+## Expected File Scope
+
+docs/architecture.md; docs/workflow-steps.md; docs/dashboard-guide.md; docs/settings-reference.md; docs/testing.md; CONCEPTS.md; changeset.
+
+## Expected Tests
+
+Docs inventory/search tests where applicable; lazy view inventory unchanged unless dashboard imports change.
+
+## Exit Gate
+
+User-facing docs use the same state names as API/UI tests, and a patch changeset exists if published behavior changed.
+
+## Full Plan
+
+See `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`.

--- a/docs/solutions/architecture-patterns/workflow-owned-merge-stack-feedback-resolution.md
+++ b/docs/solutions/architecture-patterns/workflow-owned-merge-stack-feedback-resolution.md
@@ -220,6 +220,7 @@ pnpm --filter @fusion/engine exec vitest run \
   src/__tests__/workflow-merge-nodes.test.ts \
   src/__tests__/workflow-node-retry-policy.test.ts \
   src/__tests__/workflow-recovery-events.test.ts \
+  src/__tests__/workflow-scheduler-policy-deletion.test.ts \
   src/__tests__/workflow-merge-policy-deletion.test.ts \
   src/__tests__/workflow-self-healing-policy-deletion.test.ts \
   src/__tests__/workflow-cutover-matrix.test.ts \

--- a/docs/solutions/architecture-patterns/workflow-owned-merge-stack-feedback-resolution.md
+++ b/docs/solutions/architecture-patterns/workflow-owned-merge-stack-feedback-resolution.md
@@ -1,0 +1,246 @@
+---
+title: "Resolving review feedback across workflow-owned merge stack PRs"
+date: 2026-06-10
+category: architecture-patterns
+module: workflow-owned merge
+problem_type: architecture_pattern
+component: development_workflow
+severity: high
+applies_when:
+  - "Migrating merge ownership across stacked PR branches"
+  - "Review feedback changes an invariant inherited by descendant slices"
+  - "Workflow projection, retry scheduling, merge classification, or recovery events span multiple PRs"
+  - "Commit shape and review-thread state are part of merge readiness"
+tags: [workflow-owned-merge, stacked-prs, review-feedback, retry-scheduling, recovery-events, deletion-guards]
+related_components:
+  - testing_framework
+  - documentation
+  - tooling
+---
+
+# Resolving review feedback across workflow-owned merge stack PRs
+
+## Context
+
+The workflow-owned merge migration was shipped as stacked PRs: each slice branch
+depended on the previous one, and each PR represented a narrow migration stage.
+Review feedback arrived across the stack after implementation had already been
+added, which made the normal "fix the current branch" reflex unsafe.
+
+Several comments were stack-level invariant checks rather than isolated nits:
+merge-request projection could leave stale manual-hold work, merge classifier
+fallbacks could route transient results as failures, retry backoff could overflow
+dates, recovery events could invent errors, zero retry attempts could disappear,
+and deletion guards could pass while reading the wrong file. Fixing those only
+on the top branch would make later PRs look correct while earlier PRs still
+exported the broken contract to every descendant.
+
+Session history reinforced the same pattern: a prior branch-fix session found
+that the active workspace had updated call sites while another descendant
+worktree still carried a stale signature, showing why stacked review feedback
+must be fixed at the earliest affected branch and rebased forward. It also
+showed that validation must use repo-documented commands rather than assumed
+package scripts. (session history)
+
+## Guidance
+
+Treat stacked PR review feedback as a stack invariant audit.
+
+1. Inventory every unresolved thread across the stack before editing.
+2. Classify each comment by the earliest slice whose contract is wrong.
+3. Fix that earliest branch, including a focused regression test.
+4. Rebase every descendant branch in order.
+5. Preserve each slice as a reviewable unit, typically one compliant commit with
+   the required task prefix and trailer.
+6. Verify the top branch with targeted tests and typechecks that include every
+   changed invariant.
+7. Push with `--force-with-lease`, then reply to and resolve each review thread
+   with the concrete fix.
+
+The implementation fixes should live where the invariant first appears, not
+where the reviewer happened to comment last.
+
+### Projection cleanup
+
+When one durable state is projected into workflow work, clean up stale
+opposite-kind work for the same task. In the merge-request projection path, a
+manual hold and a succeeded merge are mutually exclusive active interpretations:
+
+```ts
+const kind = record.state === "manual-required" ? "manual-hold" : "merge";
+const item = this.upsertWorkflowWorkItem({
+  runId,
+  taskId,
+  nodeId,
+  kind,
+  state,
+  attempt,
+  lastError,
+  blockedReason,
+});
+
+this.cancelActiveWorkflowWorkItemsForTask(taskId, {
+  kinds: [kind === "manual-hold" ? "merge" : "manual-hold"],
+  now: opts.now ?? record.updatedAt,
+  lastError: "superseded-by-merge-request-projection",
+});
+```
+
+The regression should use one task that transitions from `manual-required` to
+`succeeded`; table-driven tests that create a fresh task per state do not catch
+stale projection rows.
+
+### Routing signal classification
+
+Merge primitive results can carry routing signals in `value` even when `data` is
+absent. If the signal is transient or manual-routing metadata, route it through
+the workflow graph as a successful primitive with a retry/manual value:
+
+```ts
+if (value === "transient-failure" || value === "manual-required" || value === "stale-head" || value === "not-actionable") {
+  return { outcome: "success", value };
+}
+return { outcome: primitiveOutcome, value };
+```
+
+### Retry and projection values
+
+Use nullish checks for state values where zero is meaningful:
+
+```ts
+attempt: task.mergeRetries ?? task.mergeTransientRetryCount ?? undefined,
+```
+
+Cap exponential retry delay before building timestamps:
+
+```ts
+const baseDelayMs = Math.max(1_000, Math.floor(input.baseDelayMs ?? 30_000));
+const maxDelayMs = 24 * 60 * 60_000;
+const delayMs = Math.min(baseDelayMs * 2 ** Math.max(0, attempt - 1), maxDelayMs);
+```
+
+### Recovery events
+
+Do not manufacture an error string for informational recovery work:
+
+```ts
+lastError: input.reason ?? null,
+```
+
+When self-healing still performs legacy cleanup during a migration, also emit
+workflow recovery work so the workflow-owned path can observe and route the
+fact:
+
+```ts
+publishWorkflowRecoveryEvent(this.store, {
+  taskId: task.id,
+  kind: "transient-merge-failure",
+  source: "self-healing",
+  reason: errorSnippet,
+});
+```
+
+### Guard tests
+
+Deletion guards must read the boundary they claim to protect. When the legacy
+owner still exists during a staged migration, a useful guard can assert both
+sides of the boundary:
+
+- the legacy owner still contains the old mechanism until the deletion slice
+  removes it;
+- the workflow-owned processor or recovery publisher remains isolated from that
+  mechanism.
+
+This turns the guard into a migration boundary assertion instead of a false
+green.
+
+## Why This Matters
+
+Stacked migrations fail in ways single PRs do not. A late-branch fix can hide
+the fact that an earlier PR still exports the broken behavior; after review,
+squash, or rebase, the stack can regress even though the top branch looked
+right.
+
+Workflow-owned merge state has especially tight invariants:
+
+- `0` is a valid retry value, not absence;
+- manual-hold and succeeded merge projections must not both stay active;
+- transient/manual routing values should select workflow edges, not permanent
+  primitive failure;
+- retry backoff must remain operationally bounded;
+- recovery facts must not invent errors;
+- guard tests must prove the actual boundary being migrated.
+
+Resolving feedback at the earliest affected branch makes those invariants part
+of the stack's ancestry. Rebasing descendants then verifies that every later
+slice inherits the corrected contract.
+
+## When to Apply
+
+- Stacked PRs where each branch depends on the previous branch.
+- Workflow, merge, retry, recovery, or self-healing migrations.
+- Review feedback that identifies an invariant shared by multiple slices.
+- Projection code that maps one domain state model into another.
+- Migration guard tests that could pass by reading a file where the legacy
+  behavior never existed.
+- Branches whose commit shape is part of the merge gate or audit contract.
+
+## Examples
+
+### Stack repair loop
+
+```bash
+# Fix the earliest affected branch.
+git checkout feature/workflow-owned-merge-s02-merge-request-projection
+# edit, run focused tests, amend the slice commit
+
+# Rebase each descendant in order.
+git checkout feature/workflow-owned-merge-s03-generic-scheduler-claim
+git rebase --onto feature/workflow-owned-merge-s02-merge-request-projection <old-s02-sha>
+
+# Publish rewritten branches safely.
+git push --force-with-lease origin feature/workflow-owned-merge-s02-merge-request-projection ...
+```
+
+Use `--onto` when the parent branch was rewritten; a normal rebase can try to
+replay old parent commits and create add/add conflicts in slice docs.
+
+### Verification set
+
+The corrected workflow-owned merge stack was verified with focused tests and
+typechecks:
+
+```bash
+pnpm --filter @fusion/core exec vitest run \
+  src/__tests__/merge-request-record.test.ts \
+  src/__tests__/workflow-work-projection.test.ts \
+  --silent=passed-only --reporter=dot
+
+pnpm --filter @fusion/engine exec vitest run \
+  src/__tests__/workflow-merge-nodes.test.ts \
+  src/__tests__/workflow-node-retry-policy.test.ts \
+  src/__tests__/workflow-recovery-events.test.ts \
+  src/__tests__/workflow-merge-policy-deletion.test.ts \
+  src/__tests__/workflow-self-healing-policy-deletion.test.ts \
+  src/__tests__/workflow-cutover-matrix.test.ts \
+  --silent=passed-only --reporter=dot
+
+pnpm --filter @fusion/core typecheck
+pnpm --filter @fusion/engine typecheck
+```
+
+Do not substitute assumed scripts for the documented verification commands.
+A prior session attempted a package-level TypeScript script that did not exist;
+that added noise without validating the stack. (session history)
+
+## Related
+
+- `docs/solutions/architecture-patterns/workflow-native-runtime-primitives.md`
+  covers the broader workflow policy / runtime primitive / engine substrate
+  split that this stack is migrating toward.
+- `docs/solutions/best-practices/merge-conflict-extraction-vs-semantics-and-parallel-bootstrap.md`
+  covers adjacent merge hygiene when branch structure and semantics diverge.
+- `docs/solutions/architecture-patterns/thin-trusted-merge-gate.md` covers the
+  project rule that merge gates stay thin and trusted.
+- GitHub issues related to this area include Runfusion/Fusion#1453,
+  Runfusion/Fusion#1356, and Runfusion/Fusion#1376.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,6 +26,13 @@ pnpm build             # build workspace packages (excludes desktop/mobile)
 pnpm verify:workspace  # deep opt-in verification: lint -> test:full -> build (NOT the merge gate)
 ```
 
+Workflow-owned merge/retry/recovery migration guard tests live in
+`packages/engine/src/__tests__/workflow-*-deletion.test.ts` and
+`packages/engine/src/__tests__/workflow-cutover-matrix.test.ts`. Run the relevant
+targeted file when touching `workflow-work-scheduler.ts`,
+`workflow-work-processor.ts`, `workflow-recovery-events.ts`, or workflow merge
+node capability code.
+
 `pnpm test:full` runs each package's default test script with capped worker fanout (`FUSION_TEST_TOTAL_WORKERS=4 FUSION_TEST_CONCURRENCY=2 pnpm -r --workspace-concurrency=2 test`). Do not casually raise worker counts; dashboard/jsdom and integration-heavy packages destabilize when oversubscribed. Use `VITEST_MAX_WORKERS=<n>` only for targeted package-level investigation.
 
 ## Fresh-worktree dist bootstrap

--- a/docs/workflow-owned-merge-runtime.md
+++ b/docs/workflow-owned-merge-runtime.md
@@ -1,0 +1,37 @@
+# Workflow-Owned Merge Runtime
+
+Fusion now has a workflow-owned merge/retry/recovery substrate that can run in
+parallel with the legacy queue while slices are reviewed.
+
+## Implemented Runtime Surfaces
+
+- `workflow_work_items` persists runnable, running, retrying, held, manual,
+  recovery, succeeded, failed, cancelled, and exhausted workflow work.
+- `TaskStore.projectMergeRequestToWorkflowWorkItem` projects legacy merge request
+  rows onto workflow work items.
+- Completion handoff creates workflow merge work at `merge-gate`; `autoMerge:false`
+  creates `manual-required` work at `merge-manual-hold`.
+- `claimDueWorkflowWorkItem` leases due work without reading task lifecycle
+  columns.
+- `WorkflowTaskRuntime.runWorkItem` executes a leased node and persists the work
+  item terminal state.
+- `runWorkflowMergeAttemptNode` calls the existing guarded merge primitive and
+  maps outcomes to workflow values such as `merged`, `already-landed`,
+  `transient-failure`, and `manual-required`.
+- `publishWorkflowRecoveryEvent` records self-healing facts as runnable
+  `recovery-router` work.
+- `projectWorkflowWorkStatus` gives dashboard/API/CLI surfaces a workflow-first
+  projection with legacy fields as fallback only.
+
+## Cutover Guards
+
+The migration carries deletion guards under `packages/engine/src/__tests__/`:
+
+- `workflow-scheduler-policy-deletion.test.ts`
+- `workflow-merge-policy-deletion.test.ts`
+- `workflow-self-healing-policy-deletion.test.ts`
+- `workflow-cutover-matrix.test.ts`
+
+These tests fail if the new workflow-owned paths start depending on task-column
+merge/retry policy, hidden merge queue APIs, or direct self-healing lifecycle
+mutation.

--- a/docs/workflow-owned-merge-runtime.md
+++ b/docs/workflow-owned-merge-runtime.md
@@ -5,8 +5,11 @@ parallel with the legacy queue while slices are reviewed.
 
 ## Implemented Runtime Surfaces
 
-- `workflow_work_items` persists runnable, running, retrying, held, manual,
-  recovery, succeeded, failed, cancelled, and exhausted workflow work.
+- `workflow_work_items` persists workflow work item states: `runnable`,
+  `running`, `held`, `retrying`, `manual-required`, `succeeded`, `failed`,
+  `cancelled`, and `exhausted`.
+- Workflow work item kinds are `task`, `merge`, `retry`, `manual-hold`, and
+  `recovery`.
 - `TaskStore.projectMergeRequestToWorkflowWorkItem` projects legacy merge request
   rows onto workflow work items.
 - Completion handoff creates workflow merge work at `merge-gate`; `autoMerge:false`


### PR DESCRIPTION
## Stack Slice
- Slice: S18
- Milestone: Release
- Base branch: `feature/workflow-owned-merge-s17-cutover-matrix`
- Full plan: `docs/plans/2026-06-09-003-refactor-workflow-owned-merge-full-migration-slices-plan.md`

## Goal
Update architecture, settings, dashboard, CLI, and testing docs for workflow-owned policy and compatibility projections.

## Dependency
S17 end-to-end cutover matrix.

## Expected Scope
docs/architecture.md; docs/workflow-steps.md; docs/dashboard-guide.md; docs/settings-reference.md; docs/testing.md; CONCEPTS.md; changeset.

## Expected Tests
Docs inventory/search tests where applicable; lazy view inventory unchanged unless dashboard imports change.

## Exit Gate
User-facing docs use the same state names as API/UI tests, and a patch changeset exists if published behavior changed.

## Status
Draft stack placeholder. This PR reserves ordering and review context; implementation should replace or extend the handoff artifact before this slice is marked ready.

## Implementation Added

- Added docs/workflow-owned-merge-runtime.md documenting the implemented runtime APIs and deletion guards.\n- Linked the runtime doc from architecture and testing guidance.
