### PR TITLE
fix: root local runtime at home dir, not process.cwd()

### DIFF
--- a/.changeset/fix-appimage-local-runtime-root.md
+++ b/.changeset/fix-appimage-local-runtime-root.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix "Couldn't start local Fusion" on the Linux AppImage (and any packaged build launched from a desktop launcher). The embedded local runtime now roots its data at the user's home directory (`~/.fusion`) instead of `process.cwd()`, which was `/` or the read-only AppImage mount point and caused database creation to fail with EACCES/EROFS. Set `FUSION_HOME` to override the location.


### PR DESCRIPTION
## Problem

The Linux AppImage starts but fails with **"Couldn't start local Fusion"** when clicking *Run Fusion Locally*.

The embedded local runtime rooted its data at `process.cwd()`:

```ts
localRuntimeManager = new LocalRuntimeManager({ rootDir: process.cwd() });
```

When a packaged build is launched from a desktop launcher or file manager (notably the AppImage), `process.cwd()` is `/` or the read-only squashfs mount point. `TaskStore` then tries to create `<cwd>/.fusion/fusion.db`, which fails with `EACCES`/`EROFS`. The error bubbles up through `startEmbedded()` and surfaces as the launch-gate error. It only worked from a terminal because cwd happened to be writable there.

## Fix

Resolve the runtime root from the user's home directory instead, so data lives in `~/.fusion` (consistent with the CLI). `FUSION_HOME` overrides the location for power users.

```ts
export function resolveLocalRuntimeRoot(): string {
  const override = process.env.FUSION_HOME?.trim();
  if (override) return resolve(override);
  return app.getPath("home");
}
```

## Tests

Added two tests exercising `resolveLocalRuntimeRoot()` directly (home-dir default + `FUSION_HOME` override). Both pass; typecheck clean.

> Note: `main.test.ts`'s `initializeApp` tests are red on a clean tree too (vitest 4 can't `new` the arrow-function constructor mocks like `BrowserWindow`) — a pre-existing, unrelated issue. The new tests deliberately call the resolver directly to avoid that broken bootstrap rather than expand scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed startup failures for local Fusion runs on Linux AppImage and packaged desktop-launcher builds. The embedded local runtime's data directory now defaults to the user's home directory (`~/.fusion`) instead of the current working directory, which may be read-only or inaccessible. Users can override this by setting the `FUSION_HOME` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->