### PR TITLE
fix: resolve all failing full-suite CI tests on main

### DIFF
--- a/packages/cli/skill/fusion/references/engine-tools.md
+++ b/packages/cli/skill/fusion/references/engine-tools.md
@@ -15,6 +15,7 @@ This reference documents tools injected by the engine at runtime for specific ag
 | `fn_task_log` | executor, heartbeat | Write significant task log entries | `message` (string), `outcome?` (string) |
 | `fn_task_document_write` | triage, executor, heartbeat; chat/planning (explicit `task_id`) | Save/update a named task document revision | `key` (string), `content` (string), `author?` (string); chat/planning also require `task_id` (string) |
 | `fn_task_document_read` | triage, executor, heartbeat; chat/planning (explicit `task_id`) | Read one task document or list all | `key?` (string); chat/planning also require `task_id` (string) |
+| `fn_task_prompt_write` | plan/spec review (Plan Review reviewer) | Replace the task's authoritative PROMPT.md with revised plan/spec content during Plan Review/spec repair; routed through TaskStore so PROMPT.md validation and task.json sync stay the single persistence path. Provide the complete final PROMPT.md content; do not implement product code from plan review | `content` (string) |
 | `fn_goal_list` | triage, executor, heartbeat | List goals with concise citation-ready snippets and active-goal warning details | `status?` (`active` \| `archived` \| `all`) |
 | `fn_goal_show` | triage, executor, heartbeat | Show one goal's full detail on demand, including the full description body | `id` (string) |
 | `fn_workflow_list` | executor | List the project's custom workflows (read-only built-ins plus user definitions) | none |

--- a/packages/cli/src/__tests__/extension-experiment-finalize.test.ts
+++ b/packages/cli/src/__tests__/extension-experiment-finalize.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { workflowAuthoringEngineMock } from "./helpers/engine-workflow-authoring-mock.js";
 
 function makeConstructibleMock<T extends (...args: any[]) => unknown>(impl?: T) {
   const mock = vi.fn(function () {});
@@ -55,6 +56,7 @@ vi.mock("@fusion/dashboard", () => ({
 }));
 
 vi.mock("@fusion/engine", () => ({
+  ...workflowAuthoringEngineMock,
   createFnAgent: vi.fn(),
   fetchWebContent: vi.fn(),
   emitGoalRetrievalAudit: vi.fn(),

--- a/packages/cli/src/__tests__/extension-fn-secret-get.test.ts
+++ b/packages/cli/src/__tests__/extension-fn-secret-get.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { workflowAuthoringEngineMock } from "./helpers/engine-workflow-authoring-mock.js";
 
 const resolveSecretAccessPolicyMock = vi.hoisted(() => vi.fn());
 const revealSecretMock = vi.hoisted(() => vi.fn());
@@ -10,6 +11,7 @@ const assertNoSecretPlaintextMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@fusion/dashboard", () => ({ registerGithubTrackingHook: vi.fn() }));
 vi.mock("@fusion/engine", () => ({
+  ...workflowAuthoringEngineMock,
   createFnAgent: vi.fn(),
   fetchWebContent: vi.fn(),
   assertNoSecretPlaintext: assertNoSecretPlaintextMock,

--- a/packages/cli/src/__tests__/extension-github-tracking.test.ts
+++ b/packages/cli/src/__tests__/extension-github-tracking.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TaskStore, setTaskCreatedHook } from "@fusion/core";
 import { runGhJsonAsync } from "@fusion/core/gh-cli";
+import { workflowAuthoringEngineMock } from "./helpers/engine-workflow-authoring-mock.js";
 
 const hookSpy = vi.hoisted(() => vi.fn(async () => {}));
 const registerGithubTrackingHookMock = vi.hoisted(() => vi.fn(() => {
@@ -28,6 +29,7 @@ vi.mock("@fusion/core/gh-cli", () => ({
 }));
 
 vi.mock("@fusion/engine", () => ({
+  ...workflowAuthoringEngineMock,
   createFnAgent: vi.fn(),
   fetchWebContent: vi.fn(),
   assertNoSecretPlaintext: vi.fn(),

--- a/packages/cli/src/__tests__/extension-web-fetch.test.ts
+++ b/packages/cli/src/__tests__/extension-web-fetch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { workflowAuthoringEngineMock } from "./helpers/engine-workflow-authoring-mock.js";
 
 const fetchWebContentMock = vi.hoisted(() => vi.fn());
 
@@ -7,6 +8,7 @@ vi.mock("@fusion/dashboard", () => ({
 }));
 
 vi.mock("@fusion/engine", () => ({
+  ...workflowAuthoringEngineMock,
   createFnAgent: vi.fn(),
   fetchWebContent: fetchWebContentMock,
   emitGoalRetrievalAudit: vi.fn(),

--- a/packages/cli/src/__tests__/helpers/engine-workflow-authoring-mock.ts
+++ b/packages/cli/src/__tests__/helpers/engine-workflow-authoring-mock.ts
@@ -1,0 +1,19 @@
+/*
+FNXC:SkillSync 2026-07-01-20:05:
+`src/extension.ts` registers the workflow-authoring + trait tools at module load, pulling their TypeBox param schemas and `createWorkflowAuthoringTools` from `@fusion/engine`. Any test that replaces `@fusion/engine` with a bare `vi.mock` factory must therefore still expose these named exports, or importing `../extension.js` throws `No "workflowListParams" export is defined on the "@fusion/engine" mock`. Centralize the passthrough stubs here so a future engine workflow-tool addition only updates one place instead of drifting each extension test's factory. The param schemas are used only as `.parameters` passthroughs and `createWorkflowAuthoringTools` is only invoked in the exec path, so empty schemas / an empty tool list keep the module-load contract without exercising engine behavior.
+*/
+
+/** Stub TypeBox param schema — only ever forwarded as a tool `.parameters` value. */
+const emptyParams = {} as const;
+
+export const workflowAuthoringEngineMock = {
+  workflowListParams: emptyParams,
+  workflowGetParams: emptyParams,
+  workflowSelectParams: emptyParams,
+  workflowCreateParams: emptyParams,
+  workflowUpdateParams: emptyParams,
+  workflowDeleteParams: emptyParams,
+  workflowSettingsParams: emptyParams,
+  traitListParams: emptyParams,
+  createWorkflowAuthoringTools: () => [] as unknown[],
+};

--- a/packages/dashboard/src/__tests__/chat-room-routes.test.ts
+++ b/packages/dashboard/src/__tests__/chat-room-routes.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -8,8 +9,13 @@ import { ChatManager } from "../chat.js";
 import { request } from "../test-request.js";
 import { RoomReplyGenerationError } from "../chat.js";
 
-class MockStore {
-  constructor(private readonly rootDir: string, private readonly db: Database) {}
+// FNXC:DashboardTests 2026-07-01-19:55: createServer now subscribes via store.on("task:moved") (TaskStore extends EventEmitter) to purge task-planner chats on archive; extend EventEmitter so startup wiring works instead of throwing "store.on is not a function".
+class MockStore extends EventEmitter {
+  constructor(private readonly rootDir: string, private readonly db: Database) {
+    super();
+    // A single MockStore is intentionally reused across several createServer() calls in these tests; uncap listeners so the repeated task:moved subscriptions do not emit a spurious MaxListenersExceededWarning.
+    this.setMaxListeners(0);
+  }
 
   getRootDir(): string { return this.rootDir; }
   getFusionDir(): string { return join(this.rootDir, ".fusion"); }

--- a/packages/dashboard/src/__tests__/pi-extensions-routes.test.ts
+++ b/packages/dashboard/src/__tests__/pi-extensions-routes.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { request } from "../test-request.js";
 import { createServer } from "../server.js";
@@ -31,7 +32,8 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 }));
 
 // Minimal store implementation for the test server
-class MinimalStore {
+// FNXC:DashboardTests 2026-07-01-19:55: createServer now subscribes via store.on("task:moved") (TaskStore extends EventEmitter) to purge task-planner chats on archive; extend EventEmitter so startup wiring works instead of throwing "store.on is not a function".
+class MinimalStore extends EventEmitter {
   getRootDir(): string {
     return "/tmp/fn-1944";
   }

--- a/packages/dashboard/src/__tests__/routes-run-audit-goal-events.test.ts
+++ b/packages/dashboard/src/__tests__/routes-run-audit-goal-events.test.ts
@@ -2,6 +2,7 @@
 FNXC:DashboardTests 2026-06-14-09:58:
 FN-6444 rescues this server route test from the curated skip-list; the fake SQLite statement returns better-sqlite-style mutation metadata so createServer boot sweeps exercise real startup paths.
 */
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { request } from "../test-request.js";
 
@@ -20,7 +21,8 @@ vi.mock("@fusion/core", async (importOriginal) => ({
   deterministicGuardLocks: new Map(),
 }));
 
-class MockStore {
+// FNXC:DashboardTests 2026-07-01-19:55: createServer now subscribes via store.on("task:moved") (TaskStore extends EventEmitter) to purge task-planner chats on archive; back the mock store with a real EventEmitter so startup wiring works instead of throwing "store.on is not a function".
+class MockStore extends EventEmitter {
   getRunAuditEvents = mockGetRunAuditEvents;
   getAgentLogsByTimeRange = vi.fn().mockResolvedValue([]);
   getMutationsForRun = vi.fn().mockResolvedValue([]);

--- a/packages/dashboard/src/__tests__/session-reconnect.test.ts
+++ b/packages/dashboard/src/__tests__/session-reconnect.test.ts
@@ -53,6 +53,8 @@ vi.mock("@fusion/engine", () => ({
     resolvedSkillNames: [],
     skillSource: "none" as const,
   })),
+  // FNXC:DashboardSessionTests 2026-07-01-19:55: planning/subtask/mission sessions now resolve MCP servers via resolveMcpServersForStore before createFnAgent; focused engine mock must export it (returning the real empty-runtime shape) so session generation completes instead of throwing on a missing mock export and timing out.
+  resolveMcpServersForStore: vi.fn(async () => ({ servers: [], errors: [] })),
   createFnAgent: mockCreateFnAgent,
   createResolvedAgentSession: vi.fn(async () => ({
     session: { state: { messages: [] }, prompt: vi.fn(), dispose: vi.fn() },

--- a/packages/dashboard/src/__tests__/workflow-routes.test.ts
+++ b/packages/dashboard/src/__tests__/workflow-routes.test.ts
@@ -314,23 +314,34 @@ describe("workflow routes (U4)", () => {
     expect(complete?.flags.complete).toBe(true);
   });
 
-  it("POST /workflows/:id/compile returns steps for linear and 422 for branching", async () => {
+  /*
+  FNXC:CustomWorkflows 2026-07-02-07:40:
+  FN-7360 removed the linear WorkflowStep compiler and POST /api/workflows/:id/compile.
+  parseWorkflowIr (which accepts branching graphs) is now the sole validity gate, so
+  branching custom workflows are persistable and run on the graph interpreter instead
+  of being rejected as interpreter-only. This test locks the inverted invariant: a
+  branching IR is accepted at create (201), matching how the equivalent core
+  selection test was reframed. (The removed /compile endpoint is not exercised here
+  because this in-process express harness does not finalize unmatched-route
+  responses.)
+  */
+  it("POST /workflows accepts branching IR (FN-7360 removed the linear compiler /compile gate)", async () => {
+    // Linear IR still creates successfully.
     const linear = await post("/api/workflows", { name: "L", ir: linearIr() });
-    const linearId = (linear.body as { id: string }).id;
-    const okCompile = await post(`/api/workflows/${linearId}/compile`, {});
-    expect(okCompile.status).toBe(200);
-    expect((okCompile.body as { steps: unknown[] }).steps).toHaveLength(1);
+    expect(linear.status).toBe(201);
 
+    // Branching IR used to be rejected as interpreter-only; it now persists (201)
+    // because the graph interpreter runs branching graphs directly.
     const branchy = await post("/api/workflows", { name: "B", ir: branchingIr() });
-    const branchyId = (branchy.body as { id: string }).id;
-    const badCompile = await post(`/api/workflows/${branchyId}/compile`, {});
-    expect(badCompile.status).toBe(422);
-    expect((badCompile.body as { error: string }).error).toMatch(/interpreter \(deferred\)/i);
+    expect(branchy.status).toBe(201);
+    expect((branchy.body as { id: string }).id).toMatch(/^WF-\d{3}$/);
   });
 
   /*
   FNXC:CustomWorkflows 2026-06-18-11:03:
-  FN-6645 locks the per-task workflow selection route contract: missing or non-string workflowId returns 400, unknown ids return 404, uncompilable custom IR returns 422, explicit null clears, and workflow:updated SSE is emitted only after successful select or clear mutations.
+  FN-6645 locks the per-task workflow selection route contract: missing or non-string workflowId returns 400, unknown ids return 404, explicit null clears, and workflow:updated SSE is emitted only after successful select or clear mutations.
+  FNXC:CustomWorkflows 2026-07-02-07:40:
+  FN-7360 removed the linear compiler, so the "uncompilable custom IR returns 422" clause no longer applies — branching IR is now valid and selectable (see the FN-7360 branching-selection test below). The remaining 400/404/null-clear/SSE clauses still hold.
   */
   it("PUT /tasks/:taskId/workflow selects and reflects on the task", async () => {
     const wf = await post("/api/workflows", { name: "QA", ir: linearIr() });
@@ -387,15 +398,26 @@ describe("workflow routes (U4)", () => {
     },
   );
 
-  it("PUT /tasks/:taskId/workflow maps uncompilable custom workflow IR to 422 without SSE", async () => {
+  /*
+  FNXC:CustomWorkflows 2026-07-02-07:40:
+  FN-7360 removed the linear WorkflowStep compiler, so branching custom IR is no
+  longer "uncompilable." parseWorkflowIr is the sole validity gate and the graph
+  interpreter runs branching graphs directly, so selecting a branching workflow now
+  succeeds (200) and emits the workflow:updated SSE exactly like a linear selection.
+  The previous 422-without-SSE contract is inverted.
+  */
+  it("PUT /tasks/:taskId/workflow selects a branching workflow on the graph interpreter (FN-7360)", async () => {
     const branchy = await post("/api/workflows", { name: "Branching", ir: branchingIr() });
     const branchyId = (branchy.body as { id: string }).id;
     const task = await store.createTask({ description: "T", enabledWorkflowSteps: [] });
     vi.mocked(emitWorkflowSseEvent).mockClear();
 
     const res = await put(`/api/tasks/${task.id}/workflow`, { workflowId: branchyId });
-    expect(res.status).toBe(422);
-    expect(emitWorkflowSseEvent).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect((res.body as { workflowId: string }).workflowId).toBe(branchyId);
+    // Successful selection emits workflow:updated exactly once (the previous
+    // rejection path asserted SSE was NOT emitted; that contract is inverted).
+    expect(emitWorkflowSseEvent).toHaveBeenCalledTimes(1);
   });
 
   it("PUT /tasks/:taskId/workflow emits workflow:updated exactly once after select and clear", async () => {

--- a/packages/desktop/src/__tests__/release-workflow.test.ts
+++ b/packages/desktop/src/__tests__/release-workflow.test.ts
@@ -76,7 +76,8 @@ describe("desktop release workflow wiring", () => {
       expect(workflow).toContain("build-android:");
       expect(workflow).toContain("runs-on: ubuntu-latest");
       expect(workflow).toContain("actions/setup-java@v4");
-      expect(workflow).toContain('java-version: "17"');
+      // FNXC:AndroidRelease 2026-07-01-19:52: Capacitor 7 @capacitor/android compiles with JavaVersion.VERSION_21, so the Android release Gradle build must provision JDK 21 (JDK 17 fails with `invalid source release: 21`). Assert the intended JDK here.
+      expect(workflow).toContain('java-version: "21"');
       expect(workflow).toContain("pnpm --filter @fusion/mobile cap add android");
       expect(workflow).toContain("pnpm --filter @fusion/mobile cap sync android");
       expect(workflow).toContain("ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}");

--- a/packages/engine/src/__tests__/executor-implicit-task-done-budget.test.ts
+++ b/packages/engine/src/__tests__/executor-implicit-task-done-budget.test.ts
@@ -63,8 +63,15 @@ describe("FN-4946 implicit refusal budget handling", () => {
 
     await (executor as any).handleImplicitTaskDoneRefusal(task(3), refusal());
 
-    expect(store.updateTask).toHaveBeenCalledWith("FN-4946-B", expect.objectContaining({ status: "failed" }));
-    expect(store.moveTask).toHaveBeenCalledWith("FN-4946-B", "in-review");
+    // FNXC:WorkflowLifecycle 2026-07-01-20:25: At refusal-budget exhaustion the implicit path now parks
+    // the task `status: "failed"` IN PLACE (worktree/branch cleared), mirroring the explicit fn_task_done
+    // exhaustion path and the workflow-graph failure-in-place model. status="failed" is the surfaced
+    // terminal + self-healing-exemption marker; the legacy FN-1284 move-to-in-review escalation was
+    // superseded. The protected invariant — budget exhaustion is terminal, not another requeue — holds
+    // via the failed parking + persisted token usage.
+    expect(store.updateTask).toHaveBeenCalledWith("FN-4946-B", expect.objectContaining({ status: "failed", worktree: null, branch: null }));
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-4946-B", "in-review");
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-4946-B", "todo", { preserveProgress: true });
     expect(persistSpy).toHaveBeenCalledWith("FN-4946-B");
   });
 
@@ -95,8 +102,13 @@ describe("FN-4946 implicit refusal budget handling", () => {
       refusal(),
     );
 
-    const inReviewMoves = store.moveTask.mock.calls.filter((call: any[]) => call[0] === "FN-4946-B2" && call[1] === "in-review");
-    expect(inReviewMoves.length).toBeGreaterThanOrEqual(1);
+    // FNXC:WorkflowLifecycle 2026-07-01-20:25: The shared-budget invariant is that once the explicit path
+    // has burned the retry budget (2->3), the follow-up implicit refusal escalates IMMEDIATELY instead of
+    // requeuing again. That terminal escalation now parks the task `status: "failed"` in place (no
+    // move-to-in-review — the legacy FN-1284 escalation was superseded by the failure-in-place model). The
+    // budget-sharing invariant is proven by the terminal failed update carrying no further taskDoneRetryCount
+    // bump, and by the absence of a second todo requeue for the implicit refusal.
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-4946-B2", "in-review");
     const implicitEscalationUpdate = store.updateTask.mock.calls.find(
       ([id, patch]: [string, Record<string, unknown>]) =>
         id === "FN-4946-B2" && patch.status === "failed" && !("taskDoneRetryCount" in patch),

--- a/packages/engine/src/__tests__/executor-prompt.test.ts
+++ b/packages/engine/src/__tests__/executor-prompt.test.ts
@@ -2019,19 +2019,32 @@ describe("TaskExecutor global pause behavior", () => {
     const disposeFn2 = vi.fn();
     let callCount = 0;
 
+    /*
+    FNXC:WorkflowLifecycle 2026-07-01-20:35:
+    With workflowGraphExecutor default-on, each task's thrown session error is classified for
+    pause-provenance at handleGraphFailure time: a throw that lands BEFORE globalPause registers is a
+    genuine execution failure (parked `failed`), while a throw AFTER the pause is a benign global-pause
+    abort (moved to todo, progress preserved). The legacy harness fired the pause only inside the
+    second-created task's prompt, so the first task raced ahead and threw before the pause registered,
+    landing it `failed` and defeating the disposal invariant under the graph. Gate both prompts on a
+    two-party barrier so BOTH sessions are genuinely in-flight when the single globalPause fires, then let
+    both throw — faithfully modeling "global pause aborts every in-flight task to todo without failing it".
+    */
+    // Each session's first prompt blocks on the barrier so BOTH tasks are genuinely in-flight at their
+    // first graph node (createFnAgent invoked) before the pause fires. The test body detects both
+    // in-flight, fires the single globalPause, then releases the barrier so both sessions throw AFTER the
+    // pause is registered — a graph-node count is unreliable because a coding task now traverses several
+    // agent nodes (planning/plan-review/execute/code-review), so we gate on distinct in-flight task ids.
+    let releaseBarrier: () => void = () => {};
+    const barrier = new Promise<void>((resolve) => { releaseBarrier = resolve; });
+
     mockedCreateFnAgent.mockImplementation(async () => {
       callCount++;
       const dispose = callCount === 1 ? disposeFn1 : disposeFn2;
       return {
         session: {
           prompt: vi.fn().mockImplementation(async () => {
-            // Wait for the global pause to fire; only fire once for first task
-            if (callCount === 2) {
-              store._trigger("settings:updated", {
-                settings: { globalPause: true },
-                previous: { globalPause: false },
-              });
-            }
+            await barrier;
             throw new Error("Session terminated");
           }),
           dispose,
@@ -2041,19 +2054,37 @@ describe("TaskExecutor global pause behavior", () => {
 
     const executor = new TaskExecutor(store, "/tmp/test");
 
-    // Execute two tasks concurrently
-    await Promise.all([
+    // Execute two tasks concurrently (do NOT await yet — the prompts block on the barrier).
+    // Distinct worktrees per task: the active-session registry now rejects two tasks claiming the same
+    // checkout path, so without unique worktrees FN-002 would fail on a path-collision guard rather than
+    // exercise the pause-disposal invariant. existsSync is stubbed true (resume) so each stored path is
+    // reused verbatim instead of regenerating a shared name.
+    const run = Promise.all([
       executor.execute({
         id: "FN-001", title: "T1", description: "T", column: "in-progress",
+        worktree: "/tmp/test/.worktrees/wt-001", branch: "fusion/fn-001",
         dependencies: [], steps: [], currentStep: 0, log: [],
         createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
       }),
       executor.execute({
         id: "FN-002", title: "T2", description: "T", column: "in-progress",
+        worktree: "/tmp/test/.worktrees/wt-002", branch: "fusion/fn-002",
         dependencies: [], steps: [], currentStep: 0, log: [],
         createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
       }),
     ]);
+
+    // Wait until BOTH tasks have an active in-flight session (registered by execute()), then fire the
+    // single global pause and release the sessions so their terminations classify as pause aborts.
+    await vi.waitFor(() => {
+      if (callCount < 2) throw new Error("waiting for both sessions in-flight");
+    }, { timeout: 5000 });
+    store._trigger("settings:updated", {
+      settings: { globalPause: true },
+      previous: { globalPause: false },
+    });
+    releaseBarrier();
+    await run;
 
     // Global pause should move both tasks out of in-progress without marking failed.
     const moveCalls = store.moveTask.mock.calls;

--- a/packages/engine/src/__tests__/executor-task-done-invariant.test.ts
+++ b/packages/engine/src/__tests__/executor-task-done-invariant.test.ts
@@ -690,8 +690,31 @@ describe("FN-5241 executor handoff auditing", () => {
     };
   }
 
-  it("emits task:handoff and enqueues merge work on successful fn_task_done", async () => {
+  /*
+  FNXC:WorkflowLifecycle 2026-07-01-22:10:
+  workflowGraphExecutor is default-on, so the FN-5241 "atomic in-review handoff seam" auditing was
+  superseded by the graph lifecycle:
+    - SUCCESSFUL builtin:coding completion reaches in-review via the MERGE-NODE boundary moveTask
+      (executor.ts:6106, "handoff-invariant-violation-allowlist: workflow merge node owns the merge
+      lifecycle boundary"), NOT the review-seam handoffTaskToReview("workflow-graph-review"). There is no
+      longer a task:handoff("workflow-graph-review") event nor a review-seam merge-queue enqueue on this
+      path; the merge boundary records task:move audits instead.
+    - EXHAUSTION/no-fn_task_done budget now FAILS IN PLACE (executor.ts:2088 "in-review is reserved for
+      clean completion handoffs"); the "max-task-done-retries-exhausted" in-review reason no longer exists.
+  These tests are migrated to assert the CURRENT mechanisms; they still protect the FN-5241 intent (a clean
+  completion reaches in-review; an exhausted no-fn_task_done run is terminal), just via the graph seams.
+  */
+
+  it("moves a cleanly completed task to in-review via the merge-node boundary", async () => {
     const { task, worktreePath } = await createExecutorTask();
+    // Graph-native implementation proof: the mock agent signals completion via fn_task_done without running
+    // the foreach step-execute nodes, so the merge-boundary FN-7260/FN-7271 proof gate needs an explicit
+    // node-source pre-merge pass to model a genuinely-implemented task reaching the merge boundary.
+    await store.updateTask(task.id, {
+      workflowStepResults: [
+        { workflowStepId: "execute", workflowStepName: "Execute", phase: "pre-merge", source: "node", status: "passed" },
+      ],
+    } as any);
     mockedExec.mockImplementation(((cmd: string, _opts: unknown, cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
       if (!cb) return undefined as any;
       if (cmd.includes("rev-parse --show-toplevel")) return cb(null, `${worktreePath}\n`, "");
@@ -715,21 +738,25 @@ describe("FN-5241 executor handoff auditing", () => {
     }) as any);
 
     const executor = new TaskExecutor(store as any, rootDir);
+    // The merge-node boundary requests merge via the injected requester before it inline-merges; returning
+    // a non-merged "queued" result keeps the task terminal in-review (autoMerge deferred) instead of
+    // finalizing it to done, so we observe the review-staging state under test.
+    executor.setMergeRequester(async () => ({ merged: false, noOp: false, reason: "queued" }) as any);
     await executor.execute(task as any);
 
+    // CURRENT completion mechanism: task ends in-review via the merge-node boundary moveTask.
     expect((await store.getTask(task.id))?.column).toBe("in-review");
-    expect(store.peekMergeQueue()).toEqual([
-      expect.objectContaining({ taskId: task.id, priority: task.priority }),
-    ]);
-    const handoff = store.getRunAuditEvents({ taskId: task.id, mutationType: "task:handoff", limit: 10 })[0];
-    expect(handoff?.metadata).toMatchObject({
-      taskId: task.id,
-      reason: "workflow-graph-review",
-      alreadyEnqueued: false,
-    });
+    // Forensic intent preserved via the mechanism that actually fires now: the merge boundary records a
+    // task:move into in-review (the review-seam task:handoff("workflow-graph-review") event and the
+    // review-seam merge-queue enqueue no longer occur on this path).
+    const moveToReview = store
+      .getRunAuditEvents({ taskId: task.id, mutationType: "task:move", limit: 20 })
+      .find((event) => (event.metadata as { to?: string })?.to === "in-review");
+    expect(moveToReview).toBeDefined();
+    expect(store.getRunAuditEvents({ taskId: task.id, mutationType: "task:handoff", limit: 10 })).toHaveLength(0);
   });
 
-  it("emits failed-status handoff auditing when no-fn_task_done retry budget is exhausted", async () => {
+  it("fails a no-fn_task_done retry-budget-exhausted run in place without moving to in-review", async () => {
     const { task, worktreePath } = await createExecutorTask(3);
     mockedExec.mockImplementation(((cmd: string, _opts: unknown, cb?: (err: Error | null, stdout: string, stderr: string) => void) => {
       if (!cb) return undefined as any;
@@ -754,17 +781,12 @@ describe("FN-5241 executor handoff auditing", () => {
     await executor.execute(task as any);
 
     const latest = await store.getTask(task.id);
-    expect(latest?.column).toBe("in-review");
-    expect(latest?.status).toBe("failed");
-    expect(String(latest?.error ?? "")).toContain("without calling fn_task_done");
-    expect(store.peekMergeQueue()).toEqual([
-      expect.objectContaining({ taskId: task.id, priority: task.priority }),
-    ]);
-    const handoff = store.getRunAuditEvents({ taskId: task.id, mutationType: "task:handoff", limit: 10 })[0];
-    expect(handoff?.metadata).toMatchObject({
-      taskId: task.id,
-      reason: "max-task-done-retries-exhausted",
-      alreadyEnqueued: false,
-    });
+    // A no-fn_task_done run that cannot cleanly complete is NOT a review handoff (executor.ts:2088:
+    // "in-review is reserved for clean completion handoffs"). It must never advance to in-review, and the
+    // FN-5241 review-seam handoff auditing (task:handoff "workflow-graph-review" /
+    // "max-task-done-retries-exhausted") + merge-queue enqueue are superseded — none of them fire here.
+    expect(latest?.column).not.toBe("in-review");
+    expect(store.getRunAuditEvents({ taskId: task.id, mutationType: "task:handoff", limit: 10 })).toHaveLength(0);
+    expect(store.peekMergeQueue()).toEqual([]);
   });
 });

--- a/packages/engine/src/__tests__/executor-task-done-revise-verdict-guard.test.ts
+++ b/packages/engine/src/__tests__/executor-task-done-revise-verdict-guard.test.ts
@@ -83,7 +83,12 @@ describe("FN-4851 REVISE verdict task-done guard", () => {
 
     expect(result.details.refusalClass).toBe("pending-code-review-revise");
     expect(result.details.error).toContain("pending-code-review-revise");
-    expect(store.moveTask).toHaveBeenCalledWith("FN-4851", "in-review");
+    // FNXC:WorkflowLifecycle 2026-07-01-20:28: At fn_task_done refusal-budget exhaustion the task is parked
+    // `status: "failed"` IN PLACE (executor.ts fn_task_done refusal exhaustion branch) rather than moved to
+    // in-review — the same workflow-graph failure-in-place model that superseded FN-1284's legacy in-review
+    // escalation. The protected invariant (a pending REVISE at budget exhaustion is terminal, not another
+    // requeue) holds via the failed update and the absence of a further todo requeue.
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-4851", "in-review");
     expect(store.updateTask).toHaveBeenCalledWith("FN-4851", expect.objectContaining({ status: "failed" }));
   });
 

--- a/packages/engine/src/__tests__/executor-worktree-liveness.test.ts
+++ b/packages/engine/src/__tests__/executor-worktree-liveness.test.ts
@@ -1,10 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./executor-test-helpers.js";
 import { TaskExecutor } from "../executor.js";
 import * as worktreePool from "../worktree-pool.js";
 import { resolveWorktreesDir } from "../worktree-paths.js";
 import * as worktreeAcquisition from "../worktree-acquisition.js";
-import { createMockStore, mockedCreateFnAgent, mockedExecSync, resetExecutorMocks } from "./executor-test-helpers.js";
+import { createMockStore, mockedCreateFnAgent, mockedExecSync, mockedExistsSync, resetExecutorMocks } from "./executor-test-helpers.js";
 
 function task(overrides: Record<string, unknown> = {}) {
   return {
@@ -14,6 +14,8 @@ function task(overrides: Record<string, unknown> = {}) {
     column: "in-progress",
     worktree: "/repo/.worktrees/swift-falcon",
     branch: "fusion/fn-4114",
+    // FNXC:WorkflowLifecycle 2026-07-01-19:58: workflowGraphExecutor graduated to default-on, so every task now traverses the built-in coding graph including the default-on plan-review/code-review gate groups. This suite only exercises the pre-workflow worktree liveness gate; a bare mock agent session never satisfies the gates, causing a spurious rebound moveTask(FN-4114, todo, preserveProgress) that broke the accept-path assertions. Disabling the optional groups keeps the graph at planning->execute->review->merge so the liveness invariant stays isolated.
+    enabledWorkflowSteps: [],
     taskDoneRetryCount: 0,
     steps: [{ name: "Step 1", status: "in-progress" as const }],
     currentStep: 0,
@@ -22,6 +24,31 @@ function task(overrides: Record<string, unknown> = {}) {
     updatedAt: new Date().toISOString(),
     ...overrides,
   };
+}
+
+// FNXC:WorkflowLifecycle 2026-07-01-19:58: With workflowGraphExecutor default-on the execute node hands off to in-review only when the agent calls fn_task_done; a bare prompt session that resolves undefined trips the "finished without fn_task_done" rebound to todo, which would masquerade as a liveness-gate rejection. Accept-path assertions must drive a completing agent so the ONLY todo rebound under test is the liveness gate itself.
+function mockCompletingAgent() {
+  // FN-009 carve-out: fn_task_done's verifyWorktreeInvariants skips git validation when the
+  // worktree dir does not exist. These liveness tests use fabricated worktree paths, so treating
+  // them as absent lets the completing agent hand off to in-review without tripping the
+  // wrong_toplevel invariant refusal (which would masquerade as a liveness-gate rebound to todo).
+  mockedExistsSync.mockReturnValue(false);
+  mockedCreateFnAgent.mockImplementation((async (opts: any) => {
+    const customTools = opts.customTools || [];
+    return {
+      session: {
+        prompt: vi.fn().mockImplementation(async () => {
+          const taskDoneTool = customTools.find((t: any) => t.name === "fn_task_done");
+          if (taskDoneTool) await taskDoneTool.execute("tool-1", {});
+        }),
+        dispose: vi.fn(),
+        subscribe: vi.fn(),
+        on: vi.fn(),
+        sessionManager: { getLeafId: vi.fn().mockReturnValue("leaf-1") },
+        state: {},
+      },
+    };
+  }) as any);
 }
 
 describe("FN-4114 worktree liveness assertion", () => {
@@ -35,6 +62,14 @@ describe("FN-4114 worktree liveness assertion", () => {
       if (cmd.includes("rev-list --count")) return Buffer.from("1\n");
       return Buffer.from("");
     });
+  });
+
+  // FNXC:ExecutorTests 2026-07-01-20:40: mockCompletingAgent flips the module-level existsSync mock to
+  // false (FN-009 worktree-absent completion carve-out). resetExecutorMocks does NOT reset existsSync, so
+  // without this restore the `false` leaks into later files sharing the vitest worker and silently breaks
+  // their default (worktree-present) assumptions. Restore the module default (true) after each test.
+  afterEach(() => {
+    mockedExistsSync.mockReturnValue(true);
   });
 
   it("FN-4114 aborts before createFnAgent when worktree is missing", async () => {
@@ -113,9 +148,7 @@ describe("FN-4114 worktree liveness assertion", () => {
     store.recordRunAuditEvent = vi.fn().mockResolvedValue(undefined);
     store.getTask.mockResolvedValue(task({ worktree: "/repo", sessionFile: null }));
 
-    mockedCreateFnAgent.mockImplementation(async () => ({
-      session: { prompt: vi.fn().mockResolvedValue(undefined), dispose: vi.fn() },
-    }) as any);
+    mockCompletingAgent();
 
     const executor = new TaskExecutor(store as any, "/repo");
     await executor.execute(task({ worktree: "/repo", sessionFile: null }) as any);
@@ -149,11 +182,10 @@ describe("FN-4114 worktree liveness assertion", () => {
     expect(store.moveTask).toHaveBeenCalledWith("FN-4114", "todo", { preserveProgress: true });
 
     mockedCreateFnAgent.mockReset();
-    mockedCreateFnAgent.mockImplementation(async () => ({
-      session: { prompt: vi.fn().mockResolvedValue(undefined), dispose: vi.fn() },
-    }) as any);
+    mockCompletingAgent();
 
     store.moveTask.mockReset();
+    store.moveTask.mockResolvedValue({});
     store.getTask.mockResolvedValue(task({ worktree: allowedWorktree }));
 
     const acceptExecutor = new TaskExecutor(store as any, "/repo");

--- a/packages/engine/src/__tests__/executor-worktree.test.ts
+++ b/packages/engine/src/__tests__/executor-worktree.test.ts
@@ -137,7 +137,16 @@ describe("TaskExecutor with semaphore", () => {
       updatedAt: new Date().toISOString(),
     });
 
+    // FNXC:WorkflowLifecycle 2026-07-01-20:10: With workflowGraphExecutor default-on, terminal
+    // execution failures are parked `status: "failed"` IN PLACE by the workflow-graph failure model
+    // (handleGraphFailure / the legacy terminal catch in executor.ts). status="failed" doubles as the
+    // self-healing review-revival exemption marker, so the task is intentionally NOT moved to in-review
+    // — this supersedes FN-1284's legacy in-review escalation (confirmed by the sibling "fails after 3
+    // attempts" / "fails fast when rootDir not git" tests, which assert failed without any in-review
+    // move). The protected invariant here is unchanged: an execution throw marks the task failed with an
+    // error message and fires onError.
     expect(store.updateTask).toHaveBeenCalledWith("FN-001", { status: "failed", error: expect.any(String) });
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-001", "in-review");
     expect(onError).toHaveBeenCalled();
   });
 

--- a/packages/engine/src/__tests__/invariant-stranded-in-review-recovery.test.ts
+++ b/packages/engine/src/__tests__/invariant-stranded-in-review-recovery.test.ts
@@ -70,6 +70,13 @@ describe("FN-4115 stranded in-review recovery", () => {
     const store = createStore([task], { autoMerge: true });
     const mgr = new SelfHealingManager(store as any, opts);
     vi.spyOn(mgr as any, "findAlreadyMergedTaskCommit").mockResolvedValue({ sha: "abc12345", strategy: "task-id-trailer" });
+    // FNXC:WorkflowRecovery 2026-07-01-20:20: FN-7143 added a branchTipForeignOwnership precondition —
+    // before trusting already-merged evidence for a task WITH a branch, self-healing verifies the branch
+    // tip is the task's own (non-foreign) work via git. That git probe cannot run against this in-memory
+    // fake store/rootDir (git rev-parse fails → "ownership-unverifiable" → candidate rejected), so the
+    // recovery short-circuits before findAlreadyMergedTaskCommit. Stub the ownership probe to null to
+    // faithfully model a verified-own tip, which is the precondition the recovery invariant assumes.
+    vi.spyOn(mgr as any, "branchTipForeignOwnership").mockResolvedValue(null);
     const recovered = await mgr.recoverAlreadyMergedReviewTasks();
     expect(recovered).toBe(1);
     expect((await store.getTask("FN-4115-A"))?.column).toBe("done");
@@ -103,6 +110,9 @@ describe("FN-4115 stranded in-review recovery", () => {
     const store = createStore([merged, downstream], { autoMerge: true });
     const mgr = new SelfHealingManager(store as any, opts);
     vi.spyOn(mgr as any, "findAlreadyMergedTaskCommit").mockResolvedValue({ sha: "abc12345", strategy: "task-id-trailer" });
+    // FNXC:WorkflowRecovery 2026-07-01-20:20: FN-7143 non-foreign-tip precondition (see the auto-finalize
+    // test above) — model a verified-own branch tip so the already-merged recovery proceeds in-memory.
+    vi.spyOn(mgr as any, "branchTipForeignOwnership").mockResolvedValue(null);
     await mgr.recoverAlreadyMergedReviewTasks();
     await mgr.clearStaleBlockedBy();
     expect((await store.getTask("FN-4115-MERGED"))?.column).toBe("done");

--- a/packages/engine/src/__tests__/plan-review-unavailable-recovery.test.ts
+++ b/packages/engine/src/__tests__/plan-review-unavailable-recovery.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../pi.js", () => ({
   describeModel: vi.fn().mockReturnValue("mock-provider/mock-model"),
+  formatModelMarkerDetails: vi.fn((model: string) => model),
   promptWithFallback: vi.fn(async (session: any, prompt: string, options?: any) => {
     if (options == null) await session.prompt(prompt);
     else await session.prompt(prompt, options);

--- a/packages/engine/src/__tests__/reliability-interactions/executor-no-task-done-vs-worktree-reclaim.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/executor-no-task-done-vs-worktree-reclaim.test.ts
@@ -127,7 +127,13 @@ describe("reliability interactions: executor no-fn_task_done vs worktree reclaim
     const executor = new TaskExecutor(store as any, "/tmp/test");
     await executor.execute(state);
 
-    expect(store.moveTask).toHaveBeenCalledWith("FN-4601", "in-review");
+    // FNXC:WorkflowLifecycle 2026-07-01-21:05: A non-recoverable execute error follows the terminal
+    // FAILURE path, which under the workflow-graph model parks the task `status: "failed"` IN PLACE (the
+    // failure-in-place model that superseded FN-1284's in-review escalation). The invariant under test is
+    // that this path is DISTINCT from the FN-4806 reclaim self-heal (silent todo requeue, no failed): a
+    // non-recoverable error marks the task failed and does NOT silently requeue to todo.
+    expect(store.updateTask).toHaveBeenCalledWith("FN-4601", expect.objectContaining({ status: "failed" }));
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-4601", "todo", { preserveProgress: true });
   });
 
   it("reclaim path ignores requeue budget and always silently requeues (FN-4806)", async () => {

--- a/packages/engine/src/__tests__/reliability-interactions/post-done-continuation-no-wedge.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/post-done-continuation-no-wedge.test.ts
@@ -396,14 +396,20 @@ describe("FN-5866 reliability interactions: post-done continuation no wedge", ()
     const executor = new TaskExecutor(store, "/tmp/test", { onError });
     await executor.execute(task);
 
-    expect(task.column).toBe("in-review");
+    // FNXC:WorkflowLifecycle 2026-07-01-21:15: When the non-continuable fresh-session retry budget is
+    // exhausted, the run falls through to the TERMINAL failure path, which under the workflow-graph model
+    // parks the task `status: "failed"` IN PLACE (column preserved, worktree/session state cleared, onError
+    // surfaced) — the failure-in-place model that superseded the legacy FN-1284 move-to-in-review
+    // escalation. The invariant under test is the wedge-avoidance one: budget exhaustion is TERMINAL (not a
+    // silent resume-preserving requeue) and clears the recovery bookkeeping so the task cannot re-wedge.
+    expect(task.column).toBe("in-progress");
     expect(task.status).toBe("failed");
     expect(task.error).toContain("Cannot continue from message role: assistant");
     expect(task.recoveryRetryCount).toBeNull();
     expect(task.nextRecoveryAt).toBeNull();
     expect(task.sessionFile).toBeNull();
     expect(store.moveTask).not.toHaveBeenCalledWith(task.id, "todo", { preserveResumeState: true });
-    expect(store.handoffToReview).toHaveBeenCalledTimes(1);
+    expect(store.handoffToReview).not.toHaveBeenCalled();
     expect(onError).toHaveBeenCalledTimes(1);
     expect((task.log ?? []).some((entry: any) => entry.action.includes("fresh-session retries exhausted"))).toBe(true);
   });

--- a/packages/engine/src/__tests__/reliability-interactions/pr-mode-worktree-invariants.slow.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/pr-mode-worktree-invariants.slow.test.ts
@@ -18,6 +18,26 @@ function git(cwd: string, command: string): string {
   return execSync(`git ${command}`, { cwd, encoding: "utf8" }).trim();
 }
 
+/*
+FNXC:PrMergeAutoMerge 2026-07-01-21:30:
+FN-7133 made processPullRequestMergeTask resolve owner/repo from its cwd via
+getCurrentRepo() (git remote get-url origin) and THROW when it cannot — multi-project
+daemons can no longer rely on process cwd. These PR-merge unit tests previously passed a
+bogus "/tmp/repo" cwd, which now trips "could not determine repository". Give them a real
+throwaway repo with an `origin` remote so getCurrentRepo() resolves a concrete slug,
+exercising the real repo-resolution path instead of stubbing it.
+*/
+const prRepoCwds: string[] = [];
+function makeRepoWithOrigin(): string {
+  const dir = mkdtempSync(join(tmpdir(), "fn-prmode-repo-"));
+  prRepoCwds.push(dir);
+  git(dir, "init -b main");
+  git(dir, "config user.name 'Fusion'");
+  git(dir, "config user.email 'hi@runfusion.ai'");
+  git(dir, "remote add origin https://github.com/Runfusion/Fusion.git");
+  return dir;
+}
+
 function createStore(tasks: Task[], settingsOverrides: Record<string, unknown> = {}) {
   const emitter = new EventEmitter() as any;
   const audits: any[] = [];
@@ -67,6 +87,9 @@ describe("FN-5420 reliability interactions: PR mode worktree invariants", () => 
   afterEach(() => {
     activeSessionRegistry.clear();
     vi.restoreAllMocks();
+    while (prRepoCwds.length > 0) {
+      rmSync(prRepoCwds.pop()!, { recursive: true, force: true });
+    }
   });
 
   it("FN-5420/FN-5147: autoMerge=false keeps in-review stable; PR flow still finalizes on merged status", async () => {
@@ -113,7 +136,7 @@ describe("FN-5420 reliability interactions: PR mode worktree invariants", () => 
     };
 
     const { processPullRequestMergeTask } = await loadPrLifecycleModule();
-    await processPullRequestMergeTask(store as any, "/tmp/repo", task.id, github as any, () => undefined);
+    await processPullRequestMergeTask(store as any, makeRepoWithOrigin(), task.id, github as any, () => undefined);
     expect(store.moveTask).toHaveBeenCalledWith(task.id, "done");
     manager.stop();
   });
@@ -328,7 +351,7 @@ describe("FN-5420 reliability interactions: PR mode worktree invariants", () => 
     };
 
     const { processPullRequestMergeTask } = await loadPrLifecycleModule();
-    const result = await processPullRequestMergeTask(store as any, "/tmp/repo", task.id, github as any, () => undefined);
+    const result = await processPullRequestMergeTask(store as any, makeRepoWithOrigin(), task.id, github as any, () => undefined);
     expect(result).toBe("waiting");
     expect(github.getPrMergeStatus).toHaveBeenCalled();
   });

--- a/packages/engine/src/__tests__/reliability-interactions/task-done-refusal-x-invariant.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/task-done-refusal-x-invariant.test.ts
@@ -97,6 +97,12 @@ describe("FN-4851 reliability interactions: task-done refusals x invariant", () 
   it("shares one retry budget across mixed refusal classes", async () => {
     const { doneTool, reviewTool, store, getTask } = await setup({ steps: [{ name: "S1", status: "in-progress" }, { name: "S2", status: "pending" }] });
 
+    // FNXC:WorkflowLifecycle 2026-07-01-21:20: setup()'s execute() drives a bare mock agent through the
+    // default-on workflow graph; the agent never calls fn_task_done, so the graph's no-fn_task_done requeue
+    // pre-bumps taskDoneRetryCount by one before the refusal sequence under test begins. Reset the shared
+    // budget to zero so this test measures ONLY the mixed-refusal-class budget sharing it is asserting.
+    getTask().taskDoneRetryCount = 0;
+
     await doneTool.execute("1", { summary: "Task is not complete." });
     expect(getTask().taskDoneRetryCount).toBe(1);
 
@@ -111,6 +117,12 @@ describe("FN-4851 reliability interactions: task-done refusals x invariant", () 
 
     const fourth = await doneTool.execute("4", { summary: "Task is not complete." });
     expect(fourth.details.refusalClass).toBe("pending-code-review-revise");
-    expect(store.moveTask).toHaveBeenCalledWith("FN-4851", "in-review");
+    // FNXC:WorkflowLifecycle 2026-07-01-21:20: The shared retry budget is exhausted on the 4th refusal
+    // (count already 3). Exhaustion is terminal and now parks the task `status: "failed"` in place under
+    // the workflow-graph failure model (superseding FN-1284's move-to-in-review escalation); the invariant
+    // proven here is that a SINGLE budget is shared across mixed refusal classes and its exhaustion is
+    // terminal, not that the terminal state is in-review.
+    expect(store.updateTask).toHaveBeenCalledWith("FN-4851", expect.objectContaining({ status: "failed" }));
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-4851", "in-review");
   });
 });

--- a/packages/engine/src/__tests__/reliability-interactions/workflow-interpreter-cutover.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/workflow-interpreter-cutover.test.ts
@@ -24,12 +24,21 @@ const readyParity = {
   recentDrift: [],
 };
 
+// FNXC:WorkflowInterpreterCutover 2026-07-01-21:35: BUILTIN_CODING_WORKFLOW_IR graduated to include
+// default-on optional groups (plan-review, browser-verification, code-review). Disabling them via
+// enabledWorkflowSteps:[] keeps the authoritative driver's seam-only run from routing into those group
+// nodes (which WorkflowAuthoritativeDriver's hardcoded runCustomNode rejects). NOTE: this does NOT rescue
+// the three tests that require the graph to reach merge — the IR also gained an ALWAYS-ON `completion-summary`
+// custom node that the driver's runCustomNode throws on ("unexpected custom node ... completion-summary"),
+// so a clean run cannot complete. That is a product gap in workflow-authoritative-driver.ts (owned by the
+// lead), not a test-side staleness; those three tests are left failing pending a driver fix or retirement.
 const baseTask = {
   id: "FN-5770",
   column: "in-progress",
   steps: [],
   review: null,
   mergeDetails: null,
+  enabledWorkflowSteps: [],
 } as unknown as TaskDetail;
 
 function settingsWith(flags: Record<string, boolean>, overrides: Partial<Settings> = {}): Settings {

--- a/packages/engine/src/__tests__/restart.integration.test.ts
+++ b/packages/engine/src/__tests__/restart.integration.test.ts
@@ -37,6 +37,12 @@ vi.mock("../pi.js", () => ({
       await session.prompt(prompt, options);
     }
   }),
+  // FNXC:EngineTests 2026-07-02-07:40:
+  // Both triage.ts and executor.ts now call formatModelMarkerDetails (from
+  // pi.js) to build the model-marker log line after resolving an agent
+  // session. The mock must expose the export so the resume/triage paths can
+  // reach finalization instead of throwing on a missing mock member.
+  formatModelMarkerDetails: vi.fn((model: string) => model),
 }));
 vi.mock("../reviewer.js", () => ({
   reviewStep: vi.fn(),

--- a/packages/engine/src/__tests__/reviewer-prompt-single-source.test.ts
+++ b/packages/engine/src/__tests__/reviewer-prompt-single-source.test.ts
@@ -12,6 +12,7 @@ import {
 vi.mock("../pi.js", () => ({
   createFnAgent: vi.fn(),
   describeModel: vi.fn().mockReturnValue("mock-provider/mock-model"),
+  formatModelMarkerDetails: vi.fn((model: string) => model),
   promptWithFallback: vi.fn(async (session, prompt, options) => {
     if (options === undefined) {
       await session.prompt(prompt);

--- a/packages/engine/src/__tests__/triage-fast-mode-workflow-variant.test.ts
+++ b/packages/engine/src/__tests__/triage-fast-mode-workflow-variant.test.ts
@@ -25,6 +25,12 @@ vi.mock("../pi.js", () => ({
   createFnAgent: mockCreateFnAgent,
   describeModel: vi.fn().mockReturnValue("mock-model"),
   promptWithFallback: mockPromptWithFallback,
+  // FNXC:TriageTests 2026-07-02-07:40:
+  // triage.ts specifyTask now calls formatModelMarkerDetails (from pi.js) to
+  // build the model-marker log line after the agent session resolves. The mock
+  // must expose the export so the planning path can reach finalization
+  // (moveTask todo) instead of throwing on a missing mock member.
+  formatModelMarkerDetails: vi.fn((model: string) => model),
 }));
 
 vi.mock("@fusion/core", async (importOriginal) => {

--- a/packages/engine/src/__tests__/triage-stuck-requeue-preserve-draft.test.ts
+++ b/packages/engine/src/__tests__/triage-stuck-requeue-preserve-draft.test.ts
@@ -20,6 +20,13 @@ vi.mock("../agent-session-helpers.js", () => ({
 vi.mock("../pi.js", () => ({
   describeModel: vi.fn().mockReturnValue("mock-model"),
   promptWithFallback: mockPromptWithFallback,
+  // FNXC:TriageTests 2026-07-02-07:40:
+  // triage.ts specifyTask now calls formatModelMarkerDetails (from pi.js) to
+  // build the model-marker log line after the agent session resolves. The mock
+  // must expose the export so the stuck-requeue planning path can reach
+  // finalization (moveTask todo / needs-replan) instead of throwing on a
+  // missing mock member.
+  formatModelMarkerDetails: vi.fn((model: string) => model),
 }));
 
 function createTask(overrides: Partial<Task> = {}): Task {

--- a/packages/engine/src/__tests__/web-fetch-universal.test.ts
+++ b/packages/engine/src/__tests__/web-fetch-universal.test.ts
@@ -16,7 +16,17 @@ describe("fn_web_fetch universal registration", () => {
   });
 
   it("reviewer registers fn_web_fetch", () => {
-    expect(readSource("reviewer.ts")).toContain("customTools: [createWebFetchTool()");
+    // FNXC:WebFetchUniversal 2026-07-01-20:20:
+    // FN-7293's inline-fix reviewer refactor extracted the reviewer custom-tool list
+    // into a `reviewCustomTools` array (to conditionally append the prompt-write and
+    // memory tools), so the old inline `customTools: [createWebFetchTool()` literal no
+    // longer appears. The universal-registration invariant is unchanged: the reviewer
+    // still registers fn_web_fetch as its first custom tool. Assert the current wiring —
+    // createWebFetchTool() heads the reviewCustomTools array and that array is the
+    // session's customTools — so this surface stays enumerated without pinning the literal.
+    const reviewerSrc = readSource("reviewer.ts");
+    expect(reviewerSrc).toMatch(/reviewCustomTools\s*=\s*\[\s*createWebFetchTool\(\),/);
+    expect(reviewerSrc).toContain("customTools: reviewCustomTools");
   });
 
   it("merger registers fn_web_fetch", () => {

--- a/packages/engine/src/__tests__/workflow-graph-merge-region-collapse.test.ts
+++ b/packages/engine/src/__tests__/workflow-graph-merge-region-collapse.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { TaskDetail, WorkflowIr, WorkflowIrNodeKind } from "@fusion/core";
 import { BUILTIN_CODING_WORKFLOW_IR } from "@fusion/core";
 
-import { WorkflowGraphExecutor } from "../workflow-graph-executor.js";
-import type { WorkflowLegacySeams } from "../workflow-node-handlers.js";
+import { WorkflowGraphExecutor, type WorkflowNodeHandler } from "../workflow-graph-executor.js";
 
 const task = { id: "FN-6294" } as TaskDetail;
 const settings = { experimentalFeatures: { workflowGraphExecutor: true } };
@@ -19,20 +18,35 @@ const mergeRegionEntries: Array<{ id: string; kind: WorkflowIrNodeKind }> = [
 ];
 const rawMergeRegionNodeIds = mergeRegionEntries.map((entry) => entry.id);
 
-// U6: the task carries no `enabledWorkflowSteps`, so the pre-merge
-// browser-verification optional-group is BYPASSED — its node is visited but its
-// body never runs. The legacy `workflowStep` seam is retained here only for shape
-// (it is no longer reached by the migrated coding IR).
-function createSeams(overrides: Partial<WorkflowLegacySeams> = {}): WorkflowLegacySeams {
-  return {
-    planning: async () => ({ outcome: "success" }),
-    execute: async () => ({ outcome: "success" }),
-    workflowStep: async () => ({ outcome: "success" }),
-    review: async () => ({ outcome: "success" }),
-    merge: async () => ({ outcome: "success" }),
-    schedule: async () => ({ outcome: "success" }),
-    ...overrides,
-  };
+/*
+ * FNXC:WorkflowGraphTests 2026-07-01-20:10:
+ * Post-cutover harness. The built-in coding workflow now routes every task through
+ * the graph by default, inserting the default-on `plan-review` group before execute
+ * and the default-on `code-review` template + `completion-summary` before review,
+ * plus a `post-merge-verification` hop after a successful collapsed merge. The legacy
+ * seams-only harness routed `plan-review` to `plan-replan` and never reached merge.
+ * We drive the graph with a single `prompt` handler (mirroring the passing
+ * workflow-graph-executor-retry-coding-workflow reference) so every plan/code-review
+ * gate APPROVES via a plain `{ outcome: "success" }`. The `merge` seam node is a
+ * synthetic prompt node with id `"merge"` (config.seam:"merge") that the collapse
+ * emits, so merge spying/failure-injection now keys on `node.id === "merge"` inside
+ * the prompt handler instead of a legacy `seams.merge`. The MERGE-REGION COLLAPSE
+ * invariant is unchanged: raw merge primitives (merge-gate/merge-attempt/...) must
+ * never appear in `visitedNodeIds`, and the whole region must collapse to the single
+ * legacy `merge` node dispatched exactly once.
+ */
+
+type PromptOverrides = {
+  merge?: () => { outcome: "success" | "failure"; value?: string };
+  review?: () => { outcome: "success" | "failure"; value?: string };
+};
+
+function createPrompt(overrides: PromptOverrides = {}) {
+  return vi.fn<WorkflowNodeHandler>(async (node) => {
+    if (node.id === "merge" && overrides.merge) return overrides.merge();
+    if (node.id === "review" && overrides.review) return overrides.review();
+    return { outcome: "success" };
+  });
 }
 
 function expectNoRawMergeRegionVisits(visitedNodeIds: string[]) {
@@ -52,76 +66,86 @@ function irEnteringMergeRegionAt(entryId: string): WorkflowIr {
   };
 }
 
+// FNXC:WorkflowGraphTests 2026-07-01-20:10: Post-cutover success topology for
+// builtin:coding, derived empirically and sanity-checked against the passing
+// workflow-graph-executor-retry-coding-workflow reference test.
+const SUCCESS_PATH = [
+  "start",
+  "planning",
+  "plan-review",
+  "plan-review::plan-review-step",
+  "execute",
+  "browser-verification",
+  "code-review",
+  "code-review::code-review-step",
+  "completion-summary",
+  "review",
+  "merge",
+  "post-merge-verification",
+];
+// Same path, stopped before the post-merge hop (merge itself failed).
+const MERGE_FAILURE_PATH = SUCCESS_PATH.slice(0, SUCCESS_PATH.indexOf("merge") + 1);
+// Same path, stopped at review (review failed before the merge-policy region).
+const REVIEW_FAILURE_PATH = SUCCESS_PATH.slice(0, SUCCESS_PATH.indexOf("review") + 1);
+
 describe("WorkflowGraphExecutor merge-region collapse", () => {
   it("collapses the built-in merge-policy region to one legacy merge seam", async () => {
     const calls: string[] = [];
-    const merge = vi.fn(async () => {
-      calls.push("merge");
-      return { outcome: "success" as const };
+    const prompt = createPrompt({
+      merge: () => {
+        calls.push("merge");
+        return { outcome: "success" as const };
+      },
     });
-    const executor = new WorkflowGraphExecutor({ seams: createSeams({ merge }) });
+    const executor = new WorkflowGraphExecutor({ handlers: { prompt } });
 
     const result = await executor.run(task, settings, BUILTIN_CODING_WORKFLOW_IR);
 
     expect(result.outcome).toBe("success");
-    expect(merge).toHaveBeenCalledOnce();
+    // The whole merge-policy region collapses to exactly one merge dispatch.
     expect(calls).toEqual(["merge"]);
-    expect(result.visitedNodeIds).toEqual([
-      "start",
-      "planning",
-      "execute",
-      "browser-verification",
-      "code-review",
-      "review",
-      "merge",
-    ]);
+    expect(prompt.mock.calls.filter(([node]) => node.id === "merge")).toHaveLength(1);
+    expect(result.visitedNodeIds).toEqual(SUCCESS_PATH);
     expect(result.context["node:merge:outcome"]).toBe("success");
     expectNoRawMergeRegionVisits(result.visitedNodeIds);
   });
 
   it("routes legacy merge seam failures to a failure terminal without visiting raw merge primitives", async () => {
-    const merge = vi.fn(async () => ({ outcome: "failure" as const, value: "FileScopeViolationError" }));
-    const executor = new WorkflowGraphExecutor({ seams: createSeams({ merge }) });
+    const calls: string[] = [];
+    const prompt = createPrompt({
+      merge: () => {
+        calls.push("merge");
+        return { outcome: "failure" as const, value: "FileScopeViolationError" };
+      },
+    });
+    const executor = new WorkflowGraphExecutor({ handlers: { prompt } });
 
     const result = await executor.run(task, settings, BUILTIN_CODING_WORKFLOW_IR);
 
     expect(result.outcome).toBe("failure");
-    expect(merge).toHaveBeenCalledOnce();
-    expect(result.visitedNodeIds).toEqual([
-      "start",
-      "planning",
-      "execute",
-      "browser-verification",
-      "code-review",
-      "review",
-      "merge",
-    ]);
+    expect(calls).toEqual(["merge"]);
+    expect(result.visitedNodeIds).toEqual(MERGE_FAILURE_PATH);
     expect(result.context["node:merge:outcome"]).toBe("failure");
     expect(result.context["node:merge:value"]).toBe("FileScopeViolationError");
     expectNoRawMergeRegionVisits(result.visitedNodeIds);
   });
 
   it("does not collapse to merge when review fails before the merge-policy region", async () => {
-    const merge = vi.fn(async () => ({ outcome: "success" as const }));
-    const executor = new WorkflowGraphExecutor({
-      seams: createSeams({
-        review: async () => ({ outcome: "failure", value: "manual-merge-required" }),
-        merge,
-      }),
+    const calls: string[] = [];
+    const prompt = createPrompt({
+      review: () => ({ outcome: "failure" as const, value: "manual-merge-required" }),
+      merge: () => {
+        calls.push("merge");
+        return { outcome: "success" as const };
+      },
     });
+    const executor = new WorkflowGraphExecutor({ handlers: { prompt } });
 
     const result = await executor.run(task, settings, BUILTIN_CODING_WORKFLOW_IR);
 
     expect(result.outcome).toBe("failure");
-    expect(merge).not.toHaveBeenCalled();
-    expect(result.visitedNodeIds).toEqual([
-      "start",
-      "planning",
-      "execute",
-      "browser-verification",
-      "code-review",
-      "review",
-    ]);
+    expect(calls).toEqual([]);
+    expect(result.visitedNodeIds).toEqual(REVIEW_FAILURE_PATH);
     expect(result.visitedNodeIds).not.toContain("merge");
     expectNoRawMergeRegionVisits(result.visitedNodeIds);
   });
@@ -129,22 +153,20 @@ describe("WorkflowGraphExecutor merge-region collapse", () => {
   it.each(mergeRegionEntries)(
     "treats $kind as a merge-region boundary when entered directly",
     async ({ id }) => {
-      const merge = vi.fn(async () => ({ outcome: "success" as const }));
-      const executor = new WorkflowGraphExecutor({ seams: createSeams({ merge }) });
+      const calls: string[] = [];
+      const prompt = createPrompt({
+        merge: () => {
+          calls.push("merge");
+          return { outcome: "success" as const };
+        },
+      });
+      const executor = new WorkflowGraphExecutor({ handlers: { prompt } });
 
       const result = await executor.run(task, settings, irEnteringMergeRegionAt(id));
 
       expect(result.outcome).toBe("success");
-      expect(merge).toHaveBeenCalledOnce();
-      expect(result.visitedNodeIds).toEqual([
-        "start",
-        "planning",
-        "execute",
-        "browser-verification",
-        "code-review",
-        "review",
-        "merge",
-      ]);
+      expect(calls).toEqual(["merge"]);
+      expect(result.visitedNodeIds).toEqual(SUCCESS_PATH);
       expectNoRawMergeRegionVisits(result.visitedNodeIds);
     },
   );

--- a/packages/engine/src/__tests__/worktree-acquisition-backend.test.ts
+++ b/packages/engine/src/__tests__/worktree-acquisition-backend.test.ts
@@ -64,8 +64,16 @@ describe("acquireTaskWorktree backend wiring", () => {
 
     expect(result.branch).toBe("fusion/fn-1");
     expect(result.worktreePath).toBe("/repo/.worktrees/fn-1");
+    /*
+     * FNXC:WorktreeIsolation 2026-07-02-07:40:
+     * acquireTaskWorktree now resolves the integration branch via `git symbolic-ref` and pins fresh worktree creation to that start point so new task branches never inherit the root checkout's ambient HEAD. With an empty mock stdout the resolver falls back to "main", so the native create command appends "main" as the start point and there are two exec calls (symbolic-ref + worktree add).
+     */
     expect(execMock).toHaveBeenCalledWith(
-      'git worktree add -b "fusion/fn-1" "/repo/.worktrees/fn-1"',
+      "git symbolic-ref --short refs/remotes/origin/HEAD",
+      expect.objectContaining({ cwd: "/repo" }),
+    );
+    expect(execMock).toHaveBeenCalledWith(
+      'git worktree add -b "fusion/fn-1" "/repo/.worktrees/fn-1" "main"',
       expect.objectContaining({ cwd: "/repo" }),
     );
     expect(audit.git).not.toHaveBeenCalledWith(
@@ -125,7 +133,16 @@ describe("acquireTaskWorktree backend wiring", () => {
       }),
     ).rejects.toMatchObject({ name: "WorktrunkOperationError", code: "worktrunk_binary_missing" });
 
-    expect(execMock).not.toHaveBeenCalled();
+    /*
+     * FNXC:WorktreeIsolation 2026-07-02-07:40:
+     * The integration-branch resolution (`git symbolic-ref`) runs before the worktrunk binary check, so one exec call is expected. No worktrunk `switch` command should be attempted when the binary is missing.
+     */
+    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(execMock).toHaveBeenCalledWith(
+      "git symbolic-ref --short refs/remotes/origin/HEAD",
+      expect.objectContaining({ cwd: "/repo" }),
+    );
+    expect(execMock.mock.calls.some((call) => String(call[0]).includes('"switch"'))).toBe(false);
   });
 
   it("throws worktrunk_operation_failed and preserves stderr", async () => {
@@ -170,6 +187,14 @@ describe("acquireTaskWorktree backend wiring", () => {
     expect(result.worktreePath).toBe("/tmp/backend");
     expect(result.branch).toBe("fusion/fn-backend");
     expect(create).toHaveBeenCalledTimes(1);
-    expect(execMock).not.toHaveBeenCalled();
+    /*
+     * FNXC:WorktreeIsolation 2026-07-02-07:40:
+     * The integration-branch resolution runs before the explicit backend's create is invoked, so the only exec call is the `git symbolic-ref` lookup. The custom backend's create mock performs no exec.
+     */
+    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(execMock).toHaveBeenCalledWith(
+      "git symbolic-ref --short refs/remotes/origin/HEAD",
+      expect.objectContaining({ cwd: "/repo" }),
+    );
   });
 });

--- a/packages/engine/src/__tests__/worktree-acquisition-worktrunk.test.ts
+++ b/packages/engine/src/__tests__/worktree-acquisition-worktrunk.test.ts
@@ -65,8 +65,14 @@ describe("acquireTaskWorktree worktrunk wiring", () => {
     });
 
     expect(result).toMatchObject({ source: "fresh", branch: "fusion/fn-1" });
-    expect(execMock).toHaveBeenCalledTimes(1);
-    expect(execMock.mock.calls[0]?.[0]).toContain("git worktree add -b");
+    /*
+     * FNXC:WorktreeIsolation 2026-07-02-07:40:
+     * acquireTaskWorktree now resolves the integration branch via `git symbolic-ref` (returning empty here, so it falls back to "main") and pins the fresh worktree to that start point. Two exec calls happen: the symbolic-ref lookup, then the native `git worktree add -b ... "main"` create.
+     */
+    expect(execMock).toHaveBeenCalledTimes(2);
+    expect(execMock.mock.calls[0]?.[0]).toBe("git symbolic-ref --short refs/remotes/origin/HEAD");
+    expect(execMock.mock.calls[1]?.[0]).toContain('git worktree add -b "fusion/fn-1"');
+    expect(execMock.mock.calls[1]?.[0]).toContain('"main"');
   });
 
   it("prefers explicit createWorktree override", async () => {
@@ -223,6 +229,14 @@ describe("acquireTaskWorktree worktrunk wiring", () => {
 
     expect(result.branch).toBe("fusion/fn-1-custom");
     expect(create).toHaveBeenCalledTimes(1);
-    expect(execMock).not.toHaveBeenCalled();
+    /*
+     * FNXC:WorktreeIsolation 2026-07-02-07:40:
+     * The integration-branch resolution runs before the custom backend's create, so the only exec call is the `git symbolic-ref` lookup. The backend's create mock performs no exec.
+     */
+    expect(execMock).toHaveBeenCalledTimes(1);
+    expect(execMock).toHaveBeenCalledWith(
+      "git symbolic-ref --short refs/remotes/origin/HEAD",
+      expect.objectContaining({ cwd: "/repo" }),
+    );
   });
 });

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1724,6 +1724,21 @@ export class TaskExecutor {
   private pendingEphemeralDeletions = new Set<string>();
   private workspaceConfig: WorkspaceConfig | null | undefined = undefined;
 
+  /*
+  FNXC:WorkflowLifecycle 2026-07-01-16:20:
+  Breadcrumb task-log writes on the abort/pause/finalize paths are best-effort diagnostics and must NEVER break control flow. FN-7335 wired store.logEntry() straight into the SYNCHRONOUS markPausedAborted() as `void this.store.logEntry(...).catch(...)`; when store.logEntry is absent/throws synchronously (undefined method, store closed mid-abort, corrupted pager) the call throws a TypeError BEFORE the promise exists, so the trailing .catch() never runs and the exception unwinds out of markPausedAborted — aborting hard-cancel/pause and stranding the in-review handoff. Route every breadcrumb write through safeLogEntry() so both synchronous throws and async rejections are swallowed into a warn.
+  */
+  private safeLogEntry(taskId: string, message: string): void {
+    try {
+      const result = this.store.logEntry(taskId, message, undefined, this.getRunContextFor(taskId));
+      void Promise.resolve(result).catch((error) => {
+        executorLog.warn(`${taskId}: failed to write task-log breadcrumb: ${error instanceof Error ? error.message : String(error)}`);
+      });
+    } catch (error) {
+      executorLog.warn(`${taskId}: failed to write task-log breadcrumb: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   private markPausedAborted(
     taskId: string,
     provenance: "global-pause" | "merge-seam" | "hard-cancel" | "completion-finalize" = "hard-cancel",
@@ -1738,14 +1753,10 @@ export class TaskExecutor {
       FNXC:WorkflowLifecycle 2026-07-01-22:24:
       Pause aborts are frequent enough that operators need task-log breadcrumbs at the marker source, not only at the later graph-failure sink. Log first-mark/provenance-change events so a task card shows why a workflow was interrupted and which code path owned the abort.
       */
-      void this.store.logEntry(
+      this.safeLogEntry(
         taskId,
         `Pause abort marked: provenance=${provenance} source=${source}${previousProvenance && previousProvenance !== provenance ? ` previous=${previousProvenance}` : ""}`,
-        undefined,
-        this.getRunContextFor(taskId),
-      ).catch((error) => {
-        executorLog.warn(`${taskId}: failed to log pause-abort marker: ${error instanceof Error ? error.message : String(error)}`);
-      });
+      );
     }
   }
 
@@ -2564,14 +2575,10 @@ export class TaskExecutor {
 
     if (hadActiveSurface) {
       executorLog.log(`${taskId}: awaited abort of in-flight work — ${reason}`);
-      await this.store.logEntry(
+      this.safeLogEntry(
         taskId,
         `Pause abort cleanup completed: reason=${reason}; surfaces=${abortedSurfaces.join(", ") || "none"}`,
-        undefined,
-        this.getRunContextFor(taskId),
-      ).catch((error) => {
-        executorLog.warn(`${taskId}: failed to log pause-abort cleanup: ${error instanceof Error ? error.message : String(error)}`);
-      });
+      );
     }
   }
 
@@ -8221,11 +8228,9 @@ export class TaskExecutor {
       if (pausedAborted || live.paused || live.userPaused || abortProvenance) {
         const failedNodeForLog = result.visitedNodeIds[result.visitedNodeIds.length - 1] ?? "unknown";
         const failureValueForLog = this.graphFailureValue(result) ?? "none";
-        await this.store.logEntry(
+        this.safeLogEntry(
           task.id,
           `Pause abort classified: provenance=${abortProvenance ?? "unknown"}; node=${failedNodeForLog}; interrupted=${result.interruptedNodeId ?? "none"}; abortKind=${result.interruptedAbortKind ?? "none"}; column=${live.column}; status=${live.status ?? "none"}; paused=${live.paused === true}; userPaused=${live.userPaused === true}; value=${failureValueForLog}; genuine=${genuinePauseAbort}; mergeSeam=${mergeSeamAborted}; completionSuppressed=${suppressFinalizedCompletionAbort}`,
-          undefined,
-          this.getRunContextFor(task.id),
         );
       }
       if (genuinePauseAbort && await this.isReentrantPausedAbortedInFlightNode(live, result, abortProvenance, pausedAborted, this.userCanceledTaskIds.has(task.id))) {

--- a/packages/engine/src/workflow-authoritative-driver.ts
+++ b/packages/engine/src/workflow-authoritative-driver.ts
@@ -195,7 +195,31 @@ export class WorkflowAuthoritativeDriver {
       },
       primitives: this.deps.executor.createAuthoritativeWorkflowPrimitives?.(settings) ?? primitivesFromLegacySeams(seams),
       seams,
+      /*
+      FNXC:WorkflowInterpreterCutover 2026-07-01-21:05:
+      BUILTIN_CODING_WORKFLOW_IR graduated to carry default-on/always-on custom
+      lifecycle nodes: the plan-review/code-review/browser-verification/post-merge
+      optional groups (bypassed at their group node when a task disables them via
+      enabledWorkflowSteps) and an ALWAYS-ON `completion-summary` prompt node
+      (kind:"prompt", summaryTarget:"task") that records the pre-review summary.
+      The transitional authoritative driver validates SEAM-LEVEL parity
+      (planning/execute/review/merge/schedule) against the legacy executor; it does
+      not reproduce custom-node side effects. Previously runCustomNode threw on any
+      custom node, so the always-on completion-summary aborted every clean run
+      before it could reach review→merge. Pass built-in auxiliary custom nodes
+      (task-summary nodes and bypassable optional groups) through as success so the
+      seam pipeline completes, mirroring the main executor's completion path for
+      parity purposes. Genuinely unexpected custom nodes still fail loudly.
+      */
       runCustomNode: async (node) => {
+        const isBuiltinAuxiliaryNode =
+          node.config?.summaryTarget === "task" || node.kind === "optional-group";
+        if (isBuiltinAuxiliaryNode) {
+          executorLog.log(
+            `[workflow-authoritative] ${task.id}: passing auxiliary custom node '${node.id}' through as success (seam-parity run)`,
+          );
+          return { outcome: "success" };
+        }
         throw new Error(`unexpected custom node in builtin authoritative workflow: ${node.id}`);
       },
       onEvent: (event) => {


### PR DESCRIPTION
## Summary

Fixes all failing tests in the non-blocking full-suite CI run [28561416741](https://github.com/Runfusion/Fusion/actions/runs/28561416741) on main.

## Root causes and fixes

### 1. Missing `formatModelMarkerDetails` mock export (5 files, 17 tests)

Production code in `reviewer.ts` and `triage.ts` calls `formatModelMarkerDetails()` after resolving an agent session to build a model-marker log line. Five test files mocked `../pi.js` without exporting this function, so every reviewer/triage/restart path threw `[vitest] No "formatModelMarkerDetails" export is defined` before reaching finalization assertions.

**Files:** `reviewer-prompt-single-source`, `plan-review-unavailable-recovery`, `triage-fast-mode-workflow-variant`, `triage-stuck-requeue-preserve-draft`, `restart.integration`

### 2. Outdated worktree acquisition assertions (2 files, 5 tests)

A production fix added `git symbolic-ref --short refs/remotes/origin/HEAD` resolution to ensure fresh task worktrees never inherit the root checkout's ambient HEAD. The tests didn't account for this new exec call or the appended start point.

**Files:** `worktree-acquisition-backend`, `worktree-acquisition-worktrunk`

### 3. Stale workflow compiler tests (1 file, 2 tests)

FN-7360 removed the linear `WorkflowStep` compiler and `/compile` endpoint, making `parseWorkflowIr` the sole validity gate. Branching custom workflows are now valid on the graph interpreter. Two dashboard tests still asserted 422 for branching IR.

**File:** `workflow-routes`

### 4. Graph cutover production fixes + test migrations (from closed PR #1869)

- `executor.ts`: `safeLogEntry()` wrapper prevents synchronous `store.logEntry` throws from aborting pause/abort/finalize control flow
- `workflow-authoritative-driver.ts`: built-in auxiliary custom nodes (completion-summary, optional-groups) pass through as success instead of throwing
- Test migrations across engine, CLI, dashboard, and desktop for graph-native runtime paths

## Verification

- All affected tests pass: engine (87 tests across 7 files), dashboard (53 tests), plus the cherry-picked migration tests
- Merge gate (`pnpm test:gate`): 319 engine-core + 63 CI-shape tests green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for branching workflow content in more places, including workflow creation and selection.
  * Added a new shared runtime tool available to plan/review agents for writing task prompts.

* **Bug Fixes**
  * Improved task failure handling so retries now end cleanly instead of bouncing through extra states.
  * Made pause, recovery, and worktree-related behavior more reliable during long-running operations and restarts.
  * Updated Android release automation to use JDK 21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->