### PR TITLE
fix(core): export package metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,8 @@
       "types": "./src/gh-cli.ts",
       "source": "./src/gh-cli.ts",
       "import": "./dist/gh-cli.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Exposes @fusion/core/package.json through package exports so agent inspection/self-diagnostics that resolve package metadata do not crash under Node package exports enforcement.

## Test Plan
- corepack pnpm --filter @fusion/core exec node - <<'NODE'
const { createRequire } = require('node:module');
const req = createRequire(process.cwd() + '/packages/cli/dist/bin.js');
const pkg = req('@fusion/core/package.json');
if (pkg.name !== '@fusion/core') throw new Error('unexpected package name');
console.log(pkg.name, pkg.version);
NODE
- corepack pnpm --filter @fusion/core build

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1761">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new package subpath export for `package.json`, improving compatibility for tools and integrations that need to read package metadata directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->