### PR TITLE
Raise min agent heartbeat staleness floor 5m -> 10m

### DIFF
--- a/.changeset/heartbeat-staleness-10min.md
+++ b/.changeset/heartbeat-staleness-10min.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Raise the minimum agent heartbeat staleness floor from 5 to 10 minutes. Agents go silent during long-running but legitimate work (notably a verification step running a multi-minute test command, where the agent is blocked awaiting the command and cannot tick/heartbeat). The 5-minute floor could misread such a busy agent as dead and reclaim its in-progress task mid-run; 10 minutes gives long operations room before the liveness gate acts.

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -460,15 +460,18 @@ describe("executeHeartbeat", () => {
       expect(section).toMatch(/\| Long Interval \| active \| FN-209 \| .* \| healthy \|/);
     });
 
-    it("buildReportsHealthSection enforces a 5-minute minimum staleness floor", async () => {
+    it("buildReportsHealthSection enforces a 10-minute minimum staleness floor", async () => {
       const now = Date.now();
       const store = createStoreWithAgentForExec();
       vi.mocked(store.getCachedAgent).mockImplementation((id: string) => ({
         id,
         runtimeConfig: { heartbeatIntervalMs: 1_000 },
       }) as unknown as Agent);
+      // 7 minutes silent with a 1s interval: under the old 5-minute floor this
+      // would read as stale, but the 10-minute floor must still treat a busy
+      // long-running agent as healthy (e.g. mid multi-minute test command).
       vi.mocked(store.getAgentsByReportsTo).mockResolvedValue([
-        { id: "agent-fast", name: "Fast Poller", state: "active", taskId: "FN-210", lastHeartbeatAt: new Date(now - 2 * 60_000).toISOString(), updatedAt: new Date(now - 2 * 60_000).toISOString() } as Agent,
+        { id: "agent-fast", name: "Fast Poller", state: "active", taskId: "FN-210", lastHeartbeatAt: new Date(now - 7 * 60_000).toISOString(), updatedAt: new Date(now - 7 * 60_000).toISOString() } as Agent,
       ]);
       const monitor = new HeartbeatMonitor({ store, taskStore: mockTaskStore, rootDir: "/tmp" });
 

--- a/packages/engine/src/agent-heartbeat.ts
+++ b/packages/engine/src/agent-heartbeat.ts
@@ -204,8 +204,11 @@ const REPORTS_STALE_INTERVAL_MULTIPLIER = 1.5;
 
 /**
  * Minimum staleness threshold floor for very short heartbeat intervals.
+ * 10 minutes: long-running but legitimately-busy agents (e.g. a verification
+ * step running a multi-minute test command, during which the agent does not
+ * tick/heartbeat) must not be misread as dead and reclaimed mid-run.
  */
-const MIN_HEARTBEAT_STALENESS_MS = 5 * 60_000;
+const MIN_HEARTBEAT_STALENESS_MS = 10 * 60_000;
 
 /** Format milliseconds into a human-readable duration string (e.g. "5m", "1h 20m", "2h"). */
 export function formatDuration(ms: number): string {


### PR DESCRIPTION
## What & why

Raise the minimum agent heartbeat **staleness floor from 5 → 10 minutes** (`MIN_HEARTBEAT_STALENESS_MS`, `agent-heartbeat.ts:208`).

Agent heartbeats are tick-driven (the agent records one each loop tick). During a long but legitimate operation — most notably a verification step running a multi-minute `pnpm test` — the agent is blocked awaiting the command and cannot tick, so it stops heartbeating. Under the 5-minute floor the liveness gate could misread that busy agent as **dead** and reclaim its in-progress task mid-run (observed: a task bounced in-progress → todo while its step-4 test command was still running). 10 minutes gives long operations room before the gate acts.

This is a targeted mitigation; reducing how long verification commands actually take is tracked separately.

## Change
- `MIN_HEARTBEAT_STALENESS_MS`: `5 * 60_000` → `10 * 60_000`, with rationale comment.
- Strengthened the floor test: a fast-interval agent **7 minutes** silent now stays healthy (it would have read `stale` under the old 5-minute floor, so the test actually exercises the new floor).

## Verification
- `pnpm --filter @fusion/engine typecheck` → clean.
- `heartbeat-executor.test.ts` → **148/148 pass** (incl. the updated floor test and the existing 60-min-interval-healthy-at-45-min case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the minimum agent heartbeat staleness detection threshold from 5 to 10 minutes. Agents engaged in long-running work will no longer be incorrectly marked as inactive and have their tasks prematurely reclaimed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->