### PR TITLE
fix(engine): map anthropic-compatible custom providers to anthropic-messages api

### DIFF
--- a/.changeset/fix-anthropic-compatible-custom-provider.md
+++ b/.changeset/fix-anthropic-compatible-custom-provider.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+Fix anthropic-compatible custom providers failing with "No API provider registered for api: anthropic".
+
+`resolveCustomProviderApiType` mapped the `anthropic-compatible` provider type to the api key `"anthropic"`, but pi-ai registers the Anthropic Messages API under `"anthropic-messages"`. Any custom provider configured as `anthropic-compatible` (self-hosted Claude proxy, gateway, etc.) therefore selected a model whose `api` did not match a registered provider and threw at stream time. Mapped it to `"anthropic-messages"` and added a regression assertion alongside the existing openai-compatible / openai-responses coverage.

--- a/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
+++ b/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
@@ -1395,15 +1395,40 @@ describe("createFnAgent", () => {
       apiKey: "RESPONSES_API_KEY",
       models: [expect.objectContaining({ id: "responses-model", name: "Responses Model" })],
     }));
-    // anthropic-compatible must map to pi-ai's registered "anthropic-messages"
-    // api key, NOT bare "anthropic" (which throws "No API provider registered
-    // for api: anthropic" at stream time). Regression guard for that bug.
+    /*
+    FNXC:CustomProviders 2026-06-21-13:45:
+    Invariant (FN-5893 surface = providers/execution paths): every custom-provider apiType must map to an api key pi-ai's registry actually registers. anthropic-compatible maps to "anthropic-messages", NOT bare "anthropic" — the latter registered fine but threw "No API provider registered for api: anthropic" the moment a task streamed. Assert the corrected value AND that the broken bare key is never used, so a future regression to "anthropic" fails here.
+    */
     expect(registerProviderMock).toHaveBeenCalledWith("custom-anthropic", expect.objectContaining({
       baseUrl: "https://anthropic.example",
       api: "anthropic-messages",
       apiKey: "ANTHROPIC_API_KEY",
       models: [expect.objectContaining({ id: "anthropic-model", name: "Anthropic Model" })],
     }));
+    // Negative guard: the unregistered bare "anthropic" api key must never be emitted for any provider.
+    expect(registerProviderMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ api: "anthropic" }),
+    );
+    // Invariant: every api key handed to registerProvider must be one pi-ai registers
+    // (mirrors @earendil-works/pi-ai register-builtins). Catches a typo in any arm.
+    const PI_AI_REGISTERED_APIS = new Set([
+      "anthropic-messages",
+      "openai-completions",
+      "openai-responses",
+      "azure-openai-responses",
+      "openai-codex-responses",
+      "google-generative-ai",
+      "google-vertex",
+      "mistral-conversations",
+      "bedrock-converse-stream",
+    ]);
+    for (const [, config] of registerProviderMock.mock.calls) {
+      const api = (config as { api?: string } | undefined)?.api;
+      if (typeof api === "string") {
+        expect(PI_AI_REGISTERED_APIS.has(api)).toBe(true);
+      }
+    }
   });
 
   it("avoids lock-based SettingsManager.create when loading extension providers", async () => {

--- a/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
+++ b/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
@@ -1363,6 +1363,14 @@ describe("createFnAgent", () => {
         apiKey: "RESPONSES_API_KEY",
         models: [{ id: "responses-model", name: "Responses Model" }],
       },
+      {
+        id: "770e8400-e29b-41d4-a716-446655440002",
+        name: "Custom Anthropic",
+        apiType: "anthropic-compatible",
+        baseUrl: "https://anthropic.example",
+        apiKey: "ANTHROPIC_API_KEY",
+        models: [{ id: "anthropic-model", name: "Anthropic Model" }],
+      },
     ] as any);
 
     const { createFnAgent } = await import("../pi.js");
@@ -1386,6 +1394,15 @@ describe("createFnAgent", () => {
       api: "openai-responses",
       apiKey: "RESPONSES_API_KEY",
       models: [expect.objectContaining({ id: "responses-model", name: "Responses Model" })],
+    }));
+    // anthropic-compatible must map to pi-ai's registered "anthropic-messages"
+    // api key, NOT bare "anthropic" (which throws "No API provider registered
+    // for api: anthropic" at stream time). Regression guard for that bug.
+    expect(registerProviderMock).toHaveBeenCalledWith("custom-anthropic", expect.objectContaining({
+      baseUrl: "https://anthropic.example",
+      api: "anthropic-messages",
+      apiKey: "ANTHROPIC_API_KEY",
+      models: [expect.objectContaining({ id: "anthropic-model", name: "Anthropic Model" })],
     }));
   });
 

--- a/packages/engine/src/pi.ts
+++ b/packages/engine/src/pi.ts
@@ -1006,12 +1006,22 @@ export interface AgentOptions {
   permanentAgentGating?: PermanentAgentGatingContext;
 }
 
+/**
+ * Map a user-facing custom-provider `apiType` to the pi-ai api-registry key.
+ *
+ * FNXC:CustomProviders 2026-06-21-13:45:
+ * Every arm must return a key that pi-ai's api-registry actually registers
+ * (see @earendil-works/pi-ai register-builtins). `anthropic-compatible` resolves
+ * to "anthropic-messages" — the key the Anthropic Messages API is registered
+ * under. The bare "anthropic" key is never registered, so returning it let a
+ * provider register but threw "No API provider registered for api: anthropic"
+ * the moment a task tried to stream.
+ *
+ * @param apiType - the custom provider's declared compatibility type.
+ * @returns the registered pi-ai api key to stream against.
+ */
 function resolveCustomProviderApiType(apiType: string): "anthropic-messages" | "openai-responses" | "openai-completions" {
   if (apiType === "anthropic-compatible") {
-    // pi-ai registers the Anthropic Messages API under the key
-    // "anthropic-messages" (see @earendil-works/pi-ai register-builtins).
-    // Returning bare "anthropic" throws "No API provider registered for
-    // api: anthropic" at stream time, so map to the real registry key.
     return "anthropic-messages";
   }
   if (apiType === "openai-responses") {

--- a/packages/engine/src/pi.ts
+++ b/packages/engine/src/pi.ts
@@ -1006,9 +1006,13 @@ export interface AgentOptions {
   permanentAgentGating?: PermanentAgentGatingContext;
 }
 
-function resolveCustomProviderApiType(apiType: string): "anthropic" | "openai-responses" | "openai-completions" {
+function resolveCustomProviderApiType(apiType: string): "anthropic-messages" | "openai-responses" | "openai-completions" {
   if (apiType === "anthropic-compatible") {
-    return "anthropic";
+    // pi-ai registers the Anthropic Messages API under the key
+    // "anthropic-messages" (see @earendil-works/pi-ai register-builtins).
+    // Returning bare "anthropic" throws "No API provider registered for
+    // api: anthropic" at stream time, so map to the real registry key.
+    return "anthropic-messages";
   }
   if (apiType === "openai-responses") {
     return "openai-responses";


### PR DESCRIPTION
## Problem

Adding a custom provider with `apiType: "anthropic-compatible"` (e.g. a self-hosted Claude proxy or an enterprise AI gateway) registers fine, but any task that tries to run a model from it fails at stream time with:

```
Error: No API provider registered for api: anthropic
```

The provider is visible in the model picker and `[pi] Registered custom provider "<name>"` is logged, so it looks configured — the failure only surfaces when an agent actually streams.

## Root cause

`resolveCustomProviderApiType` in `packages/engine/src/pi.ts` maps `anthropic-compatible` to the api key `"anthropic"`:

```ts
if (apiType === "anthropic-compatible") {
  return "anthropic";
}
```

But pi-ai (`@earendil-works/pi-ai`) registers the Anthropic Messages API under **`"anthropic-messages"`** (see `registerBuiltInApiProviders()` in `dist/providers/register-builtins.js` — the registered keys are `anthropic-messages`, `openai-completions`, `openai-responses`, `azure-openai-responses`, `openai-codex-responses`, `google-generative-ai`, `google-vertex`, `mistral-conversations`, `bedrock-converse-stream`).

At stream time, pi-ai's `resolveApiProvider(model.api)` calls `getApiProvider("anthropic")`, gets `undefined`, and throws. The other two arms of `resolveCustomProviderApiType` (`openai-responses` and the default `openai-completions`) map to real registry keys and work — only the anthropic arm pointed at a key that is never registered.

## Fix

Map `anthropic-compatible` → `"anthropic-messages"` (one line + clarifying comment).

## Tests

The existing registration test (`registers custom providers from global settings`) covered `openai-compatible` and `openai-responses` but **not** `anthropic-compatible` — which is how this shipped. Extended it with an `anthropic-compatible` provider asserting `api: "anthropic-messages"` is what gets registered, as a regression guard.

- `pnpm --filter @fusion/engine test:core` → 649 passed
- `pi-create-fn-agent.test.ts` → 76 passed
- `pnpm --filter @fusion/engine typecheck` → clean
- eslint → clean

## Verification

Reproduced end-to-end against a real `anthropic-compatible` gateway: before the fix, planning failed with `No API provider registered for api: anthropic`; after the fix (running from source via `pnpm dev dashboard`), a task planned successfully using `<provider>/claude-opus-4-8` with the model streaming normally and no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a runtime issue where anthropic-compatible custom providers failed to register due to an incorrect API mapping.
  * Custom provider registration now uses the correct Anthropic Messages API configuration.

* **Tests**
  * Added regression coverage to verify anthropic-compatible providers register with the expected API key and base configuration.
  * Strengthened assertions to prevent accidental use of unsupported API identifiers during provider registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->