### PR TITLE
fix: repair two post-merge Full Suite failures

### DIFF
--- a/.changeset/fix-full-suite-schema-and-cancel-error.md
+++ b/.changeset/fix-full-suite-schema-and-cancel-error.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix two post-merge Full Suite test failures. Sync the roadmap store's schema-version assertion to core's `SCHEMA_VERSION` (116 → 117). Stop `useCeSessions` background refreshes (poll fallback and push events) from clearing an error a `cancel`/`remove` just surfaced — an in-flight session kept the poll running, which silently erased the action error before the user could see it.

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/useCeSessions.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/useCeSessions.ts
@@ -77,19 +77,27 @@ export function useCeSessions(options: UseCeSessionsOptions = {}): UseCeSessions
     };
   }, []);
 
-  const refresh = useCallback(async () => {
-    try {
-      const next = await transport.list(projectId);
-      if (mounted.current) {
-        setSessions(next);
-        setError(undefined);
+  // clearErrorOnSuccess: a user-initiated refresh (or the initial fetch) clears
+  // any prior error on success. Background refreshes (poll fallback, push
+  // events) pass false so a successful list fetch doesn't silently erase an
+  // error a cancel/remove just surfaced — an in-flight session keeps the poll
+  // running, which would otherwise wipe the action error before the user sees it.
+  const refresh = useCallback(
+    async (clearErrorOnSuccess = true) => {
+      try {
+        const next = await transport.list(projectId);
+        if (mounted.current) {
+          setSessions(next);
+          if (clearErrorOnSuccess) setError(undefined);
+        }
+      } catch (err) {
+        if (mounted.current) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (mounted.current) setLoading(false);
       }
-    } catch (err) {
-      if (mounted.current) setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      if (mounted.current) setLoading(false);
-    }
-  }, [transport, projectId]);
+    },
+    [transport, projectId],
+  );
 
   // Initial fetch (and on project switch).
   useEffect(() => {
@@ -102,7 +110,7 @@ export function useCeSessions(options: UseCeSessionsOptions = {}): UseCeSessions
   useEffect(() => {
     if (!enabled || !subscribe) return;
     return subscribe(() => {
-      void refresh();
+      void refresh(false);
     });
   }, [enabled, subscribe, refresh]);
 
@@ -111,7 +119,7 @@ export function useCeSessions(options: UseCeSessionsOptions = {}): UseCeSessions
   useEffect(() => {
     if (!enabled || !anyInFlight) return;
     const timer = setInterval(() => {
-      void refresh();
+      void refresh(false);
     }, pollIntervalMs);
     return () => clearInterval(timer);
   }, [enabled, anyInFlight, pollIntervalMs, refresh]);

--- a/plugins/fusion-plugin-roadmap/src/store/__tests__/roadmap-store.test.ts
+++ b/plugins/fusion-plugin-roadmap/src/store/__tests__/roadmap-store.test.ts
@@ -743,10 +743,10 @@ describe("RoadmapStore", () => {
   });
 
   describe("schema version", () => {
-    it("schema version is 116 after init", () => {
+    it("schema version is 117 after init", () => {
       // Tracks @fusion/core's SCHEMA_VERSION (the roadmap store layers on core's
       // Database). Bump this in lockstep when core adds a migration.
-      expect(db.getSchemaVersion()).toBe(116);
+      expect(db.getSchemaVersion()).toBe(117);
     });
   });
 


### PR DESCRIPTION
## Problem
The **Full Suite (non-blocking)** workflow on `main` is consistently red on shards 2 and 4. (PR Checks stay green because this post-merge tier never runs on PRs.) Two independent, deterministic failures:

1. **Shard 2 — stale schema assertion.** `roadmap-store.test.ts` asserted `getSchemaVersion()` is `116`, but `@fusion/core` bumped `SCHEMA_VERSION` to `117` in `bffae81a9` (FN-6277). The roadmap store tracks core's version, but the assertion wasn't bumped in lockstep.

2. **Shard 4 — poll erases the cancel error.** `useCeSessions.test.tsx` "cancel() surfaces a transport error" failed every run:
   - The seeded session has an in-flight status, so the hook keeps a poll running.
   - On cancel failure the hook sets the error, then the background poll's successful `refresh()` calls `setError(undefined)` and wipes it before the assertion.
   - Confirmed by experiment: a non-in-flight status (no poll) makes the test pass unchanged.
   This is a real UX bug too — in production a transient cancel/remove error would silently vanish on the next poll.

## Fix
- Sync the roadmap schema assertion `116 → 117`.
- `useCeSessions.refresh()` takes `clearErrorOnSuccess` (default `true`). Background refreshes — the poll fallback and push-event subscription — pass `false`, so a successful list fetch no longer erases an error a `cancel`/`remove` just surfaced. Initial fetch and user-initiated refresh still clear as before.

## Verification
- `useCeSessions.test.tsx`: 7/7 passed.
- `roadmap-store.test.ts`: 86/86 passed.
- Grepped for other hardcoded `116` schema assertions — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where background session refresh operations would incorrectly clear error messages from user-initiated cancel or remove actions, ensuring error states are properly preserved.
  * Updated the internal schema version to 117 for consistency.

* **Tests**
  * Updated Full Suite test assertions to verify the new schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->