### PR TITLE
feat(acp): enable Claude CLI via ACP bridge by default (experimental switch) + status

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3170,9 +3170,14 @@ export interface GlobalSettings {
    *    "another-experiment": false
    *  }
    *
-   *  Default: workflow columns, graph executor, dual-observe, and authoritative
-   *  interpreter flags enabled; operators may explicitly set individual flags
-   *  false while rollout controls remain available. */
+   *  Default: workflow columns, graph executor, dual-observe, authoritative
+   *  interpreter, and `claudeCliAcp` flags enabled; operators may explicitly set
+   *  individual flags false while rollout controls remain available.
+   *
+   *  `claudeCliAcp` (default ON): routes the Claude CLI provider through the
+   *  `claude-code-cli-acp` ACP bridge instead of `claude -p`. Effective only when
+   *  the acp-runtime plugin is installed (it publishes the bundled bridge path);
+   *  otherwise the provider fails closed to `-p`. Set false to force `-p`. */
   experimentalFeatures?: Record<string, boolean>;
   /** Per-adapter CLI-agent launch configuration (CLI Agent Executor, U15).
    *  Keyed by adapter id (e.g. `"claude-code"`, `"codex"`, `"generic"`). Each

--- a/packages/dashboard/app/api/legacy.ts
+++ b/packages/dashboard/app/api/legacy.ts
@@ -1674,6 +1674,18 @@ export interface ClaudeCliStatus {
     reason?: string;
   } | null;
   ready: boolean;
+  /** Route A ACP transport state (Claude CLI via the claude-code-cli-acp bridge). */
+  acp?: {
+    /** experimentalFeatures.claudeCliAcp (default ON). */
+    enabled: boolean;
+    /** The acp-runtime plugin published a bundled bridge path. */
+    bridgeAvailable: boolean;
+    /** Claude CLI is actually routing through the bridge (enabled + flag + bridge). */
+    active: boolean;
+    /** The bridged `claude` returned "Not logged in" — needs fallback or re-auth (R17). */
+    authFailed: boolean;
+    authReason?: string;
+  };
 }
 
 export interface DroidCliStatus {

--- a/packages/dashboard/app/components/ClaudeCliProviderCard.tsx
+++ b/packages/dashboard/app/components/ClaudeCliProviderCard.tsx
@@ -4,6 +4,8 @@ import { Loader2 } from "lucide-react";
 import {
   fetchClaudeCliStatus,
   setClaudeCliEnabled,
+  fetchGlobalSettings,
+  updateGlobalSettings,
   type ClaudeCliStatus,
 } from "../api";
 import { ProviderIcon } from "./ProviderIcon";
@@ -122,6 +124,29 @@ export function ClaudeCliProviderCard({
     [onToggled, refresh],
   );
 
+  // R17 fallback: the bridge can't authenticate Claude. Turn the ACP transport
+  // off (experimentalFeatures.claudeCliAcp=false) so Claude CLI uses `claude -p`.
+  const handleFallbackToDashP = useCallback(async () => {
+    setBusy("disabling");
+    setLastAction(null);
+    try {
+      const gs = await fetchGlobalSettings();
+      await updateGlobalSettings({
+        experimentalFeatures: { ...(gs.experimentalFeatures ?? {}), claudeCliAcp: false },
+      });
+      if (mountedRef.current) {
+        setLastAction({ kind: "disabled", restartRequired: false });
+      }
+      await refresh();
+    } catch (err) {
+      if (mountedRef.current) {
+        setLastAction({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+      }
+    } finally {
+      if (mountedRef.current) setBusy(null);
+    }
+  }, [refresh]);
+
   const binaryAvailable = status?.binary.available ?? false;
   const currentlyEnabled = status?.enabled ?? authenticated;
 
@@ -217,6 +242,39 @@ export function ClaudeCliProviderCard({
         </strong>
         {description}
         <ClaudeCliStatusLine status={status} authenticated={authenticated} />
+        {status?.acp?.authFailed && (
+          <div
+            className="onboarding-provider-card__alert"
+            role="alert"
+            data-testid="claude-cli-acp-auth-banner"
+          >
+            <strong>
+              {t("setup.claudeCli.acpAuthFailedTitle", "Claude CLI bridge can't authenticate")}
+            </strong>
+            <p>
+              {status.acp.authReason ??
+                t(
+                  "setup.claudeCli.acpAuthFailed",
+                  "The ACP bridge reached a Claude session that isn't logged in. Fall back to `claude -p`, or fix authentication and re-test.",
+                )}
+            </p>
+            <div className="onboarding-provider-card__actions">
+              <button type="button" onClick={handleFallbackToDashP} disabled={busy !== null}>
+                {busy === "disabling" && <Loader2 className="spin" size={14} />}
+                {t("setup.claudeCli.useDashP", "Use claude -p")}
+              </button>
+              <button type="button" onClick={handleTest} disabled={busy !== null}>
+                {t("setup.claudeCli.recheckAuth", "I fixed auth — re-test")}
+              </button>
+            </div>
+            <p className="onboarding-provider-card__hint">
+              {t(
+                "setup.claudeCli.fixAuthHint",
+                "To fix: run `claude` in a terminal and complete login, then re-test.",
+              )}
+            </p>
+          </div>
+        )}
       </div>
       <div className="onboarding-provider-card__actions">{actions}</div>
       {lastAction && <ClaudeCliActionToast action={lastAction} />}

--- a/packages/dashboard/app/components/ClaudeCliProviderCard.tsx
+++ b/packages/dashboard/app/components/ClaudeCliProviderCard.tsx
@@ -260,7 +260,7 @@ export function ClaudeCliProviderCard({
             </p>
             <div className="onboarding-provider-card__actions">
               <button type="button" onClick={handleFallbackToDashP} disabled={busy !== null}>
-                {busy === "disabling" && <Loader2 className="spin" size={14} />}
+                {busy === "disabling" && <Loader2 className="animate-spin" size={14} />}
                 {t("setup.claudeCli.useDashP", "Use claude -p")}
               </button>
               <button type="button" onClick={handleTest} disabled={busy !== null}>

--- a/packages/dashboard/src/routes/register-auth-routes.ts
+++ b/packages/dashboard/src/routes/register-auth-routes.ts
@@ -1,4 +1,7 @@
 import type { Request } from "express";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 import { isGhAvailable, isGhAuthenticated } from "@fusion/core";
 import { probeClaudeCli } from "../claude-cli-probe.js";
 import { probeDroidCli } from "../droid-cli-probe.js";
@@ -600,6 +603,23 @@ export const registerAuthRoutes: ApiRouteRegistrar = (ctx) => {
       const acpBridgeAvailable =
         typeof process.env.FUSION_CLAUDE_ACP_BRIDGE === "string" &&
         process.env.FUSION_CLAUDE_ACP_BRIDGE.length > 0;
+      // R17: the driver writes this signal when a turn comes back "Not logged in"
+      // (the bridged `claude` can't authenticate). Surface it so the UI can offer
+      // fall-back-to-`-p` or fix-auth. Path matches ACP_BRIDGE_AUTH_SIGNAL_PATH.
+      let acpAuthFailed = false;
+      let acpAuthReason: string | undefined;
+      try {
+        const signalPath = join(tmpdir(), "fusion-acp-bridge-auth.json");
+        if (existsSync(signalPath)) {
+          const sig = JSON.parse(readFileSync(signalPath, "utf8")) as { authFailed?: boolean; reason?: string };
+          if (sig?.authFailed) {
+            acpAuthFailed = true;
+            acpAuthReason = typeof sig.reason === "string" ? sig.reason : undefined;
+          }
+        }
+      } catch {
+        // best-effort; absence of the signal means no known auth failure
+      }
 
       res.json({
         binary,
@@ -609,6 +629,8 @@ export const registerAuthRoutes: ApiRouteRegistrar = (ctx) => {
           enabled: acpEnabled,
           bridgeAvailable: acpBridgeAvailable,
           active: enabled && acpEnabled && acpBridgeAvailable,
+          authFailed: acpAuthFailed,
+          authReason: acpAuthReason,
         },
         // Convenience field: the provider card considers everything "ready"
         // when the binary is available, the user has enabled the toggle,

--- a/packages/dashboard/src/routes/register-auth-routes.ts
+++ b/packages/dashboard/src/routes/register-auth-routes.ts
@@ -580,21 +580,36 @@ export const registerAuthRoutes: ApiRouteRegistrar = (ctx) => {
     try {
       const binary = await probeClaudeCli();
       let enabled = false;
+      let acpEnabled = true; // experimentalFeatures.claudeCliAcp defaults ON
       if (store) {
         try {
           const globalSettings = await store.getGlobalSettingsStore().getSettings();
           enabled = globalSettings.useClaudeCli === true;
+          acpEnabled =
+            (globalSettings as { experimentalFeatures?: Record<string, boolean> })
+              .experimentalFeatures?.claudeCliAcp !== false;
         } catch {
           // Best-effort: unreadable settings still allow the binary probe
           // to surface, just with enabled=false.
         }
       }
       const extension = options?.getClaudeCliExtensionStatus?.() ?? null;
+      // ACP transport (Route A): active only when Claude CLI is on, the
+      // experimental flag is on, AND the acp-runtime plugin published a bridge
+      // path (FUSION_CLAUDE_ACP_BRIDGE). Otherwise the provider uses `claude -p`.
+      const acpBridgeAvailable =
+        typeof process.env.FUSION_CLAUDE_ACP_BRIDGE === "string" &&
+        process.env.FUSION_CLAUDE_ACP_BRIDGE.length > 0;
 
       res.json({
         binary,
         enabled,
         extension,
+        acp: {
+          enabled: acpEnabled,
+          bridgeAvailable: acpBridgeAvailable,
+          active: enabled && acpEnabled && acpBridgeAvailable,
+        },
         // Convenience field: the provider card considers everything "ready"
         // when the binary is available, the user has enabled the toggle,
         // AND the host loaded the extension without error. Surfacing this

--- a/packages/dashboard/src/routes/register-auth-routes.ts
+++ b/packages/dashboard/src/routes/register-auth-routes.ts
@@ -603,6 +603,12 @@ export const registerAuthRoutes: ApiRouteRegistrar = (ctx) => {
       const acpBridgeAvailable =
         typeof process.env.FUSION_CLAUDE_ACP_BRIDGE === "string" &&
         process.env.FUSION_CLAUDE_ACP_BRIDGE.length > 0;
+      // FNXC:ClaudeAcp 2026-06-15-11:40:
+      // `active` must reflect the ACTUAL dispatch determinant — FUSION_CLAUDE_ACP
+      // (set by applyClaudeAcpEnable from the flag OR the operator force-override),
+      // not the flag alone — so the status isn't misleading when an operator forces
+      // it on/off.
+      const acpEnvOn = process.env.FUSION_CLAUDE_ACP === "1";
       // R17: the driver writes this signal when a turn comes back "Not logged in"
       // (the bridged `claude` can't authenticate). Surface it so the UI can offer
       // fall-back-to-`-p` or fix-auth. Path matches ACP_BRIDGE_AUTH_SIGNAL_PATH.
@@ -628,7 +634,7 @@ export const registerAuthRoutes: ApiRouteRegistrar = (ctx) => {
         acp: {
           enabled: acpEnabled,
           bridgeAvailable: acpBridgeAvailable,
-          active: enabled && acpEnabled && acpBridgeAvailable,
+          active: enabled && acpBridgeAvailable && acpEnvOn,
           authFailed: acpAuthFailed,
           authReason: acpAuthReason,
         },

--- a/packages/engine/src/__tests__/claude-acp-enable.test.ts
+++ b/packages/engine/src/__tests__/claude-acp-enable.test.ts
@@ -16,22 +16,22 @@ describe("claudeAcpExperimentalEnabled — default ON", () => {
 });
 
 describe("applyClaudeAcpEnable — translates the flag to FUSION_CLAUDE_ACP", () => {
-  it("sets FUSION_CLAUDE_ACP=1 when enabled (default ON) and env unset", () => {
+  it("sets FUSION_CLAUDE_ACP=1 when enabled (default ON)", () => {
     const env: NodeJS.ProcessEnv = {};
     expect(applyClaudeAcpEnable({}, env)).toBe(true);
     expect(env.FUSION_CLAUDE_ACP).toBe("1");
   });
-  it("does NOT set the env when the flag is explicitly false", () => {
-    const env: NodeJS.ProcessEnv = {};
+  it("sets FUSION_CLAUDE_ACP=0 when the flag is explicitly false (recomputed each call)", () => {
+    const env: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP: "1" }; // stale prior value
     expect(applyClaudeAcpEnable({ experimentalFeatures: { claudeCliAcp: false } }, env)).toBe(false);
-    expect(env.FUSION_CLAUDE_ACP).toBeUndefined();
+    expect(env.FUSION_CLAUDE_ACP).toBe("0"); // flip takes effect — no latch on our own write
   });
-  it("honors an explicit env override (operator/test wins over the flag)", () => {
-    const off: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP: "0" };
-    expect(applyClaudeAcpEnable({}, off)).toBe(false); // flag default-on, but env says off
+  it("honors the operator force-override FUSION_CLAUDE_ACP_FORCE over the flag", () => {
+    const off: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP_FORCE: "0" };
+    expect(applyClaudeAcpEnable({}, off)).toBe(false); // flag default-on, but forced off
     expect(off.FUSION_CLAUDE_ACP).toBe("0");
 
-    const on: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP: "1" };
+    const on: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP_FORCE: "1" };
     expect(applyClaudeAcpEnable({ experimentalFeatures: { claudeCliAcp: false } }, on)).toBe(true);
     expect(on.FUSION_CLAUDE_ACP).toBe("1");
   });

--- a/packages/engine/src/__tests__/claude-acp-enable.test.ts
+++ b/packages/engine/src/__tests__/claude-acp-enable.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { claudeAcpExperimentalEnabled, applyClaudeAcpEnable } from "../claude-acp-enable.js";
+
+describe("claudeAcpExperimentalEnabled — default ON", () => {
+  it("is ON when no settings / no experimentalFeatures", () => {
+    expect(claudeAcpExperimentalEnabled(undefined)).toBe(true);
+    expect(claudeAcpExperimentalEnabled({})).toBe(true);
+    expect(claudeAcpExperimentalEnabled({ experimentalFeatures: {} })).toBe(true);
+  });
+  it("is ON when explicitly true", () => {
+    expect(claudeAcpExperimentalEnabled({ experimentalFeatures: { claudeCliAcp: true } })).toBe(true);
+  });
+  it("is OFF only when explicitly false", () => {
+    expect(claudeAcpExperimentalEnabled({ experimentalFeatures: { claudeCliAcp: false } })).toBe(false);
+  });
+});
+
+describe("applyClaudeAcpEnable — translates the flag to FUSION_CLAUDE_ACP", () => {
+  it("sets FUSION_CLAUDE_ACP=1 when enabled (default ON) and env unset", () => {
+    const env: NodeJS.ProcessEnv = {};
+    expect(applyClaudeAcpEnable({}, env)).toBe(true);
+    expect(env.FUSION_CLAUDE_ACP).toBe("1");
+  });
+  it("does NOT set the env when the flag is explicitly false", () => {
+    const env: NodeJS.ProcessEnv = {};
+    expect(applyClaudeAcpEnable({ experimentalFeatures: { claudeCliAcp: false } }, env)).toBe(false);
+    expect(env.FUSION_CLAUDE_ACP).toBeUndefined();
+  });
+  it("honors an explicit env override (operator/test wins over the flag)", () => {
+    const off: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP: "0" };
+    expect(applyClaudeAcpEnable({}, off)).toBe(false); // flag default-on, but env says off
+    expect(off.FUSION_CLAUDE_ACP).toBe("0");
+
+    const on: NodeJS.ProcessEnv = { FUSION_CLAUDE_ACP: "1" };
+    expect(applyClaudeAcpEnable({ experimentalFeatures: { claudeCliAcp: false } }, on)).toBe(true);
+    expect(on.FUSION_CLAUDE_ACP).toBe("1");
+  });
+});

--- a/packages/engine/src/claude-acp-enable.ts
+++ b/packages/engine/src/claude-acp-enable.ts
@@ -8,8 +8,10 @@
  *      `FUSION_CLAUDE_ACP_BRIDGE` on load — KTD10; absent → fail-closed to `-p`).
  *
  * The user-facing switch is `experimentalFeatures.claudeCliAcp`: ON unless the
- * user explicitly sets it to `false`. An explicit `FUSION_CLAUDE_ACP` env value
- * always wins (operator / test override) — see {@link applyClaudeAcpEnable}.
+ * user explicitly sets it to `false`. An operator force-override
+ * (`FUSION_CLAUDE_ACP_FORCE=0|1`) always wins. The decision is recomputed every
+ * call (each `createFnAgent`) so flipping the flag — e.g. the UI "use `claude -p`"
+ * fallback after an auth failure — takes effect on the next turn, no restart.
  */
 
 /** True unless `experimentalFeatures.claudeCliAcp === false` (default ON). */
@@ -29,8 +31,11 @@ export function applyClaudeAcpEnable(
   globalSettings: Record<string, unknown> | undefined,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  if (typeof env.FUSION_CLAUDE_ACP === "string") return env.FUSION_CLAUDE_ACP === "1";
-  const enabled = claudeAcpExperimentalEnabled(globalSettings);
-  if (enabled) env.FUSION_CLAUDE_ACP = "1";
+  // Operator force-override (set in the launch environment), re-read every call
+  // so our own writes to FUSION_CLAUDE_ACP can't latch the decision.
+  const force = env.FUSION_CLAUDE_ACP_FORCE;
+  const enabled =
+    force === "1" ? true : force === "0" ? false : claudeAcpExperimentalEnabled(globalSettings);
+  env.FUSION_CLAUDE_ACP = enabled ? "1" : "0";
   return enabled;
 }

--- a/packages/engine/src/claude-acp-enable.ts
+++ b/packages/engine/src/claude-acp-enable.ts
@@ -1,4 +1,5 @@
 /**
+ * FNXC:ClaudeAcp 2026-06-15-11:40:
  * Route A enable resolution (experimental, DEFAULT ON).
  *
  * The `pi-claude-cli` provider drives Claude through the `claude-code-cli-acp`

--- a/packages/engine/src/claude-acp-enable.ts
+++ b/packages/engine/src/claude-acp-enable.ts
@@ -1,0 +1,36 @@
+/**
+ * Route A enable resolution (experimental, DEFAULT ON).
+ *
+ * The `pi-claude-cli` provider drives Claude through the `claude-code-cli-acp`
+ * ACP bridge instead of `claude -p` when BOTH hold at dispatch time:
+ *   1. `FUSION_CLAUDE_ACP=1` (this module sets it from the experimental flag), and
+ *   2. a bridge path is resolvable (the acp-runtime plugin publishes
+ *      `FUSION_CLAUDE_ACP_BRIDGE` on load — KTD10; absent → fail-closed to `-p`).
+ *
+ * The user-facing switch is `experimentalFeatures.claudeCliAcp`: ON unless the
+ * user explicitly sets it to `false`. An explicit `FUSION_CLAUDE_ACP` env value
+ * always wins (operator / test override) — see {@link applyClaudeAcpEnable}.
+ */
+
+/** True unless `experimentalFeatures.claudeCliAcp === false` (default ON). */
+export function claudeAcpExperimentalEnabled(
+  globalSettings: Record<string, unknown> | undefined,
+): boolean {
+  const exp = ((globalSettings ?? {}).experimentalFeatures ?? {}) as Record<string, unknown>;
+  return exp.claudeCliAcp !== false;
+}
+
+/**
+ * Translate the experimental flag into the `FUSION_CLAUDE_ACP` dispatch the
+ * provider reads. No-op when the env var is already set (explicit override wins),
+ * so operators/tests keep full control. Returns the resolved enabled state.
+ */
+export function applyClaudeAcpEnable(
+  globalSettings: Record<string, unknown> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (typeof env.FUSION_CLAUDE_ACP === "string") return env.FUSION_CLAUDE_ACP === "1";
+  const enabled = claudeAcpExperimentalEnabled(globalSettings);
+  if (enabled) env.FUSION_CLAUDE_ACP = "1";
+  return enabled;
+}

--- a/packages/engine/src/pi.ts
+++ b/packages/engine/src/pi.ts
@@ -57,6 +57,7 @@ import {
   type SkillSelectionContext,
 } from "./skill-resolver.js";
 import { isContextLimitError } from "./context-limit-detector.js";
+import { applyClaudeAcpEnable } from "./claude-acp-enable.js";
 import { createFusionAuthStorage, getModelRegistryModelsPath } from "./auth-storage.js";
 import { piLog, extensionsLog } from "./logger.js";
 import { readCustomProviders } from "./custom-providers.js";
@@ -1368,10 +1369,18 @@ async function registerExtensionProviders(cwd: string, modelRegistry: ModelRegis
 
   try {
     const agentDir = getPackageManagerAgentDir();
+    const settingsView = createReadOnlyPiSettingsView(cwd, agentDir);
+
+    // Route A enable (experimental, DEFAULT ON): translate
+    // experimentalFeatures.claudeCliAcp into the FUSION_CLAUDE_ACP dispatch the
+    // pi-claude-cli provider reads. Still fail-closed — with no bridge path
+    // published (acp-runtime plugin absent), the provider falls back to `-p`.
+    applyClaudeAcpEnable(settingsView.getGlobalSettings() as Record<string, unknown>);
+
     const packageManager = new DefaultPackageManager({
       cwd,
       agentDir,
-      settingsManager: createReadOnlyPiSettingsView(cwd, agentDir) as any,
+      settingsManager: settingsView as any,
     });
     const resolvedPaths = await packageManager.resolve();
     const packageExtensionPaths = resolvedPaths.extensions

--- a/packages/pi-claude-cli/src/__tests__/acp-driver.test.ts
+++ b/packages/pi-claude-cli/src/__tests__/acp-driver.test.ts
@@ -6,7 +6,9 @@ import { PassThrough } from "node:stream";
 let scriptedUpdates: Array<Record<string, unknown>> = [];
 
 // Driver validates the bridge path with existsSync — make the fake path "exist".
-vi.mock("node:fs", () => ({ existsSync: () => true }));
+// writeFileSync/unlinkSync back the R17 auth-failure signal (spied).
+const fsSpies = vi.hoisted(() => ({ writeFileSync: vi.fn(), unlinkSync: vi.fn() }));
+vi.mock("node:fs", () => ({ existsSync: () => true, writeFileSync: fsSpies.writeFileSync, unlinkSync: fsSpies.unlinkSync }));
 
 vi.mock("node:child_process", () => ({
   spawn: vi.fn(() => {
@@ -117,6 +119,19 @@ describe("streamViaAcp — ACP→pi translation (U11)", () => {
     expect(eventsOf(stream).some((e) => e.type === "toolcall_start")).toBe(true);
     const done = eventsOf(stream).find((e) => e.type === "done");
     expect(done!.reason).toBe("toolUse");
+  });
+
+  it("records the R17 auth-failure signal when the bridge turn is only 'Not logged in'", async () => {
+    fsSpies.writeFileSync.mockClear();
+    scriptedUpdates = [
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Not logged in · Please run /login" } },
+    ];
+    const stream = streamViaAcp(MODEL, CTX, OPTS) as unknown as { _events: Array<Record<string, unknown>> };
+    await flush();
+    // signal file written with authFailed:true
+    const wrote = fsSpies.writeFileSync.mock.calls.find((c) => String(c[1]).includes("authFailed"));
+    expect(wrote).toBeTruthy();
+    expect(String(wrote![1])).toContain("\"authFailed\":true");
   });
 
   it("ends with done even when the turn produces no content", async () => {

--- a/packages/pi-claude-cli/src/__tests__/acp-driver.test.ts
+++ b/packages/pi-claude-cli/src/__tests__/acp-driver.test.ts
@@ -121,17 +121,33 @@ describe("streamViaAcp — ACP→pi translation (U11)", () => {
     expect(done!.reason).toBe("toolUse");
   });
 
-  it("records the R17 auth-failure signal when the bridge turn is only 'Not logged in'", async () => {
+  it("R17 auth-signal: sets on a 'Not logged in' turn, clears on a real response, ignores long answers", async () => {
+    const run = async (text: string) => {
+      scriptedUpdates = [{ sessionUpdate: "agent_message_chunk", content: { type: "text", text } }];
+      streamViaAcp(MODEL, CTX, OPTS);
+      await flush();
+    };
+    const wroteAuthFailed = () =>
+      fsSpies.writeFileSync.mock.calls.some((c) => String(c[1]).includes('"authFailed":true'));
+
+    // Baseline: a real response leaves the signal cleared (lastAuthFailed=false).
+    await run("Here is a normal answer.");
     fsSpies.writeFileSync.mockClear();
-    scriptedUpdates = [
-      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Not logged in · Please run /login" } },
-    ];
-    const stream = streamViaAcp(MODEL, CTX, OPTS) as unknown as { _events: Array<Record<string, unknown>> };
-    await flush();
-    // signal file written with authFailed:true
-    const wrote = fsSpies.writeFileSync.mock.calls.find((c) => String(c[1]).includes("authFailed"));
-    expect(wrote).toBeTruthy();
-    expect(String(wrote![1])).toContain("\"authFailed\":true");
+    fsSpies.unlinkSync.mockClear();
+
+    // 1. A turn that is ONLY the bridge's "Not logged in" message → signal written.
+    await run("Not logged in · Please run /login");
+    expect(wroteAuthFailed()).toBe(true);
+
+    // 2. A real response → signal cleared (unlink).
+    fsSpies.unlinkSync.mockClear();
+    await run("Sure — here's the result you asked for.");
+    expect(fsSpies.unlinkSync).toHaveBeenCalled();
+
+    // 3. A LONG legit answer that merely mentions the phrase → NOT flagged.
+    fsSpies.writeFileSync.mockClear();
+    await run(`If you are not logged in, the CLI prompts you to authenticate. ${"detail ".repeat(20)}`);
+    expect(wroteAuthFailed()).toBe(false);
   });
 
   it("ends with done even when the turn produces no content", async () => {

--- a/packages/pi-claude-cli/src/acp-driver.ts
+++ b/packages/pi-claude-cli/src/acp-driver.ts
@@ -207,12 +207,18 @@ export function streamViaAcp(
       // R17: a turn that is ONLY "Not logged in" (no tools, no real text) means
       // the bridged `claude` can't authenticate — signal it for the UI. A real
       // response (tools or non-trivial text) clears the signal.
-      const fullText = (bridge.getOutput().content ?? [])
+      const trimmedText = (bridge.getOutput().content ?? [])
         .filter((c) => (c as { type?: string }).type === "text")
         .map((c) => (c as { text?: string }).text ?? "")
-        .join("");
-      if (toolCount === 0 && NOT_LOGGED_IN_RE.test(fullText)) recordBridgeAuthState(true);
-      else if (toolCount > 0 || fullText.trim().length > 0) recordBridgeAuthState(false);
+        .join("")
+        .trim();
+      // Only treat it as an auth failure when the WHOLE turn is essentially the
+      // bridge's short "Not logged in · Please run /login" message — not when a
+      // long, legitimate answer merely mentions the phrase (avoids false positives).
+      const isAuthFailure =
+        toolCount === 0 && trimmedText.length > 0 && trimmedText.length <= 80 && NOT_LOGGED_IN_RE.test(trimmedText);
+      if (isAuthFailure) recordBridgeAuthState(true);
+      else if (toolCount > 0 || trimmedText.length > 0) recordBridgeAuthState(false);
       const effective: "stop" | "tool_use" = reason === "tool_use" && toolCount > 0 ? "tool_use" : "stop";
       bridge.handleEvent({ type: "message_delta", delta: { stop_reason: effective === "tool_use" ? "tool_use" : "end_turn" } } as ClaudeApiEvent);
       stream.push({ type: "done", reason: effective === "tool_use" ? "toolUse" : "stop", message: bridge.getOutput() });

--- a/packages/pi-claude-cli/src/acp-driver.ts
+++ b/packages/pi-claude-cli/src/acp-driver.ts
@@ -35,8 +35,9 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { Readable, Writable } from "node:stream";
-import { isAbsolute } from "node:path";
-import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { existsSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import {
   ClientSideConnection,
   ndJsonStream,
@@ -76,6 +77,35 @@ const INACTIVITY_TIMEOUT_MS = 30 * 60_000;
 const MAX_CHUNK_CHARS = 64 * 1024;
 const MAX_TURN_CHARS = 5_000_000;
 const MAX_ID_CHARS = 256;
+
+/**
+ * Cross-process signal for the dashboard: when the bridged `claude` can't
+ * authenticate (R17 — e.g. a detached daemon with no keychain), the turn comes
+ * back as "Not logged in · Please run /login" instead of a real answer. We
+ * record that here so `GET /providers/claude-cli/status` can surface it and the
+ * UI can prompt the user to fall back to `-p` or fix auth. A real response
+ * clears it. Best-effort; the path is recomputed identically dashboard-side.
+ */
+export const ACP_BRIDGE_AUTH_SIGNAL_PATH = join(tmpdir(), "fusion-acp-bridge-auth.json");
+const NOT_LOGGED_IN_RE = /not logged in|please run \/login/i;
+let lastAuthFailed: boolean | undefined;
+
+function recordBridgeAuthState(failed: boolean, reason?: string): void {
+  if (lastAuthFailed === failed) return; // only write on transition
+  lastAuthFailed = failed;
+  try {
+    if (failed) {
+      writeFileSync(
+        ACP_BRIDGE_AUTH_SIGNAL_PATH,
+        JSON.stringify({ authFailed: true, at: new Date().toISOString(), reason: reason ?? "Claude in the ACP bridge is not logged in" }),
+      );
+    } else {
+      unlinkSync(ACP_BRIDGE_AUTH_SIGNAL_PATH);
+    }
+  } catch {
+    /* best-effort signal — never let it affect the turn */
+  }
+}
 
 /**
  * Bridge subprocess env allow-list. The bridged `claude` needs HOME (for
@@ -173,6 +203,15 @@ export function streamViaAcp(
       // Downgrade a tool_use turn that surfaced zero pi tool calls → stop, so pi
       // doesn't try to dispatch non-existent tools (mirrors provider.ts:366-375).
       const toolCount = (bridge.getOutput().content ?? []).filter((c) => (c as { type?: string }).type === "toolCall").length;
+      // R17: a turn that is ONLY "Not logged in" (no tools, no real text) means
+      // the bridged `claude` can't authenticate — signal it for the UI. A real
+      // response (tools or non-trivial text) clears the signal.
+      const fullText = (bridge.getOutput().content ?? [])
+        .filter((c) => (c as { type?: string }).type === "text")
+        .map((c) => (c as { text?: string }).text ?? "")
+        .join("");
+      if (toolCount === 0 && NOT_LOGGED_IN_RE.test(fullText)) recordBridgeAuthState(true);
+      else if (toolCount > 0 || fullText.trim().length > 0) recordBridgeAuthState(false);
       const effective: "stop" | "tool_use" = reason === "tool_use" && toolCount > 0 ? "tool_use" : "stop";
       bridge.handleEvent({ type: "message_delta", delta: { stop_reason: effective === "tool_use" ? "tool_use" : "end_turn" } } as ClaudeApiEvent);
       stream.push({ type: "done", reason: effective === "tool_use" ? "toolUse" : "stop", message: bridge.getOutput() });

--- a/packages/pi-claude-cli/src/acp-driver.ts
+++ b/packages/pi-claude-cli/src/acp-driver.ts
@@ -79,6 +79,7 @@ const MAX_TURN_CHARS = 5_000_000;
 const MAX_ID_CHARS = 256;
 
 /**
+ * FNXC:ClaudeAcp 2026-06-15-11:40:
  * Cross-process signal for the dashboard: when the bridged `claude` can't
  * authenticate (R17 — e.g. a detached daemon with no keychain), the turn comes
  * back as "Not logged in · Please run /login" instead of a real answer. We

--- a/plugins/fusion-plugin-acp-runtime/src/index.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/index.ts
@@ -49,6 +49,7 @@ const plugin: FusionPlugin = definePlugin({
             "will be auto-approved under an allow-all policy. Prefer an approval-required policy.",
         );
       }
+      // FNXC:ClaudeAcp 2026-06-15-11:40:
       // KTD10 (Route A): publish the bundled `claude-code-cli-acp` bridge path
       // process-wide so the pi-claude-cli provider's kill-switch can resolve it
       // WITHOUT a manual FUSION_CLAUDE_ACP_BRIDGE env var. This only PUBLISHES the


### PR DESCRIPTION
## Summary

Follow-up to #1680 (Route A core, merged). Flips the Route A ACP transport from a manual `FUSION_CLAUDE_ACP` env var to an **experimental feature switch, default ON**, and surfaces its state to operators.

## Changes

- **Experimental switch (default ON).** `experimentalFeatures.claudeCliAcp` is on unless explicitly set `false`. The engine translates it into the `FUSION_CLAUDE_ACP` dispatch the `pi-claude-cli` provider reads, at `registerExtensionProviders` time (new testable helper `claude-acp-enable.ts`, 6 tests).
  - **Fail-closed:** with no bridge path published (acp-runtime plugin absent / bridge not installed), the provider falls back to `claude -p`. So "default on" only engages where the bridge is actually available.
  - **Explicit `FUSION_CLAUDE_ACP` env always wins** (operator / test override).
- **U12 — status surface.** `GET /providers/claude-cli/status` now returns an `acp` block (`enabled` / `bridgeAvailable` / `active`) so operators can see whether Claude CLI is routing through the ACP bridge vs `-p`.

## Net effect

With the acp-runtime plugin installed, Claude CLI routes through the `claude-code-cli-acp` bridge **by default**; set `experimentalFeatures.claudeCliAcp=false` to force `-p`. The Claude-via-pi OAuth path is unchanged.

The safety gate this rests on (forwarded MCP tools + native tools refuse to execute when cancelled; no TOCTOU) was verified live in #1680.

## Remaining

U13 (workflow `model`-node regression) is largely covered by the dispatch + enable unit tests (the workflow path goes through the same `createFnAgent → streamSimple` routing). Runtime fallback-on-auth-failure (detached-daemon robustness) and OS sandboxing remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental “Claude CLI ACP” flag to control ACP bridge routing (default-enabled unless explicitly disabled or overridden).
  * Extended Claude CLI status responses and the provider card UI to report ACP availability, activity, and ACP auth-failure state.
  * Implemented cross-process ACP auth-failure signaling and an automatic dashboard fallback to route via `-p` with re-test support.
* **Documentation**
  * Expanded guidance for `claudeCliAcp`, including effectiveness conditions and how to force `-p`.
* **Tests**
  * Added/updated tests for enable/disable semantics, environment override behavior, and auth-failure signal recording/clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->