### PR TITLE
fix(cli): add electron as runtime dependency for fusion desktop

### DIFF
--- a/.changeset/fix-desktop-electron-dep.md
+++ b/.changeset/fix-desktop-electron-dep.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Add `electron` as a runtime dependency so `fusion desktop` works from a published npm install.
+category: fix
+dev: `packages/cli/package.json` now depends on `electron`. Previously the desktop launcher called `require("electron")`, which is only available inside the source checkout (via `pnpm-workspace.yaml` `onlyBuiltDependencies`) and is missing for npm consumers, causing `fusion desktop` to hang or fail silently.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
     "@earendil-works/pi-coding-agent": "^0.80.3",
     "dockerode": "^4.0.12",
     "express": "^5.1.0",
+    "electron": "^33.4.11",
     "i18next": "^26.3.1",
     "ink": "^7.0.5",
     "ink-spinner": "^5.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ ignoredBuiltDependencies:
   - ssh2
 onlyBuiltDependencies:
   - '@homebridge/node-pty-prebuilt-multiarch'
-  - electron
   - esbuild
   - koffi
   - protobufjs


### PR DESCRIPTION
---
"@runfusion/fusion": patch
---

summary: Add `electron` as a runtime dependency so `fusion desktop` works from a published npm install.
category: fix
dev: `packages/cli/package.json` now depends on `electron`. Previously the desktop launcher called `require("electron")`, which is only available inside the source checkout (via `pnpm-workspace.yaml` `onlyBuiltDependencies`) and is missing for npm consumers, causing `fusion desktop` to hang or fail silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop app startup reliability in published installs by ensuring the required runtime is available.
  * Prevented the desktop launcher from hanging or failing silently in environments where the app was installed from npm.

* **Chores**
  * Updated package metadata to include the needed runtime dependency.
  * Adjusted workspace configuration to reflect the new dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->