### PR TITLE
feat(FN-7010): opt-in LLM diff-review verification step

### DIFF
--- a/.changeset/llm-review-verification.md
+++ b/.changeset/llm-review-verification.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": minor
+---
+
+summary: Add an opt-in LLM diff-review verification step for task verification.
+category: feature
+dev: New project setting `verificationLlmReview` ("off" default | "advisory" | "blocking"). When not "off", an AI reviews the task diff for correctness/regressions as an additional step after the test/build commands in both the merger (`runDeterministicVerification`) and executor verification gates. Advisory logs findings but never fails; blocking fails on a passed:false high-severity verdict; any LLM/infra error degrades to a non-blocking advisory-unavailable result. Reuses createFnAgent/promptWithFallback (no new AI SDK dep). Default-off path is byte-identical to prior behavior. Implemented in `packages/engine/src/llm-review-verification.ts`.

--- a/packages/core/src/settings-schema.ts
+++ b/packages/core/src/settings-schema.ts
@@ -380,6 +380,10 @@ export const DEFAULT_PROJECT_SETTINGS = {
   // proportional to the change; the thin merge gate carries cross-cutting
   // coverage. Falls back to package/explicit command when no tests resolve.
   scopeVerificationToChangedFiles: true,
+  // FNXC:Verification 2026-06-25-00:00: OPT-IN LLM diff-review verification.
+  // Default "off" so the verification gate is byte-identical to pre-feature
+  // behavior until a project explicitly opts into "advisory" or "blocking".
+  verificationLlmReview: "off",
   ephemeralAgentsEnabled: true,
   agentProvisioning: {},
   sandboxProvisioning: {},

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4053,6 +4053,20 @@ export interface ProjectSettings {
    * package-scoped/explicit command. Set false to always run the broader
    * package/full command. Default: true. */
   scopeVerificationToChangedFiles?: boolean;
+  /**
+   * FNXC:Verification 2026-06-25-00:00:
+   * OPT-IN, default-off LLM diff-review verification step. When not "off", an AI
+   * reviews the task's diff for correctness/regressions as an ADDITIONAL
+   * verification step after the (possibly empty) test/build commands.
+   * - "off" (default): never invoked; the verification gate is byte-identical to
+   *   pre-feature behavior.
+   * - "advisory": runs the review and logs findings to the task, but NEVER fails
+   *   verification on it.
+   * - "blocking": a verdict of passed:false with a high-severity finding fails
+   *   verification, exactly like a failed test/build command.
+   * Any LLM/infra failure yields a non-blocking "advisory unavailable" result in
+   * every mode — an LLM outage must never hard-block a merge. Default: "off". */
+  verificationLlmReview?: "off" | "advisory" | "blocking";
   /** When enabled, AI-generated task specifications require manual approval
    *  before the task can move from triage to todo. Tasks with approved specs
    *  remain in triage with status "awaiting-approval" until a user approves

--- a/packages/engine/src/__tests__/llm-review-verification.test.ts
+++ b/packages/engine/src/__tests__/llm-review-verification.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Settings, TaskStore } from "@fusion/core";
+import {
+  resolveLlmReviewMode,
+  parseLlmReviewResponse,
+  evaluateLlmReviewGate,
+  runLlmReviewVerification,
+  runLlmReviewGate,
+  type LlmReviewAgentDeps,
+  type LlmReviewVerdict,
+} from "../llm-review-verification.js";
+
+/**
+ * FNXC:Verification 2026-06-25-00:00:
+ * Unit coverage for the OPT-IN LLM diff-review verification. The agent is mocked
+ * via the `deps` seam (createFnAgent/promptWithFallback substitutes) so no real
+ * AI call is made. Invariants under test:
+ * - advisory mode NEVER fails verification,
+ * - blocking mode fails ONLY on a passed:false + high-severity verdict,
+ * - any infra/LLM error → advisory-unavailable (non-blocking) in EVERY mode,
+ * - off mode → the reviewer agent is NOT invoked.
+ */
+
+// ── Mock agent (createFnAgent + promptWithFallback substitutes) ──────────
+
+interface MockAgentOpts {
+  response?: string;
+  throwOnCreate?: Error;
+  throwOnPrompt?: Error;
+  sessionError?: string;
+}
+
+function makeAgentDeps(opts: MockAgentOpts): { deps: LlmReviewAgentDeps; createSpy: ReturnType<typeof vi.fn>; promptSpy: ReturnType<typeof vi.fn> } {
+  let onTextCb: ((delta: string) => void) | undefined;
+  const session = {
+    state: opts.sessionError ? { errorMessage: opts.sessionError } : undefined,
+    dispose: vi.fn(),
+  };
+  const createSpy = vi.fn(async (agentOpts: { onText?: (d: string) => void }) => {
+    if (opts.throwOnCreate) throw opts.throwOnCreate;
+    onTextCb = agentOpts.onText;
+    return { session };
+  });
+  const promptSpy = vi.fn(async () => {
+    if (opts.throwOnPrompt) throw opts.throwOnPrompt;
+    if (opts.response && onTextCb) onTextCb(opts.response);
+  });
+  return {
+    deps: { createAgent: createSpy as unknown as LlmReviewAgentDeps["createAgent"], prompt: promptSpy as unknown as LlmReviewAgentDeps["prompt"] },
+    createSpy,
+    promptSpy,
+  };
+}
+
+function makeStore(): TaskStore {
+  return {
+    logEntry: vi.fn(async () => undefined),
+    appendAgentLog: vi.fn(async () => undefined),
+  } as unknown as TaskStore;
+}
+
+const PASS_RESPONSE = JSON.stringify({ passed: true, summary: "looks good", findings: [] });
+const HIGH_FAIL_RESPONSE = JSON.stringify({
+  passed: false,
+  summary: "introduces a regression",
+  findings: [{ severity: "high", file: "src/foo.ts", summary: "null deref" }],
+});
+const MEDIUM_FAIL_RESPONSE = JSON.stringify({
+  passed: false,
+  summary: "minor concern",
+  findings: [{ severity: "medium", file: "src/foo.ts", summary: "missing edge case" }],
+});
+
+// ── resolveLlmReviewMode ─────────────────────────────────────────────────
+
+describe("resolveLlmReviewMode", () => {
+  it("defaults to off when unset or unknown", () => {
+    expect(resolveLlmReviewMode(undefined)).toBe("off");
+    expect(resolveLlmReviewMode({} as Settings)).toBe("off");
+    expect(resolveLlmReviewMode({ verificationLlmReview: "bogus" } as unknown as Settings)).toBe("off");
+    expect(resolveLlmReviewMode({ verificationLlmReview: "off" } as Settings)).toBe("off");
+  });
+  it("returns the opt-in modes verbatim", () => {
+    expect(resolveLlmReviewMode({ verificationLlmReview: "advisory" } as Settings)).toBe("advisory");
+    expect(resolveLlmReviewMode({ verificationLlmReview: "blocking" } as Settings)).toBe("blocking");
+  });
+});
+
+// ── parseLlmReviewResponse ───────────────────────────────────────────────
+
+describe("parseLlmReviewResponse", () => {
+  it("parses a clean JSON verdict", () => {
+    const v = parseLlmReviewResponse(HIGH_FAIL_RESPONSE);
+    expect(v.passed).toBe(false);
+    expect(v.advisoryUnavailable).toBe(false);
+    expect(v.findings).toEqual([{ severity: "high", file: "src/foo.ts", summary: "null deref" }]);
+  });
+  it("strips markdown fences", () => {
+    const v = parseLlmReviewResponse("```json\n" + PASS_RESPONSE + "\n```");
+    expect(v.passed).toBe(true);
+  });
+  it("normalizes severity aliases and missing files", () => {
+    const v = parseLlmReviewResponse(JSON.stringify({ passed: false, findings: [{ severity: "critical", summary: "x" }] }));
+    expect(v.findings[0]).toEqual({ severity: "high", file: "(unknown)", summary: "x" });
+  });
+  it("throws on invalid JSON", () => {
+    expect(() => parseLlmReviewResponse("not json at all")).toThrow();
+  });
+  it("throws when 'passed' is missing", () => {
+    expect(() => parseLlmReviewResponse(JSON.stringify({ summary: "x", findings: [] }))).toThrow();
+  });
+});
+
+// ── evaluateLlmReviewGate ────────────────────────────────────────────────
+
+const verdict = (over: Partial<LlmReviewVerdict>): LlmReviewVerdict => ({
+  passed: true,
+  findings: [],
+  summary: "",
+  advisoryUnavailable: false,
+  ...over,
+});
+
+describe("evaluateLlmReviewGate", () => {
+  it("advisory mode never blocks, even on a high-severity failure", () => {
+    expect(evaluateLlmReviewGate("advisory", verdict({ passed: false, findings: [{ severity: "high", file: "a", summary: "b" }] })).blocks).toBe(false);
+  });
+  it("off mode never blocks", () => {
+    expect(evaluateLlmReviewGate("off", verdict({ passed: false, findings: [{ severity: "high", file: "a", summary: "b" }] })).blocks).toBe(false);
+  });
+  it("blocking mode blocks on passed:false + high severity", () => {
+    const res = evaluateLlmReviewGate("blocking", verdict({ passed: false, findings: [{ severity: "high", file: "a", summary: "b" }] }));
+    expect(res.blocks).toBe(true);
+    expect(res.reason).toContain("high-severity");
+  });
+  it("blocking mode does NOT block when passed:true", () => {
+    expect(evaluateLlmReviewGate("blocking", verdict({ passed: true, findings: [{ severity: "high", file: "a", summary: "b" }] })).blocks).toBe(false);
+  });
+  it("blocking mode does NOT block on medium-only findings", () => {
+    expect(evaluateLlmReviewGate("blocking", verdict({ passed: false, findings: [{ severity: "medium", file: "a", summary: "b" }] })).blocks).toBe(false);
+  });
+  it("advisory-unavailable never blocks, even in blocking mode", () => {
+    expect(evaluateLlmReviewGate("blocking", verdict({ passed: false, advisoryUnavailable: true, findings: [{ severity: "high", file: "a", summary: "b" }] })).blocks).toBe(false);
+  });
+});
+
+// ── runLlmReviewVerification (mocked agent) ──────────────────────────────
+
+describe("runLlmReviewVerification", () => {
+  it("returns the parsed verdict from the model", async () => {
+    const { deps } = makeAgentDeps({ response: HIGH_FAIL_RESPONSE });
+    const v = await runLlmReviewVerification({ rootDir: "/x", diff: "diff --git a b", deps });
+    expect(v.passed).toBe(false);
+    expect(v.advisoryUnavailable).toBe(false);
+    expect(v.findings[0].severity).toBe("high");
+  });
+
+  it("treats an empty diff as a clean pass without invoking the agent", async () => {
+    const { deps, createSpy } = makeAgentDeps({ response: PASS_RESPONSE });
+    const v = await runLlmReviewVerification({ rootDir: "/x", diff: "   ", deps });
+    expect(v.passed).toBe(true);
+    expect(v.advisoryUnavailable).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns advisory-unavailable (non-blocking) when agent creation fails", async () => {
+    const { deps } = makeAgentDeps({ throwOnCreate: new Error("provider down") });
+    const v = await runLlmReviewVerification({ rootDir: "/x", diff: "diff", deps });
+    expect(v.advisoryUnavailable).toBe(true);
+    expect(v.passed).toBe(true);
+  });
+
+  it("returns advisory-unavailable when the prompt call throws", async () => {
+    const { deps } = makeAgentDeps({ throwOnPrompt: new Error("rate limited") });
+    const v = await runLlmReviewVerification({ rootDir: "/x", diff: "diff", deps });
+    expect(v.advisoryUnavailable).toBe(true);
+  });
+
+  it("returns advisory-unavailable when the session reports an error state", async () => {
+    const { deps } = makeAgentDeps({ sessionError: "usage limit reached" });
+    const v = await runLlmReviewVerification({ rootDir: "/x", diff: "diff", deps });
+    expect(v.advisoryUnavailable).toBe(true);
+  });
+
+  it("returns advisory-unavailable on malformed (non-JSON) output", async () => {
+    const { deps } = makeAgentDeps({ response: "I think it's fine, ship it!" });
+    const v = await runLlmReviewVerification({ rootDir: "/x", diff: "diff", deps });
+    expect(v.advisoryUnavailable).toBe(true);
+  });
+});
+
+// ── runLlmReviewGate (mode wiring) ───────────────────────────────────────
+
+const fixedDiff = async () => "diff --git a/x b/x";
+
+describe("runLlmReviewGate", () => {
+  it("off mode: does NOT invoke the reviewer and never blocks", async () => {
+    const { deps, createSpy } = makeAgentDeps({ response: HIGH_FAIL_RESPONSE });
+    const gate = await runLlmReviewGate({
+      store: makeStore(),
+      rootDir: "/x",
+      taskId: "FN-1",
+      settings: { verificationLlmReview: "off" } as Settings,
+      deps,
+      captureDiff: fixedDiff,
+    });
+    expect(gate.ran).toBe(false);
+    expect(gate.verdict).toBeNull();
+    expect(gate.blocked).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("advisory mode: runs, never blocks on a high-severity failure", async () => {
+    const { deps } = makeAgentDeps({ response: HIGH_FAIL_RESPONSE });
+    const gate = await runLlmReviewGate({
+      store: makeStore(),
+      rootDir: "/x",
+      taskId: "FN-1",
+      settings: { verificationLlmReview: "advisory" } as Settings,
+      deps,
+      captureDiff: fixedDiff,
+    });
+    expect(gate.ran).toBe(true);
+    expect(gate.verdict?.passed).toBe(false);
+    expect(gate.blocked).toBe(false);
+  });
+
+  it("blocking mode: blocks on a passed:false + high-severity verdict", async () => {
+    const { deps } = makeAgentDeps({ response: HIGH_FAIL_RESPONSE });
+    const gate = await runLlmReviewGate({
+      store: makeStore(),
+      rootDir: "/x",
+      taskId: "FN-1",
+      settings: { verificationLlmReview: "blocking" } as Settings,
+      deps,
+      captureDiff: fixedDiff,
+    });
+    expect(gate.blocked).toBe(true);
+  });
+
+  it("blocking mode: does NOT block on medium-only findings", async () => {
+    const { deps } = makeAgentDeps({ response: MEDIUM_FAIL_RESPONSE });
+    const gate = await runLlmReviewGate({
+      store: makeStore(),
+      rootDir: "/x",
+      taskId: "FN-1",
+      settings: { verificationLlmReview: "blocking" } as Settings,
+      deps,
+      captureDiff: fixedDiff,
+    });
+    expect(gate.blocked).toBe(false);
+  });
+
+  it("blocking mode: an LLM/infra error degrades to advisory-unavailable (non-blocking)", async () => {
+    const { deps } = makeAgentDeps({ throwOnPrompt: new Error("outage") });
+    const gate = await runLlmReviewGate({
+      store: makeStore(),
+      rootDir: "/x",
+      taskId: "FN-1",
+      settings: { verificationLlmReview: "blocking" } as Settings,
+      deps,
+      captureDiff: fixedDiff,
+    });
+    expect(gate.verdict?.advisoryUnavailable).toBe(true);
+    expect(gate.blocked).toBe(false);
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -66,6 +66,7 @@ import {
   VERIFICATION_LOG_MAX_CHARS,
   type VerificationResult,
 } from "./verification-utils.js";
+import { resolveLlmReviewMode, runLlmReviewGate, type LlmReviewAgentDeps } from "./llm-review-verification.js";
 import { canonicalFusionBranchName, canonicalStepInstanceBranchName, generateWorktreeName, resolveTaskWorkingBranch } from "./worktree-names.js";
 import { resolveTaskWorktreePath, resolveWorktreesDir } from "./worktree-paths.js";
 import { Type, type Static } from "@earendil-works/pi-ai";
@@ -12125,10 +12126,19 @@ ${feedback}
   ): Promise<VerificationResult> {
     const testCommand = settings.testCommand?.trim();
     const buildCommand = settings.buildCommand?.trim();
+    const llmReviewMode = resolveLlmReviewMode(settings);
 
     if (!testCommand && !buildCommand) {
-      executorLog.log(`${task.id}: no test/build commands configured — skipping verification`);
-      return { allPassed: true };
+      // FNXC:Verification 2026-06-25-00:00: When LLM review is off (default) this
+      // is byte-identical to before. When opted in, the review still runs as the
+      // verification step even with no test/build commands.
+      if (llmReviewMode === "off") {
+        executorLog.log(`${task.id}: no test/build commands configured — skipping verification`);
+        return { allPassed: true };
+      }
+      const result: VerificationResult = { allPassed: true };
+      await this.runExecutorLlmReviewGate(task, worktreePath, settings, result);
+      return result;
     }
 
     const parts: string[] = [];
@@ -12174,6 +12184,16 @@ ${feedback}
       }
     }
 
+    // FNXC:Verification 2026-06-25-00:00: OPT-IN LLM diff review runs AFTER the
+    // test/build commands. In blocking mode a high-severity failing verdict marks
+    // result.allPassed=false (like a failed command); advisory/unavailable never fail.
+    if (llmReviewMode !== "off") {
+      await this.runExecutorLlmReviewGate(task, worktreePath, settings, result);
+      if (!result.allPassed) {
+        return result;
+      }
+    }
+
     executorLog.log(`${task.id}: [verification] passed`);
     await this.store.logEntry(
       task.id,
@@ -12182,6 +12202,46 @@ ${feedback}
       this.getRunContextFor(task.id),
     );
     return result;
+  }
+
+  /**
+   * FNXC:Verification 2026-06-25-00:00:
+   * Run the OPT-IN LLM diff-review gate in the executor verification path and
+   * mirror the verdict onto `result.llmReview`. In blocking mode a high-severity
+   * failing verdict sets `result.allPassed=false` / `failedCommand="llmReview"`
+   * (this gate returns its result rather than throwing); advisory mode and any
+   * advisory-unavailable (LLM/infra error) verdict are recorded but never fail.
+   * The review diff is `git diff <task.baseCommitSha>..HEAD` in the worktree.
+   */
+  private async runExecutorLlmReviewGate(
+    task: Task,
+    worktreePath: string,
+    settings: Settings,
+    result: VerificationResult,
+    deps?: LlmReviewAgentDeps,
+  ): Promise<void> {
+    const gate = await runLlmReviewGate({
+      store: this.store,
+      rootDir: worktreePath,
+      taskId: task.id,
+      settings,
+      baseRef: task.baseCommitSha,
+      taskTitle: task.title,
+      agentLabel: "executor",
+      deps,
+    });
+    if (gate.verdict) {
+      result.llmReview = {
+        passed: gate.verdict.passed,
+        advisoryUnavailable: gate.verdict.advisoryUnavailable,
+        findings: gate.verdict.findings,
+        summary: gate.verdict.summary,
+      };
+    }
+    if (gate.blocked) {
+      result.allPassed = false;
+      result.failedCommand = "llmReview";
+    }
   }
 
   /**

--- a/packages/engine/src/llm-review-verification.ts
+++ b/packages/engine/src/llm-review-verification.ts
@@ -1,0 +1,399 @@
+/**
+ * LLM diff-review verification — an OPT-IN, default-off verification step that
+ * has an AI review a task's diff for correctness/regressions, in addition to (or
+ * instead of) running test/build commands.
+ *
+ * FNXC:Verification 2026-06-25-00:00:
+ * This sits on the merge-critical verification gate (merger.runDeterministicVerification
+ * and executor.runExecutorDeterministicVerification), so the contract is strict:
+ * - Controlled by the project setting `verificationLlmReview` (default "off").
+ *   - "off": never invoked. The gate path is byte-identical to pre-feature behavior.
+ *   - "advisory": runs, logs findings to the task, but NEVER fails verification.
+ *   - "blocking": a verdict of passed:false WITH a high-severity finding fails
+ *     verification, exactly like a failed test/build command.
+ * - Defensive by construction: ANY LLM/infra error (spawn failure, malformed
+ *   output, timeout, abort) yields an "advisory unavailable" verdict that NEVER
+ *   blocks a merge. We do not hard-block merges on an LLM outage.
+ * - Reuses the existing reviewer/agent plumbing (createFnAgent + promptWithFallback
+ *   from ./pi.js); no new direct AI SDK dependency.
+ */
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+import type { Settings, TaskStore } from "@fusion/core";
+import { createFnAgent, promptWithFallback } from "./pi.js";
+import { createLogger } from "./logger.js";
+
+const execFile = promisify(execFileCb);
+const llmReviewLog = createLogger("llm-review");
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type LlmReviewMode = "off" | "advisory" | "blocking";
+export type LlmReviewSeverity = "high" | "medium" | "low";
+
+export interface LlmReviewFinding {
+  severity: LlmReviewSeverity;
+  /** File the finding applies to (best-effort; "(unknown)" when the model omits it). */
+  file: string;
+  summary: string;
+}
+
+export interface LlmReviewVerdict {
+  /** The model's overall pass/fail judgement of the diff. */
+  passed: boolean;
+  findings: LlmReviewFinding[];
+  summary: string;
+  /**
+   * True when the review could not be obtained at all (LLM/infra error, malformed
+   * output). An advisory-unavailable verdict is non-blocking in EVERY mode — an
+   * LLM outage must never hard-block a merge.
+   */
+  advisoryUnavailable: boolean;
+}
+
+export interface LlmReviewGateResult {
+  mode: LlmReviewMode;
+  /** True when the review actually ran (mode !== "off"). */
+  ran: boolean;
+  verdict: LlmReviewVerdict | null;
+  /**
+   * True only when the gate should FAIL verification: mode "blocking", a real
+   * (not advisory-unavailable) verdict, passed === false, and at least one
+   * high-severity finding.
+   */
+  blocked: boolean;
+}
+
+/** Injectable seam so tests can mock the agent without touching ./pi.js internals. */
+export interface LlmReviewAgentDeps {
+  createAgent: typeof createFnAgent;
+  prompt: typeof promptWithFallback;
+}
+
+const DEFAULT_AGENT_DEPS: LlmReviewAgentDeps = {
+  createAgent: createFnAgent,
+  prompt: promptWithFallback,
+};
+
+// ── Mode resolution ────────────────────────────────────────────────────
+
+/**
+ * Resolve the effective LLM-review mode from project settings. Anything other
+ * than the two opt-in values resolves to "off" so the feature stays default-off
+ * and a stray/legacy value can never silently start blocking merges.
+ */
+export function resolveLlmReviewMode(settings: Pick<Settings, "verificationLlmReview"> | undefined | null): LlmReviewMode {
+  const raw = settings?.verificationLlmReview;
+  return raw === "advisory" || raw === "blocking" ? raw : "off";
+}
+
+// ── Prompt ─────────────────────────────────────────────────────────────
+
+const LLM_REVIEW_SYSTEM_PROMPT = `You are a meticulous senior engineer performing a final pre-merge review of a code diff.
+
+Your job: judge whether the diff is correct and free of regressions before it merges.
+You are NOT rewriting the code. You are returning a structured verdict.
+
+Return STRICT JSON with this EXACT shape and nothing else:
+{
+  "passed": true | false,
+  "summary": "1-3 sentence overall judgement",
+  "findings": [
+    { "severity": "high" | "medium" | "low", "file": "path/to/file", "summary": "concise problem statement" }
+  ]
+}
+
+Rules:
+- Output valid JSON only. No markdown fences, no prose outside the JSON object.
+- "passed": false ONLY when you found a concrete correctness/regression problem in the diff.
+- Use severity "high" for bugs, regressions, broken contracts, or data-loss risks;
+  "medium" for likely-incorrect behavior or missing edge cases; "low" for style/nits.
+- A merge will be BLOCKED only when passed is false AND at least one finding is "high".
+  Do not invent high-severity findings; reserve "high" for real, defensible problems.
+- If the diff is correct, return passed: true with an empty findings array.
+- Be specific: cite the file path for every finding.`;
+
+function buildReviewPrompt(diff: string, context?: { taskId?: string; taskTitle?: string }): string {
+  const header: string[] = ["Review the following diff for correctness and regressions."];
+  if (context?.taskId) header.push(`Task: ${context.taskId}${context.taskTitle ? ` — ${context.taskTitle}` : ""}`);
+  header.push("Respond with strict JSON matching the required schema.");
+  return [header.join("\n"), "```diff", diff, "```"].join("\n\n");
+}
+
+// ── Parsing (defensive) ────────────────────────────────────────────────
+
+function extractJsonCandidate(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (trimmed.startsWith("```") && trimmed.endsWith("```")) {
+    return trimmed.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+  }
+  const firstBrace = trimmed.indexOf("{");
+  const lastBrace = trimmed.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    return trimmed.slice(firstBrace, lastBrace + 1);
+  }
+  return trimmed;
+}
+
+function normalizeSeverity(value: unknown): LlmReviewSeverity {
+  const s = String(value ?? "").toLowerCase();
+  if (s === "high" || s === "critical" || s === "blocker") return "high";
+  if (s === "medium" || s === "moderate" || s === "warning") return "medium";
+  return "low";
+}
+
+function normalizeFindings(value: unknown): LlmReviewFinding[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry): LlmReviewFinding | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const record = entry as Record<string, unknown>;
+      const summary = typeof record.summary === "string" ? record.summary.trim() : "";
+      if (!summary) return null;
+      const file = typeof record.file === "string" && record.file.trim() ? record.file.trim() : "(unknown)";
+      return { severity: normalizeSeverity(record.severity), file, summary: summary.slice(0, 500) };
+    })
+    .filter((finding): finding is LlmReviewFinding => finding !== null);
+}
+
+/**
+ * Parse the model's raw text into a structured verdict. Throws on unrecoverable
+ * malformed output so the caller routes it into the advisory-unavailable path.
+ */
+export function parseLlmReviewResponse(raw: string): LlmReviewVerdict {
+  const candidate = extractJsonCandidate(raw);
+  if (!candidate) {
+    throw new Error("empty LLM review response");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    throw new Error("LLM review response was not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("LLM review response was not a JSON object");
+  }
+  const record = parsed as Record<string, unknown>;
+  if (typeof record.passed !== "boolean") {
+    throw new Error("LLM review response missing boolean 'passed'");
+  }
+  const findings = normalizeFindings(record.findings);
+  const summary = typeof record.summary === "string" && record.summary.trim()
+    ? record.summary.trim().slice(0, 1000)
+    : (record.passed ? "Diff reviewed: no concerns." : "Diff reviewed: concerns found.");
+  return { passed: record.passed, findings, summary, advisoryUnavailable: false };
+}
+
+// ── Gate decision ──────────────────────────────────────────────────────
+
+/**
+ * Decide whether a verdict should FAIL verification under a given mode. This is
+ * the single source of truth for the blocking semantics and is exhaustively
+ * unit-tested.
+ */
+export function evaluateLlmReviewGate(mode: LlmReviewMode, verdict: LlmReviewVerdict): { blocks: boolean; reason?: string } {
+  // Advisory-unavailable never blocks, regardless of mode — an LLM outage must
+  // not hard-block a merge.
+  if (verdict.advisoryUnavailable) return { blocks: false };
+  if (mode !== "blocking") return { blocks: false };
+  const highSeverity = verdict.findings.filter((f) => f.severity === "high");
+  if (!verdict.passed && highSeverity.length > 0) {
+    return {
+      blocks: true,
+      reason: `LLM diff review failed with ${highSeverity.length} high-severity finding(s): ${highSeverity.map((f) => `${f.file}: ${f.summary}`).join("; ").slice(0, 600)}`,
+    };
+  }
+  return { blocks: false };
+}
+
+// ── Diff capture ───────────────────────────────────────────────────────
+
+/**
+ * Capture the task's diff for review. Reuses git directly (`git diff <base>..HEAD`
+ * when a base ref is known, else the last commit) so it works in both the merger
+ * worktree and the executor task worktree. Never throws — returns "" on any git
+ * failure so review degrades to advisory-unavailable rather than crashing the gate.
+ */
+export async function captureReviewDiff(
+  rootDir: string,
+  baseRef: string | undefined,
+  signal?: AbortSignal,
+): Promise<string> {
+  const range = baseRef && baseRef.trim() ? `${baseRef.trim()}..HEAD` : "HEAD~1..HEAD";
+  try {
+    const { stdout } = await execFile("git", ["diff", range], {
+      cwd: rootDir,
+      maxBuffer: 20 * 1024 * 1024,
+      signal,
+    });
+    return stdout ?? "";
+  } catch (error) {
+    llmReviewLog.warn(`could not capture review diff (${range}) in ${rootDir}: ${String(error)}`);
+    return "";
+  }
+}
+
+// ── Core review ────────────────────────────────────────────────────────
+
+export interface RunLlmReviewOptions {
+  rootDir: string;
+  diff: string;
+  taskId?: string;
+  taskTitle?: string;
+  /** Model lane for the review agent. When undefined, createFnAgent resolves defaults. */
+  modelProvider?: string;
+  modelId?: string;
+  signal?: AbortSignal;
+  /** Test seam: inject mock createFnAgent/promptWithFallback. */
+  deps?: LlmReviewAgentDeps;
+}
+
+/**
+ * Run the LLM diff review and return a structured verdict. NEVER throws: any
+ * LLM/infra failure is caught and returned as an advisory-unavailable verdict.
+ */
+export async function runLlmReviewVerification(options: RunLlmReviewOptions): Promise<LlmReviewVerdict> {
+  const deps = options.deps ?? DEFAULT_AGENT_DEPS;
+
+  // Empty diff → nothing to review. This is a clean pass, not an outage.
+  if (!options.diff || !options.diff.trim()) {
+    return { passed: true, findings: [], summary: "No diff to review.", advisoryUnavailable: false };
+  }
+
+  try {
+    let responseText = "";
+    const { session } = await deps.createAgent({
+      cwd: options.rootDir,
+      systemPrompt: LLM_REVIEW_SYSTEM_PROMPT,
+      tools: "readonly",
+      defaultProvider: options.modelProvider,
+      defaultModelId: options.modelId,
+      onText: (delta: string) => {
+        responseText += delta;
+      },
+    });
+
+    try {
+      await deps.prompt(session, buildReviewPrompt(options.diff, { taskId: options.taskId, taskTitle: options.taskTitle }));
+      const sessionError = session.state as { errorMessage?: string; error?: string } | undefined;
+      const stateErr = sessionError?.errorMessage ?? sessionError?.error;
+      if (stateErr) {
+        throw new Error(stateErr);
+      }
+    } finally {
+      try {
+        session.dispose();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
+    return parseLlmReviewResponse(responseText);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    llmReviewLog.warn(`LLM review advisory unavailable for ${options.taskId ?? "task"}: ${message}`);
+    return {
+      passed: true,
+      findings: [],
+      summary: `LLM review advisory unavailable: ${message}`,
+      advisoryUnavailable: true,
+    };
+  }
+}
+
+// ── Gate orchestration (used by merger/executor verification gates) ──────
+
+export interface RunLlmReviewGateOptions {
+  store: TaskStore;
+  rootDir: string;
+  taskId: string;
+  settings: Settings;
+  /** Base ref for the diff range (e.g. the integration base or task.baseCommitSha). */
+  baseRef?: string;
+  taskTitle?: string;
+  signal?: AbortSignal;
+  /** Log label for store agent-log entries (e.g. "merger", "executor"). */
+  agentLabel?: string;
+  /** Test seam: inject mock agent deps. */
+  deps?: LlmReviewAgentDeps;
+  /** Test seam: override diff capture. */
+  captureDiff?: (rootDir: string, baseRef: string | undefined, signal?: AbortSignal) => Promise<string>;
+}
+
+/**
+ * Run the LLM-review verification step as part of a verification gate. Resolves
+ * the mode from settings, runs the review when not "off", logs findings to the
+ * task, and reports whether the gate should block. Returns `{ ran:false }` for
+ * "off" so callers can treat the off-path as a no-op.
+ *
+ * This function NEVER throws on review failure — it returns `blocked` and lets
+ * the caller decide how to surface a block (e.g. throw VerificationError).
+ */
+export async function runLlmReviewGate(options: RunLlmReviewGateOptions): Promise<LlmReviewGateResult> {
+  const mode = resolveLlmReviewMode(options.settings);
+  if (mode === "off") {
+    return { mode, ran: false, verdict: null, blocked: false };
+  }
+
+  const label = options.agentLabel ?? "merger";
+  await options.store.logEntry(options.taskId, `[verification] Running LLM diff review (${mode})`).catch(() => undefined);
+
+  const capture = options.captureDiff ?? captureReviewDiff;
+  const diff = await capture(options.rootDir, options.baseRef, options.signal);
+
+  // Resolve the review model lane from the validator/reviewer lane when configured.
+  // Falls back to createFnAgent's resolved defaults when the lane is unset.
+  const hasValidatorLane = Boolean(options.settings.validatorProvider && options.settings.validatorModelId);
+  const modelProvider = hasValidatorLane ? options.settings.validatorProvider : undefined;
+  const modelId = hasValidatorLane ? options.settings.validatorModelId : undefined;
+
+  const verdict = await runLlmReviewVerification({
+    rootDir: options.rootDir,
+    diff,
+    taskId: options.taskId,
+    taskTitle: options.taskTitle,
+    modelProvider,
+    modelId,
+    signal: options.signal,
+    deps: options.deps,
+  });
+
+  await logVerdict(options.store, options.taskId, mode, verdict, label);
+
+  const { blocks, reason } = evaluateLlmReviewGate(mode, verdict);
+  if (blocks && reason) {
+    await options.store.logEntry(options.taskId, `[verification] LLM diff review BLOCKED merge: ${reason}`, "VerificationError").catch(() => undefined);
+    await options.store.appendAgentLog(options.taskId, "LLM diff review failed", "tool_error", reason, label as never).catch(() => undefined);
+  }
+
+  return { mode, ran: true, verdict, blocked: blocks };
+}
+
+async function logVerdict(
+  store: TaskStore,
+  taskId: string,
+  mode: LlmReviewMode,
+  verdict: LlmReviewVerdict,
+  label: string,
+): Promise<void> {
+  if (verdict.advisoryUnavailable) {
+    await store.logEntry(taskId, `[verification] LLM diff review unavailable (non-blocking): ${verdict.summary}`).catch(() => undefined);
+    await store.appendAgentLog(taskId, "LLM diff review unavailable", "text", verdict.summary, label as never).catch(() => undefined);
+    return;
+  }
+
+  const findingLines = verdict.findings.length > 0
+    ? verdict.findings.map((f) => `  • [${f.severity}] ${f.file}: ${f.summary}`).join("\n")
+    : "  • (no findings)";
+  const body = `[verification] LLM diff review (${mode}) — ${verdict.passed ? "passed" : "concerns found"}: ${verdict.summary}\n${findingLines}`;
+  await store.logEntry(taskId, body).catch(() => undefined);
+  await store.appendAgentLog(
+    taskId,
+    `LLM diff review ${verdict.passed ? "passed" : "found concerns"}`,
+    verdict.passed ? "text" : "tool_result",
+    findingLines,
+    label as never,
+  ).catch(() => undefined);
+}

--- a/packages/engine/src/merger.ts
+++ b/packages/engine/src/merger.ts
@@ -38,6 +38,7 @@ import {
 } from "./verification-utils.js";
 import { resolveSandboxBackend } from "./sandbox/index.js";
 import type { SandboxBackend } from "./sandbox/types.js";
+import { resolveLlmReviewMode, runLlmReviewGate, type LlmReviewAgentDeps } from "./llm-review-verification.js";
 
 // Re-export for backward compatibility (tests import from merger.ts)
 export {
@@ -1601,14 +1602,31 @@ async function runDeterministicVerification(
   testSource?: "explicit" | "inferred" | "inferred-scoped",
   buildSource?: "explicit" | "inferred",
   signal?: AbortSignal,
+  /**
+   * FNXC:Verification 2026-06-25-00:00:
+   * OPT-IN LLM diff-review context. `baseRef` is the integration base used to
+   * compute the task diff for the review; `deps` is a test seam for the agent.
+   * Only consumed when `settings.verificationLlmReview !== "off"`, so omitting it
+   * (every default-off caller) is byte-identical to pre-feature behavior.
+   */
+  llmReviewContext?: { baseRef?: string; deps?: LlmReviewAgentDeps },
 ): Promise<VerificationResult> {
   const result: VerificationResult = { allPassed: true };
   const settings = await store.getSettings();
   const verificationCommandTimeoutMs = settings.verificationCommandTimeoutMs;
+  const llmReviewMode = resolveLlmReviewMode(settings);
 
   // Nothing to verify
   if (!testCommand && !buildCommand) {
-    mergerLog.log(`${taskId}: no verification commands configured — skipping`);
+    // FNXC:Verification 2026-06-25-00:00: When LLM review is off (default) the
+    // no-command path is byte-identical to before. When opted in, the review
+    // still runs as the verification step even with no test/build commands.
+    if (llmReviewMode === "off") {
+      mergerLog.log(`${taskId}: no verification commands configured — skipping`);
+      return result;
+    }
+    mergerLog.log(`${taskId}: no verification commands configured — running LLM diff review only (${llmReviewMode})`);
+    await runMergerLlmReviewGate(store, rootDir, taskId, settings, result, llmReviewContext, signal);
     return result;
   }
 
@@ -1853,6 +1871,13 @@ async function runDeterministicVerification(
     }
   }
 
+  // FNXC:Verification 2026-06-25-00:00: OPT-IN LLM diff review runs AFTER the
+  // test/build commands. In blocking mode a high-severity failing verdict throws
+  // VerificationError (like a failed command); advisory/unavailable never throw.
+  if (llmReviewMode !== "off") {
+    await runMergerLlmReviewGate(store, rootDir, taskId, settings, result, llmReviewContext, signal);
+  }
+
   mergerLog.log(`${taskId}: deterministic verification passed`);
   await store.logEntry(taskId, "Deterministic merge verification passed");
   await store.appendAgentLog(taskId, "Deterministic merge verification passed", "text", undefined, "merger");
@@ -1869,6 +1894,51 @@ async function runDeterministicVerification(
   }
 
   return result;
+}
+
+/**
+ * FNXC:Verification 2026-06-25-00:00:
+ * Run the OPT-IN LLM diff-review gate inside the merger verification path and
+ * mirror the verdict onto `result.llmReview`. In blocking mode, a high-severity
+ * failing verdict throws VerificationError so the merge aborts like a failed
+ * command; advisory mode and any advisory-unavailable (LLM/infra error) verdict
+ * are recorded but never throw.
+ */
+async function runMergerLlmReviewGate(
+  store: TaskStore,
+  rootDir: string,
+  taskId: string,
+  settings: Settings,
+  result: VerificationResult,
+  llmReviewContext: { baseRef?: string; deps?: LlmReviewAgentDeps } | undefined,
+  signal?: AbortSignal,
+): Promise<void> {
+  const gate = await runLlmReviewGate({
+    store,
+    rootDir,
+    taskId,
+    settings,
+    baseRef: llmReviewContext?.baseRef,
+    signal,
+    agentLabel: "merger",
+    deps: llmReviewContext?.deps,
+  });
+  if (gate.verdict) {
+    result.llmReview = {
+      passed: gate.verdict.passed,
+      advisoryUnavailable: gate.verdict.advisoryUnavailable,
+      findings: gate.verdict.findings,
+      summary: gate.verdict.summary,
+    };
+  }
+  if (gate.blocked) {
+    result.allPassed = false;
+    result.failedCommand = "llmReview";
+    throw new VerificationError(
+      `LLM diff review verification failed for ${taskId}`,
+      result,
+    );
+  }
 }
 
 async function runVerificationCommand(
@@ -5984,7 +6054,16 @@ async function applyBranchCommitsPreservingHistory(params: {
     }
   }
 
-  if (testCommand || buildCommand) {
+  // FNXC:Verification 2026-06-25-00:00: Run the verification gate when test/build
+  // commands exist OR when the OPT-IN LLM diff review is enabled (so the review
+  // runs even with no commands). When neither holds (default), this is a no-op
+  // and the merge path is byte-identical to before. `baseRef` (the integration
+  // base) is forwarded so the review diff is `git diff <baseRef>..HEAD`.
+  let shouldVerify = Boolean(testCommand || buildCommand);
+  if (!shouldVerify) {
+    shouldVerify = resolveLlmReviewMode(await store.getSettings()) !== "off";
+  }
+  if (shouldVerify) {
     throwIfAborted(signal, taskId);
     await runDeterministicVerification(
       store,
@@ -5995,6 +6074,7 @@ async function applyBranchCommitsPreservingHistory(params: {
       testSource,
       buildSource,
       signal,
+      { baseRef },
     );
   }
 

--- a/packages/engine/src/verification-utils.ts
+++ b/packages/engine/src/verification-utils.ts
@@ -95,6 +95,19 @@ export interface VerificationResult {
     packageName: string;
     recovered: boolean;
   };
+  /**
+   * FNXC:Verification 2026-06-25-00:00:
+   * Structured verdict from the OPT-IN LLM diff-review step, when it ran (setting
+   * `verificationLlmReview` !== "off"). Present in advisory and blocking modes;
+   * `failedCommand === "llmReview"` marks a blocking-mode failure. Absent when the
+   * feature is off, keeping the default-off path byte-identical.
+   */
+  llmReview?: {
+    passed: boolean;
+    advisoryUnavailable: boolean;
+    findings: Array<{ severity: "high" | "medium" | "low"; file: string; summary: string }>;
+    summary: string;
+  };
 }
 
 // ── Process group exec ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds an **opt-in, default-off** LLM diff-review verification step. When enabled, an AI reviews a task's diff for correctness/regressions as an **additional** verification step that runs **after** the (possibly empty) test/build commands, in both the merger and executor verification gates.

## Setting & modes

New project setting `verificationLlmReview` (default `"off"`):

- **off** (default): reviewer is never invoked. The verification gate path is byte-identical to pre-feature behavior.
- **advisory**: runs the review and logs findings to the task, but **never** fails verification.
- **blocking**: a verdict of `passed:false` **with at least one high-severity finding** fails verification, exactly like a failed test/build command.

Any LLM/infra failure (spawn error, malformed output, session error) degrades to a non-blocking **advisory-unavailable** result in **every** mode — an LLM outage never hard-blocks a merge.

## Where it's wired

- `packages/engine/src/llm-review-verification.ts` (new) — verdict logic, structured-JSON parsing, gate-decision (`evaluateLlmReviewGate`), diff capture, and the `runLlmReviewGate` orchestrator. Reuses `createFnAgent` + `promptWithFallback` from `./pi.js` (no new AI SDK dependency).
- `merger.ts` `runDeterministicVerification` — runs the review after test/build; blocking throws `VerificationError`. Runs even with no commands when enabled. The integration `baseRef` is forwarded so the diff is `git diff <baseRef>..HEAD`.
- `executor.ts` `runExecutorDeterministicVerification` — same, using `task.baseCommitSha` as the diff base; blocking sets `result.allPassed=false`.
- `packages/core` — `verificationLlmReview` added to `ProjectSettings` with default `"off"` in `settings-schema.ts`.

## Default-off safety

When the setting is `off`/undefined, `resolveLlmReviewMode` returns `"off"` and both gates short-circuit before any new work, preserving the exact prior control flow and logging. A unit test asserts the reviewer agent is **not** invoked in off mode.

## Tests

`packages/engine/src/__tests__/llm-review-verification.test.ts` (mocked agent, no real AI call): advisory never fails; blocking fails only on high-severity `passed:false`; infra error → advisory-unavailable (non-blocking) in all modes; off → reviewer not invoked; plus parser and gate-decision coverage.

Verification gate (all green):
- `vitest run llm-review-verification.test.ts merger-verification.test.ts verification-utils.test.ts` → 127 passed
- `tsc --noEmit` clean for `@fusion/core` and `@fusion/engine`
- `eslint` on changed files → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->