### PR TITLE
fix(FN-7039): show enabled workflow steps in the detail progress bar

### DIFF
--- a/packages/dashboard/app/components/TaskDetailModal.tsx
+++ b/packages/dashboard/app/components/TaskDetailModal.tsx
@@ -58,6 +58,7 @@ import { resolveEffectiveGithubRepoDefault } from "./githubTracking";
 import type { TFunction } from "i18next";
 import { linkifyFilePaths, linkifyReactChildren } from "../utils/filePathLinkify";
 import { getInReviewStallCopy, shouldShowInReviewStallBadge } from "../utils/inReviewStallCopy";
+import { getUnifiedTaskProgress } from "../utils/taskProgress";
 import { getStalePausedReviewCopy, shouldShowStalePausedReviewBadge } from "../utils/stalePausedReviewCopy";
 import { getTaskAgeStalenessCopy } from "../utils/taskAgeStalenessCopy";
 import { findInReviewStallLogEntry, IN_REVIEW_STALL_LOG_REGEX } from "../utils/findInReviewStallLogEntry";
@@ -117,11 +118,25 @@ function toTaskChatModelInfo(model: ModelSelection): { provider: string; modelId
   return model.modelId ? { provider: model.provider, modelId: model.modelId } : { provider: model.provider };
 }
 
+/*
+FNXC:WorkflowStepResults 2026-06-26-18:00:
+The detail Progress bar renders the UNIFIED step model (implementation steps + enabled
+workflow steps), so its segment colors must cover the workflow-step statuses too:
+`passed`→done/success, `failed`→error (blocking gate), `advisory_failure`→warning (amber,
+non-blocking), `running`→in-progress, plus the implementation statuses. Colors mirror the
+TaskCard step dots so the two surfaces read identically.
+*/
 function getStepStatusColor(status: string): string {
   switch (status) {
     case "done":
+    case "passed":
       return "var(--color-success)";
+    case "failed":
+      return "var(--color-error-dark)";
+    case "advisory_failure":
+      return "var(--ws-warning)";
     case "in-progress":
+    case "running":
       return "var(--in-progress)";
     case "skipped":
       return "var(--text-dim)";
@@ -553,6 +568,18 @@ export function TaskDetailContent({
         : task.overlapBlockedBy === undefined ? fullDetail.overlapBlockedBy : task.overlapBlockedBy,
     } as TaskDetail)
     : ({ ...task, prompt: "" } as TaskDetail);
+  /*
+  FNXC:WorkflowStepResults 2026-06-26-18:00:
+  The detail Progress bar must show a segment for each ENABLED workflow step, not only
+  implementation steps. Drive it from the same unified model the cards use
+  (getUnifiedTaskProgress: task.steps + enabledWorkflowSteps, statuses from
+  task.workflowStepResults) so an enabled optional step (e.g. "Code Review") gets its own
+  segment even before it runs (pending).
+  */
+  const unifiedProgress = useMemo(
+    () => getUnifiedTaskProgress(workingTask),
+    [workingTask.steps, workingTask.enabledWorkflowSteps, workingTask.workflowStepResults],
+  );
   const canRetryTask =
     task.status === "failed" ||
     task.status === "stuck-killed" ||
@@ -3637,20 +3664,20 @@ export function TaskDetailContent({
           </div>
           <div className="detail-section detail-step-progress">
             <h4>{t("taskDetail.progress.heading", "Progress")}</h4>
-            {workingTask.steps && workingTask.steps.length > 0 ? (
+            {unifiedProgress.total > 0 ? (
               <div className="step-progress-wrapper">
                 <div className="step-progress-bar">
-                  {workingTask.steps.map((step, index) => (
+                  {unifiedProgress.items.map((item) => (
                     <div
-                      key={index}
-                      className={`step-progress-segment step-progress-segment--${step.status}`}
-                      data-tooltip={`${step.name} (${step.status})`}
-                      style={{ backgroundColor: getStepStatusColor(step.status) }}
+                      key={item.id}
+                      className={`step-progress-segment step-progress-segment--${item.status} step-progress-segment--source-${item.source}`}
+                      data-tooltip={`${item.name} (${item.source === "workflow" ? "workflow step · " : ""}${item.status})`}
+                      style={{ backgroundColor: getStepStatusColor(item.status) }}
                     />
                   ))}
                 </div>
                 <span className="step-progress-label">
-                  {t("taskDetail.progress.stepCount", { count: workingTask.steps.filter(s => s.status === "done").length, total: workingTask.steps.length, defaultValue_one: "{{count}}/{{total}} step", defaultValue_other: "{{count}}/{{total}} steps" })}
+                  {t("taskDetail.progress.stepCount", { count: unifiedProgress.completed, total: unifiedProgress.total, defaultValue_one: "{{count}}/{{total}} step", defaultValue_other: "{{count}}/{{total}} steps" })}
                 </span>
               </div>
             ) : (

--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.models-progress-workflow.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.models-progress-workflow.test.tsx
@@ -693,6 +693,40 @@ describe("TaskDetailModal", () => {
       expect(segments[3].classList.contains("step-progress-segment--skipped")).toBe(true);
     });
 
+    it("renders a segment for each ENABLED workflow step, not only implementation steps", () => {
+      // Regression: the detail Progress bar must include enabled optional workflow steps.
+      const { container } = render(
+        <TaskDetailModal
+          initialTab="definition"
+          task={makeTask({
+            steps: [
+              { name: "Step 1", status: "done" },
+              { name: "Step 2", status: "pending" },
+            ],
+            enabledWorkflowSteps: ["code-review", "browser-verification"],
+            workflowStepResults: [
+              { workflowStepId: "code-review", workflowStepName: "Code Review", status: "passed" },
+            ],
+          })}
+          onClose={noop}
+          onMoveTask={noopMove}
+          onDeleteTask={noopDelete}
+          onMergeTask={noopMerge}
+          onOpenDetail={noopOpenDetail}
+          addToast={noop}
+        />,
+      );
+
+      const segments = container.querySelectorAll(".step-progress-segment");
+      // 2 impl steps + 2 enabled workflow steps = 4 segments.
+      expect(segments).toHaveLength(4);
+      const workflowSegments = container.querySelectorAll(".step-progress-segment--source-workflow");
+      expect(workflowSegments).toHaveLength(2);
+      // code-review ran (passed → unified "done"); browser-verification enabled-not-run (pending).
+      expect(segments[2].classList.contains("step-progress-segment--done")).toBe(true);
+      expect(segments[3].classList.contains("step-progress-segment--pending")).toBe(true);
+    });
+
     it("segments have correct inline background colors based on status", () => {
       const { container } = render(
         <TaskDetailModal


### PR DESCRIPTION
## Show enabled workflow steps in the detail progress bar (FN-7039 follow-up)

Follow-up to the now-merged graph-native workflow-steps refactor (#1788).

**Problem:** the Task detail modal's Progress bar mapped only `workingTask.steps` (implementation steps), so an **enabled optional workflow step** (e.g. "Code Review") got **no segment** — even though the cards/list already include them.

**Fix:** drive the detail bar from `getUnifiedTaskProgress` (the same unified model the cards use), so each enabled workflow step renders its own segment — including the enabled-but-not-yet-run (pending) state. `getStepStatusColor` is extended to the workflow statuses (`passed`→success, `failed`→error, `advisory_failure`→amber, `running`→in-progress), and segments get a `--source-workflow` modifier. Adds a regression test asserting enabled steps render segments.

**Verification:** dashboard typecheck clean; `TaskDetailModal.models-progress-workflow` (45) + `taskProgress` (9) tests green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/Runfusion/Fusion/pull/1790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task progress now shows a unified step view, combining implementation and workflow steps in the progress bar.
  * The step count label now reflects total completed steps out of all visible steps.

* **Bug Fixes**
  * Progress segments now support additional workflow states, including passed, advisory failure, and running.
  * Added regression coverage to ensure workflow-derived progress segments render with the correct status styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->