### PR TITLE
[codex] Dispose completed spawned child sessions

### DIFF
--- a/.changeset/dispose-spawned-child-sessions.md
+++ b/.changeset/dispose-spawned-child-sessions.md
@@ -2,4 +2,4 @@
 "@runfusion/fusion": patch
 ---
 
-Dispose completed spawned child agent sessions so execution memory is released promptly after `fn_spawn_agent` children finish, and keep artifact registry listing metadata-only so large inline artifacts are not loaded during agent execution.
+Dispose completed spawned child agent sessions so execution memory is released promptly after `fn_spawn_agent` children finish, keep artifact registry listing metadata-only so large inline artifacts are not loaded during agent execution, and bound structured tool-result log previews before serialization.

--- a/.changeset/dispose-spawned-child-sessions.md
+++ b/.changeset/dispose-spawned-child-sessions.md
@@ -2,4 +2,4 @@
 "@runfusion/fusion": patch
 ---
 
-Dispose completed spawned child agent sessions so execution memory is released promptly after `fn_spawn_agent` children finish.
+Dispose completed spawned child agent sessions so execution memory is released promptly after `fn_spawn_agent` children finish, and keep artifact registry listing metadata-only so large inline artifacts are not loaded during agent execution.

--- a/.changeset/dispose-spawned-child-sessions.md
+++ b/.changeset/dispose-spawned-child-sessions.md
@@ -1,0 +1,5 @@
+---
+"@runfusion/fusion": patch
+---
+
+Dispose completed spawned child agent sessions so execution memory is released promptly after `fn_spawn_agent` children finish.

--- a/packages/core/src/__tests__/artifacts.test.ts
+++ b/packages/core/src/__tests__/artifacts.test.ts
@@ -172,6 +172,7 @@ describe("TaskStore artifacts", () => {
     expect(all.map((artifact) => artifact.id)).toEqual([third.id, second.id, first.id]);
     expect(all.find((artifact) => artifact.id === first.id)?.taskTitle).toBe("Alpha task");
     expect(all.find((artifact) => artifact.id === second.id)?.taskTitle).toBe("Beta task");
+    expect(all.every((artifact) => artifact.content === undefined)).toBe(true);
 
     await expect(store.listArtifacts({ type: "image" })).resolves.toMatchObject([{ id: second.id }]);
     expect((await store.listArtifacts({ authorId: "agent-alpha" })).map((artifact) => artifact.id)).toEqual([

--- a/packages/core/src/__tests__/artifacts.test.ts
+++ b/packages/core/src/__tests__/artifacts.test.ts
@@ -172,6 +172,10 @@ describe("TaskStore artifacts", () => {
     expect(all.map((artifact) => artifact.id)).toEqual([third.id, second.id, first.id]);
     expect(all.find((artifact) => artifact.id === first.id)?.taskTitle).toBe("Alpha task");
     expect(all.find((artifact) => artifact.id === second.id)?.taskTitle).toBe("Beta task");
+    /*
+     * FNXC:ArtifactRegistry 2026-06-23-09:52:
+     * Artifact registry listings are an execution-time discovery surface, so tests must lock the metadata-only contract that prevents inline content from being loaded during list operations.
+     */
     expect(all.every((artifact) => artifact.content === undefined)).toBe(true);
 
     await expect(store.listArtifacts({ type: "image" })).resolves.toMatchObject([{ id: second.id }]);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -12747,6 +12747,9 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
   /**
    * FNXC:ArtifactRegistry 2026-06-19-22:04:
    * Cross-agent registry query path for filtering artifacts across tasks, authors, and media types. LEFT JOIN keeps task-less registry artifacts visible while excluding artifacts attached to soft-deleted tasks.
+   *
+   * FNXC:ArtifactRegistry 2026-06-23-12:48:
+   * Agent execution can list artifacts frequently while large generated outputs are stored inline. The registry list is metadata-only, so avoid selecting artifact content here and require callers to use getArtifact for the full payload.
    */
   async listArtifacts(options?: {
     type?: ArtifactType;
@@ -12760,7 +12763,24 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
     const offset = Math.max(0, options?.offset ?? 0);
 
     let sql = `
-      SELECT a.*, t.title as taskTitle, t.description as taskDescription, t.column as taskColumn
+      SELECT
+        a.id,
+        a.type,
+        a.title,
+        a.description,
+        a.mimeType,
+        a.sizeBytes,
+        a.uri,
+        NULL as content,
+        a.authorId,
+        a.authorType,
+        a.taskId,
+        a.metadata,
+        a.createdAt,
+        a.updatedAt,
+        t.title as taskTitle,
+        t.description as taskDescription,
+        t.column as taskColumn
       FROM artifacts a
       LEFT JOIN tasks t ON a.taskId = t.id
       WHERE (a.taskId IS NULL OR t.${TaskStore.ACTIVE_TASKS_WHERE})

--- a/packages/engine/src/__tests__/agent-logger.test.ts
+++ b/packages/engine/src/__tests__/agent-logger.test.ts
@@ -417,6 +417,26 @@ describe("AgentLogger", () => {
     expect(call[3]).toBe(longResult);
   });
 
+  it("bounds structured tool result previews before logging", async () => {
+    const store = createMockStore();
+    const logger = new AgentLogger({
+      store,
+      taskId: "FN-017B",
+      agent: "executor",
+    });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    circular.payload = "x".repeat(20_000);
+
+    logger.onToolEnd("Search", false, circular);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const call = (store.appendAgentLog as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[3].length).toBeLessThan(5_000);
+    expect(call[3]).toContain("[tool output truncated to keep dashboard log views responsive]");
+    expect(call[3]).toContain("[Circular]");
+  });
+
   it("handles undefined result in onToolEnd", async () => {
     const store = createMockStore();
     const logger = new AgentLogger({

--- a/packages/engine/src/__tests__/agent-logger.test.ts
+++ b/packages/engine/src/__tests__/agent-logger.test.ts
@@ -432,6 +432,10 @@ describe("AgentLogger", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     const call = (store.appendAgentLog as ReturnType<typeof vi.fn>).mock.calls[0];
+    /*
+     * FNXC:AgentLogging 2026-06-23-09:52:
+     * Tool-result logging must bound structured previews before persistence while preserving truncation and circular-reference evidence for execution-memory regression coverage.
+     */
     expect(call[3].length).toBeLessThan(5_000);
     expect(call[3]).toContain("[tool output truncated to keep dashboard log views responsive]");
     expect(call[3]).toContain("[Circular]");

--- a/packages/engine/src/__tests__/executor-pause.test.ts
+++ b/packages/engine/src/__tests__/executor-pause.test.ts
@@ -709,7 +709,8 @@ describe("Agent Spawning - runSpawnedChild", () => {
     // Should transition: running → active
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "running");
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "active");
-    // Should clean up
+    // Should clean up and release session resources
+    expect(mockSession.dispose).toHaveBeenCalledOnce();
     expect(internals.childSessions.has("agent-test")).toBe(false);
     expect(internals.totalSpawnedCount).toBe(0);
   });
@@ -732,7 +733,8 @@ describe("Agent Spawning - runSpawnedChild", () => {
 
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "running");
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "error");
-    // Should still clean up
+    // Should still clean up and release session resources
+    expect(mockSession.dispose).toHaveBeenCalledOnce();
     expect(internals.childSessions.has("agent-test")).toBe(false);
     expect(internals.totalSpawnedCount).toBe(0);
   });
@@ -751,6 +753,7 @@ describe("Agent Spawning - runSpawnedChild", () => {
     // Should not throw even when state updates fail
     await internals.runSpawnedChild("agent-test", mockSession, "Do the research");
 
+    expect(mockSession.dispose).toHaveBeenCalledOnce();
     expect(internals.childSessions.has("agent-test")).toBe(false);
     expect(internals.totalSpawnedCount).toBe(0);
   });

--- a/packages/engine/src/__tests__/executor-pause.test.ts
+++ b/packages/engine/src/__tests__/executor-pause.test.ts
@@ -709,7 +709,7 @@ describe("Agent Spawning - runSpawnedChild", () => {
     // Should transition: running → active
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "running");
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "active");
-    // Should clean up and release session resources
+    // FNXC:AgentSpawning 2026-06-23-09:52: Completed spawned child sessions must dispose during cleanup so execution memory is released on the normal success path.
     expect(mockSession.dispose).toHaveBeenCalledOnce();
     expect(internals.childSessions.has("agent-test")).toBe(false);
     expect(internals.totalSpawnedCount).toBe(0);
@@ -733,7 +733,7 @@ describe("Agent Spawning - runSpawnedChild", () => {
 
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "running");
     expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-test", "error");
-    // Should still clean up and release session resources
+    // FNXC:AgentSpawning 2026-06-23-09:52: Failed spawned child sessions must still dispose during cleanup so error paths do not retain provider/runtime state.
     expect(mockSession.dispose).toHaveBeenCalledOnce();
     expect(internals.childSessions.has("agent-test")).toBe(false);
     expect(internals.totalSpawnedCount).toBe(0);

--- a/packages/engine/src/agent-logger.ts
+++ b/packages/engine/src/agent-logger.ts
@@ -24,6 +24,89 @@ const FLUSH_SIZE_BYTES = 1024;
 /** Default timer interval (ms) for periodic flush of small writes. */
 const FLUSH_INTERVAL_MS = 500;
 const ENTRY_BATCH_SIZE = 50;
+const TOOL_RESULT_DETAIL_LIMIT = 4_096;
+const TOOL_RESULT_DETAIL_TRUNCATION_NOTICE = "\n\n[tool output truncated to keep dashboard log views responsive]";
+const TOOL_RESULT_MAX_ARRAY_ITEMS = 25;
+const TOOL_RESULT_MAX_OBJECT_KEYS = 50;
+
+function truncateToolResultDetail(value: string): string {
+  if (value.length <= TOOL_RESULT_DETAIL_LIMIT) return value;
+  return `${value.slice(0, TOOL_RESULT_DETAIL_LIMIT)}${TOOL_RESULT_DETAIL_TRUNCATION_NOTICE}`;
+}
+
+function summarizeToolResultValue(value: unknown, state: { remainingChars: number; seen: WeakSet<object> }): unknown {
+  if (state.remainingChars <= 0) return "[truncated]";
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") {
+    const truncated = value.length > state.remainingChars
+      ? `${value.slice(0, state.remainingChars)}${TOOL_RESULT_DETAIL_TRUNCATION_NOTICE}`
+      : value;
+    state.remainingChars -= Math.min(value.length, state.remainingChars);
+    return truncated;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "function" || typeof value === "symbol") return `[${typeof value}]`;
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: summarizeToolResultValue(value.message, state),
+      ...(value.stack ? { stack: summarizeToolResultValue(value.stack, state) } : {}),
+    };
+  }
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+    return `<Buffer ${value.byteLength} bytes>`;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return `<${value.constructor.name} ${value.byteLength} bytes>`;
+  }
+  if (value instanceof ArrayBuffer) {
+    return `<ArrayBuffer ${value.byteLength} bytes>`;
+  }
+  if (typeof value !== "object") return String(value);
+  if (state.seen.has(value)) return "[Circular]";
+  state.seen.add(value);
+  if (Array.isArray(value)) {
+    const summarized = value
+      .slice(0, TOOL_RESULT_MAX_ARRAY_ITEMS)
+      .map((item) => summarizeToolResultValue(item, state));
+    if (value.length > TOOL_RESULT_MAX_ARRAY_ITEMS) summarized.push(`[${value.length - TOOL_RESULT_MAX_ARRAY_ITEMS} more items truncated]`);
+    return summarized;
+  }
+  const summarized: Record<string, unknown> = {};
+  let count = 0;
+  for (const key in value as Record<string, unknown>) {
+    if (count >= TOOL_RESULT_MAX_OBJECT_KEYS) {
+      summarized.__truncatedKeys = true;
+      break;
+    }
+    summarized[key] = summarizeToolResultValue((value as Record<string, unknown>)[key], state);
+    count += 1;
+    if (state.remainingChars <= 0) {
+      summarized.__truncated = true;
+      break;
+    }
+  }
+  return summarized;
+}
+
+function summarizeToolResultDetail(result: unknown): string | undefined {
+  if (result === undefined || result === null) return undefined;
+  if (typeof result === "string") return truncateToolResultDetail(result);
+  /*
+   * FNXC:AgentLogging 2026-06-23-09:26:
+   * Execution memory can spike when tools return large structured payloads. Build a bounded preview before JSON serialization so logging cannot materialize multi-megabyte tool results after the dashboard-safe log detail limit would discard them anyway.
+   */
+  try {
+    const preview = summarizeToolResultValue(result, {
+      remainingChars: TOOL_RESULT_DETAIL_LIMIT,
+      seen: new WeakSet<object>(),
+    });
+    return truncateToolResultDetail(JSON.stringify(preview));
+  } catch {
+    return truncateToolResultDetail(String(result));
+  }
+}
 
 /**
  * Produce a human-readable summary from tool arguments.
@@ -269,10 +352,7 @@ export class AgentLogger {
    */
   onToolEnd(name: string, isError: boolean, result?: unknown): void {
     const type = isError ? "tool_error" : "tool_result";
-    let detail: string | undefined;
-    if (result !== undefined && result !== null) {
-      detail = typeof result === "string" ? result : JSON.stringify(result);
-    }
+    const detail = summarizeToolResultDetail(result);
     this.writeEntry(name, type, detail, `Failed to log tool end "${name}" (${type}) for ${this.taskId}`);
     // Record completion as tool_result/tool_error with a duration descriptor.
     // meta NEVER includes the tool result payload — only non-sensitive metrics.

--- a/packages/engine/src/agent-logger.ts
+++ b/packages/engine/src/agent-logger.ts
@@ -75,7 +75,7 @@ function summarizeToolResultValue(value: unknown, state: { remainingChars: numbe
   }
   const summarized: Record<string, unknown> = {};
   let count = 0;
-  for (const key in value as Record<string, unknown>) {
+  for (const key of Object.keys(value as Record<string, unknown>)) {
     if (count >= TOOL_RESULT_MAX_OBJECT_KEYS) {
       summarized.__truncatedKeys = true;
       break;

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -15607,7 +15607,18 @@ You have access to the file system to review changes.${verdictBlock}`;
       const errorMessage = err instanceof Error ? err.message : String(err);
       executorLog.warn(`Child agent ${agentId} failed: ${errorMessage}`);
     } finally {
-      this.childSessions.delete(agentId);
+      /*
+      FNXC:AgentSpawning 2026-06-23-12:25:
+      Server memory must return to baseline after spawned child execution. A normally completed child session owns provider/runtime state until disposed; deleting it from childSessions first makes later parent cleanup unable to reach it.
+      */
+      if (this.childSessions.get(agentId) === childSession) {
+        try {
+          childSession.dispose();
+        } catch (disposeErr) {
+          executorLog.warn(`Child agent ${agentId} session dispose failed: ${disposeErr instanceof Error ? disposeErr.message : String(disposeErr)}`);
+        }
+        this.childSessions.delete(agentId);
+      }
       this.totalSpawnedCount = Math.max(0, this.totalSpawnedCount - 1);
     }
   }

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -15613,7 +15613,7 @@ You have access to the file system to review changes.${verdictBlock}`;
       */
       if (this.childSessions.get(agentId) === childSession) {
         try {
-          childSession.dispose();
+          await childSession.dispose();
         } catch (disposeErr) {
           executorLog.warn(`Child agent ${agentId} session dispose failed: ${disposeErr instanceof Error ? disposeErr.message : String(disposeErr)}`);
         }


### PR DESCRIPTION
## Summary

Fixes execution-time server memory growth in three concrete paths:

- `runSpawnedChild()` now disposes completed child agent sessions before removing them from `childSessions`, so provider/runtime state is released after `fn_spawn_agent` children finish.
- Artifact registry listing is now metadata-only and no longer selects inline artifact `content`, preventing large generated artifacts from being loaded just because an agent enumerates the registry.
- `AgentLogger.onToolEnd()` now builds bounded structured result previews before JSON serialization, so large tool result objects cannot be fully materialized just to be truncated by log storage.

## Validation

- `pnpm --filter @fusion/engine exec vitest run src/__tests__/executor-pause.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/core exec vitest run src/__tests__/artifacts.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/engine exec vitest run src/__tests__/agent-logger.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/engine typecheck`
- `pnpm --filter @fusion/core typecheck`

## Changeset

Includes a patch changeset for `@runfusion/fusion`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spawned child agent sessions are now properly disposed to release execution memory promptly when completed.
  * Artifact registry listing now returns metadata-only results, avoiding large inline content loads during execution.

* **Performance**
  * Tool result logging is bounded and truncated to prevent dashboard slowness on large or circular outputs.

* **Tests**
  * Expanded test coverage for session cleanup and artifact metadata-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->