### PR TITLE
fix(i18n): fill missing translations for dashboard and workflow keys

### DIFF
--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -1933,7 +1933,7 @@
     "loadingProgress": "Progreso de carga del panel",
     "updatingMessage": "Actualizando panel de Fusion",
     "updatingVersion": "Actualizando a una nueva versión de frontend...",
-    "title": ""
+    "title": "Panel del proyecto"
   },
   "dbBanner": {
     "body": "La verificación de integridad de SQLite de Fusion en segundo plano informó de corrupción. Revise los objetos con error a continuación antes de continuar con operaciones críticas.",
@@ -8538,16 +8538,16 @@
     "widgetDefault": ""
   },
   "workflowSwitcher": {
-    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}",
+    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}{{mergingSuffix}}",
     "done": "Done",
     "inProgress": "In Progress",
     "label": "Workflow",
+    "merging": "Fusionando",
+    "mergingTitle": "{{count}} tarea{{plural}} fusionándose",
     "todo": "Todo",
     "triggerAria": "Select workflow. Current workflow: {{name}}",
     "editWorkflow": "Edit workflow",
-    "newWorkflow": "New workflow",
-    "merging": "",
-    "mergingTitle": ""
+    "newWorkflow": "New workflow"
   },
   "workspace": {
     "projectRoot": "Raíz del proyecto",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -1933,7 +1933,7 @@
     "loadingProgress": "Progression du chargement du tableau de bord",
     "updatingMessage": "Mise à jour du tableau de bord Fusion",
     "updatingVersion": "Mise à jour vers une nouvelle version de l'interface...",
-    "title": ""
+    "title": "Tableau de bord du projet"
   },
   "dbBanner": {
     "body": "La vérification d'intégrité SQLite en arrière-plan de Fusion a signalé une corruption. Veuillez examiner les objets défaillants ci-dessous avant de continuer les opérations critiques.",
@@ -8538,16 +8538,16 @@
     "widgetDefault": ""
   },
   "workflowSwitcher": {
-    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}",
+    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}{{mergingSuffix}}",
     "done": "Done",
     "inProgress": "In Progress",
     "label": "Workflow",
+    "merging": "Fusion",
+    "mergingTitle": "{{count}} tâche{{plural}} en fusion",
     "todo": "Todo",
     "triggerAria": "Select workflow. Current workflow: {{name}}",
     "editWorkflow": "Edit workflow",
-    "newWorkflow": "New workflow",
-    "merging": "",
-    "mergingTitle": ""
+    "newWorkflow": "New workflow"
   },
   "workspace": {
     "projectRoot": "Racine du projet",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -1933,7 +1933,7 @@
     "loadingProgress": "대시보드 로딩 진행 상황",
     "updatingMessage": "Fusion 대시보드 업데이트 중",
     "updatingVersion": "새 프런트엔드 버전으로 업데이트 중...",
-    "title": ""
+    "title": "프로젝트 대시보드"
   },
   "dbBanner": {
     "body": "Fusion의 백그라운드 SQLite 무결성 검사에서 손상이 발견되었습니다. 중요한 작업을 계속하기 전에 아래의 실패한 개체를 검토하세요.",
@@ -8538,16 +8538,16 @@
     "widgetDefault": ""
   },
   "workflowSwitcher": {
-    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}",
+    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}{{mergingSuffix}}",
     "done": "Done",
     "inProgress": "In Progress",
     "label": "Workflow",
+    "merging": "병합 중",
+    "mergingTitle": "{{count}}개 병합 중 작업{{plural}}",
     "todo": "Todo",
     "triggerAria": "Select workflow. Current workflow: {{name}}",
     "editWorkflow": "Edit workflow",
-    "newWorkflow": "New workflow",
-    "merging": "",
-    "mergingTitle": ""
+    "newWorkflow": "New workflow"
   },
   "workspace": {
     "projectRoot": "프로젝트 루트",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -1933,7 +1933,7 @@
     "loadingProgress": "仪表板加载进度",
     "updatingMessage": "更新 Fusion 仪表板",
     "updatingVersion": "更新到新的前端版本...",
-    "title": ""
+    "title": "项目仪表板"
   },
   "dbBanner": {
     "body": "Fusion 的后台 SQLite 完整性检查报告有损坏。继续关键操作之前，请查看下面的失败对象。",
@@ -8538,16 +8538,16 @@
     "widgetDefault": ""
   },
   "workflowSwitcher": {
-    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}",
+    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}{{mergingSuffix}}",
     "done": "Done",
     "inProgress": "In Progress",
     "label": "Workflow",
+    "merging": "合并中",
+    "mergingTitle": "{{count}} 个合并中任务{{plural}}",
     "todo": "Todo",
     "triggerAria": "Select workflow. Current workflow: {{name}}",
     "editWorkflow": "Edit workflow",
-    "newWorkflow": "New workflow",
-    "merging": "",
-    "mergingTitle": ""
+    "newWorkflow": "New workflow"
   },
   "workspace": {
     "projectRoot": "项目根目录",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -1933,7 +1933,7 @@
     "loadingProgress": "儀表板加載進度",
     "updatingMessage": "更新 Fusion 儀表板",
     "updatingVersion": "更新到新的前端版本...",
-    "title": ""
+    "title": "專案儀表板"
   },
   "dbBanner": {
     "body": "Fusion 的背景 SQLite 完整性檢查報告有損毀。繼續重要操作之前，請查看下面的失敗物件。",
@@ -8538,16 +8538,16 @@
     "widgetDefault": ""
   },
   "workflowSwitcher": {
-    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}",
+    "countsAria": "{{todoLabel}}: {{todo}}, {{inProgressLabel}}: {{inProgress}}, {{doneLabel}}: {{done}}{{mergingSuffix}}",
     "done": "Done",
     "inProgress": "In Progress",
     "label": "Workflow",
+    "merging": "合併中",
+    "mergingTitle": "{{count}} 個合併中任務{{plural}}",
     "todo": "Todo",
     "triggerAria": "Select workflow. Current workflow: {{name}}",
     "editWorkflow": "Edit workflow",
-    "newWorkflow": "New workflow",
-    "merging": "",
-    "mergingTitle": ""
+    "newWorkflow": "New workflow"
   },
   "workspace": {
     "projectRoot": "項目根目錄",


### PR DESCRIPTION
## Summary

Fill in proper translations for three i18n keys that were added as empty strings to all non-English locales. Also adds the `{{mergingSuffix}}` interpolation to `workflowSwitcher.countsAria` to match the English catalog.

## Changes

Keys fixed across zh-CN, zh-TW, fr, es, ko:

| Key | Change |
|-----|--------|
| `dashboard.title` | Empty string -> proper translation |
| `workflowSwitcher.merging` | Empty string -> proper translation |
| `workflowSwitcher.mergingTitle` | Empty string -> proper translation |
| `workflowSwitcher.countsAria` | Added missing `{{mergingSuffix}}` interpolation |

## Verification

- `pnpm --filter @fusion/i18n vitest run src/__tests__/parity.test.ts src/__tests__/i18n-gate-coverage.test.ts` passes (7/7 tests)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1760">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized dashboard titles for Spanish, French, Korean, Simplified Chinese, and Traditional Chinese.
  * Added/updated workflow switcher text for the merging state, including clearer task-count messaging and new labels in the same languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->