### PR TITLE
fix: classify harmless merge worktree cleanup failures

### DIFF
--- a/.changeset/fn-343-merge-worktree-cleanup.md
+++ b/.changeset/fn-343-merge-worktree-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fusion/engine": patch
+---
+
+Classify harmless temporary merge worktree cleanup failures after `git worktree prune`/porcelain inspection while keeping still-registered worktree leaks visible in merger diagnostics.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -140,3 +140,21 @@ FN-5416 extends resume-correlation coverage to stream-focused hooks and their pr
 - Route shells
   - `DevServerView`: `remount` / `route-active` / `route-inactive`
   - `ResearchView`: `remount` / `route-active` / `route-inactive`
+
+## Merge temp worktree cleanup classification (`[merger]`)
+
+Fusion merge cleanup treats a narrow class of temporary merge/post-merge worktree removal failures as non-fatal only after Git admin state proves there is no registered worktree leak.
+
+- Applies to Fusion-created temp merge paths such as `fusion-ai-merge-*` and post-merge paths such as `post-merge-*` during `merger-cleanup` / `merger-post-merge` removal.
+- Trigger shape: `git worktree remove --force <path>` fails with validation text such as `fatal: validation failed, cannot remove working tree: '<path>/.git' is not a .git file`.
+- Recovery proof: Fusion runs `git worktree prune`, then inspects `git worktree list --porcelain`.
+- Harmless classification: if the target path is absent from porcelain after prune, the merger logs that cleanup remove failed but no registered worktree remains. If a directory still exists, Fusion reports it as residue for operator inspection; it does not delete arbitrary `/var/folders` content.
+- Leak classification: if the target path is still present in porcelain after prune, the cleanup failure remains visible as a real registered-worktree leak.
+
+Operator verification command:
+
+```bash
+git worktree list --porcelain | grep -F "<temp-worktree-path>"
+```
+
+No output means Git no longer registers that temp path; matching `worktree <temp-worktree-path>` output means the leak is still registered and needs operator cleanup.

--- a/packages/dashboard/app/components/__tests__/workflow-flow-mapping.test.ts
+++ b/packages/dashboard/app/components/__tests__/workflow-flow-mapping.test.ts
@@ -198,6 +198,35 @@ describe("workflow-flow-mapping v2 round-trip", () => {
     expect(byId.j1.config?.onBranchFailure).toBe("fail-fast");
   });
 
+
+  it("preserves aliased IR node kinds when round-tripping through editor render kinds", () => {
+    const ir: WorkflowDefinition["ir"] = {
+      version: "v2",
+      name: "merge aliases",
+      columns: [{ id: "in-progress", name: "In progress", traits: [] }],
+      nodes: [
+        { id: "gate", kind: "merge-gate", column: "in-progress", config: { name: "Gate" } },
+        { id: "attempt", kind: "merge-attempt", column: "in-progress" },
+        { id: "hold", kind: "manual-merge-hold", column: "in-progress", config: { release: "manual" } },
+        { id: "retry", kind: "retry-backoff", column: "in-progress", config: { maxIterations: 2, template: { nodes: [], edges: [] } } },
+      ] as WorkflowDefinition["ir"]["nodes"],
+      edges: [],
+    };
+
+    const { nodes, edges } = irToFlow(v2Def(ir));
+    expect(nodes.find((node) => node.id === "gate")?.type).toBe("merge");
+    expect(nodes.find((node) => node.id === "hold")?.type).toBe("hold");
+    expect(nodes.find((node) => node.id === "retry")?.type).toBe("loop");
+
+    const { ir: out } = flowToIr("merge aliases", nodes, edges, columnsOf(v2Def(ir)));
+    if (out.version !== "v2") throw new Error("expected v2");
+    const byId = Object.fromEntries(out.nodes.map((node) => [node.id, node]));
+    expect(byId.gate.kind).toBe("merge-gate");
+    expect(byId.attempt.kind).toBe("merge-attempt");
+    expect(byId.hold.kind).toBe("manual-merge-hold");
+    expect(byId.retry.kind).toBe("retry-backoff");
+  });
+
   it("emits swimlane band group nodes that flowToIr strips back out", () => {
     const { nodes } = irToFlow(v2Def(ir));
     const bands = nodes.filter((n) => isColumnBandNode(n.id));

--- a/packages/dashboard/app/components/__tests__/workflow-flow-mapping.test.ts
+++ b/packages/dashboard/app/components/__tests__/workflow-flow-mapping.test.ts
@@ -208,7 +208,18 @@ describe("workflow-flow-mapping v2 round-trip", () => {
         { id: "gate", kind: "merge-gate", column: "in-progress", config: { name: "Gate" } },
         { id: "attempt", kind: "merge-attempt", column: "in-progress" },
         { id: "hold", kind: "manual-merge-hold", column: "in-progress", config: { release: "manual" } },
-        { id: "retry", kind: "retry-backoff", column: "in-progress", config: { maxIterations: 2, template: { nodes: [], edges: [] } } },
+        {
+          id: "retry",
+          kind: "retry-backoff",
+          column: "in-progress",
+          config: {
+            maxIterations: 2,
+            template: {
+              nodes: [{ id: "retry-step", kind: "prompt", config: { prompt: "try again" } }],
+              edges: [{ from: "retry-step", to: "retry-step", condition: "retry", kind: "rework" }],
+            },
+          },
+        },
       ] as WorkflowDefinition["ir"]["nodes"],
       edges: [],
     };
@@ -222,9 +233,18 @@ describe("workflow-flow-mapping v2 round-trip", () => {
     if (out.version !== "v2") throw new Error("expected v2");
     const byId = Object.fromEntries(out.nodes.map((node) => [node.id, node]));
     expect(byId.gate.kind).toBe("merge-gate");
+    expect(byId.gate.config?.name).toBe("Gate");
     expect(byId.attempt.kind).toBe("merge-attempt");
     expect(byId.hold.kind).toBe("manual-merge-hold");
+    expect(byId.hold.config?.release).toBe("manual");
     expect(byId.retry.kind).toBe("retry-backoff");
+    expect(byId.retry.config).toEqual({
+      maxIterations: 2,
+      template: {
+        nodes: [{ id: "retry-step", kind: "prompt", config: { prompt: "try again" } }],
+        edges: [{ from: "retry-step", to: "retry-step", condition: "retry", kind: "rework" }],
+      },
+    });
   });
 
   it("emits swimlane band group nodes that flowToIr strips back out", () => {

--- a/packages/dashboard/app/components/workflow-flow-mapping.ts
+++ b/packages/dashboard/app/components/workflow-flow-mapping.ts
@@ -188,6 +188,14 @@ function nodeLabel(node: WorkflowIr["nodes"][number]): string {
   return node.id;
 }
 
+function dataIrKind(node: WorkflowIrNode, editorNodeKind: WorkflowEditorNodeKind): Partial<WorkflowFlowNodeData> {
+  return node.kind === editorNodeKind ? {} : { irKind: node.kind };
+}
+
+function preservedIrKind(data: WorkflowFlowNodeData): WorkflowIrNode["kind"] | undefined {
+  return typeof data.irKind === "string" ? (data.irKind as WorkflowIrNode["kind"]) : undefined;
+}
+
 /** Build React Flow swimlane band group nodes from the workflow's columns. */
 export function columnsToBandNodes(columns: WorkflowIrColumn[]): FlowNode<WorkflowFlowNodeData>[] {
   return columns.map((col, index): FlowNode<WorkflowFlowNodeData> => ({
@@ -313,7 +321,7 @@ export function irToFlow(def: WorkflowDefinition): {
           position: childPos,
           parentId: node.id,
           extent: "parent",
-          data: { kind: innerKind, label: nodeLabel(inner), config: { ...(inner.config ?? {}) } },
+          data: { kind: innerKind, ...dataIrKind(inner, innerKind), label: nodeLabel(inner), config: { ...(inner.config ?? {}) } },
           deletable: true,
           zIndex: WF_STEP_NODE_Z_INDEX,
         });
@@ -329,6 +337,7 @@ export function irToFlow(def: WorkflowDefinition): {
         position: pos ?? { x: 80 + index * 180, y: fallbackY },
         data: {
           kind,
+          ...dataIrKind(node, kind),
           label: nodeLabel(node),
           config: { ...restCfg },
           column,
@@ -346,6 +355,7 @@ export function irToFlow(def: WorkflowDefinition): {
       position: pos ?? { x: 80 + index * 180, y: fallbackY },
       data: {
         kind,
+        ...dataIrKind(node, kind),
         label: nodeLabel(node),
         config: { ...(node.config ?? {}) },
         column,
@@ -418,7 +428,11 @@ export function flowToIr(
   function toIrNode(node: FlowNode<WorkflowFlowNodeData>, localId: string): WorkflowIrNode {
     const data = node.data;
     const config = nodeConfig(node);
+    const originalKind = preservedIrKind(data);
     if (data.kind === "merge") {
+      if (originalKind) {
+        return { id: localId, kind: originalKind, config: config && Object.keys(config).length ? config : undefined };
+      }
       return { id: localId, kind: "prompt", config: { ...(config ?? {}), seam: "merge" } };
     }
     if (data.kind === "foreach" || data.kind === "loop") {
@@ -436,13 +450,13 @@ export function flowToIr(
       const baseCfg = (config ?? {}) as Record<string, unknown>;
       return {
         id: localId,
-        kind: data.kind,
+        kind: originalKind ?? data.kind,
         config: { ...baseCfg, template: { nodes: templateNodes, edges: templateEdges } },
       };
     }
     return {
       id: localId,
-      kind: data.kind as WorkflowIrNode["kind"],
+      kind: originalKind ?? (data.kind as WorkflowIrNode["kind"]),
       config: config && Object.keys(config).length ? config : undefined,
     };
   }
@@ -988,7 +1002,7 @@ function irNodeToFlowNode(
     id,
     type: kind,
     position,
-    data: { kind, label: nodeLabel(node), config: { ...(node.config ?? {}) } },
+    data: { kind, ...dataIrKind(node, kind), label: nodeLabel(node), config: { ...(node.config ?? {}) } },
     deletable: node.kind !== "start" && node.kind !== "end",
     zIndex: WF_STEP_NODE_Z_INDEX,
   };
@@ -1066,7 +1080,7 @@ export function insertFragment(
           position: childPos,
           parentId: id,
           extent: "parent",
-          data: { kind: innerKind, label: nodeLabel(inner), config: { ...(inner.config ?? {}) } },
+          data: { kind: innerKind, ...dataIrKind(inner, innerKind), label: nodeLabel(inner), config: { ...(inner.config ?? {}) } },
           deletable: true,
           zIndex: WF_STEP_NODE_Z_INDEX,
         });
@@ -1082,6 +1096,7 @@ export function insertFragment(
         position: pos,
         data: {
           kind: groupKind,
+          ...dataIrKind(node, groupKind),
           label: nodeLabel(node),
           config: { ...restCfg },
           templateEmpty: template.nodes.length === 0,

--- a/packages/dashboard/app/components/workflow-flow-mapping.ts
+++ b/packages/dashboard/app/components/workflow-flow-mapping.ts
@@ -436,6 +436,9 @@ export function flowToIr(
       return { id: localId, kind: "prompt", config: { ...(config ?? {}), seam: "merge" } };
     }
     if (data.kind === "foreach" || data.kind === "loop") {
+      if (originalKind && originalKind !== "foreach" && originalKind !== "loop") {
+        return { id: localId, kind: originalKind, config: config && Object.keys(config).length ? config : undefined };
+      }
       // Reassemble the template from this group's children.
       const children = childrenByGroup.get(node.id) ?? [];
       const templateNodes: WorkflowIrNode[] = children.map((c) => {

--- a/packages/dashboard/app/components/workflow-flow-mapping.ts
+++ b/packages/dashboard/app/components/workflow-flow-mapping.ts
@@ -173,7 +173,6 @@ function isSameKindEditorNodeKind(
 function editorKind(node: WorkflowIr["nodes"][number]): WorkflowEditorNodeKind {
   const seam = node.config?.seam;
   if (seam === "merge") return "merge";
-
   const mapped = GRAPH_ONLY_EDITOR_KIND[node.kind];
   if (mapped) return mapped;
 

--- a/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
@@ -22,6 +22,26 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...actual, existsSync: existsSpy, readdirSync: readdirSpy };
 });
 
+
+function mockWorktreeRemoveFailure(postMergePath: string, porcelainOutput: string): void {
+  execSpy.mockImplementation((cmd: string, _opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+    if (cmd.includes("git worktree remove")) {
+      const stderr = `fatal: validation failed, cannot remove working tree: '${postMergePath}/.git' is not a .git file, error code 2`;
+      cb(Object.assign(new Error(stderr), { stderr, status: 2 }), "", stderr);
+      return;
+    }
+    if (cmd === "git worktree prune") {
+      cb(null, "", "");
+      return;
+    }
+    if (cmd === "git worktree list --porcelain") {
+      cb(null, porcelainOutput, "");
+      return;
+    }
+    cb(null, "", "");
+  });
+}
+
 function storeForSelfHealing(settings: Partial<Settings>, task: Partial<Task>): TaskStore & EventEmitter {
   const emitter = new EventEmitter();
   return Object.assign(emitter, {
@@ -59,22 +79,7 @@ describe("reliability interactions: worktrunk worktree removal routing", () => {
   it("merger post-merge cleanup logs harmless classified temp residue when porcelain is absent after prune", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const postMergePath = "/repo/.worktrees/post-merge-FN-343-abcd1234";
-    execSpy.mockImplementation((cmd: string, _opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
-      if (cmd.includes("git worktree remove")) {
-        const stderr = `fatal: validation failed, cannot remove working tree: '${postMergePath}/.git' is not a .git file, error code 2`;
-        cb(Object.assign(new Error(stderr), { stderr, status: 2 }), "", stderr);
-        return;
-      }
-      if (cmd === "git worktree prune") {
-        cb(null, "", "");
-        return;
-      }
-      if (cmd === "git worktree list --porcelain") {
-        cb(null, "worktree /repo\nbranch refs/heads/main\n", "");
-        return;
-      }
-      cb(null, "", "");
-    });
+    mockWorktreeRemoveFailure(postMergePath, "worktree /repo\nbranch refs/heads/main\n");
 
     await mergerTestHooks.removePostMergeWorktree("/repo", postMergePath, "FN-343", {});
 
@@ -91,22 +96,7 @@ describe("reliability interactions: worktrunk worktree removal routing", () => {
   it("merger post-merge cleanup keeps still-registered temp worktree failures visible", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const postMergePath = "/repo/.worktrees/post-merge-FN-343-abcd1234";
-    execSpy.mockImplementation((cmd: string, _opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
-      if (cmd.includes("git worktree remove")) {
-        const stderr = `fatal: validation failed, cannot remove working tree: '${postMergePath}/.git' is not a .git file, error code 2`;
-        cb(Object.assign(new Error(stderr), { stderr, status: 2 }), "", stderr);
-        return;
-      }
-      if (cmd === "git worktree prune") {
-        cb(null, "", "");
-        return;
-      }
-      if (cmd === "git worktree list --porcelain") {
-        cb(null, `worktree /repo\nbranch refs/heads/main\n\nworktree ${postMergePath}\nbranch refs/heads/fusion/fn-343\n`, "");
-        return;
-      }
-      cb(null, "", "");
-    });
+    mockWorktreeRemoveFailure(postMergePath, `worktree /repo\nbranch refs/heads/main\n\nworktree ${postMergePath}\nbranch refs/heads/fusion/fn-343\n`);
 
     await mergerTestHooks.removePostMergeWorktree("/repo", postMergePath, "FN-343", {});
 

--- a/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
@@ -89,7 +89,7 @@ describe("reliability interactions: worktrunk worktree removal routing", () => {
       "git worktree list --porcelain",
     ]);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("post-merge worktree cleanup remove failed, but no registered worktree remains after prune"),
+      expect.stringContaining("post-merge worktree cleanup classified harmless"),
     );
   });
 

--- a/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import type { Settings, TaskStore, Task } from "@fusion/core";
 import { cleanupOrphanedWorktrees } from "../../worktree-pool.js";
@@ -41,6 +41,10 @@ describe("reliability interactions: worktrunk worktree removal routing", () => {
     existsSpy.mockReturnValue(true);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("merger post-merge cleanup calls worktrunk backend remove and avoids native git remove", async () => {
     const removeSpy = vi.spyOn(WorktrunkWorktreeBackend.prototype, "remove").mockResolvedValue(undefined);
 
@@ -50,6 +54,66 @@ describe("reliability interactions: worktrunk worktree removal routing", () => {
 
     expect(removeSpy).toHaveBeenCalledWith(expect.objectContaining({ rootDir: "/repo", worktreePath: "/repo/.worktrees/post", taskId: "FN-100" }));
     expect(execSpy.mock.calls.some((call) => String(call[0]).includes("git worktree remove"))).toBe(false);
+  });
+
+  it("merger post-merge cleanup logs harmless classified temp residue when porcelain is absent after prune", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const postMergePath = "/repo/.worktrees/post-merge-FN-343-abcd1234";
+    execSpy.mockImplementation((cmd: string, _opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      if (cmd.includes("git worktree remove")) {
+        const stderr = `fatal: validation failed, cannot remove working tree: '${postMergePath}/.git' is not a .git file, error code 2`;
+        cb(Object.assign(new Error(stderr), { stderr, status: 2 }), "", stderr);
+        return;
+      }
+      if (cmd === "git worktree prune") {
+        cb(null, "", "");
+        return;
+      }
+      if (cmd === "git worktree list --porcelain") {
+        cb(null, "worktree /repo\nbranch refs/heads/main\n", "");
+        return;
+      }
+      cb(null, "", "");
+    });
+
+    await mergerTestHooks.removePostMergeWorktree("/repo", postMergePath, "FN-343", {});
+
+    expect(execSpy.mock.calls.map((call) => String(call[0]))).toEqual([
+      `git worktree remove --force "${postMergePath}"`,
+      "git worktree prune",
+      "git worktree list --porcelain",
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("post-merge worktree cleanup remove failed, but no registered worktree remains after prune"),
+    );
+  });
+
+  it("merger post-merge cleanup keeps still-registered temp worktree failures visible", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const postMergePath = "/repo/.worktrees/post-merge-FN-343-abcd1234";
+    execSpy.mockImplementation((cmd: string, _opts: unknown, cb: (err: any, stdout: string, stderr: string) => void) => {
+      if (cmd.includes("git worktree remove")) {
+        const stderr = `fatal: validation failed, cannot remove working tree: '${postMergePath}/.git' is not a .git file, error code 2`;
+        cb(Object.assign(new Error(stderr), { stderr, status: 2 }), "", stderr);
+        return;
+      }
+      if (cmd === "git worktree prune") {
+        cb(null, "", "");
+        return;
+      }
+      if (cmd === "git worktree list --porcelain") {
+        cb(null, `worktree /repo\nbranch refs/heads/main\n\nworktree ${postMergePath}\nbranch refs/heads/fusion/fn-343\n`, "");
+        return;
+      }
+      cb(null, "", "");
+    });
+
+    await mergerTestHooks.removePostMergeWorktree("/repo", postMergePath, "FN-343", {});
+
+    expect(execSpy.mock.calls.map((call) => String(call[0]))).toContain("git worktree list --porcelain");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`failed to remove post-merge worktree ${postMergePath}`),
+    );
   });
 
   it("self-healing recover path calls worktrunk backend remove and not native remove", async () => {

--- a/packages/engine/src/__tests__/worktree-backend.test.ts
+++ b/packages/engine/src/__tests__/worktree-backend.test.ts
@@ -1032,6 +1032,45 @@ describe("removeWorktree", () => {
     );
   });
 
+
+  it("preserves the original remove failure when classification probes fail", async () => {
+    const tempPath = "/var/folders/demo/T/fusion-ai-merge-fn-327-A5uY3j";
+    const validationError = {
+      message: `Command failed: git worktree remove --force ${tempPath}`,
+      stderr: `fatal: validation failed, cannot remove working tree: '${tempPath}/.git' is not a .git file, error code 2`,
+      status: 2,
+    };
+    const probeError = new Error("git worktree prune failed");
+    execMock
+      .mockRejectedValueOnce(validationError)
+      .mockRejectedValueOnce(probeError);
+    const audit = { git: vi.fn().mockResolvedValue(undefined) } as any;
+
+    await expect(
+      removeWorktree({
+        rootDir: "/repo",
+        worktreePath: tempPath,
+        settings: {},
+        audit,
+        taskId: "FN-327",
+        reason: RemovalReason.MergerCleanup,
+      }),
+    ).rejects.toBe(validationError);
+
+    expect(execMock).toHaveBeenNthCalledWith(2, "git worktree prune", expect.objectContaining({ cwd: "/repo" }));
+    expect(audit.git).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "worktree:remove-classification-probe-failed",
+        target: tempPath,
+        metadata: expect.objectContaining({
+          reason: RemovalReason.MergerCleanup,
+          stderrPreview: expect.stringContaining("is not a .git file"),
+          probeError: expect.stringContaining("git worktree prune failed"),
+        }),
+      }),
+    );
+  });
+
   it("uses worktrunk remove and emits worktree:worktrunk-remove", async () => {
     execMock.mockResolvedValue({ stdout: "", stderr: "" });
     const audit = { git: vi.fn().mockResolvedValue(undefined) } as any;

--- a/packages/engine/src/__tests__/worktree-backend.test.ts
+++ b/packages/engine/src/__tests__/worktree-backend.test.ts
@@ -938,7 +938,12 @@ describe("removeWorktree", () => {
         taskId: "FN-327",
         reason: RemovalReason.MergerCleanup,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({
+      removed: false,
+      harmless: true,
+      classification: "not-registered-after-prune",
+      message: expect.stringContaining("no registered worktree remains after prune"),
+    });
 
     expect(execMock).toHaveBeenNthCalledWith(
       2,
@@ -962,6 +967,28 @@ describe("removeWorktree", () => {
         }),
       }),
     );
+  });
+
+  it("does not downgrade non-temp merger cleanup failures even when porcelain would be absent", async () => {
+    const worktreePath = "/repo/.worktrees/fn-327";
+    const validationError = {
+      message: `Command failed: git worktree remove --force ${worktreePath}`,
+      stderr: `fatal: validation failed, cannot remove working tree: '${worktreePath}/.git' is not a .git file, error code 2`,
+      status: 2,
+    };
+    execMock.mockRejectedValueOnce(validationError);
+
+    await expect(
+      removeWorktree({
+        rootDir: "/repo",
+        worktreePath,
+        settings: {},
+        taskId: "FN-327",
+        reason: RemovalReason.MergerCleanup,
+      }),
+    ).rejects.toBe(validationError);
+
+    expect(execMock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps FN-343 remove failures visible when the temp path remains registered after prune", async () => {

--- a/packages/engine/src/__tests__/worktree-backend.test.ts
+++ b/packages/engine/src/__tests__/worktree-backend.test.ts
@@ -911,6 +911,100 @@ describe("removeWorktree", () => {
     expect(audit.git).toHaveBeenCalledWith({ type: "worktree:remove", target: "/repo/.worktrees/fn-1" });
   });
 
+  it("classifies FN-343 nonstandard temp merge worktree remove failures as harmless when porcelain is absent after prune", async () => {
+    const tempPath = "/var/folders/demo/T/fusion-ai-merge-fn-327-A5uY3j";
+    const validationError = {
+      message: `Command failed: git worktree remove --force ${tempPath}`,
+      stderr: `fatal: validation failed, cannot remove working tree: '${tempPath}/.git' is not a .git file, error code 2`,
+      status: 2,
+    };
+    execMock
+      .mockRejectedValueOnce(validationError)
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "worktree /repo\nbranch refs/heads/main\n", stderr: "" });
+    const audit = { git: vi.fn().mockResolvedValue(undefined) } as any;
+
+    // A real-git fixture for this exact macOS temp shape is git-version sensitive:
+    // some versions prune the malformed admin entry before emitting the validation
+    // string. Keep the classifier deterministic by simulating the exact FN-327
+    // command stderr, then assert the porcelain proof that no registered worktree
+    // remains for the temp path.
+    await expect(
+      removeWorktree({
+        rootDir: "/repo",
+        worktreePath: tempPath,
+        settings: {},
+        audit,
+        taskId: "FN-327",
+        reason: RemovalReason.MergerCleanup,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(execMock).toHaveBeenNthCalledWith(
+      2,
+      "git worktree prune",
+      expect.objectContaining({ cwd: "/repo" }),
+    );
+    expect(execMock).toHaveBeenNthCalledWith(
+      3,
+      "git worktree list --porcelain",
+      expect.objectContaining({ cwd: "/repo" }),
+    );
+    expect(audit.git).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "worktree:remove-classified-harmless",
+        target: tempPath,
+        metadata: expect.objectContaining({
+          reason: RemovalReason.MergerCleanup,
+          classification: "not-registered-after-prune",
+          registeredAfterPrune: false,
+          stderrPreview: expect.stringContaining("is not a .git file"),
+        }),
+      }),
+    );
+  });
+
+  it("keeps FN-343 remove failures visible when the temp path remains registered after prune", async () => {
+    const tempPath = "/var/folders/demo/T/fusion-ai-merge-fn-327-A5uY3j";
+    const validationError = {
+      message: `Command failed: git worktree remove --force ${tempPath}`,
+      stderr: `fatal: validation failed, cannot remove working tree: '${tempPath}/.git' is not a .git file, error code 2`,
+      status: 2,
+    };
+    execMock
+      .mockRejectedValueOnce(validationError)
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: `worktree /repo\nbranch refs/heads/main\n\nworktree ${tempPath}\nbranch refs/heads/fusion/fn-327\n`,
+        stderr: "",
+      });
+    const audit = { git: vi.fn().mockResolvedValue(undefined) } as any;
+
+    await expect(
+      removeWorktree({
+        rootDir: "/repo",
+        worktreePath: tempPath,
+        settings: {},
+        audit,
+        taskId: "FN-327",
+        reason: RemovalReason.MergerCleanup,
+      }),
+    ).rejects.toMatchObject({ stderr: expect.stringContaining("is not a .git file") });
+
+    expect(execMock).toHaveBeenNthCalledWith(2, "git worktree prune", expect.objectContaining({ cwd: "/repo" }));
+    expect(execMock).toHaveBeenNthCalledWith(3, "git worktree list --porcelain", expect.objectContaining({ cwd: "/repo" }));
+    expect(audit.git).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "worktree:remove-leaked-registered-worktree",
+        target: tempPath,
+        metadata: expect.objectContaining({
+          reason: RemovalReason.MergerCleanup,
+          registeredAfterPrune: true,
+        }),
+      }),
+    );
+  });
+
   it("uses worktrunk remove and emits worktree:worktrunk-remove", async () => {
     execMock.mockResolvedValue({ stdout: "", stderr: "" });
     const audit = { git: vi.fn().mockResolvedValue(undefined) } as any;

--- a/packages/engine/src/merger.ts
+++ b/packages/engine/src/merger.ts
@@ -7312,6 +7312,7 @@ async function removePostMergeWorktree(
   postMergeWorktree: string,
   taskId: string,
   settings: Partial<Settings>,
+  audit?: RunAuditor,
 ): Promise<void> {
   try {
     const outcome = await removeWorktree({
@@ -7320,9 +7321,10 @@ async function removePostMergeWorktree(
       settings,
       taskId,
       reason: RemovalReason.MergerPostMerge,
+      audit,
     });
-    if (outcome && "harmless" in outcome && outcome.harmless) {
-      mergerLog.warn(`${taskId}: post-merge worktree cleanup remove failed, but no registered worktree remains after prune for ${postMergeWorktree}: ${outcome.message}`);
+    if ("harmless" in outcome && outcome.harmless) {
+      mergerLog.warn(`${taskId}: post-merge worktree cleanup classified harmless for ${postMergeWorktree}: ${outcome.message}`);
     }
   } catch (err: unknown) {
     mergerLog.warn(`${taskId}: failed to remove post-merge worktree ${postMergeWorktree}: ${getCommandErrorMessage(err)}`);
@@ -10520,7 +10522,7 @@ export async function aiMergeTask(
       // Non-fatal — task still moves to done
     } finally {
       if (postMergeWorktree) {
-        await removePostMergeWorktree(rootDir, postMergeWorktree, taskId, settings);
+        await removePostMergeWorktree(rootDir, postMergeWorktree, taskId, settings, audit);
       }
     }
   }
@@ -10580,10 +10582,10 @@ export async function aiMergeTask(
             audit,
             reason: RemovalReason.MergerCleanup,
           });
-          if (outcome && "harmless" in outcome && outcome.harmless) {
-            mergerLog.warn(`${taskId}: merge worktree cleanup remove failed, but no registered worktree remains after prune for ${worktreePath}: ${outcome.message}`);
+          if ("harmless" in outcome && outcome.harmless) {
+            mergerLog.warn(`${taskId}: merge worktree cleanup classified harmless for ${worktreePath}: ${outcome.message}`);
           }
-          result.worktreeRemoved = outcome?.removed ?? true;
+          result.worktreeRemoved = outcome.removed || ("harmless" in outcome && outcome.harmless);
         }
         if (result.worktreeRemoved) {
           try {

--- a/packages/engine/src/merger.ts
+++ b/packages/engine/src/merger.ts
@@ -7314,13 +7314,16 @@ async function removePostMergeWorktree(
   settings: Partial<Settings>,
 ): Promise<void> {
   try {
-    await removeWorktree({
+    const outcome = await removeWorktree({
       rootDir,
       worktreePath: postMergeWorktree,
       settings,
       taskId,
       reason: RemovalReason.MergerPostMerge,
     });
+    if (outcome && "harmless" in outcome && outcome.harmless) {
+      mergerLog.warn(`${taskId}: post-merge worktree cleanup remove failed, but no registered worktree remains after prune for ${postMergeWorktree}: ${outcome.message}`);
+    }
   } catch (err: unknown) {
     mergerLog.warn(`${taskId}: failed to remove post-merge worktree ${postMergeWorktree}: ${getCommandErrorMessage(err)}`);
   }
@@ -10569,7 +10572,7 @@ export async function aiMergeTask(
             metadata: { taskId, reason: RemovalReason.MergerCleanup, kind: "merger" },
           });
         } else {
-          await removeWorktree({
+          const outcome = await removeWorktree({
             rootDir,
             worktreePath,
             settings,
@@ -10577,7 +10580,10 @@ export async function aiMergeTask(
             audit,
             reason: RemovalReason.MergerCleanup,
           });
-          result.worktreeRemoved = true;
+          if (outcome && "harmless" in outcome && outcome.harmless) {
+            mergerLog.warn(`${taskId}: merge worktree cleanup remove failed, but no registered worktree remains after prune for ${worktreePath}: ${outcome.message}`);
+          }
+          result.worktreeRemoved = outcome?.removed ?? true;
         }
         if (result.worktreeRemoved) {
           try {

--- a/packages/engine/src/run-audit.ts
+++ b/packages/engine/src/run-audit.ts
@@ -93,6 +93,7 @@ export type GitMutationType =
   | "worktree:remove"
   | "worktree:remove-fallback"
   | "worktree:remove-classified-harmless"
+  | "worktree:remove-classification-probe-failed"
   | "worktree:remove-leaked-registered-worktree"
   | "worktree:reuse"
   | "worktree:incomplete-detected"

--- a/packages/engine/src/run-audit.ts
+++ b/packages/engine/src/run-audit.ts
@@ -92,6 +92,8 @@ export type GitMutationType =
   | "worktree:create"
   | "worktree:remove"
   | "worktree:remove-fallback"
+  | "worktree:remove-classified-harmless"
+  | "worktree:remove-leaked-registered-worktree"
   | "worktree:reuse"
   | "worktree:incomplete-detected"
   | "worktree:reanchored"

--- a/packages/engine/src/worktree-backend.ts
+++ b/packages/engine/src/worktree-backend.ts
@@ -95,20 +95,37 @@ async function classifyHarmlessMergeRemoveFailure(input: {
   const pathExists = existsSync(input.worktreePath);
   const gitFileExists = existsSync(resolve(input.worktreePath, ".git"));
 
-  await execAsync("git worktree prune", {
-    cwd: input.rootDir,
-    encoding: "utf-8",
-    timeout: NATIVE_TIMEOUT_MS,
-    maxBuffer: MAX_BUFFER,
-  });
+  let stdout: string;
+  try {
+    await execAsync("git worktree prune", {
+      cwd: input.rootDir,
+      encoding: "utf-8",
+      timeout: NATIVE_TIMEOUT_MS,
+      maxBuffer: MAX_BUFFER,
+    });
 
-  const listResult = await execAsync("git worktree list --porcelain", {
-    cwd: input.rootDir,
-    encoding: "utf-8",
-    timeout: 10_000,
-    maxBuffer: MAX_BUFFER,
-  });
-  const stdout = typeof listResult === "string" ? listResult : String(listResult.stdout ?? "");
+    const listResult = await execAsync("git worktree list --porcelain", {
+      cwd: input.rootDir,
+      encoding: "utf-8",
+      timeout: 10_000,
+      maxBuffer: MAX_BUFFER,
+    });
+    stdout = typeof listResult === "string" ? listResult : String(listResult.stdout ?? "");
+  } catch (probeError) {
+    await input.audit?.git({
+      type: "worktree:remove-classification-probe-failed",
+      target: input.worktreePath,
+      metadata: {
+        taskId: input.taskId,
+        reason: input.reason,
+        stderrPreview,
+        probeError: previewError(probeError),
+        pathExists,
+        gitFileExists,
+      },
+    });
+    return null;
+  }
   const registeredAfterPrune = porcelainContainsWorktree(stdout, input.worktreePath);
 
   if (registeredAfterPrune) {

--- a/packages/engine/src/worktree-backend.ts
+++ b/packages/engine/src/worktree-backend.ts
@@ -30,6 +30,133 @@ const NATIVE_TIMEOUT_MS = 120_000;
 const REMOVE_TIMEOUT_MS = 60_000;
 const MAX_BUFFER = 10 * 1024 * 1024;
 
+
+export type WorktreeRemoveOutcome =
+  | { removed: true; classification: "removed" }
+  | {
+      removed: false;
+      harmless: true;
+      classification: "not-registered-after-prune";
+      message: string;
+      stderrPreview: string;
+      pathExists: boolean;
+      gitFileExists: boolean;
+    };
+
+const HARMLESS_MERGE_REMOVE_ERROR_PATTERNS = [
+  /validation failed, cannot remove working tree/i,
+  /is not a \.git file/i,
+  /is not a working tree/i,
+  /not a git repository/i,
+  /No such file or directory/i,
+] as const;
+
+function previewError(error: unknown): string {
+  const stderr = getErrorStderr(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return (stderr || message).slice(0, 4096);
+}
+
+function normalizeComparablePath(value: string): string {
+  const resolved = resolve(value);
+  return resolved.startsWith("/private/var/") ? resolved.slice("/private".length) : resolved;
+}
+
+function porcelainContainsWorktree(stdout: string, worktreePath: string): boolean {
+  const target = normalizeComparablePath(worktreePath);
+  const privateTarget = target.startsWith("/var/") ? `/private${target}` : target;
+  for (const line of stdout.split("\n")) {
+    if (!line.startsWith("worktree ")) continue;
+    const candidate = normalizeComparablePath(line.slice("worktree ".length).trim());
+    if (candidate === target || candidate === privateTarget) return true;
+  }
+  return false;
+}
+
+function isMergeTempCleanupCandidate(input: { worktreePath: string; reason: RemovalReason }, error: unknown): boolean {
+  if (input.reason !== RemovalReason.MergerCleanup && input.reason !== RemovalReason.MergerPostMerge) return false;
+  const base = basename(input.worktreePath);
+  const looksLikeFusionMergeTemp = base.startsWith("fusion-ai-merge-") || base.startsWith("post-merge-");
+  if (!looksLikeFusionMergeTemp) return false;
+  const detail = previewError(error);
+  return HARMLESS_MERGE_REMOVE_ERROR_PATTERNS.some((pattern) => pattern.test(detail));
+}
+
+async function classifyHarmlessMergeRemoveFailure(input: {
+  rootDir: string;
+  worktreePath: string;
+  reason: RemovalReason;
+  taskId?: string;
+  audit?: RunAuditor;
+}, error: unknown): Promise<WorktreeRemoveOutcome | null> {
+  if (!isMergeTempCleanupCandidate(input, error)) return null;
+
+  const stderrPreview = previewError(error);
+  const pathExists = existsSync(input.worktreePath);
+  const gitFileExists = existsSync(resolve(input.worktreePath, ".git"));
+
+  await execAsync("git worktree prune", {
+    cwd: input.rootDir,
+    encoding: "utf-8",
+    timeout: NATIVE_TIMEOUT_MS,
+    maxBuffer: MAX_BUFFER,
+  });
+
+  const { stdout } = await execAsync("git worktree list --porcelain", {
+    cwd: input.rootDir,
+    encoding: "utf-8",
+    timeout: 10_000,
+    maxBuffer: MAX_BUFFER,
+  });
+  const registeredAfterPrune = porcelainContainsWorktree(String(stdout ?? ""), input.worktreePath);
+
+  if (registeredAfterPrune) {
+    await input.audit?.git({
+      type: "worktree:remove-leaked-registered-worktree",
+      target: input.worktreePath,
+      metadata: {
+        taskId: input.taskId,
+        reason: input.reason,
+        registeredAfterPrune: true,
+        stderrPreview,
+        pathExists,
+        gitFileExists,
+      },
+    });
+    return null;
+  }
+
+  const message = pathExists
+    ? "cleanup remove failed, but no registered worktree remains after prune; leftover directory was not deleted automatically"
+    : "cleanup remove failed, but no registered worktree remains after prune";
+  await input.audit?.git({
+    type: "worktree:remove-classified-harmless",
+    target: input.worktreePath,
+    metadata: {
+      taskId: input.taskId,
+      reason: input.reason,
+      classification: "not-registered-after-prune",
+      registeredAfterPrune: false,
+      stderrPreview,
+      pathExists,
+      gitFileExists,
+      nextAction: pathExists
+        ? "inspect the leftover temp directory before deleting filesystem residue"
+        : "no operator action required",
+    },
+  });
+
+  return {
+    removed: false,
+    harmless: true,
+    classification: "not-registered-after-prune",
+    message,
+    stderrPreview,
+    pathExists,
+    gitFileExists,
+  };
+}
+
 /**
  * worktrunk CLI mapping (verified 2026-05-15 from README + worktrunk.dev docs):
  * - create -> `wt switch --create <branch> [--base <startPoint>]`
@@ -822,7 +949,7 @@ export async function removeWorktree(input: {
   liveOwnerProbe?: LiveBindingProbe;
   processActiveProbe?: ProcessActiveProbe;
   reconcileMinIdleMs?: number;
-}): Promise<void> {
+}): Promise<void | WorktreeRemoveOutcome> {
   const logger = {
     log: (_message: string): void => {},
     warn: (_message: string): void => {},
@@ -896,8 +1023,11 @@ export async function removeWorktree(input: {
         target: input.worktreePath,
       });
     }
-    return;
+    return { removed: true, classification: "removed" };
   } catch (error) {
+    const classified = await classifyHarmlessMergeRemoveFailure(input, error);
+    if (classified) return classified;
+
     if (!(error instanceof WorktrunkOperationError) || input.settings.worktrunk?.onFailure !== "fallback-native") {
       throw error;
     }
@@ -915,8 +1045,15 @@ export async function removeWorktree(input: {
     });
 
     const native = new NativeWorktreeBackend({ logger, settings: input.settings });
-    await native.remove(removeInput);
-    await input.audit?.git({ type: "worktree:remove", target: input.worktreePath });
+    try {
+      await native.remove(removeInput);
+      await input.audit?.git({ type: "worktree:remove", target: input.worktreePath });
+      return { removed: true, classification: "removed" };
+    } catch (nativeError) {
+      const classified = await classifyHarmlessMergeRemoveFailure(input, nativeError);
+      if (classified) return classified;
+      throw nativeError;
+    }
   }
 }
 

--- a/packages/engine/src/worktree-backend.ts
+++ b/packages/engine/src/worktree-backend.ts
@@ -967,7 +967,7 @@ export async function removeWorktree(input: {
   liveOwnerProbe?: LiveBindingProbe;
   processActiveProbe?: ProcessActiveProbe;
   reconcileMinIdleMs?: number;
-}): Promise<void | WorktreeRemoveOutcome> {
+}): Promise<WorktreeRemoveOutcome> {
   const logger = {
     log: (_message: string): void => {},
     warn: (_message: string): void => {},

--- a/packages/engine/src/worktree-backend.ts
+++ b/packages/engine/src/worktree-backend.ts
@@ -102,13 +102,14 @@ async function classifyHarmlessMergeRemoveFailure(input: {
     maxBuffer: MAX_BUFFER,
   });
 
-  const { stdout } = await execAsync("git worktree list --porcelain", {
+  const listResult = await execAsync("git worktree list --porcelain", {
     cwd: input.rootDir,
     encoding: "utf-8",
     timeout: 10_000,
     maxBuffer: MAX_BUFFER,
   });
-  const registeredAfterPrune = porcelainContainsWorktree(String(stdout ?? ""), input.worktreePath);
+  const stdout = typeof listResult === "string" ? listResult : String(listResult.stdout ?? "");
+  const registeredAfterPrune = porcelainContainsWorktree(stdout, input.worktreePath);
 
   if (registeredAfterPrune) {
     await input.audit?.git({


### PR DESCRIPTION
## Summary
- classify Fusion-created merge/post-merge temp worktree removal failures as harmless only when `git worktree prune` plus `git worktree list --porcelain` proves the path is no longer registered
- keep still-registered leaked worktrees visible as cleanup failures/audit events
- document the diagnostic distinction and add a changeset for operator-visible cleanup logging
- include the existing dashboard workflow-node type mapping fix required for CI typecheck on current main (`merge-gate`, `merge-attempt`, etc.)

## Test Plan
- `corepack pnpm --filter @fusion/engine exec vitest run src/__tests__/worktree-backend.test.ts src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts --silent=passed-only --reporter=dot` — 2 files / 60 tests passed
- `corepack pnpm --filter @fusion/engine typecheck` — passed
- `corepack pnpm --filter @fusion/engine build` — passed
- `corepack pnpm lint -- packages/engine/src/worktree-backend.ts packages/engine/src/merger.ts packages/engine/src/run-audit.ts packages/engine/src/__tests__/worktree-backend.test.ts packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts` — passed with existing test-file ignored warnings
- `corepack pnpm typecheck` — passed after adding the workflow-node type mapping fix
- `corepack pnpm build` — passed

## CI
- GitHub Actions Build, Gate, Lint, Typecheck: passing on the latest push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added diagnostics guidance describing how merge cleanup can classify certain temporary worktree removal failures as harmless after Git verification.

* **Bug Fixes**
  * Merge cleanup now downgrades specific transient removal failures to harmless, logs a warning, and only marks worktrees removed when confirmed.
  * New audit events track harmless classifications, probe failures, and leaked registered worktrees.

* **Tests**
  * Expanded tests covering worktree removal classification and workflow editor round-trip preservation of original node kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->