### PR TITLE
Build Compound Engineering plugin dist before its tests (fix Full Suite)

### DIFF
--- a/.changeset/fix-compound-engineering-dist-freshness.md
+++ b/.changeset/fix-compound-engineering-dist-freshness.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix the persistent non-blocking Full Suite failure caused by the Compound Engineering plugin's `dist-freshness.test.ts`. The test reads the plugin's compiled `dist/settings.js` and `dist/session/orchestrator.js`, but the plugin had no `pretest` build and was absent from `ensure-test-artifacts.mjs`, so on a fresh checkout `dist/` did not exist and the freshness guard threw "dist/ is missing — run pnpm build first". Register the plugin's required artifacts in `ensure-test-artifacts.mjs` and add a `pretest` hook that builds them, matching the other bundled plugins.

--- a/plugins/fusion-plugin-compound-engineering/package.json
+++ b/plugins/fusion-plugin-compound-engineering/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "tsc && node scripts/copy-css.mjs",
+    "pretest": "node ../../scripts/ensure-test-artifacts.mjs",
     "test": "vitest run --silent=passed-only --reporter=dot"
   },
   "dependencies": {

--- a/scripts/ensure-test-artifacts.mjs
+++ b/scripts/ensure-test-artifacts.mjs
@@ -63,6 +63,18 @@ export const REQUIRED_BUILD_PACKAGES = [
     requiredArtifacts: ["plugins/fusion-plugin-paperclip-runtime/dist/index.js"],
     staleAgainstGlobs: [{ sourcePath: "plugins/fusion-plugin-paperclip-runtime/src" }],
   },
+  {
+    // dist-freshness.test.ts reads the compiled settings + orchestrator to guard
+    // against stale dist (FN-6596). dist/ is build output, so a fresh CI checkout
+    // must build the plugin before its tests run or the guard throws "dist/ is
+    // missing". Build these artifacts up front like the other bundled plugins.
+    name: "@fusion-plugin-examples/compound-engineering",
+    requiredArtifacts: [
+      "plugins/fusion-plugin-compound-engineering/dist/settings.js",
+      "plugins/fusion-plugin-compound-engineering/dist/session/orchestrator.js",
+    ],
+    staleAgainstGlobs: [{ sourcePath: "plugins/fusion-plugin-compound-engineering/src" }],
+  },
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

The non-blocking **Full Suite** has been red on every `main` commit for days (visible on the post-merge runs for #1686, #1687, and earlier). Root cause is a single test, unrelated to those PRs:

`plugins/fusion-plugin-compound-engineering/src/__tests__/dist-freshness.test.ts` reads the plugin's **compiled** output — `dist/settings.js` and `dist/session/orchestrator.js` — to guard against shipping stale dist (FN-6596). But:
- the plugin had **no `pretest` build**, and
- it was **absent from `scripts/ensure-test-artifacts.mjs`** (the registry that builds required dist artifacts before tests).

So on a fresh CI checkout `dist/` doesn't exist and the guard throws `dist/ is missing — run pnpm build first`, failing test shard 4/4.

## Fix

Mirror exactly how the other bundled plugins (dependency-graph, hermes, openclaw, paperclip) handle the same dist-before-test requirement:
- Register the plugin's required artifacts + source inputs in `ensure-test-artifacts.mjs`.
- Add `"pretest": "node ../../scripts/ensure-test-artifacts.mjs"` to the plugin so its dist is built (and freshness-cached) before `vitest` runs.

## Verification

With `dist/` absent locally (the exact CI scenario), `pnpm --filter @fusion-plugin-examples/compound-engineering test` now builds the dist via the new `pretest` and **all 192 plugin tests pass**, including the two `dist-freshness` cases that were failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1688">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a persistent test failure in the Compound Engineering plugin that occurred on fresh repository checkouts by ensuring required build artifacts are properly generated before tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->