### PR TITLE
build(desktop): allow redirecting staged deploy via FUSION_DESKTOP_DEPLOY_DIR

### DIFF
--- a/packages/desktop/scripts/workspace-tools.ts
+++ b/packages/desktop/scripts/workspace-tools.ts
@@ -130,7 +130,17 @@ point electron-builder at that staged directory via --projectDir.
 - The stage has no pnpm-lock, so electron-builder treats it as a plain flat
   project and packs the whole node_modules — no dedup gap.
 */
-export const desktopDeployDir = resolve(packageRoot, "deploy");
+/*
+ * FNXC:DesktopBuild 2026-07-03-10:20:
+ * `pnpm deploy` materializes the flat production closure by renaming a temp dir into place. On some
+ * Windows filesystems (notably the orca-managed workspace mount used for local dev) that final rename
+ * hits EPERM and also litters deeply-nested deploy_tmp_* dirs that are painful to remove. Allow
+ * redirecting the staged deploy to an external, plain-NTFS path via FUSION_DESKTOP_DEPLOY_DIR so local
+ * Windows installer builds can sidestep the race; CI and the default path are unchanged.
+ */
+export const desktopDeployDir = process.env.FUSION_DESKTOP_DEPLOY_DIR
+  ? resolve(process.env.FUSION_DESKTOP_DEPLOY_DIR)
+  : resolve(packageRoot, "deploy");
 
 export async function stageDesktopDeploy(): Promise<void> {
   console.log("[desktop:build] Staging complete production closure via pnpm deploy...");


### PR DESCRIPTION
Follow-up to #1878 (merged). While building the Windows desktop installer locally, `pnpm deploy`'s final temp-dir rename hits `EPERM` on the orca-managed Windows workspace mount and litters deeply-nested `deploy_tmp_*` dirs that are painful to remove.

This lets local Windows installer builds redirect the staged production closure to an external, plain-NTFS path via a new `FUSION_DESKTOP_DEPLOY_DIR` env var. **CI and the default in-tree `packages/desktop/deploy` path are unchanged** — the override is opt-in.

Verified locally: with `FUSION_DESKTOP_DEPLOY_DIR=C:\Users\...\fusion-build\deploy`, `pnpm --filter @fusion/desktop build` stages the full closure externally without the EPERM race, and `electron-builder --projectDir <that dir> --win nsis --x64` produces a signed installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop deployment staging can now be configured with an environment variable, making it easier to customize where build files are prepared.
* **Documentation**
  * Added notes about updated desktop deployment behavior on Windows, including common rename and cleanup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->