### PR TITLE
Fix Compound Engineering artifact project scoping

### DIFF
--- a/.changeset/fix-compound-artifact-project-scope.md
+++ b/.changeset/fix-compound-artifact-project-scope.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Prevent Compound Engineering artifacts from showing stale project files after project switches.
+category: fix
+dev: Clears cached artifact discovery on project changes and opens CE artifacts through the project workspace.

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
@@ -223,7 +223,7 @@ function ArtifactRow({
         type="button"
         className="ce-artifact-open"
         data-testid="ce-artifact-open"
-        onClick={() => openFile?.(entry.path)}
+        onClick={() => openFile?.(entry.path, { workspace: "project" })}
       >
         Open
       </button>

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { DiscoveryResult } from "../../artifacts/discovery.js";
 
 // Mock the network layer so the view renders from seeded discovery results.
-const listArtifacts = vi.fn(async (): Promise<DiscoveryResult> => {
+const listArtifacts = vi.fn(async (_projectId?: string): Promise<DiscoveryResult> => {
   throw new Error("listArtifacts mock not configured");
 });
 const listSessions = vi.fn(async (): Promise<CeSession[]> => []);
@@ -15,7 +15,7 @@ const getSession = vi.fn(async (_id: string, _projectId?: string): Promise<CeSes
   throw new Error("getSession mock not configured");
 });
 vi.mock("../hooks/api.js", () => ({
-  listArtifacts: () => listArtifacts(),
+  listArtifacts: (projectId?: string) => listArtifacts(projectId),
   getArtifactPreviewUrl: (id: string) => `/preview/${id}`,
   listSessions: () => listSessions(),
   deleteSession: (id: string, projectId?: string) => deleteSession(id, projectId),
@@ -95,6 +95,7 @@ describe("CompoundEngineeringView", () => {
     render(<CompoundEngineeringView projectId="p1" enabledOverride />);
 
     await screen.findByTestId("ce-empty-state");
+    expect(listArtifacts).toHaveBeenCalledWith("p1");
     expect(screen.getByText(/Start your compounding pipeline/i)).toBeInTheDocument();
     const start = screen.getByTestId("ce-start-action");
     expect(start).toBeInTheDocument();
@@ -144,7 +145,7 @@ describe("CompoundEngineeringView", () => {
 
     await screen.findByTestId("ce-artifact");
     fireEvent.click(screen.getByTestId("ce-artifact-open"));
-    expect(openFile).toHaveBeenCalledWith("STRATEGY.md");
+    expect(openFile).toHaveBeenCalledWith("STRATEGY.md", { workspace: "project" });
   });
 
   it("renders artifact open button without crashing when openFile is not in context", async () => {

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/useArtifacts.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/useArtifacts.ts
@@ -57,6 +57,9 @@ export function useArtifacts({
       return;
     }
 
+    setResult(undefined);
+    setError(undefined);
+
     const controller = new AbortController();
     setLoading(true);
     listArtifacts(projectId)


### PR DESCRIPTION
## Summary
- Clear Compound Engineering artifact results when switching selected projects before the next scoped fetch resolves
- Keep artifact Open actions explicitly scoped to the project workspace
- Assert projectId is passed into artifact discovery and update file-open test coverage

## Verification
- pnpm --filter @fusion-plugin-examples/compound-engineering test
- pnpm --filter @fusion-plugin-examples/compound-engineering build
- pnpm check:changesets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed artifact browsing so project files no longer appear stale after switching projects.
  * Opening an artifact now takes you to the correct project workspace.
  * Removed outdated on-screen artifact data while fresh results are loading, reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
