### PR TITLE
fix(core): await secrets store close during TaskStore shutdown

### DIFF
--- a/.changeset/thin-rocks-post.md
+++ b/.changeset/thin-rocks-post.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Wait for task store secret database handles to close before cleanup.
+category: fix
+dev: Awaits the async secrets store close path during TaskStore shutdown to avoid teardown races.

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -16135,8 +16135,17 @@ ${stepsSection}`;
       this._archiveDb = null;
     }
     if (this.secretsCentralCore) {
-      void this.secretsCentralCore.close();
+      // Await the secrets central core close: CentralCore.close() is async, so a
+      // fire-and-forget call would let close() resolve while the secrets SQLite
+      // handle is still draining on a later microtask, racing temp-root cleanup
+      // under the loaded package test lane. Await it like the other handles above.
+      const secretsCentralCore = this.secretsCentralCore;
       this.secretsCentralCore = null;
+      try {
+        await secretsCentralCore.close();
+      } catch (err) {
+        console.warn(`[fusion] Could not close secrets central core on TaskStore close:`, err);
+      }
     }
     this.secretsStore = null;
     if (this.pluginStore) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -16135,10 +16135,11 @@ ${stepsSection}`;
       this._archiveDb = null;
     }
     if (this.secretsCentralCore) {
-      // Await the secrets central core close: CentralCore.close() is async, so a
-      // fire-and-forget call would let close() resolve while the secrets SQLite
-      // handle is still draining on a later microtask, racing temp-root cleanup
-      // under the loaded package test lane. Await it like the other handles above.
+      /**
+       * FNXC:TaskStoreShutdown 2026-06-29-13:04:
+       * TaskStore.close() must deterministically await the cached secrets CentralCore close before temp-root cleanup and test teardown continue.
+       * CentralCore.close() is currently synchronous internally, but awaiting the async contract prevents unhandled rejections and preserves shutdown safety if the central secrets handle gains asynchronous cleanup.
+       */
       const secretsCentralCore = this.secretsCentralCore;
       this.secretsCentralCore = null;
       try {


### PR DESCRIPTION
## Summary
- Waits for the task store's secrets database handle to close during shutdown before returning.
- Updates workflow gate expectations for the current built-in lifecycle nodes.
- Adds a patch changeset for the published CLI package.

## Test Plan
- `corepack pnpm install`
- `corepack pnpm check:changesets`
- `corepack pnpm lint`
- `corepack pnpm build`
- `corepack pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so task-store cleanup now waits for secrets storage to close before finishing.
  * Reduced the chance of teardown race conditions and incomplete cleanup during app shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->