### PR TITLE
fix: add cursor-runtime vitest aliases to unblock 48 dashboard tests

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -78,6 +78,18 @@ export default defineConfig({
         find: /^@fusion-plugin-examples\/paperclip-runtime$/,
         replacement: resolve(__dirname, "../../plugins/fusion-plugin-paperclip-runtime/src/index.ts"),
       },
+      /*
+      FNXC:PluginTests 2026-07-03-12:30:
+      runtime-provider-probes.ts (transitively imported by dashboard) imports probeCursorBinary from @fusion-plugin-examples/cursor-runtime. Without these source aliases, Vite tries to resolve the package's dist/ exports which don't exist in a source checkout.
+      */
+      {
+        find: /^@fusion-plugin-examples\/cursor-runtime\/probe$/,
+        replacement: resolve(__dirname, "../../plugins/fusion-plugin-cursor-runtime/src/probe.ts"),
+      },
+      {
+        find: /^@fusion-plugin-examples\/cursor-runtime$/,
+        replacement: resolve(__dirname, "../../plugins/fusion-plugin-cursor-runtime/src/index.ts"),
+      },
       { find: /^@fusion\/test-utils$/, replacement: resolve(__dirname, "../core/src/__test-utils__/workspace.ts") },
     ],
   },

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -518,6 +518,18 @@ export default defineConfig({
         __dirname,
         "../../plugins/fusion-plugin-linear-import/src/index.ts",
       ),
+      /*
+      FNXC:PluginTests 2026-07-03-12:30:
+      runtime-provider-probes.ts imports probeCursorBinary from @fusion-plugin-examples/cursor-runtime. Without these source aliases, Vite tries to resolve the package's dist/ exports which don't exist in a source checkout, causing every dashboard test that transitively imports the runtime provider to fail with "Failed to resolve entry for package".
+      */
+      "@fusion-plugin-examples/cursor-runtime/probe": resolve(
+        __dirname,
+        "../../plugins/fusion-plugin-cursor-runtime/src/probe.ts",
+      ),
+      "@fusion-plugin-examples/cursor-runtime": resolve(
+        __dirname,
+        "../../plugins/fusion-plugin-cursor-runtime/src/index.ts",
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Fixes 48 dashboard test files failing in CI run [28681317913](https://github.com/Runfusion/Fusion/actions/runs/28681317913) with `Failed to resolve entry for package "@fusion-plugin-examples/cursor-runtime"`.

## Root cause

`runtime-provider-probes.ts` imports `probeCursorBinary` from `@fusion-plugin-examples/cursor-runtime`, but neither the dashboard nor CLI vitest configs had source aliases for this package. The cursor-runtime plugin was added (with `runtime-provider-probes.ts` consuming it) without updating the vitest configs to resolve the package to its TypeScript source entry points.

Without the aliases, Vite tries to resolve the package's `exports.import` field (`dist/index.js`) which doesn't exist in a source checkout, causing every dashboard test that transitively imports the runtime provider to fail at import time.

## Fix

Added `@fusion-plugin-examples/cursor-runtime` and `@fusion-plugin-examples/cursor-runtime/probe` source aliases to:
- `packages/dashboard/vitest.config.ts`
- `packages/cli/vitest.config.ts`

This mirrors the existing pattern for droid-runtime, hermes-runtime, openclaw-runtime, and paperclip-runtime.

## Verification

- Previously-failing dashboard tests now pass (295+ tests across 10 sampled files)
- Merge gate (`pnpm test:gate`) passes: 319 engine-core + 63 CI-shape tests green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test setup so the dashboard can load the cursor runtime directly from source, preventing missing export errors in local checkouts.
  * Added support for resolving the cursor runtime’s probe entry during test runs, avoiding Vite resolution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->