### PR TITLE
Fix Full Suite test failures: productivity fixtures + delete teardown race

### DIFF
--- a/packages/dashboard/app/components/command-center/__tests__/CommandCenter.mobile-scroll.test.tsx
+++ b/packages/dashboard/app/components/command-center/__tests__/CommandCenter.mobile-scroll.test.tsx
@@ -117,6 +117,7 @@ function populatedProductivityFixture() {
     commits: 2,
     pullRequests: 1,
     loc: { value: 42, unavailable: false },
+    hoursSaved: { value: 3, unavailable: false },
     taskDuration: {
       completedTasks: 2,
       averageMs: 1_800_000,
@@ -135,6 +136,7 @@ function emptyProductivityFixture() {
     commits: 0,
     pullRequests: 0,
     loc: { value: null, unavailable: true },
+    hoursSaved: { value: null, unavailable: true },
     taskDuration: {
       completedTasks: 0,
       averageMs: null,

--- a/packages/dashboard/app/components/command-center/__tests__/CommandCenter.tablet-layout.test.tsx
+++ b/packages/dashboard/app/components/command-center/__tests__/CommandCenter.tablet-layout.test.tsx
@@ -105,6 +105,7 @@ function populatedProductivityFixture() {
     commits: 2,
     pullRequests: 1,
     loc: { value: 42, unavailable: false },
+    hoursSaved: { value: 3, unavailable: false },
     taskDuration: {
       completedTasks: 2,
       averageMs: 1_800_000,
@@ -123,6 +124,7 @@ function emptyProductivityFixture() {
     commits: 0,
     pullRequests: 0,
     loc: { value: null, unavailable: true },
+    hoursSaved: { value: null, unavailable: true },
     taskDuration: {
       completedTasks: 0,
       averageMs: null,

--- a/packages/dashboard/src/__tests__/github-tracking-delete.test.ts
+++ b/packages/dashboard/src/__tests__/github-tracking-delete.test.ts
@@ -106,8 +106,11 @@ describe("github tracking delete flow", () => {
   afterEach(async () => {
     stateService.stop();
     store.close();
-    await rm(rootDir, { recursive: true, force: true });
-    await rm(globalDir, { recursive: true, force: true });
+    // The delete handlers are fire-and-forget (`void this.handleTaskDeleted`), so a
+    // trailing async write into `.fusion` can race this cleanup and surface as
+    // ENOTEMPTY. `maxRetries`/`retryDelay` make rm tolerant of that teardown race.
+    await rm(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    await rm(globalDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   });
 
   it("closes the linked issue as not_planned when a tracked task is deleted", async () => {


### PR DESCRIPTION
## Summary

Fixes all failures in the non-blocking **Full Suite** workflow (shards 2 and 4). Test-only changes — no shipped behavior changes.

## Shard 4 — 5 failures, one root cause

Commit `59d3eee7f` (FN-6721) added a `hoursSaved` field that `ProductivityArea.tsx:77` reads unconditionally (`data.hoursSaved.unavailable`). Two CommandCenter regression fixtures were never updated, so the area threw `TypeError: Cannot read properties of undefined (reading 'unavailable')`. That uncaught exception:

- crashed the CommandCenter render → `CommandCenter.mobile-scroll` / `CommandCenter.tablet-layout` couldn't find `[data-testid="command-center"]`, and
- polluted the shared vitest worker → 3 collateral `QuickEntryBox` failures (which pass cleanly in isolation).

**Fix:** add `hoursSaved` to the populated/empty productivity fixtures in both test files. Swept the repo — no other fixtures missing it.

## Shard 2 — 1 failure

`github-tracking-delete.test.ts` flaked with `ENOTEMPTY: ... rmdir '.../.fusion'`. The delete handler is fire-and-forget (`void this.handleTaskDeleted`), so a trailing async write into `.fusion` races `afterEach`'s `rm`.

**Fix:** make `rm` tolerant via the built-in `maxRetries`/`retryDelay` options.

## Verification (local)

- CommandCenter layout tests: 11/11 pass
- QuickEntryBox: 247/247 pass
- github-tracking-delete: 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1689">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to include new data fields for improved test coverage.
  * Enhanced test cleanup logic with retry handling to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->