### PR TITLE
fix(desktop): make Windows desktop work end-to-end — boot, onboarding, models, first-run UX

### DIFF
--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1791,7 +1791,16 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
         cwd,
         central: centralCoreForEngine,
         logPrefix: "dashboard",
-        autoRegister: true,
+        /*
+         * FNXC:CliProjectOnboarding 2026-07-03-03:45:
+         * Bare `fusion` / `fn` / `fn dashboard` / `fusion dashboard` must NOT auto-register the CWD as
+         * a project. Auto-registration silently created a project for whatever directory the dashboard
+         * happened to launch from. Instead: use the CWD project only if it is ALREADY registered,
+         * otherwise start with no CWD project and let the dashboard prompt the operator through
+         * onboarding (ProjectOverview "Add your first project" -> SetupWizard). Operators who want the
+         * CWD registered can still run `fn init`.
+         */
+        autoRegister: false,
       }).catch(() => undefined as Awaited<ReturnType<typeof ensureCwdProjectRegistered>> | undefined),
       (async () => {
         try {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -200,6 +200,15 @@ function runWorkspaceCommand(command: string, args: string[], cwd: string, timeo
       cwd,
       stdio: "inherit",
       env: process.env,
+      /*
+       * FNXC:DesktopPackaging 2026-07-02-15:10:
+       * On Windows `pnpm` (and other npm bins) resolve to a `.cmd` shim that Node refuses to
+       * spawn without a shell (ENOENT / EINVAL since CVE-2024-27980). Without shell:true the CLI
+       * package build failed with `spawn pnpm ENOENT` on Windows at the "building @fusion/desktop"
+       * step. The command/args here are fixed repo build invocations (no untrusted input), so shell
+       * quoting is safe.
+       */
+      shell: process.platform === "win32",
     });
     const timer = setTimeout(() => {
       child.kill("SIGTERM");

--- a/packages/dashboard/app/components/CliBinaryInstallBanner.tsx
+++ b/packages/dashboard/app/components/CliBinaryInstallBanner.tsx
@@ -16,6 +16,17 @@ interface Props {
 /** localStorage key for permanent dismissal. */
 const DISMISS_KEY = "fusion:cli-binary-banner-dismissed";
 
+/*
+ * FNXC:CliBanner 2026-07-03-09:25:
+ * Delay the CLI-install nudge so it does not clutter the first-run experience. We stamp the first time
+ * the banner becomes eligible (binary missing / version-mismatch) and suppress it until a grace period
+ * elapses. The Settings → General → CLI Binary panel still installs on demand in the meantime, so this
+ * only defers the passive nudge — it never hides the capability. Re-evaluated on each launch, so once
+ * the grace period passes the banner appears on a later run rather than immediately after onboarding.
+ */
+const FIRST_SEEN_KEY = "fusion:cli-binary-banner-first-seen";
+const SHOW_DELAY_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
 function isDismissed(): boolean {
   if (typeof window === "undefined") return false;
   try {
@@ -32,6 +43,39 @@ function persistDismissal(): void {
   } catch {
     // Ignore quota / private-mode errors — dismissal lasts the session only.
   }
+}
+
+/** Returns the ms timestamp the banner first became eligible, or null if never stamped. */
+function readFirstSeen(): number | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(FIRST_SEEN_KEY);
+    if (!raw) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Records the first-eligible timestamp once; later calls are no-ops so the grace window is stable. */
+function stampFirstSeen(now: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (!window.localStorage.getItem(FIRST_SEEN_KEY)) {
+      window.localStorage.setItem(FIRST_SEEN_KEY, String(now));
+    }
+  } catch {
+    // Ignore quota / private-mode errors — without a stamp the banner simply stays deferred.
+  }
+}
+
+/** The banner is eligible to show only for a missing / mismatched binary that isn't opt-out-skipped. */
+function bannerEligible(status: FnBinaryStatus | null): boolean {
+  if (!status) return false;
+  if (status.state === "installed") return false;
+  if (status.state === "skipped") return false;
+  return true;
 }
 
 /**
@@ -57,7 +101,10 @@ export function CliBinaryInstallBanner({ onOpenSettings }: Props) {
     let cancelled = false;
     void fetchFnBinaryStatus()
       .then((next) => {
-        if (!cancelled) setStatus(next);
+        if (cancelled) return;
+        setStatus(next);
+        // Start the grace window the first time the banner would otherwise be eligible.
+        if (bannerEligible(next)) stampFirstSeen(Date.now());
       })
       .catch(() => {
         // Treat probe failure as "don't show banner" — better silent than
@@ -104,6 +151,10 @@ export function CliBinaryInstallBanner({ onOpenSettings }: Props) {
   // Honour the global `fnBinaryCheckEnabled` opt-out — when checks are
   // disabled the install banner would be misleading.
   if (status.state === "skipped") return null;
+
+  // FNXC:CliBanner 2026-07-03-09:25: defer the nudge until the grace period after first eligibility.
+  const firstSeen = readFirstSeen();
+  if (firstSeen === null || Date.now() - firstSeen < SHOW_DELAY_MS) return null;
 
   const isMismatch = status.state === "version-mismatch";
   const installedVersion = status.binary.version;

--- a/packages/dashboard/app/components/DesktopLaunchGate.tsx
+++ b/packages/dashboard/app/components/DesktopLaunchGate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type PropsWithChildren } from "react";
 import { useTranslation } from "react-i18next";
 import type { ShellConnectionState } from "../types/native-shell";
+import { getShellHostContext } from "../shell-host";
 import "./DesktopLaunchGate.css";
 
 type Phase =
@@ -92,9 +93,23 @@ export function DesktopLaunchGate({ children }: PropsWithChildren) {
         // current page URL; if remote, App handles the redirect to the
         // active profile already.
         if (state.desktopMode === "local") {
-          const params = new URLSearchParams(window.location.search);
-          if (params.has("serverBaseUrl")) {
-            setPhase({ kind: "ready", serverBaseUrl: params.get("serverBaseUrl") ?? undefined });
+          /*
+           * FNXC:DesktopLaunchGate 2026-07-03-01:05:
+           * Detect a completed local handoff via the CACHED shell-host context, NOT the raw URL.
+           * applyServerBaseUrl() reloads the page with ?serverBaseUrl=…, but main.tsx calls
+           * bootstrapShellHostContext() at module load (before this effect runs), which STRIPS every
+           * shell query param from the URL via history.replaceState. So reading window.location.search
+           * here always misses serverBaseUrl → we would re-run the handoff → window.location.replace →
+           * reload → strip → an INFINITE reload loop, seen as rapid "Starting local Fusion runtime…"
+           * flashing that never connects. The bootstrap preserves the captured value in
+           * getShellHostContext().serverUrl, so read that (fall back to any not-yet-stripped URL param).
+           */
+          const shellHost = getShellHostContext();
+          const handoffBaseUrl = shellHost.kind === "desktop-shell" ? shellHost.serverUrl : undefined;
+          const urlParamBaseUrl = new URLSearchParams(window.location.search).get("serverBaseUrl") ?? undefined;
+          const existingBaseUrl = handoffBaseUrl ?? urlParamBaseUrl;
+          if (existingBaseUrl) {
+            setPhase({ kind: "ready", serverBaseUrl: existingBaseUrl });
             return;
           }
           setPhase({ kind: "starting-local", message: t("desktop.startingLocalRuntime", "Starting local Fusion runtime…") });

--- a/packages/dashboard/app/components/DesktopLaunchGate.tsx
+++ b/packages/dashboard/app/components/DesktopLaunchGate.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, type PropsWithChildren } from "react";
 import { useTranslation } from "react-i18next";
 import type { ShellConnectionState } from "../types/native-shell";
-import { getShellHostContext } from "../shell-host";
 import "./DesktopLaunchGate.css";
 
 type Phase =
@@ -51,15 +50,20 @@ async function waitForLocalRuntime(
   throw new Error("Local runtime did not become ready in time");
 }
 
-function applyServerBaseUrl(baseUrl: string): void {
-  // Reload the page with the local runtime URL so shell-host bootstrap reads
-  // it and routes API calls through it (the page itself is loaded via file://
-  // so relative /api fetches would otherwise fail).
-  const url = new URL(window.location.href);
-  url.searchParams.set("serverBaseUrl", baseUrl);
-  url.searchParams.set("shellKind", "desktop-shell");
-  url.searchParams.set("shellMode", "local");
-  window.location.replace(url.toString());
+function navigateToLocalRuntimeOrigin(baseUrl: string): void {
+  /*
+   * FNXC:DesktopLaunchGate 2026-07-03-02:10:
+   * Load the UI FROM the embedded runtime's own origin (http://127.0.0.1:<port>/) rather than
+   * staying on the packaged file:// page. The dashboard client makes RELATIVE /api requests; on a
+   * file:// origin those resolve to file:///api/… and fail ("Can't reach the Fusion backend / Failed
+   * to fetch"), and the embedded server sends no CORS header so a cross-origin fetch would be blocked
+   * too. The embedded server also serves the client HTML at /, so navigating there makes /api
+   * same-origin and everything just works — this mirrors how remote mode navigates to its server URL.
+   */
+  const target = new URL("/", baseUrl);
+  target.searchParams.set("shellKind", "desktop-shell");
+  target.searchParams.set("shellMode", "local");
+  window.location.replace(target.toString());
 }
 
 export function DesktopLaunchGate({ children }: PropsWithChildren) {
@@ -94,22 +98,17 @@ export function DesktopLaunchGate({ children }: PropsWithChildren) {
         // active profile already.
         if (state.desktopMode === "local") {
           /*
-           * FNXC:DesktopLaunchGate 2026-07-03-01:05:
-           * Detect a completed local handoff via the CACHED shell-host context, NOT the raw URL.
-           * applyServerBaseUrl() reloads the page with ?serverBaseUrl=…, but main.tsx calls
-           * bootstrapShellHostContext() at module load (before this effect runs), which STRIPS every
-           * shell query param from the URL via history.replaceState. So reading window.location.search
-           * here always misses serverBaseUrl → we would re-run the handoff → window.location.replace →
-           * reload → strip → an INFINITE reload loop, seen as rapid "Starting local Fusion runtime…"
-           * flashing that never connects. The bootstrap preserves the captured value in
-           * getShellHostContext().serverUrl, so read that (fall back to any not-yet-stripped URL param).
+           * FNXC:DesktopLaunchGate 2026-07-03-02:10:
+           * If this page is already served over http(s), it's the embedded runtime serving the UI,
+           * so /api is same-origin — render the app. The packaged renderer first loads from file://
+           * (where relative /api fetches fail); there we start the runtime and navigate to its origin
+           * (navigateToLocalRuntimeOrigin). Gating on the protocol rather than a serverBaseUrl URL
+           * param also avoids the prior reload loop — main.tsx's bootstrapShellHostContext() strips
+           * shell query params at module load, so a param-based "already handed off" check always
+           * missed and reloaded forever ("rapid Starting Fusion flashing").
            */
-          const shellHost = getShellHostContext();
-          const handoffBaseUrl = shellHost.kind === "desktop-shell" ? shellHost.serverUrl : undefined;
-          const urlParamBaseUrl = new URLSearchParams(window.location.search).get("serverBaseUrl") ?? undefined;
-          const existingBaseUrl = handoffBaseUrl ?? urlParamBaseUrl;
-          if (existingBaseUrl) {
-            setPhase({ kind: "ready", serverBaseUrl: existingBaseUrl });
+          if (window.location.protocol !== "file:") {
+            setPhase({ kind: "ready" });
             return;
           }
           setPhase({ kind: "starting-local", message: t("desktop.startingLocalRuntime", "Starting local Fusion runtime…") });
@@ -141,7 +140,7 @@ export function DesktopLaunchGate({ children }: PropsWithChildren) {
           }
           const { baseUrl } = await waitForLocalRuntime(shell);
           if (cancelled) return;
-          applyServerBaseUrl(baseUrl);
+          navigateToLocalRuntimeOrigin(baseUrl);
           return;
         }
 

--- a/packages/dashboard/app/components/DesktopLaunchGate.tsx
+++ b/packages/dashboard/app/components/DesktopLaunchGate.tsx
@@ -98,6 +98,32 @@ export function DesktopLaunchGate({ children }: PropsWithChildren) {
             return;
           }
           setPhase({ kind: "starting-local", message: t("desktop.startingLocalRuntime", "Starting local Fusion runtime…") });
+          /*
+           * FNXC:DesktopLaunchGate 2026-07-02-14:35:
+           * Self-healing start. Do NOT assume main already started the embedded runtime.
+           * The gate decides to WAIT from shell `desktopMode:"local"`, but main decides to
+           * START from a separate launch-mode file; when those desync (a first local
+           * selection whose runtime start failed/was interrupted), main never starts the
+           * runtime and this branch would poll a permanently "stopped" runtime until the 30s
+           * timeout — the "hangs at Starting local runtime" bug. If the runtime is not already
+           * running or starting, actively (re)start it via setDesktopMode("local") — idempotent
+           * and awaits startup — before polling, so the gate can never wait for a runtime nobody
+           * launched.
+           */
+          const rt = state.localRuntime;
+          if (rt?.state !== "running" && rt?.state !== "starting") {
+            try {
+              await shell.setDesktopMode("local");
+            } catch (startError) {
+              if (cancelled) return;
+              setPhase({
+                kind: "local-error",
+                message: startError instanceof Error ? startError.message : String(startError),
+              });
+              return;
+            }
+            if (cancelled) return;
+          }
           const { baseUrl } = await waitForLocalRuntime(shell);
           if (cancelled) return;
           applyServerBaseUrl(baseUrl);

--- a/packages/dashboard/app/components/DesktopLaunchGate.tsx
+++ b/packages/dashboard/app/components/DesktopLaunchGate.tsx
@@ -123,8 +123,14 @@ export function DesktopLaunchGate({ children }: PropsWithChildren) {
            * running or starting, actively (re)start it via setDesktopMode("local") — idempotent
            * and awaits startup — before polling, so the gate can never wait for a runtime nobody
            * launched.
+           *
+           * Re-read the runtime state immediately before deciding: the `state` snapshot was captured
+           * at mount and may not yet reflect a runtime main already started, which would fire a
+           * redundant setDesktopMode("local") on normal boots.
            */
-          const rt = state.localRuntime;
+          const freshState = await shell.getState();
+          if (cancelled) return;
+          const rt = freshState.localRuntime;
           if (rt?.state !== "running" && rt?.state !== "starting") {
             try {
               await shell.setDesktopMode("local");
@@ -225,7 +231,7 @@ export function DesktopLaunchGate({ children }: PropsWithChildren) {
             await shell.setDesktopMode(mode);
             if (mode === "local") {
               const { baseUrl } = await waitForLocalRuntime(shell);
-              applyServerBaseUrl(baseUrl);
+              navigateToLocalRuntimeOrigin(baseUrl);
               return;
             }
             await shell.openConnectionManager();

--- a/packages/dashboard/app/components/ModelOnboardingModal.tsx
+++ b/packages/dashboard/app/components/ModelOnboardingModal.tsx
@@ -1655,9 +1655,36 @@ export function ModelOnboardingModal({
   );
 
   // Handle model selection from CustomModelDropdown
-  const handleModelSelect = useCallback((value: string) => {
-    setSelectedModel(value);
-  }, []);
+  const handleModelSelect = useCallback(
+    (value: string) => {
+      setSelectedModel(value);
+
+      /*
+       * FNXC:Onboarding 2026-07-03-09:15:
+       * Persist the picked model as the global default IMMEDIATELY on selection. Previously the choice
+       * lived only in local state until completeOnboarding ran on the final step, so a user who selected
+       * a model but exited or skipped before finishing lost the selection and then saw the post-onboarding
+       * "Select Default Model" banner despite having explicitly chosen one. Saving on pick makes the
+       * selection durable regardless of how onboarding is exited.
+       */
+      const slashIdx = value.indexOf("/");
+      const provider = slashIdx !== -1 ? value.slice(0, slashIdx) : undefined;
+      const modelId = slashIdx !== -1 ? value.slice(slashIdx + 1) : value;
+      const model = availableModels.find((m) => m.id === modelId);
+      const updates: Record<string, unknown> = {};
+      if (model) {
+        updates.defaultProvider = model.provider;
+        updates.defaultModelId = model.id;
+      } else if (provider && modelId) {
+        updates.defaultProvider = provider;
+        updates.defaultModelId = modelId;
+      }
+      if (updates.defaultModelId) {
+        void updateGlobalSettings(updates).catch(() => undefined);
+      }
+    },
+    [availableModels, updateGlobalSettings],
+  );
 
   const completeOnboarding = useCallback(async () => {
     try {
@@ -1665,13 +1692,26 @@ export function ModelOnboardingModal({
         modelOnboardingComplete: true,
       };
 
-      // If a model was selected, persist it as the default
-      if (selectedModel) {
-        const slashIdx = selectedModel.indexOf("/");
+      /*
+       * FNXC:Onboarding 2026-07-03-09:10:
+       * Persist a default model on completion so the post-onboarding "Select Default Model"
+       * recommendation does not fire for operators who connected a provider but never opened the model
+       * dropdown. selectedModel is only populated by an explicit dropdown pick (or a previously-saved
+       * default), so a fresh first-run where the user just connects Anthropic and clicks Continue would
+       * otherwise leave defaultProvider/defaultModelId unset and trip the false-positive banner. Prefer
+       * the explicit pick; otherwise fall back to the first available model from the connected provider.
+       * Only when no models are available at all do we leave the default unset.
+       */
+      const effectiveSelection =
+        selectedModel ||
+        (availableModels[0] ? `${availableModels[0].provider}/${availableModels[0].id}` : "");
+
+      if (effectiveSelection) {
+        const slashIdx = effectiveSelection.indexOf("/");
         const provider =
-          slashIdx !== -1 ? selectedModel.slice(0, slashIdx) : undefined;
+          slashIdx !== -1 ? effectiveSelection.slice(0, slashIdx) : undefined;
         const modelId =
-          slashIdx !== -1 ? selectedModel.slice(slashIdx + 1) : selectedModel;
+          slashIdx !== -1 ? effectiveSelection.slice(slashIdx + 1) : effectiveSelection;
 
         const model = availableModels.find((m) => m.id === modelId);
         if (model) {

--- a/packages/dashboard/app/components/ModelOnboardingModal.tsx
+++ b/packages/dashboard/app/components/ModelOnboardingModal.tsx
@@ -2668,7 +2668,15 @@ export function ModelOnboardingModal({
                   <div className="model-onboarding-github-optional__actions">
                     <button
                       className="btn btn-primary btn-sm"
-                      onClick={() => setStep("project-setup")}
+                      /*
+                       * FNXC:Onboarding 2026-07-03-08:00:
+                       * Advance via handleNext/handleSkip (not a raw setStep) so the GitHub step's
+                       * status is recorded. When GitHub is ready via the gh CLI, "Continue with gh CLI
+                       * auth" must COMPLETE the step (handleNext) — previously it jumped to project-setup
+                       * without adding "github" to completedSteps, so step 2 never checked off. When
+                       * GitHub isn't connected, "Continue without GitHub" is a SKIP (handleSkip).
+                       */
+                      onClick={isGitHubReadyViaCli ? handleNext : handleSkip}
                     >
                       {isGitHubReadyViaCli
                         ? t("setup.continueWithGhCli", "Continue with gh CLI auth →")

--- a/packages/dashboard/app/components/ModelOnboardingModal.tsx
+++ b/packages/dashboard/app/components/ModelOnboardingModal.tsx
@@ -1830,7 +1830,15 @@ export function ModelOnboardingModal({
   const githubStatus = getGitHubStatus();
 
   const aiProviders = authProviders.filter((provider) => provider.id !== "github");
-  const showShellConnectionSetup = shellState.host !== "web" && !shellState.activeProfileId;
+  /*
+   * FNXC:Onboarding 2026-07-03-07:20:
+   * Show the "Connect remote Fusion server" card ONLY when not already connected to a remote server
+   * (no active remote profile) — on any host, web included. Never show it in LOCAL desktop mode: a
+   * local runtime is already the connected backend, so prompting for a remote server URL just confuses
+   * first-run setup (the original report).
+   */
+  const showShellConnectionSetup =
+    !shellState.activeProfileId && shellState.desktopMode !== "local";
   const orderedAiProviders = [...aiProviders].sort(compareOnboardingProviders);
   const hasOauthProviders = orderedAiProviders.some((provider) => !provider.type || provider.type === "oauth");
   const providerSupportsApiKey = (provider: AuthProvider) => provider.type === "api_key";
@@ -2352,9 +2360,6 @@ export function ModelOnboardingModal({
               </p>
               <p className="onboarding-helper-text model-onboarding-primary-helper">
                 {t("setup.onlyNeedOneProvider", "You only need one provider to get started.")}
-              </p>
-              <p className="onboarding-helper-text">
-                {t("setup.researchRunsNote", "Research runs require provider credentials and an enabled Research View. After onboarding, verify these in Settings → Authentication and Settings → Experimental Features.")}
               </p>
 
               {showShellConnectionSetup && (

--- a/packages/dashboard/app/components/RightDock.tsx
+++ b/packages/dashboard/app/components/RightDock.tsx
@@ -35,9 +35,17 @@ export function readStoredRightDockWidth(): number {
   return Number.isFinite(parsed) ? clampRightDockWidth(parsed) : RIGHT_DOCK_DEFAULT_WIDTH;
 }
 
+/*
+ * FNXC:Navigation 2026-07-03-09:40:
+ * The right dock now defaults to HIDDEN when the operator has no stored preference, so first-run and
+ * onboarding land on an uncluttered board rather than the full sidebar. Users opt in via the canonical
+ * Header right-sidebar toggle, which persists "true"; an explicit stored "false" also stays hidden.
+ * Only an explicit "true" opens it. This replaces the previous visible-by-default behavior at the
+ * request of the product owner ("make sure right sidebar isn't shown by default ... on first run").
+ */
 export function readStoredRightDockOpen(): boolean {
-  if (typeof window === "undefined") return true;
-  return window.localStorage.getItem(RIGHT_DOCK_OPEN_STORAGE_KEY) !== "false";
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(RIGHT_DOCK_OPEN_STORAGE_KEY) === "true";
 }
 
 export function persistRightDockOpen(open: boolean): void {
@@ -112,8 +120,8 @@ The right dock is an auxiliary tablet/desktop surface: it remembers the last ove
 FNXC:Navigation 2026-06-21-20:14:
 FN-6882 splits right-dock entries into launcher actions and inline views. Action tabs invoke their existing Header handlers without replacing the Files body; only inline entries persist selection or expand into the modal.
 
-FNXC:Navigation 2026-06-22-09:00:
-The right dock is visible by default on tablet/desktop project screens. Show/hide is owned solely by the canonical Header right-sidebar toggle (the in-dock collapse toggle was removed); the dock takes only `open` and renders null when closed so the main content reclaims the space.
+FNXC:Navigation 2026-06-22-09:00 (updated 2026-07-03-09:40):
+The right dock is HIDDEN by default on tablet/desktop project screens (no stored preference -> closed; see readStoredRightDockOpen) so first-run/onboarding lands on an uncluttered board. Show/hide is owned solely by the canonical Header right-sidebar toggle (the in-dock collapse toggle was removed); the dock takes only `open` and renders null when closed so the main content reclaims the space.
 
 FNXC:i18n 2026-06-22-00:00:
 Right-dock affordance labels are user-facing accessibility copy, so route them through the app namespace and keep English defaults colocated with the component for tests and fallback rendering.

--- a/packages/dashboard/app/components/SetupWizardModal.tsx
+++ b/packages/dashboard/app/components/SetupWizardModal.tsx
@@ -467,6 +467,30 @@ export function SetupWizardModal({
                 </fieldset>
               </section>
 
+              {/*
+                FNXC:Onboarding 2026-07-03-08:20:
+                Folder selection comes BEFORE the project name: the name auto-derives from the chosen
+                directory, so picking the folder first pre-fills a sensible name (rather than asking for
+                a name before there's a folder to base it on).
+              */}
+              <div className="form-group">
+                <label htmlFor="project-path">{isCloneMode ? t("setup.destinationDirectory", "Destination Directory") : isInitMode ? t("setup.newRepositoryDirectory", "New Repository Directory") : t("setup.projectDirectory", "Project Directory")}</label>
+                <DirectoryPicker
+                  value={state.manualPath}
+                  onChange={handlePathChange}
+                  nodeId={state.manualNodeId || undefined}
+                  localNodeId={localNodeId}
+                  placeholder={isCloneMode ? t("setup.clonePathPlaceholder", "/path/for/new-clone") : isInitMode ? t("setup.initPathPlaceholder", "/path/to/new-project") : t("setup.projectPathPlaceholder", "/path/to/your/project")}
+                />
+                <p className="form-hint">
+                  {isCloneMode
+                    ? t("setup.clonePathHint", "Select or type an absolute destination path. Fusion will clone into this directory. The destination must be empty or absent.")
+                    : isInitMode
+                      ? t("setup.initPathHint", "Select or type an absolute path to an empty or non-git folder. Fusion will run git init during registration.")
+                      : t("setup.projectPathHint", "Select or type the absolute path to an existing git repository or workspace root.")}
+                </p>
+              </div>
+
               <div className="form-group">
                 <label htmlFor="project-name">{t("setup.projectName", "Project Name")}</label>
                 <input
@@ -484,24 +508,6 @@ export function SetupWizardModal({
                     : isInitMode
                       ? t("setup.projectNameHintInit", "By default this follows the folder name Fusion will initialize unless you edit it.")
                       : t("setup.projectNameHintExisting", "By default this follows the selected directory name unless you edit it.")}
-                </p>
-              </div>
-
-              <div className="form-group">
-                <label htmlFor="project-path">{isCloneMode ? t("setup.destinationDirectory", "Destination Directory") : isInitMode ? t("setup.newRepositoryDirectory", "New Repository Directory") : t("setup.projectDirectory", "Project Directory")}</label>
-                <DirectoryPicker
-                  value={state.manualPath}
-                  onChange={handlePathChange}
-                  nodeId={state.manualNodeId || undefined}
-                  localNodeId={localNodeId}
-                  placeholder={isCloneMode ? t("setup.clonePathPlaceholder", "/path/for/new-clone") : isInitMode ? t("setup.initPathPlaceholder", "/path/to/new-project") : t("setup.projectPathPlaceholder", "/path/to/your/project")}
-                />
-                <p className="form-hint">
-                  {isCloneMode
-                    ? t("setup.clonePathHint", "Select or type an absolute destination path. Fusion will clone into this directory. The destination must be empty or absent.")
-                    : isInitMode
-                      ? t("setup.initPathHint", "Select or type an absolute path to an empty or non-git folder. Fusion will run git init during registration.")
-                      : t("setup.projectPathHint", "Select or type the absolute path to an existing git repository or workspace root.")}
                 </p>
               </div>
 

--- a/packages/dashboard/app/components/__tests__/App.test.tsx
+++ b/packages/dashboard/app/components/__tests__/App.test.tsx
@@ -1606,27 +1606,44 @@ describe("App deep link handling", () => {
   });
 
   it("shows error toast when project param references non-existent project", async () => {
-    mockProjectsState.projects = [];
-    mockCurrentProjectState.currentProject = null;
+    /*
+     * FNXC:DeepLink 2026-07-03-09:50:
+     * The not-found toast is deferred behind a grace window so an onboarding project deep-linked before
+     * its list revalidates does not flash a spurious error. A genuinely nonexistent project stays absent
+     * past the window and still surfaces the toast — advance fake timers to reach it.
+     */
+    vi.useFakeTimers();
+    try {
+      mockProjectsState.projects = [];
+      mockCurrentProjectState.currentProject = null;
 
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: new URL("http://localhost:3000/?project=nonexistent&task=FN-123"),
-    });
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL("http://localhost:3000/?project=nonexistent&task=FN-123"),
+      });
 
-    render(<App />);
+      render(<App />);
 
-    await waitFor(() => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
       expect(fetchSettings).toHaveBeenCalled();
-    });
 
-    // Should show error toast for project not found
-    await waitFor(() => {
+      // Within the grace window nothing has toasted yet.
+      expect(screen.queryByText("Project 'nonexistent' not found")).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      // Grace window elapsed with the project still absent — the error toast now shows.
       expect(screen.getByText("Project 'nonexistent' not found")).toBeTruthy();
-    });
 
-    // Should NOT fetch the task since project wasn't found
-    expect(fetchTaskDetail).not.toHaveBeenCalled();
+      // Should NOT fetch the task since project wasn't found.
+      expect(fetchTaskDetail).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not call setCurrentProject when project param matches current project", async () => {

--- a/packages/dashboard/app/components/__tests__/DesktopLaunchGate.test.tsx
+++ b/packages/dashboard/app/components/__tests__/DesktopLaunchGate.test.tsx
@@ -1,22 +1,29 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // t() returns the provided fallback so we assert on stable English text.
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
 }));
 
-const getShellHostContext = vi.fn();
-vi.mock("../../shell-host", () => ({ getShellHostContext: () => getShellHostContext() }));
-
 import { DesktopLaunchGate } from "../DesktopLaunchGate";
 
-type LocationStub = { href: string; search: string; replace: ReturnType<typeof vi.fn>; reload: ReturnType<typeof vi.fn> };
+type LocationStub = {
+  protocol: string;
+  href: string;
+  search: string;
+  port: string;
+  replace: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+};
 
-function stubLocation(search: string): LocationStub {
+function stubLocation(href: string): LocationStub {
+  const u = new URL(href);
   const loc: LocationStub = {
-    href: `file:///C:/app/index.html${search}`,
-    search,
+    protocol: u.protocol,
+    href,
+    search: u.search,
+    port: u.port,
     replace: vi.fn(),
     reload: vi.fn(),
   };
@@ -35,51 +42,27 @@ function stubShell(state: unknown) {
   return shell;
 }
 
+const localReadyState = {
+  host: "desktop-shell",
+  desktopMode: "local",
+  desktopModeState: { isFirstRun: false, desktopMode: "local" },
+  localRuntime: { source: "embedded-local", state: "running", port: 50123, baseUrl: "http://127.0.0.1:50123" },
+  profiles: [],
+  activeProfileId: null,
+};
+
 describe("DesktopLaunchGate — local handoff", () => {
-  beforeEach(() => {
-    getShellHostContext.mockReset();
-  });
   afterEach(() => {
     delete (window as unknown as { fusionShell?: unknown }).fusionShell;
   });
 
   /*
-   * Regression: after applyServerBaseUrl() reloads with ?serverBaseUrl=…, main.tsx's
-   * bootstrapShellHostContext() strips that param from the URL before this gate runs. The gate
-   * MUST recognize the completed handoff from the cached shell-host context (serverUrl), not the
-   * stripped URL — otherwise it re-triggers the handoff → window.location.replace → reload loop
-   * ("rapid Starting local Fusion runtime flashing that never connects").
+   * Regression for "Can't reach the Fusion backend / Failed to fetch": on the packaged file:// page,
+   * relative /api requests fail, so the gate must load the UI from the embedded runtime's own origin.
    */
-  it("renders children (no reload) when the handoff is present in the cached context but stripped from the URL", async () => {
-    const location = stubLocation(""); // URL already stripped by bootstrap
-    getShellHostContext.mockReturnValue({ kind: "desktop-shell", mode: "local", serverUrl: "http://127.0.0.1:50123" });
-    stubShell({
-      host: "desktop-shell",
-      desktopMode: "local",
-      desktopModeState: { isFirstRun: false, desktopMode: "local" },
-      localRuntime: { source: "embedded-local", state: "running", port: 50123, baseUrl: "http://127.0.0.1:50123" },
-    });
-
-    render(
-      <DesktopLaunchGate>
-        <div data-testid="app-loaded">app</div>
-      </DesktopLaunchGate>,
-    );
-
-    await waitFor(() => expect(screen.getByTestId("app-loaded")).toBeTruthy());
-    // The bug was an infinite reload; assert we never reload.
-    expect(location.replace).not.toHaveBeenCalled();
-  });
-
-  it("performs the handoff exactly once on first load (no cached serverUrl yet)", async () => {
-    const location = stubLocation(""); // fresh launch, no shell params
-    getShellHostContext.mockReturnValue({ kind: "desktop-shell" }); // bootstrap saw no serverUrl
-    stubShell({
-      host: "desktop-shell",
-      desktopMode: "local",
-      desktopModeState: { isFirstRun: false, desktopMode: "local" },
-      localRuntime: { source: "embedded-local", state: "running", port: 50123, baseUrl: "http://127.0.0.1:50123" },
-    });
+  it("navigates to the runtime origin exactly once when loaded from file://", async () => {
+    const location = stubLocation("file:///C:/app/index.html");
+    stubShell(localReadyState);
 
     render(
       <DesktopLaunchGate>
@@ -88,6 +71,55 @@ describe("DesktopLaunchGate — local handoff", () => {
     );
 
     await waitFor(() => expect(location.replace).toHaveBeenCalledTimes(1));
-    expect(location.replace.mock.calls[0][0]).toContain("serverBaseUrl=http%3A%2F%2F127.0.0.1%3A50123");
+    const target = location.replace.mock.calls[0][0] as string;
+    expect(target).toMatch(/^http:\/\/127\.0\.0\.1:50123\//);
+    expect(target).toContain("shellMode=local");
+  });
+
+  /*
+   * Regression for the reload loop ("rapid Starting Fusion flashing"): once the page is served over
+   * http by the runtime, the gate must render the app and NOT navigate again.
+   */
+  it("renders the app (no navigation) when already served over http by the runtime", async () => {
+    const location = stubLocation("http://127.0.0.1:50123/");
+    const shell = stubShell(localReadyState);
+
+    render(
+      <DesktopLaunchGate>
+        <div data-testid="app-loaded">app</div>
+      </DesktopLaunchGate>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("app-loaded")).toBeTruthy());
+    expect(location.replace).not.toHaveBeenCalled();
+    expect(shell.setDesktopMode).not.toHaveBeenCalled();
+  });
+
+  it("starts the runtime when it is not running, then navigates to its origin", async () => {
+    const location = stubLocation("file:///C:/app/index.html");
+    // First getState: stopped. setDesktopMode starts it; subsequent polls: running.
+    let started = false;
+    const running = localReadyState;
+    const stopped = { ...localReadyState, localRuntime: { source: "none", state: "stopped" } };
+    const shell = {
+      getState: vi.fn(async () => (started ? running : stopped)),
+      setDesktopMode: vi.fn(async () => {
+        started = true;
+        return running;
+      }),
+      onResetDesktopModeRequest: vi.fn(() => () => undefined),
+      resetDesktopMode: vi.fn(async () => undefined),
+    };
+    (window as unknown as { fusionShell: unknown }).fusionShell = shell;
+
+    render(
+      <DesktopLaunchGate>
+        <div data-testid="app-loaded">app</div>
+      </DesktopLaunchGate>,
+    );
+
+    await waitFor(() => expect(shell.setDesktopMode).toHaveBeenCalledWith("local"));
+    await waitFor(() => expect(location.replace).toHaveBeenCalledTimes(1));
+    expect(location.replace.mock.calls[0][0]).toMatch(/^http:\/\/127\.0\.0\.1:50123\//);
   });
 });

--- a/packages/dashboard/app/components/__tests__/DesktopLaunchGate.test.tsx
+++ b/packages/dashboard/app/components/__tests__/DesktopLaunchGate.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// t() returns the provided fallback so we assert on stable English text.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+
+const getShellHostContext = vi.fn();
+vi.mock("../../shell-host", () => ({ getShellHostContext: () => getShellHostContext() }));
+
+import { DesktopLaunchGate } from "../DesktopLaunchGate";
+
+type LocationStub = { href: string; search: string; replace: ReturnType<typeof vi.fn>; reload: ReturnType<typeof vi.fn> };
+
+function stubLocation(search: string): LocationStub {
+  const loc: LocationStub = {
+    href: `file:///C:/app/index.html${search}`,
+    search,
+    replace: vi.fn(),
+    reload: vi.fn(),
+  };
+  Object.defineProperty(window, "location", { value: loc, writable: true, configurable: true });
+  return loc;
+}
+
+function stubShell(state: unknown) {
+  const shell = {
+    getState: vi.fn(async () => state),
+    setDesktopMode: vi.fn(async () => state),
+    onResetDesktopModeRequest: vi.fn(() => () => undefined),
+    resetDesktopMode: vi.fn(async () => undefined),
+  };
+  (window as unknown as { fusionShell: unknown }).fusionShell = shell;
+  return shell;
+}
+
+describe("DesktopLaunchGate — local handoff", () => {
+  beforeEach(() => {
+    getShellHostContext.mockReset();
+  });
+  afterEach(() => {
+    delete (window as unknown as { fusionShell?: unknown }).fusionShell;
+  });
+
+  /*
+   * Regression: after applyServerBaseUrl() reloads with ?serverBaseUrl=…, main.tsx's
+   * bootstrapShellHostContext() strips that param from the URL before this gate runs. The gate
+   * MUST recognize the completed handoff from the cached shell-host context (serverUrl), not the
+   * stripped URL — otherwise it re-triggers the handoff → window.location.replace → reload loop
+   * ("rapid Starting local Fusion runtime flashing that never connects").
+   */
+  it("renders children (no reload) when the handoff is present in the cached context but stripped from the URL", async () => {
+    const location = stubLocation(""); // URL already stripped by bootstrap
+    getShellHostContext.mockReturnValue({ kind: "desktop-shell", mode: "local", serverUrl: "http://127.0.0.1:50123" });
+    stubShell({
+      host: "desktop-shell",
+      desktopMode: "local",
+      desktopModeState: { isFirstRun: false, desktopMode: "local" },
+      localRuntime: { source: "embedded-local", state: "running", port: 50123, baseUrl: "http://127.0.0.1:50123" },
+    });
+
+    render(
+      <DesktopLaunchGate>
+        <div data-testid="app-loaded">app</div>
+      </DesktopLaunchGate>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("app-loaded")).toBeTruthy());
+    // The bug was an infinite reload; assert we never reload.
+    expect(location.replace).not.toHaveBeenCalled();
+  });
+
+  it("performs the handoff exactly once on first load (no cached serverUrl yet)", async () => {
+    const location = stubLocation(""); // fresh launch, no shell params
+    getShellHostContext.mockReturnValue({ kind: "desktop-shell" }); // bootstrap saw no serverUrl
+    stubShell({
+      host: "desktop-shell",
+      desktopMode: "local",
+      desktopModeState: { isFirstRun: false, desktopMode: "local" },
+      localRuntime: { source: "embedded-local", state: "running", port: 50123, baseUrl: "http://127.0.0.1:50123" },
+    });
+
+    render(
+      <DesktopLaunchGate>
+        <div data-testid="app-loaded">app</div>
+      </DesktopLaunchGate>,
+    );
+
+    await waitFor(() => expect(location.replace).toHaveBeenCalledTimes(1));
+    expect(location.replace.mock.calls[0][0]).toContain("serverBaseUrl=http%3A%2F%2F127.0.0.1%3A50123");
+  });
+});

--- a/packages/dashboard/app/components/__tests__/ModelOnboardingModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/ModelOnboardingModal.test.tsx
@@ -332,11 +332,9 @@ describe("ModelOnboardingModal", () => {
       });
     });
 
-    it("shows research setup guidance in AI setup step", async () => {
-      render(<ModelOnboardingModal onComplete={vi.fn()} addToast={vi.fn()} projectId="proj_123" />);
-
-      expect(await screen.findByText(/Research runs require provider credentials and an enabled Research View/i)).toBeInTheDocument();
-    });
+    // FNXC:Onboarding 2026-07-03: the "Research runs require provider credentials and an enabled
+    // Research View" note was intentionally removed from onboarding at the operator's request (it
+    // belongs in Settings, not first-run), so the assertion that it renders no longer applies.
 
     it("hides deprecated google CLI and antigravity providers while keeping supported Google/Gemini entries", async () => {
       mockFetchAuthStatus.mockResolvedValueOnce({

--- a/packages/dashboard/app/components/__tests__/RightDock.test.tsx
+++ b/packages/dashboard/app/components/__tests__/RightDock.test.tsx
@@ -4,9 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import {
   RightDock,
+  RIGHT_DOCK_OPEN_STORAGE_KEY,
   RIGHT_DOCK_PINNED_STORAGE_KEY,
   RIGHT_DOCK_VIEW_STORAGE_KEY,
   RIGHT_DOCK_WIDTH_STORAGE_KEY,
+  readStoredRightDockOpen,
   type RightDockProps,
 } from "../RightDock";
 import { RightDockExpandModal } from "../RightDockExpandModal";
@@ -81,10 +83,27 @@ describe("RightDock", () => {
   beforeEach(() => {
     window.localStorage.clear();
     vi.clearAllMocks();
+    // FNXC:Navigation 2026-07-03-09:40: the dock now defaults to HIDDEN, so controller-driven Harness
+    // tests below (which exercise open-dock behavior) represent an opted-in operator and must seed the
+    // stored "open" preference. Tests that render <RightDock open={...}/> directly are unaffected.
+    window.localStorage.setItem(RIGHT_DOCK_OPEN_STORAGE_KEY, "true");
   });
 
   afterEach(() => {
     window.localStorage.clear();
+  });
+
+  it("defaults the dock to hidden with no stored preference and honours explicit choices", () => {
+    // FNXC:Navigation 2026-07-03-09:40: first-run/onboarding must land on an uncluttered board, so the
+    // right dock is hidden until the operator opts in via the Header toggle (persists "true").
+    window.localStorage.removeItem(RIGHT_DOCK_OPEN_STORAGE_KEY);
+    expect(readStoredRightDockOpen()).toBe(false);
+
+    window.localStorage.setItem(RIGHT_DOCK_OPEN_STORAGE_KEY, "true");
+    expect(readStoredRightDockOpen()).toBe(true);
+
+    window.localStorage.setItem(RIGHT_DOCK_OPEN_STORAGE_KEY, "false");
+    expect(readStoredRightDockOpen()).toBe(false);
   });
 
   it("keeps right-dock divider chrome tokenized and invisible by default", () => {

--- a/packages/dashboard/app/components/useRightDockController.tsx
+++ b/packages/dashboard/app/components/useRightDockController.tsx
@@ -62,7 +62,7 @@ export interface RightDockController {
 
 /*
 FNXC:Navigation 2026-06-21-23:40:
-The right dock is visible by default and collapses from inside the dock. Keep the persisted open/collapsed state in this controller so App and Header do not need duplicate right-dock toggle wiring.
+The right dock is HIDDEN by default (no stored preference -> closed; see readStoredRightDockOpen, updated 2026-07-03) so first-run/onboarding lands on an uncluttered board; the operator opts in via the Header toggle. Keep the persisted open/collapsed state in this controller so App and Header do not need duplicate right-dock toggle wiring.
 
 FNXC:RightDock 2026-06-22-18:50:
 The popped-out expand modal is INDEPENDENT of the dock's open state. `expandedView` and the modal it drives live at the controller level (a sibling of `dock`, NOT a child of RightDock — which early-returns null when closed). Toggling the dock closed must therefore NOT clear `expandedView`: once a view is popped out it stays open and interactive even with the dock hidden, and only its own close button (`onClose -> setExpandedView(null)`) dismisses it. We still clear `expandedView` when the surface becomes inactive (project change/teardown) because that unmounts the whole controller surface, not a user dock-hide.

--- a/packages/dashboard/app/hooks/__tests__/useAuthOnboarding.test.ts
+++ b/packages/dashboard/app/hooks/__tests__/useAuthOnboarding.test.ts
@@ -63,6 +63,32 @@ describe("useAuthOnboarding", () => {
     expect(openSettings).not.toHaveBeenCalled();
   });
 
+  it("opens onboarding on a brand-new install even when the provider list is empty", async () => {
+    // Regression: a fresh install (e.g. desktop first launch) can report zero providers; the
+    // old `providers.length > 0` gate skipped onboarding entirely. First-run must still fire.
+    mockFetchAuthStatus.mockResolvedValue({ providers: [] });
+    mockFetchGlobalSettings.mockResolvedValue({
+      modelOnboardingComplete: undefined,
+      defaultProvider: undefined,
+      defaultModelId: undefined,
+    } as never);
+    mockIsOnboardingCompleted.mockReturnValue(false);
+
+    renderHook(() =>
+      useAuthOnboarding({
+        projectId: undefined,
+        setupWizardOpen: false,
+        openModelOnboarding,
+        openSettings,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(openModelOnboarding).toHaveBeenCalledTimes(1);
+    });
+    expect(openSettings).not.toHaveBeenCalled();
+  });
+
   it("opens onboarding when modelOnboardingComplete is undefined (first-run detection)", async () => {
     mockFetchAuthStatus.mockResolvedValue({
       providers: [{ id: "openai", name: "OpenAI", authenticated: false }],

--- a/packages/dashboard/app/hooks/__tests__/useDeepLink.test.ts
+++ b/packages/dashboard/app/hooks/__tests__/useDeepLink.test.ts
@@ -169,32 +169,84 @@ describe("useDeepLink", () => {
     expect(addToast).not.toHaveBeenCalled();
   });
 
-  it("shows unknown project toast only once under StrictMode", async () => {
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: new URL("http://localhost:3000/?project=missing"),
-    });
+  it("shows unknown project toast only once under StrictMode (after the grace window)", async () => {
+    vi.useFakeTimers();
+    try {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL("http://localhost:3000/?project=missing"),
+      });
 
-    const addToast = vi.fn();
-    const strictWrapper = ({ children }: PropsWithChildren) => createElement(StrictMode, null, children);
+      const addToast = vi.fn();
+      const strictWrapper = ({ children }: PropsWithChildren) => createElement(StrictMode, null, children);
 
-    renderHook(() => useDeepLink({
-      projectId: defaultProject.id,
-      projects: [defaultProject, otherProject],
-      projectsLoading: false,
-      currentProject: defaultProject,
-      setCurrentProject: vi.fn(),
-      addToast,
-      openTaskDetail: vi.fn(),
-      closeTaskDetail: vi.fn(),
-    }), { wrapper: strictWrapper });
+      renderHook(() => useDeepLink({
+        projectId: defaultProject.id,
+        projects: [defaultProject, otherProject],
+        projectsLoading: false,
+        currentProject: defaultProject,
+        setCurrentProject: vi.fn(),
+        addToast,
+        openTaskDetail: vi.fn(),
+        closeTaskDetail: vi.fn(),
+      }), { wrapper: strictWrapper });
 
-    await waitFor(() => {
+      // The not-found toast is deferred behind the grace window — nothing fires immediately.
+      expect(addToast).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(3000);
+
       expect(addToast).toHaveBeenCalledTimes(1);
       expect(addToast).toHaveBeenCalledWith("Project 'missing' not found", "error");
-    });
+      expect(mockFetchTaskDetail).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-    expect(mockFetchTaskDetail).not.toHaveBeenCalled();
+  it("does not toast when a freshly-created project appears within the grace window", async () => {
+    // FNXC:DeepLink 2026-07-03-09:50: symptom verification for the onboarding spurious
+    // "Project not found" toast — a project deep-linked before the list revalidates must NOT error.
+    vi.useFakeTimers();
+    try {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL("http://localhost:3000/?project=proj_new"),
+      });
+
+      const addToast = vi.fn();
+      const setCurrentProject = vi.fn();
+      const newProject: ProjectInfo = { ...otherProject, id: "proj_new", name: "Freshly Created" };
+
+      const { rerender } = renderHook(
+        ({ projects }: { projects: ProjectInfo[] }) =>
+          useDeepLink({
+            projectId: defaultProject.id,
+            projects,
+            projectsLoading: false,
+            currentProject: defaultProject,
+            setCurrentProject,
+            addToast,
+            openTaskDetail: vi.fn(),
+            closeTaskDetail: vi.fn(),
+          }),
+        { initialProps: { projects: [defaultProject] } },
+      );
+
+      // Missing from the (stale) list, but still inside the grace window: no toast yet.
+      expect(addToast).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // Projects list revalidates and now includes the just-created project.
+      rerender({ projects: [defaultProject, newProject] });
+
+      // Advance well past the original grace deadline; the pending toast must have been cancelled.
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(addToast).not.toHaveBeenCalled();
+      expect(setCurrentProject).toHaveBeenCalledWith(newProject);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("switches project and uses project param for task fetch", async () => {
@@ -213,21 +265,25 @@ describe("useDeepLink", () => {
     });
   });
 
-  it("shows toast and skips fetch for unknown project param", async () => {
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: new URL("http://localhost:3000/?project=missing&task=FN-123"),
-    });
+  it("shows toast and skips fetch for unknown project param (after the grace window)", async () => {
+    vi.useFakeTimers();
+    try {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: new URL("http://localhost:3000/?project=missing&task=FN-123"),
+      });
 
-    const { addToast, setCurrentProject } = renderUseDeepLink();
+      const { addToast, setCurrentProject } = renderUseDeepLink();
 
-    await waitFor(() => {
+      await vi.advanceTimersByTimeAsync(3000);
+
       expect(addToast).toHaveBeenCalledWith("Project 'missing' not found", "error");
-    });
-
-    expect(addToast).toHaveBeenCalledTimes(1);
-    expect(setCurrentProject).not.toHaveBeenCalled();
-    expect(mockFetchTaskDetail).not.toHaveBeenCalled();
+      expect(addToast).toHaveBeenCalledTimes(1);
+      expect(setCurrentProject).not.toHaveBeenCalled();
+      expect(mockFetchTaskDetail).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps task-only deep-link behavior and strips task on detail close", async () => {

--- a/packages/dashboard/app/hooks/useAuthOnboarding.ts
+++ b/packages/dashboard/app/hooks/useAuthOnboarding.ts
@@ -56,30 +56,36 @@ export function useAuthOnboarding({
     fetchAuthStatus()
       .then(({ providers }) => {
         const hasAuthenticatedProvider = providers.some((provider) => provider.authenticated);
-        const needsSetup = providers.length > 0 && !hasAuthenticatedProvider;
 
-        if (needsSetup || (providers.length > 0 && hasAuthenticatedProvider)) {
-          return fetchGlobalSettings()
-            .then((globalSettings) => {
-              const hasDefaultModel = !!(
-                globalSettings.defaultProvider && globalSettings.defaultModelId
-              );
-              // Explicit first-run detection: onboarding is incomplete when
-              // modelOnboardingComplete is false or undefined
-              const onboardingIncomplete =
-                globalSettings.modelOnboardingComplete === false ||
-                globalSettings.modelOnboardingComplete === undefined;
-              const setupIncomplete = !hasAuthenticatedProvider || !hasDefaultModel;
+        /*
+         * FNXC:Onboarding 2026-07-03-04:00:
+         * Always evaluate first-run onboarding from completion state — do NOT gate on
+         * `providers.length > 0`. A brand-new install (notably the desktop app on first launch)
+         * can report an empty provider list; the old gate skipped onboarding entirely and dropped
+         * the operator on an empty dashboard with no AI/GitHub setup. Brand-new users must be guided
+         * through AI + GitHub setup before project creation — the model-onboarding wizard owns that
+         * AI -> GitHub -> Project sequence.
+         */
+        return fetchGlobalSettings()
+          .then((globalSettings) => {
+            const hasDefaultModel = !!(
+              globalSettings.defaultProvider && globalSettings.defaultModelId
+            );
+            // Explicit first-run detection: onboarding is incomplete when
+            // modelOnboardingComplete is false or undefined
+            const onboardingIncomplete =
+              globalSettings.modelOnboardingComplete === false ||
+              globalSettings.modelOnboardingComplete === undefined;
+            const setupIncomplete = !hasAuthenticatedProvider || !hasDefaultModel;
 
-              if (onboardingIncomplete && setupIncomplete && !isOnboardingCompleted()) {
-                shouldOpenOnboarding = true;
-              } else if (!hasAuthenticatedProvider && !isOnboardingCompleted()) {
-                // Completed onboarding but no authenticated provider → fallback
-                // to Settings Authentication section (only if not locally completed)
-                shouldOpenSettings = true;
-              }
-            });
-        }
+            if (onboardingIncomplete && setupIncomplete && !isOnboardingCompleted()) {
+              shouldOpenOnboarding = true;
+            } else if (!hasAuthenticatedProvider && !isOnboardingCompleted()) {
+              // Completed onboarding but no authenticated provider → fallback
+              // to Settings Authentication section (only if not locally completed)
+              shouldOpenSettings = true;
+            }
+          });
       })
       .then(() => {
         // Execute after the promise chain resolves. Re-check the wizard:

--- a/packages/dashboard/app/hooks/useDashboardHealth.ts
+++ b/packages/dashboard/app/hooks/useDashboardHealth.ts
@@ -35,21 +35,36 @@ export function useDashboardHealth(): UseDashboardHealthResult {
 
   useEffect(() => {
     let cancelled = false;
+    let settledOnce = false;
 
-    fetchDashboardHealth()
-      .then((next) => {
-        if (!cancelled) {
+    /*
+     * FNXC:DashboardHealth 2026-07-03-08:40:
+     * Poll health periodically instead of fetching once on mount. Engine availability is transient:
+     * right after a project is created the engine is still starting, so the first fetch reports
+     * engine.available=false and the "AI engine is not running" banner shows. Without polling, health
+     * was never refreshed, so the banner stayed up permanently even after the engine came online.
+     * Re-fetching every 15s lets the banner clear on its own. Preserve the previous value on transient
+     * poll errors (only clear to null if we never had a value) so banners don't flicker.
+     */
+    const load = () => {
+      fetchDashboardHealth()
+        .then((next) => {
+          if (cancelled) return;
+          settledOnce = true;
           setHealth(next);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setHealth(null);
-        }
-      });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setHealth((prev) => (settledOnce ? prev : null));
+        });
+    };
+
+    load();
+    const interval = setInterval(load, 15_000);
 
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
   }, []);
 

--- a/packages/dashboard/app/hooks/useDeepLink.ts
+++ b/packages/dashboard/app/hooks/useDeepLink.ts
@@ -54,6 +54,30 @@ export function useDeepLink(options: UseDeepLinkOptions): UseDeepLinkResult {
   // Ensure project switching from ?project= only happens once per project value.
   const projectSwitchAppliedRef = useRef<string | null>(null);
 
+  /*
+   * FNXC:DeepLink 2026-07-03-09:50:
+   * A project selected/created during onboarding is deep-linked via ?project=<id> before the projects
+   * list has revalidated to include it, so an eager "Project not found" toast fired even though the
+   * project loads a beat later (operator report: spurious error toast on onboarding project select).
+   * Defer the not-found toast behind a grace window keyed to the pending param, and cancel it as soon
+   * as the project appears in the list (the effect re-runs when `projects` changes). Only a project
+   * that stays absent past the grace window yields the error.
+   */
+  const PROJECT_NOT_FOUND_GRACE_MS = 3000;
+  const projectNotFoundTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const projectNotFoundPendingParamRef = useRef<string | null>(null);
+
+  const clearProjectNotFoundTimer = useCallback(() => {
+    if (projectNotFoundTimerRef.current !== null) {
+      clearTimeout(projectNotFoundTimerRef.current);
+      projectNotFoundTimerRef.current = null;
+    }
+    projectNotFoundPendingParamRef.current = null;
+  }, []);
+
+  // Cancel any pending not-found timer on unmount so it never toasts after teardown.
+  useEffect(() => () => clearProjectNotFoundTimer(), [clearProjectNotFoundTimer]);
+
   useEffect(() => {
     if (!pathRewroteRef.current) {
       const pathMatch = window.location.pathname.match(/^\/tasks\/([A-Z]+-\d+)\/?$/);
@@ -81,13 +105,26 @@ export function useDeepLink(options: UseDeepLinkOptions): UseDeepLinkResult {
     if (projectParam) {
       const matchingProject = projects.find((project) => project.id === projectParam);
       if (!matchingProject) {
-        if (projectNotFoundToastRef.current !== projectParam) {
-          addToast(t("deepLink.projectNotFound", "Project '{{id}}' not found", { id: projectParam }), "error");
-          projectNotFoundToastRef.current = projectParam;
+        // Arm the deferred not-found toast once per still-missing param; a freshly-created project
+        // that arrives within the grace window cancels it via the matched branch below.
+        if (
+          projectNotFoundToastRef.current !== projectParam &&
+          projectNotFoundPendingParamRef.current !== projectParam
+        ) {
+          clearProjectNotFoundTimer();
+          projectNotFoundPendingParamRef.current = projectParam;
+          projectNotFoundTimerRef.current = setTimeout(() => {
+            addToast(t("deepLink.projectNotFound", "Project '{{id}}' not found", { id: projectParam }), "error");
+            projectNotFoundToastRef.current = projectParam;
+            projectNotFoundTimerRef.current = null;
+            projectNotFoundPendingParamRef.current = null;
+          }, PROJECT_NOT_FOUND_GRACE_MS);
         }
         return;
       }
 
+      // Project is present now — cancel any pending not-found toast and clear the one-shot guard.
+      clearProjectNotFoundTimer();
       projectNotFoundToastRef.current = null;
       taskProjectId = matchingProject.id;
 
@@ -99,6 +136,7 @@ export function useDeepLink(options: UseDeepLinkOptions): UseDeepLinkResult {
         projectSwitchAppliedRef.current = matchingProject.id;
       }
     } else {
+      clearProjectNotFoundTimer();
       projectNotFoundToastRef.current = null;
       projectSwitchAppliedRef.current = null;
     }
@@ -124,6 +162,7 @@ export function useDeepLink(options: UseDeepLinkOptions): UseDeepLinkResult {
     setCurrentProject,
     addToast,
     openTaskDetail,
+    clearProjectNotFoundTimer,
     // deepLinkFetchedRef intentionally excluded - it's a mutable ref, not state
   ]);
 

--- a/packages/dashboard/src/routes/register-fn-binary-routes.ts
+++ b/packages/dashboard/src/routes/register-fn-binary-routes.ts
@@ -73,9 +73,16 @@ function runNpmInstall(): Promise<InstallResult> {
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    /*
+     * FNXC:CliBinaryInstall 2026-07-03-03:00:
+     * On Windows `npm` resolves to `npm.cmd`; Node refuses to spawn a .cmd/.bat without a shell
+     * (spawn npm ENOENT / EINVAL since CVE-2024-27980), so the CLI-banner "Install with npm" button
+     * failed with `spawn npm ENOENT`. Use a shell on win32. The command/args are fixed constants
+     * (`npm install -g runfusion.ai`) with no caller-supplied input, so shell quoting is safe.
+     */
     const child = spawn("npm", ["install", "-g", FN_NPM_PACKAGE], {
       stdio: ["ignore", "pipe", "pipe"],
-      shell: false,
+      shell: process.platform === "win32",
     });
     const timer = setTimeout(() => {
       timedOut = true;

--- a/packages/dashboard/src/routes/register-fn-binary-routes.ts
+++ b/packages/dashboard/src/routes/register-fn-binary-routes.ts
@@ -86,7 +86,20 @@ function runNpmInstall(): Promise<InstallResult> {
     });
     const timer = setTimeout(() => {
       timedOut = true;
-      try { child.kill("SIGKILL"); } catch { /* ignore */ }
+      /*
+       * FNXC:CliBinaryInstall 2026-07-03-05:00:
+       * With shell:true on Windows the spawned child is cmd.exe; killing it leaves the underlying
+       * npm.cmd/node running in the background. Kill the whole process tree via taskkill /T so a
+       * timed-out install can't keep running detached. POSIX has no shell wrapper here, so SIGKILL
+       * on the child suffices.
+       */
+      try {
+        if (process.platform === "win32" && typeof child.pid === "number") {
+          spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" }).on("error", () => {});
+        } else {
+          child.kill("SIGKILL");
+        }
+      } catch { /* ignore */ }
     }, INSTALL_TIMEOUT_MS);
 
     const append = (target: "stdout" | "stderr", chunk: Buffer): void => {

--- a/packages/dashboard/src/routes/register-project-routes.ts
+++ b/packages/dashboard/src/routes/register-project-routes.ts
@@ -426,6 +426,19 @@ export const registerProjectRoutes: ApiRouteRegistrar = (ctx) => {
         return { activeProject, outcome: ensured.outcome };
       });
 
+      /*
+       * FNXC:Onboarding 2026-07-03-05:40:
+       * Proactively warm the new project's engine on creation. getOrCreateProjectStore fires the
+       * onProjectFirstAccessed hook (engineManager.onProjectAccessed -> ensureEngine), so the
+       * project's engine starts immediately instead of waiting for the first lazy store access.
+       * Without this, a freshly-created project (especially the operator's FIRST project on the
+       * desktop, where no other engine is running) leaves engineManager with no running engine, so
+       * /api/health reports engine.available=false and the dashboard shows "AI engine is not
+       * running" right after project creation. Fire-and-forget: engine startup is async and must not
+       * block or fail the registration response.
+       */
+      void getOrCreateProjectStore(activeProjectWithOutcome.activeProject.id).catch(() => undefined);
+
       // Bootstrap memory files (non-blocking, non-fatal)
       ensureMemoryFileWithBackend(normalizedPath).catch(() => {
         // Memory bootstrap failure is non-fatal - project registration succeeded

--- a/packages/desktop/src/__tests__/engine-runtime.test.ts
+++ b/packages/desktop/src/__tests__/engine-runtime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveDesktopRuntimePrimaryProject } from "../engine-runtime";
+
+/*
+ * The desktop embedded runtime must NEVER auto-register a project (e.g. the home directory).
+ * resolveDesktopRuntimePrimaryProject only picks an already-registered project as the primary
+ * engine target, and registers nothing.
+ */
+describe("resolveDesktopRuntimePrimaryProject", () => {
+  it("returns null when no projects are registered (never auto-registers)", async () => {
+    let registerCalled = false;
+    const central = {
+      listProjects: async () => [],
+      registerProject: async () => {
+        registerCalled = true;
+        throw new Error("resolveDesktopRuntimePrimaryProject must not register a project");
+      },
+    } as unknown as import("@fusion/core").CentralCore;
+
+    const result = await resolveDesktopRuntimePrimaryProject(central);
+    expect(result).toBeNull();
+    expect(registerCalled).toBe(false);
+  });
+
+  it("returns the first existing project as primary without registering", async () => {
+    const projects = [{ id: "proj_1" }, { id: "proj_2" }];
+    let registerCalled = false;
+    const central = {
+      listProjects: async () => projects,
+      registerProject: async () => {
+        registerCalled = true;
+        return projects[0];
+      },
+    } as unknown as import("@fusion/core").CentralCore;
+
+    const result = await resolveDesktopRuntimePrimaryProject(central);
+    expect(result?.id).toBe("proj_1");
+    expect(registerCalled).toBe(false);
+  });
+});

--- a/packages/desktop/src/__tests__/local-server.test.ts
+++ b/packages/desktop/src/__tests__/local-server.test.ts
@@ -90,6 +90,7 @@ vi.mock("@fusion/dashboard", () => ({ createServer: mocks.createServer }));
 vi.mock("@fusion/engine", () => ({
   ProjectEngineManager: mocks.ProjectEngineManager,
   createFusionAuthStorage: () => ({ reload: () => undefined, getOAuthProviders: () => [], hasAuth: () => false }),
+  createFusionModelRegistry: () => ({ listModels: () => [] }),
 }));
 
 describe("DesktopLocalServerManager", () => {

--- a/packages/desktop/src/__tests__/local-server.test.ts
+++ b/packages/desktop/src/__tests__/local-server.test.ts
@@ -87,7 +87,10 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@fusion/core", () => ({ TaskStore: mocks.TaskStore, CentralCore: mocks.CentralCore }));
 vi.mock("@fusion/dashboard", () => ({ createServer: mocks.createServer }));
-vi.mock("@fusion/engine", () => ({ ProjectEngineManager: mocks.ProjectEngineManager }));
+vi.mock("@fusion/engine", () => ({
+  ProjectEngineManager: mocks.ProjectEngineManager,
+  createFusionAuthStorage: () => ({ reload: () => undefined, getOAuthProviders: () => [], hasAuth: () => false }),
+}));
 
 describe("DesktopLocalServerManager", () => {
   beforeEach(() => {

--- a/packages/desktop/src/__tests__/local-server.test.ts
+++ b/packages/desktop/src/__tests__/local-server.test.ts
@@ -39,7 +39,9 @@ const mocks = vi.hoisted(() => {
     init: vi.fn(async () => undefined),
     close: vi.fn(async () => undefined),
     getProjectByPath: vi.fn(async () => ({ id: "project-1", name: "Repo", path: "/repo", status: "active" })),
-    listProjects: vi.fn(async () => []),
+    // Default: an operator who already onboarded a project. resolveDesktopRuntimePrimaryProject
+    // picks the first one; the runtime NEVER auto-registers the runtime root.
+    listProjects: vi.fn(async () => [{ id: "project-1", name: "Repo", path: "/repo", status: "active" }]),
     registerProject: vi.fn(async ({ path, name }: { path: string; name: string }) => ({ id: "project-1", name, path, status: "initializing" })),
     updateProject: vi.fn(async (id: string, patch: Record<string, unknown>) => ({ id, name: "Repo", path: "/repo", status: patch.status ?? "active" })),
   };
@@ -102,7 +104,8 @@ describe("DesktopLocalServerManager", () => {
     expect(manager.getPort()).toBe(4545);
     expect(manager.getState().status).toBe("ready");
     expect(mocks.engineManager.startAll).toHaveBeenCalledTimes(1);
-    expect(mocks.centralCore.getProjectByPath).toHaveBeenCalledWith("/repo");
+    // No auto-registration of the runtime root; the primary engine is the first existing project.
+    expect(mocks.centralCore.registerProject).not.toHaveBeenCalled();
     expect(mocks.engineManager.ensureEngine).toHaveBeenCalledWith("project-1");
     expect(mocks.createServer).toHaveBeenCalledWith(
       expect.anything(),
@@ -152,20 +155,22 @@ describe("DesktopLocalServerManager", () => {
     expect(manager.getState()).toMatchObject({ status: "error", error: "server failed" });
   });
 
-  it("registers an active runtime-root project when no projects exist", async () => {
-    mocks.centralCore.getProjectByPath.mockResolvedValueOnce(undefined);
+  it("never auto-registers a project and starts engine-less when no projects exist", async () => {
+    mocks.centralCore.listProjects.mockResolvedValueOnce([]);
     const { DesktopLocalServerManager } = await import("../local-server.ts");
     const manager = new DesktopLocalServerManager("/repo");
 
-    await manager.start();
+    const runtime = await manager.start();
 
-    expect(mocks.centralCore.registerProject).toHaveBeenCalledWith({
-      path: "/repo",
-      name: "repo",
-      isolationMode: "in-process",
-    });
-    expect(mocks.centralCore.updateProject).toHaveBeenCalledWith("project-1", { status: "active" });
-    expect(mocks.engineManager.ensureEngine).toHaveBeenCalledWith("project-1");
+    // Fresh install: the runtime must NOT create a project for its root; the dashboard onboards.
+    expect(mocks.centralCore.registerProject).not.toHaveBeenCalled();
+    expect(mocks.engineManager.ensureEngine).not.toHaveBeenCalled();
+    // The server still starts (engine-less) so the dashboard can render its onboarding empty state.
+    expect(runtime.port).toBe(4545);
+    expect(mocks.createServer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ engine: expect.anything() }),
+    );
   });
 
   it("returns existing runtime when start is called twice", async () => {

--- a/packages/desktop/src/__tests__/main-integration.test.ts
+++ b/packages/desktop/src/__tests__/main-integration.test.ts
@@ -231,8 +231,13 @@ async function importMainModule() {
 }
 
 async function flushPromises() {
-  await Promise.resolve();
-  await Promise.resolve();
+  // Drain ALL pending microtasks via a macrotask boundary rather than counting a
+  // fixed number of ticks. initializeApp()'s async chain length is an implementation
+  // detail (e.g. the launch-mode/shell split-brain reconciliation adds a readShellSettings
+  // await); a hardcoded tick count silently under-flushes when that chain grows and the
+  // run()-based tests then observe a half-initialized app. setTimeout(0) waits for the
+  // whole microtask queue to settle, so these tests assert on a fully-initialized app.
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe("main integration", () => {

--- a/packages/desktop/src/__tests__/main-local-mode.test.ts
+++ b/packages/desktop/src/__tests__/main-local-mode.test.ts
@@ -49,7 +49,19 @@ const mocks = vi.hoisted(() => {
     return localRuntimeManager;
   });
 
-  return { app, appHandlers, BrowserWindow, Tray, browserWindow, localRuntimeManager, LocalRuntimeManager, screen };
+  const DEFAULT_SHELL_SETTINGS = {
+    desktopMode: null as "local" | "remote" | null,
+    hasCompletedModeSelection: false,
+    activeProfileId: null,
+    profiles: [],
+  };
+  const readShellSettings = vi.fn(async () => ({ ...DEFAULT_SHELL_SETTINGS }));
+  const writeShellSettings = vi.fn(async () => undefined);
+
+  const loadDesktopLaunchMode = vi.fn(async () => "choose" as "choose" | "local" | "remote");
+  const saveDesktopLaunchMode = vi.fn(async () => undefined);
+
+  return { app, appHandlers, BrowserWindow, Tray, browserWindow, localRuntimeManager, LocalRuntimeManager, screen, readShellSettings, writeShellSettings, DEFAULT_SHELL_SETTINGS, loadDesktopLaunchMode, saveDesktopLaunchMode };
 });
 
 vi.mock("electron", () => ({
@@ -67,8 +79,8 @@ vi.mock("../ipc.js", () => ({ registerIpcHandlers: vi.fn() }));
 vi.mock("../native.js", () => ({
   DEFAULT_WINDOW_STATE: { width: 1000, height: 800 },
   loadWindowState: vi.fn(async () => null),
-  loadDesktopLaunchMode: vi.fn(async () => "choose"),
-  saveDesktopLaunchMode: vi.fn(async () => undefined),
+  loadDesktopLaunchMode: mocks.loadDesktopLaunchMode,
+  saveDesktopLaunchMode: mocks.saveDesktopLaunchMode,
   saveWindowState: vi.fn(),
   setupAutoUpdater: vi.fn(),
   startUpdateCheckInterval: vi.fn(() => vi.fn()),
@@ -76,12 +88,18 @@ vi.mock("../native.js", () => ({
 }));
 vi.mock("../deep-link.js", () => ({ registerDeepLinkProtocol: vi.fn(), setupDeepLinkHandler: vi.fn() }));
 vi.mock("../local-runtime.js", () => ({ LocalRuntimeManager: mocks.LocalRuntimeManager }));
+vi.mock("../shell-settings.js", () => ({
+  readShellSettings: mocks.readShellSettings,
+  writeShellSettings: mocks.writeShellSettings,
+}));
 
 describe("main local mode", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
     mocks.appHandlers.clear();
+    mocks.readShellSettings.mockResolvedValue({ ...mocks.DEFAULT_SHELL_SETTINGS });
+    mocks.loadDesktopLaunchMode.mockResolvedValue("choose");
     delete process.env.FUSION_DESKTOP_MODE;
   });
 
@@ -94,5 +112,42 @@ describe("main local mode", () => {
     expect(mocks.app.getPath).toHaveBeenCalledWith("home");
     expect(mocks.localRuntimeManager.startLocal).toHaveBeenCalled();
     delete process.env.FUSION_DESKTOP_MODE;
+  });
+
+  /*
+   * FNXC:DesktopRuntimeMode 2026-07-02-14:35 — regression for the "hangs at Starting
+   * local Fusion runtime" bug. Split-brain persisted state: the launch-mode file says
+   * "choose" (so main would not start the runtime) while shell-connections.json records a
+   * completed "local" selection (so the renderer gate waits for the runtime). Before the
+   * fix the runtime was never started and the gate polled until a 30s timeout on EVERY
+   * launch. initializeApp must reconcile: treat the completed shell "local" as authoritative,
+   * heal the launch-mode file, and start the runtime.
+   */
+  it("reconciles a launch-mode/shell split-brain and starts the runtime (no FUSION_DESKTOP_MODE)", async () => {
+    mocks.loadDesktopLaunchMode.mockResolvedValue("choose");
+    mocks.readShellSettings.mockResolvedValue({
+      desktopMode: "local",
+      hasCompletedModeSelection: true,
+      activeProfileId: null,
+      profiles: [],
+    });
+
+    const { initializeApp } = await import("../main.ts");
+    await initializeApp();
+
+    // Runtime is started despite launch-mode being "choose" ...
+    expect(mocks.localRuntimeManager.startLocal).toHaveBeenCalled();
+    // ... and the launch-mode file is healed to "local" so both sources agree next launch.
+    expect(mocks.saveDesktopLaunchMode).toHaveBeenCalledWith("local");
+  });
+
+  it("does NOT start the runtime when both sources agree on choose (first run / no selection)", async () => {
+    mocks.loadDesktopLaunchMode.mockResolvedValue("choose");
+    mocks.readShellSettings.mockResolvedValue({ ...mocks.DEFAULT_SHELL_SETTINGS });
+
+    const { initializeApp } = await import("../main.ts");
+    await initializeApp();
+
+    expect(mocks.localRuntimeManager.startLocal).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop/src/engine-runtime.ts
+++ b/packages/desktop/src/engine-runtime.ts
@@ -1,26 +1,21 @@
-import { basename } from "node:path";
-
 import type { CentralCore, RegisteredProject } from "@fusion/core";
 
 /*
- * FNXC:DesktopRuntime 2026-06-21-02:04:
- * Desktop local mode starts engines by default, so the embedded server should prefer the project represented by the desktop runtime root instead of whichever registered engine happens to be first. The runtime root may be a home directory, so this path must not call helpers that initialize Git repositories as a side effect.
+ * FNXC:DesktopRuntime 2026-07-03-03:30:
+ * The desktop app must NEVER auto-register a project for its runtime root (the user's home
+ * directory). Doing so created a bogus "cwd-mode" project in ~ on first launch and dropped the
+ * operator straight onto a board for a directory they never chose. Instead the embedded runtime
+ * starts with NO default project when none exist, and the dashboard's empty state prompts the
+ * operator through onboarding (ProjectOverview "Add your first project" -> SetupWizard ->
+ * POST /api/projects) to register a real project directory.
+ *
+ * This resolver only PICKS an existing project as the primary engine target (for operators who
+ * already onboarded projects); it registers nothing. Returns null when there are no projects yet.
+ * It must not call helpers that initialize Git repositories as a side effect.
  */
-export async function ensureDesktopRuntimeProject(centralCore: CentralCore, rootDir: string): Promise<RegisteredProject> {
-  const existing = await centralCore.getProjectByPath(rootDir);
-  if (existing) {
-    return existing;
-  }
-
+export async function resolveDesktopRuntimePrimaryProject(
+  centralCore: CentralCore,
+): Promise<RegisteredProject | null> {
   const projects = await centralCore.listProjects();
-  if (projects.length > 0) {
-    return projects[0]!;
-  }
-
-  const registered = await centralCore.registerProject({
-    path: rootDir,
-    name: basename(rootDir) || "Fusion Desktop",
-    isolationMode: "in-process",
-  });
-  return centralCore.updateProject(registered.id, { status: "active" });
+  return projects.length > 0 ? projects[0]! : null;
 }

--- a/packages/desktop/src/local-runtime.ts
+++ b/packages/desktop/src/local-runtime.ts
@@ -1,8 +1,29 @@
 import { once } from "node:events";
+import { appendFileSync } from "node:fs";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
 
 import { ensureDesktopRuntimeProject } from "./engine-runtime.js";
+
+/*
+ * FNXC:DesktopRuntime 2026-07-02-14:35:
+ * Env-gated startup trace. Packaged desktop builds have no file logging, so a stalled
+ * or failed embedded-runtime start is invisible to operators (the symptom is only a
+ * spinner that times out). Setting FUSION_STARTUP_TRACE=<path> appends a timestamped
+ * step-by-step trace of startLocal()/startEmbedded()/createDashboardServer() to that
+ * file — the diagnostic that pinpointed the launch-mode split-brain hang. Zero cost
+ * when unset; keep it so this class of hang is diagnosable in the field.
+ */
+const STARTUP_TRACE_FILE = process.env.FUSION_STARTUP_TRACE;
+const __traceStart = Date.now();
+function strace(msg: string): void {
+  if (!STARTUP_TRACE_FILE) return;
+  try {
+    appendFileSync(STARTUP_TRACE_FILE, `[+${((Date.now() - __traceStart) / 1000).toFixed(2)}s] ${msg}\n`);
+  } catch {
+    // best-effort
+  }
+}
 
 export type RuntimeSource = "embedded-local" | "external-cli" | "none";
 export type RuntimeState = "stopped" | "starting" | "running" | "error";
@@ -60,11 +81,17 @@ async function createDashboardServerDefault(store: TaskStoreLike, rootDir: strin
   };
 
   try {
+    strace("createDashboardServer: centralCore.init");
     await centralCore.init();
+    strace("createDashboardServer: ensureDesktopRuntimeProject");
     const rootProject = await ensureDesktopRuntimeProject(centralCore, rootDir);
+    strace(`createDashboardServer: startAll (rootProject=${rootProject.id})`);
     await engineManager.startAll();
+    strace("createDashboardServer: startAll DONE; startReconciliation");
     engineManager.startReconciliation();
+    strace("createDashboardServer: ensureEngine(rootProject)");
     const primaryEngine = await engineManager.ensureEngine(rootProject.id);
+    strace("createDashboardServer: createServer");
     const app = createServer(store as never, {
       engine: primaryEngine,
       engineManager,
@@ -72,11 +99,15 @@ async function createDashboardServerDefault(store: TaskStoreLike, rootDir: strin
       onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),
     });
 
+    strace("createDashboardServer: app.listen(0)");
+    const server = app.listen(0);
+    strace("createDashboardServer: returning server object");
     return {
-      server: app.listen(0),
+      server,
       cleanup,
     };
   } catch (error) {
+    strace(`createDashboardServer: THREW ${error instanceof Error ? error.stack : String(error)}`);
     await cleanup();
     throw error;
   }
@@ -148,8 +179,10 @@ export class LocalRuntimeManager {
   }
 
   async startLocal(): Promise<DesktopRuntimeStatus> {
+    strace("startLocal: ENTER");
     const externalPort = this.getExternalPort();
     if (externalPort) {
+      strace(`startLocal: external-cli branch (FUSION_SERVER_PORT=${externalPort}) — NOT starting embedded`);
       this.status = {
         source: "external-cli",
         state: "running",
@@ -183,13 +216,18 @@ export class LocalRuntimeManager {
     let cleanup: RuntimeCleanup | undefined;
 
     try {
+      strace(`startEmbedded: BEGIN rootDir=${this.options.rootDir}`);
       store = await this.createStore(this.options.rootDir);
+      strace("startEmbedded: store.init");
       await store.init();
+      strace("startEmbedded: store.watch");
       await store.watch();
+      strace("startEmbedded: createDashboardServer()");
 
       const dashboardServer = await this.createDashboardServer(store, this.options.rootDir);
       cleanup = "server" in dashboardServer ? dashboardServer.cleanup : undefined;
       server = "server" in dashboardServer ? dashboardServer.server : dashboardServer;
+      strace("startEmbedded: awaiting server 'listening' | 'error'");
       await Promise.race([
         once(server, "listening"),
         once(server, "error").then(([error]) => {
@@ -201,6 +239,7 @@ export class LocalRuntimeManager {
       const baseUrl = `http://127.0.0.1:${port}`;
       this.runtime = { store, server, port, baseUrl, cleanup };
       this.status = { source: "embedded-local", state: "running", port, baseUrl };
+      strace(`startEmbedded: RUNNING port=${port}`);
       return this.status;
     } catch (error) {
       if (server) {
@@ -218,6 +257,7 @@ export class LocalRuntimeManager {
         state: "error",
         error: error instanceof Error ? error.message : String(error),
       };
+      strace(`startEmbedded: CATCH/ERROR ${error instanceof Error ? error.stack : String(error)}`);
       throw error;
     }
   }

--- a/packages/desktop/src/local-runtime.ts
+++ b/packages/desktop/src/local-runtime.ts
@@ -67,7 +67,7 @@ async function createStoreDefault(rootDir: string): Promise<TaskStoreLike> {
 async function createDashboardServerDefault(store: TaskStoreLike, rootDir: string): Promise<{ server: Server; cleanup: RuntimeCleanup }> {
   const { CentralCore } = await import("@fusion/core");
   const { createServer } = await import("@fusion/dashboard");
-  const { ProjectEngineManager, createFusionAuthStorage } = await import("@fusion/engine");
+  const { ProjectEngineManager, createFusionAuthStorage, createFusionModelRegistry } = await import("@fusion/engine");
 
   /*
    * FNXC:DesktopRuntime 2026-06-20-23:39:
@@ -109,12 +109,16 @@ async function createDashboardServerDefault(store: TaskStoreLike, rootDir: strin
      * CLI-only for now; OAuth + CLI providers are available here.)
      */
     const authStorage = createFusionAuthStorage();
+    // FNXC:DesktopRuntime 2026-07-03-07:00: a ModelRegistry is required for the /api/models endpoint;
+    // without it the onboarding model picker shows "no models" even with a provider connected.
+    const modelRegistry = createFusionModelRegistry(authStorage);
     strace("createDashboardServer: createServer");
     const app = createServer(store as never, {
       ...(primaryEngine ? { engine: primaryEngine } : {}),
       engineManager,
       centralCore,
       authStorage,
+      modelRegistry,
       onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),
     });
 

--- a/packages/desktop/src/local-runtime.ts
+++ b/packages/desktop/src/local-runtime.ts
@@ -67,7 +67,7 @@ async function createStoreDefault(rootDir: string): Promise<TaskStoreLike> {
 async function createDashboardServerDefault(store: TaskStoreLike, rootDir: string): Promise<{ server: Server; cleanup: RuntimeCleanup }> {
   const { CentralCore } = await import("@fusion/core");
   const { createServer } = await import("@fusion/dashboard");
-  const { ProjectEngineManager } = await import("@fusion/engine");
+  const { ProjectEngineManager, createFusionAuthStorage } = await import("@fusion/engine");
 
   /*
    * FNXC:DesktopRuntime 2026-06-20-23:39:
@@ -99,11 +99,22 @@ async function createDashboardServerDefault(store: TaskStoreLike, rootDir: strin
     const rootProject = await resolveDesktopRuntimePrimaryProject(centralCore);
     strace(`createDashboardServer: primaryProject=${rootProject?.id ?? "none"}`);
     const primaryEngine = rootProject ? await engineManager.ensureEngine(rootProject.id) : undefined;
+    /*
+     * FNXC:DesktopRuntime 2026-07-03-06:20:
+     * Wire an auth storage into the embedded server. Without it, GET /api/auth/status throws 500
+     * "Authentication is not configured", the dashboard's first-run onboarding hook (useAuthOnboarding
+     * -> fetchAuthStatus) hits its silent catch and NEVER opens the AI/GitHub onboarding wizard, and
+     * providers can't be authenticated at all. The CLI wires the same storage (createFusionAuthStorage);
+     * the desktop must too so operators can set up AI accounts. (API-key provider wrapping remains
+     * CLI-only for now; OAuth + CLI providers are available here.)
+     */
+    const authStorage = createFusionAuthStorage();
     strace("createDashboardServer: createServer");
     const app = createServer(store as never, {
       ...(primaryEngine ? { engine: primaryEngine } : {}),
       engineManager,
       centralCore,
+      authStorage,
       onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),
     });
 

--- a/packages/desktop/src/local-runtime.ts
+++ b/packages/desktop/src/local-runtime.ts
@@ -3,7 +3,7 @@ import { appendFileSync } from "node:fs";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
 
-import { ensureDesktopRuntimeProject } from "./engine-runtime.js";
+import { resolveDesktopRuntimePrimaryProject } from "./engine-runtime.js";
 
 /*
  * FNXC:DesktopRuntime 2026-07-02-14:35:
@@ -83,17 +83,25 @@ async function createDashboardServerDefault(store: TaskStoreLike, rootDir: strin
   try {
     strace("createDashboardServer: centralCore.init");
     await centralCore.init();
-    strace("createDashboardServer: ensureDesktopRuntimeProject");
-    const rootProject = await ensureDesktopRuntimeProject(centralCore, rootDir);
-    strace(`createDashboardServer: startAll (rootProject=${rootProject.id})`);
+    /*
+     * FNXC:DesktopRuntime 2026-07-03-03:30:
+     * Do NOT auto-register the home directory as a project. Start engines for whatever projects the
+     * operator has already onboarded (none on a fresh install), and only pick a default/primary engine
+     * when such a project exists. With zero projects the server starts engine-less and the dashboard
+     * shows its onboarding empty state; new projects register via POST /api/projects and their engines
+     * spin up lazily through onProjectFirstAccessed / reconciliation.
+     */
+    void rootDir; // runtime root no longer implies a project; kept for signature/back-compat.
+    strace("createDashboardServer: startAll");
     await engineManager.startAll();
     strace("createDashboardServer: startAll DONE; startReconciliation");
     engineManager.startReconciliation();
-    strace("createDashboardServer: ensureEngine(rootProject)");
-    const primaryEngine = await engineManager.ensureEngine(rootProject.id);
+    const rootProject = await resolveDesktopRuntimePrimaryProject(centralCore);
+    strace(`createDashboardServer: primaryProject=${rootProject?.id ?? "none"}`);
+    const primaryEngine = rootProject ? await engineManager.ensureEngine(rootProject.id) : undefined;
     strace("createDashboardServer: createServer");
     const app = createServer(store as never, {
-      engine: primaryEngine,
+      ...(primaryEngine ? { engine: primaryEngine } : {}),
       engineManager,
       centralCore,
       onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),

--- a/packages/desktop/src/local-server.ts
+++ b/packages/desktop/src/local-server.ts
@@ -55,7 +55,7 @@ export class DesktopLocalServerManager {
       const { TaskStore } = await import("@fusion/core");
       const { CentralCore } = await import("@fusion/core");
       const { createServer } = await import("@fusion/dashboard");
-      const { ProjectEngineManager, createFusionAuthStorage } = await import("@fusion/engine");
+      const { ProjectEngineManager, createFusionAuthStorage, createFusionModelRegistry } = await import("@fusion/engine");
       store = new TaskStore(this.rootDir) as TaskStoreLike;
       await store.init();
       await store.watch();
@@ -77,11 +77,13 @@ export class DesktopLocalServerManager {
       const primaryEngine = rootProject ? await engineManager.ensureEngine(rootProject.id) : undefined;
       // FNXC:DesktopRuntime 2026-07-03-06:20: wire auth storage so /api/auth/status works and first-run onboarding can open (see local-runtime.ts).
       const authStorage = createFusionAuthStorage();
+      const modelRegistry = createFusionModelRegistry(authStorage);
       const app = createServer(store as never, {
         ...(primaryEngine ? { engine: primaryEngine } : {}),
         engineManager,
         centralCore,
         authStorage,
+        modelRegistry,
         onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),
       });
       server = app.listen(0);

--- a/packages/desktop/src/local-server.ts
+++ b/packages/desktop/src/local-server.ts
@@ -55,7 +55,7 @@ export class DesktopLocalServerManager {
       const { TaskStore } = await import("@fusion/core");
       const { CentralCore } = await import("@fusion/core");
       const { createServer } = await import("@fusion/dashboard");
-      const { ProjectEngineManager } = await import("@fusion/engine");
+      const { ProjectEngineManager, createFusionAuthStorage } = await import("@fusion/engine");
       store = new TaskStore(this.rootDir) as TaskStoreLike;
       await store.init();
       await store.watch();
@@ -75,10 +75,13 @@ export class DesktopLocalServerManager {
       engineManager.startReconciliation();
       const rootProject = await resolveDesktopRuntimePrimaryProject(centralCore);
       const primaryEngine = rootProject ? await engineManager.ensureEngine(rootProject.id) : undefined;
+      // FNXC:DesktopRuntime 2026-07-03-06:20: wire auth storage so /api/auth/status works and first-run onboarding can open (see local-runtime.ts).
+      const authStorage = createFusionAuthStorage();
       const app = createServer(store as never, {
         ...(primaryEngine ? { engine: primaryEngine } : {}),
         engineManager,
         centralCore,
+        authStorage,
         onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),
       });
       server = app.listen(0);

--- a/packages/desktop/src/local-server.ts
+++ b/packages/desktop/src/local-server.ts
@@ -2,7 +2,7 @@ import type { AddressInfo } from "node:net";
 import { once } from "node:events";
 import type { Server } from "node:http";
 
-import { ensureDesktopRuntimeProject } from "./engine-runtime.js";
+import { resolveDesktopRuntimePrimaryProject } from "./engine-runtime.js";
 
 type TaskStoreLike = {
   init(): Promise<void>;
@@ -70,12 +70,13 @@ export class DesktopLocalServerManager {
         await centralCore.close?.();
       };
       await centralCore.init();
-      const rootProject = await ensureDesktopRuntimeProject(centralCore, this.rootDir);
+      // FNXC:DesktopRuntime 2026-07-03-03:30: never auto-register the runtime root as a project (see engine-runtime.ts).
       await engineManager.startAll();
       engineManager.startReconciliation();
-      const primaryEngine = await engineManager.ensureEngine(rootProject.id);
+      const rootProject = await resolveDesktopRuntimePrimaryProject(centralCore);
+      const primaryEngine = rootProject ? await engineManager.ensureEngine(rootProject.id) : undefined;
       const app = createServer(store as never, {
-        engine: primaryEngine,
+        ...(primaryEngine ? { engine: primaryEngine } : {}),
         engineManager,
         centralCore,
         onProjectFirstAccessed: (projectId: string) => engineManager.onProjectAccessed(projectId),

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -181,7 +181,33 @@ export function resolveLocalRuntimeRoot(): string {
 
 export async function initializeApp(): Promise<void> {
   const state = await loadWindowState();
-  const rememberedLaunchMode = await loadDesktopLaunchMode();
+  let rememberedLaunchMode = await loadDesktopLaunchMode();
+
+  /*
+   * FNXC:DesktopRuntimeMode 2026-07-02-14:35:
+   * Split-brain reconciliation. Desktop startup has TWO persisted sources of truth
+   * that must agree: `desktop-launch-mode.json` (loadDesktopLaunchMode) decides whether
+   * THIS function STARTS the embedded local runtime, while `shell-connections.json`
+   * (readShellSettings().desktopMode) decides whether the renderer launch gate WAITS
+   * for it. They desync because shell:setDesktopMode persists shell settings BEFORE the
+   * fallible startLocalRuntimeOnce()/saveDesktopLaunchMode() — so a first local selection
+   * whose runtime start throws or is interrupted leaves shell=`local` but launch-mode=`choose`.
+   * The gate then shows "Starting local Fusion runtime…" and polls forever for a runtime
+   * nobody started, timing out after 30s on EVERY launch. Treat a completed shell "local"
+   * selection as authoritative and heal the launch-mode file so both halves agree.
+   */
+  const reconcileShellSettings = await readShellSettings();
+  if (
+    rememberedLaunchMode !== "local" &&
+    reconcileShellSettings.desktopMode === "local" &&
+    reconcileShellSettings.hasCompletedModeSelection === true
+  ) {
+    console.warn(
+      `[desktop/main] Healing launch-mode split-brain: shell desktopMode="local" but launch-mode="${rememberedLaunchMode}"; adopting "local"`,
+    );
+    rememberedLaunchMode = "local";
+    await saveDesktopLaunchMode("local");
+  }
 
   localRuntimeManager = new LocalRuntimeManager({ rootDir: resolveLocalRuntimeRoot() });
   currentDesktopLaunchMode = rememberedLaunchMode;
@@ -274,13 +300,23 @@ export async function initializeApp(): Promise<void> {
       if (mode === "local") {
         currentRemoteLaunch = null;
         localRuntimeStartupAttempted = false;
+        /*
+         * FNXC:DesktopRuntimeMode 2026-07-02-14:35:
+         * Persist launch-mode BEFORE the fallible startLocalRuntimeOnce(). shell:setDesktopMode
+         * already wrote shell-connections.json `desktopMode:"local"` before invoking this callback;
+         * if the runtime start throws/is interrupted and we saved launch-mode only afterward, the two
+         * files desync (shell=local, launch-mode=choose) and every future launch hangs at "Starting
+         * local runtime". Saving first keeps both sources in agreement so a failed start simply retries
+         * on next launch instead of deadlocking.
+         */
+        await saveDesktopLaunchMode(mode);
         await startLocalRuntimeOnce();
-      } else {
-        localRuntimeStartupAttempted = false;
-        await localRuntimeManager.stopLocal();
-        const shellSettings = await readShellSettings();
-        currentRemoteLaunch = normalizeDesktopRemoteLaunch({ ...shellSettings, desktopMode: "remote" });
+        return;
       }
+      localRuntimeStartupAttempted = false;
+      await localRuntimeManager.stopLocal();
+      const shellSettings = await readShellSettings();
+      currentRemoteLaunch = normalizeDesktopRemoteLaunch({ ...shellSettings, desktopMode: "remote" });
       await saveDesktopLaunchMode(mode);
     },
     onDesktopLaunchModeChange: async (mode) => {
@@ -291,12 +327,14 @@ export async function initializeApp(): Promise<void> {
       localRuntimeStartupAttempted = false;
       if (mode === "local") {
         currentRemoteLaunch = null;
+        // FNXC:DesktopRuntimeMode 2026-07-02-14:35: persist before the fallible start (see onDesktopModeChange).
+        await saveDesktopLaunchMode(mode);
         await startLocalRuntimeOnce();
-      } else {
-        await localRuntimeManager.stopLocal();
-        const shellSettings = await readShellSettings();
-        currentRemoteLaunch = normalizeDesktopRemoteLaunch({ ...shellSettings, desktopMode: "remote" });
+        return;
       }
+      await localRuntimeManager.stopLocal();
+      const shellSettings = await readShellSettings();
+      currentRemoteLaunch = normalizeDesktopRemoteLaunch({ ...shellSettings, desktopMode: "remote" });
       await saveDesktopLaunchMode(mode);
     },
     getRuntimeStatus: () => localRuntimeManager?.getStatus() ?? { source: "none", state: "stopped" },

--- a/packages/engine/src/auth-storage.ts
+++ b/packages/engine/src/auth-storage.ts
@@ -9,7 +9,7 @@ import {
   shouldHydrateStoredCredential,
   type StoredAuthCredential,
 } from "@fusion/core";
-import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { AuthCredential } from "@earendil-works/pi-coding-agent";
 import { getOAuthProvider } from "@earendil-works/pi-ai/oauth";
 import type { OAuthCredentials } from "@earendil-works/pi-ai/oauth";
@@ -305,6 +305,18 @@ function readModelsJsonApiKeys(home = getHomeDir()): Map<string, string> {
   }
 
   return apiKeys;
+}
+
+/*
+ * FNXC:ModelRegistry 2026-07-03-07:00:
+ * Shared model-registry factory so non-CLI hosts (the desktop embedded runtime) can wire the
+ * dashboard's models API without depending on @earendil-works/pi-coding-agent directly. Mirrors the
+ * CLI's ModelRegistry.create(authStorage, getModelRegistryModelsPath()). Without a ModelRegistry the
+ * /api/models endpoint returns an empty list, so the onboarding model picker shows "no models" even
+ * when a provider (e.g. Anthropic) is connected.
+ */
+export function createFusionModelRegistry(authStorage: AuthStorage, home?: string): ModelRegistry {
+  return ModelRegistry.create(authStorage, getModelRegistryModelsPath(home));
 }
 
 export function createFusionAuthStorage(): AuthStorage {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,6 +1,6 @@
 export { AgentLogger, type AgentLoggerOptions, summarizeToolArgs } from "./agent-logger.js";
 export { reloadExemptTools, addToExemptTools, getExemptToolNames } from "./agent-action-gate.js";
-export { createFusionAuthStorage } from "./auth-storage.js";
+export { createFusionAuthStorage, createFusionModelRegistry } from "./auth-storage.js";
 export {
   createTaskCreateTool,
   createTaskListTool,

--- a/scripts/build-workspace.mjs
+++ b/scripts/build-workspace.mjs
@@ -7,7 +7,7 @@ Root builds may skip unchanged plugin workspaces to keep local and CI feedback f
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import fg from "fast-glob";
 import YAML from "yaml";
 import {
@@ -370,7 +370,14 @@ export function runPlannedBuilds(plannedPackages, rootDir, spawnFn = spawnSync) 
   if (plannedPackages.length === 0) return { status: 0, packageNames: [] };
   const packageNames = plannedPackages.map((pkg) => pkg.name);
   const args = [...packageNames.flatMap((name) => ["--filter", name]), "build"];
-  const result = spawnFn("pnpm", args, { cwd: rootDir, stdio: "inherit" });
+  /*
+   * FNXC:WorkspaceBuild 2026-07-02-15:10:
+   * On Windows `pnpm` resolves to a `.cmd` shim; Node refuses to spawn .cmd/.bat without a
+   * shell (ENOENT / EINVAL since CVE-2024-27980). Without shell:true the root build failed
+   * with `spawn pnpm ENOENT` on Windows. The args are workspace filters + package names
+   * (no spaces or shell metacharacters), so shell quoting is safe.
+   */
+  const result = spawnFn("pnpm", args, { cwd: rootDir, stdio: "inherit", shell: process.platform === "win32" });
   return { status: result.status ?? 1, packageNames };
 }
 
@@ -422,6 +429,15 @@ export function main({ rootDir = repoRoot, spawnFn = spawnSync, gitFn = defaultG
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/*
+ * FNXC:WorkspaceBuild 2026-07-02-15:10:
+ * Cross-platform "run as main" guard. The old `import.meta.url === \`file://${process.argv[1]}\``
+ * check NEVER matched on Windows: import.meta.url is `file:///C:/…/build-workspace.mjs`
+ * (triple slash, forward slashes) while process.argv[1] is `C:\…\build-workspace.mjs`
+ * (backslashes, no scheme). So `pnpm build` at the repo root silently no-opped on Windows
+ * (exit 0, no output, no dist) — packaging then shipped empty/stale dist. Compare against the
+ * file URL of argv[1] so the guard is correct on Windows, macOS, and Linux.
+ */
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   process.exit(main());
 }


### PR DESCRIPTION
Makes the Fusion **Windows desktop app** work end-to-end: it boots into the local runtime, opens full first-run onboarding (AI provider → GitHub → project), shows models, creates a project without a false "engine not running" error, and lands on a clean board. Also fixes the Windows root build and the CLI-install button.

## Boot / local runtime (the original hang)
- **Split-brain heal** — reconcile `desktop-launch-mode.json` vs `shell-connections.json` so a `choose` launch-mode with a `local` shell no longer hangs at "Starting local runtime".
- **Reload-loop / rapid "Starting Fusion" flash** — the renderer now becomes ready by protocol check and navigates to the runtime origin instead of re-stripping shell params in a loop.
- **Backend unreachable ("Failed to fetch")** — load the local UI from `http://127.0.0.1:PORT` so relative `/api` is same-origin.

## Onboarding actually works
- **Auth storage wired** into the embedded desktop server so `/api/auth/status` returns 200 and first-run onboarding opens (previously 500 "Authentication is not configured").
- **ModelRegistry wired** so `/api/models` returns models — Anthropic no longer shows "connected" with an empty model list.
- **First-run onboarding opens even when the provider list is empty** (removed the providers-length gate).
- **gh CLI GitHub step** now checks off onboarding step 2 when authenticated via `gh`.
- Onboarding tidy: dropped the research-runs note; the remote-connect card only shows when not connected to a remote server (never in local desktop mode).
- **Project setup** asks for the folder before the name.

## No accidental projects
- Desktop never auto-creates a project in home; the `fusion`/`fn`/`fn dashboard` binaries never auto-create a project in CWD — they onboard instead.
- Engine is started on project creation so it isn't momentarily reported unavailable.

## First-run UX / false banners
- **Engine-not-running banner** — health is now polled so a stale banner clears once the engine comes online.
- **Default-model recommendation** — the picked model is persisted immediately on selection (and `completeOnboarding` falls back to the first available model), so the "Select Default Model" nudge no longer misfires after you chose one.
- **CLI-install banner** deferred behind a 3-day grace window so it doesn't clutter first run.
- **Right dock hidden by default** (opt in via the Header toggle) + board view on first run.
- **Spurious "Project not found" toast** on onboarding project-select is deferred behind a grace window and cancelled once the project appears in the (revalidated) list.

## Windows build / CLI
- Root workspace build runs on Windows (`pathToFileURL` guard; `shell: true` for pnpm/npm spawns).
- CLI-install button spawns npm with a shell on Windows (CVE-2024-27980) and tree-kills on timeout via `taskkill /T /F`.
- Local installer builds can redirect the staged deploy via `FUSION_DESKTOP_DEPLOY_DIR` to sidestep the orca-FS `pnpm deploy` EPERM race.

All changes carry FNXC requirement comments. New/updated tests cover the deep-link grace window (incl. symptom verification), the right-dock default, onboarding model persistence, and the desktop auth/model wiring.