### PR TITLE
feat: add Coding (Ideas) workflow with manual Ideas intake

### DIFF
--- a/.changeset/fn-coding-ideas-workflow.md
+++ b/.changeset/fn-coding-ideas-workflow.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": minor
+---
+
+summary: Add a "Coding (Ideas)" workflow with a manual Ideas intake and a merged Todo planner column.
+category: feature
+dev: New `builtin:coding-ideas` clones the default stepwise pipeline with an `ideas` intake (autoTriage:false) in front of a merged `todo` planner+capacity column. createTask lands cards in the workflow's intake column; the triage service plans unplanned todo tasks in place; the scheduler skips bootstrap-prompt todo tasks; TaskCard gains a Start button and a Ready badge.

--- a/packages/core/src/__tests__/builtin-coding-ideas-workflow-ir.test.ts
+++ b/packages/core/src/__tests__/builtin-coding-ideas-workflow-ir.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_CODING_IDEAS_WORKFLOW_IR,
+  parseWorkflowIr,
+  serializeWorkflowIr,
+  getBuiltinWorkflow,
+  resolveEntryColumnId,
+} from "../index.js";
+import { resolveColumnFlags } from "../trait-registry.js";
+import type { WorkflowIrV2 } from "../workflow-ir-types.js";
+
+describe("builtin coding-ideas workflow ir", () => {
+  it("parses and round-trips", () => {
+    const parsed = parseWorkflowIr(BUILTIN_CODING_IDEAS_WORKFLOW_IR);
+    const reparsed = parseWorkflowIr(serializeWorkflowIr(parsed));
+    expect(reparsed).toEqual(parsed);
+    expect(parsed.version).toBe("v2");
+  });
+
+  it("is registered in the builtin catalog as a selectable workflow", () => {
+    const workflow = getBuiltinWorkflow("builtin:coding-ideas");
+    expect(workflow).toBeDefined();
+    expect(workflow!.id).toBe("builtin:coding-ideas");
+    expect(workflow!.name).toBe("Coding (Ideas)");
+    expect(workflow!.kind).toBe("workflow");
+    expect(workflow!.ir).toBe(BUILTIN_CODING_IDEAS_WORKFLOW_IR);
+  });
+
+  it("declares the five-stage Ideas → Todo → In-progress → In-review → Done board shape plus archived", () => {
+    const ir = BUILTIN_CODING_IDEAS_WORKFLOW_IR as WorkflowIrV2;
+    expect(ir.columns.map((c) => c.id)).toEqual([
+      "ideas",
+      "todo",
+      "in-progress",
+      "in-review",
+      "done",
+      "archived",
+    ]);
+  });
+
+  it("makes the ideas column the manual (autoTriage:false) intake", () => {
+    const ir = BUILTIN_CODING_IDEAS_WORKFLOW_IR as WorkflowIrV2;
+    const ideas = ir.columns.find((c) => c.id === "ideas")!;
+    expect(resolveColumnFlags(ideas).intake).toBe(true);
+    const intakeTrait = ideas.traits.find((t) => t.trait === "intake")!;
+    expect(intakeTrait.config).toEqual({ autoTriage: false });
+    // The entry column resolves to ideas (the intake column).
+    expect(resolveEntryColumnId(ir)).toBe("ideas");
+  });
+
+  it("merges the planner and capacity-hold stages into the todo column", () => {
+    const ir = BUILTIN_CODING_IDEAS_WORKFLOW_IR as WorkflowIrV2;
+    const todo = ir.columns.find((c) => c.id === "todo")!;
+    const flags = resolveColumnFlags(todo);
+    expect(flags.hold).toBe(true);
+    expect(flags.resetOnEntry).toBe(true);
+  });
+
+  it("keeps the in-progress / in-review / done column traits from the default pipeline", () => {
+    const ir = BUILTIN_CODING_IDEAS_WORKFLOW_IR as WorkflowIrV2;
+    expect(resolveColumnFlags(ir.columns.find((c) => c.id === "in-progress")!)).toMatchObject({
+      countsTowardWip: true,
+      abortOnExit: true,
+      timing: true,
+    });
+    expect(resolveColumnFlags(ir.columns.find((c) => c.id === "in-review")!)).toMatchObject({
+      mergeBlocker: true,
+      humanReview: true,
+      stallDetection: true,
+      mergeOrchestration: true,
+    });
+    expect(resolveColumnFlags(ir.columns.find((c) => c.id === "done")!).complete).toBe(true);
+  });
+
+  it("places the start node in ideas and the planning nodes in the merged todo column", () => {
+    const ir = BUILTIN_CODING_IDEAS_WORKFLOW_IR as WorkflowIrV2;
+    const nodeColumn = (id: string) => ir.nodes.find((n) => n.id === id)?.column;
+    expect(nodeColumn("start")).toBe("ideas");
+    expect(nodeColumn("plan")).toBe("todo");
+    expect(nodeColumn("plan-review")).toBe("todo");
+    expect(nodeColumn("plan-replan")).toBe("todo");
+  });
+
+  it("retains the default-on optional plan/code review groups from the default coding graph", () => {
+    const workflow = getBuiltinWorkflow("builtin:coding-ideas")!;
+    const byId = new Map(workflow.ir.nodes.map((n) => [n.id, n]));
+    const planReview = byId.get("plan-review");
+    expect(planReview?.kind).toBe("optional-group");
+    expect(planReview?.config?.defaultOn).toBe(true);
+    const codeReview = byId.get("code-review");
+    expect(codeReview?.kind).toBe("optional-group");
+    expect(codeReview?.config?.defaultOn).toBe(true);
+  });
+
+  it("never leaves a node in a column the workflow does not declare", () => {
+    const ir = BUILTIN_CODING_IDEAS_WORKFLOW_IR as WorkflowIrV2;
+    const declared = new Set(ir.columns.map((c) => c.id));
+    for (const node of ir.nodes) {
+      expect(declared.has(node.column!), `node ${node.id} in undeclared column ${node.column}`).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/__tests__/builtin-workflows.test.ts
+++ b/packages/core/src/__tests__/builtin-workflows.test.ts
@@ -672,10 +672,10 @@ describe("built-in workflows", () => {
     expect(defaultEnabledBuiltinWorkflowIds().length).toBeGreaterThanOrEqual(5);
     expect(defaultEnabledBuiltinWorkflowIds().slice(0, 5)).toEqual([
       "builtin:coding",
+      "builtin:coding-ideas",
       "builtin:legacy-coding",
       "builtin:quick-fix",
       "builtin:review-heavy",
-      "builtin:marketing",
     ]);
     expect(defaultEnabledBuiltinWorkflowIds()).toContain("builtin:stepwise-coding");
   });

--- a/packages/core/src/__tests__/store-create-intake-column.test.ts
+++ b/packages/core/src/__tests__/store-create-intake-column.test.ts
@@ -48,4 +48,16 @@ describe("createTask intake-column wiring (Coding (Ideas))", () => {
     );
     expect(prompt).toBe(`# ${task.id}\n\n${task.description}\n`);
   });
+
+  it("keeps generateSpecifiedPrompt for a direct create into todo (not bootstrap)", async () => {
+    const store = harness.store();
+    const task = await store.createTask({ description: "direct todo create", column: "todo" });
+    expect(task.column).toBe("todo");
+    const prompt = await readFile(
+      join(harness.rootDir(), ".fusion", "tasks", task.id, "PROMPT.md"),
+      "utf-8",
+    );
+    // A direct todo create is NOT an intake column, so it must NOT get the bootstrap stub.
+    expect(prompt).not.toBe(`# ${task.id}\n\n${task.description}\n`);
+  });
 });

--- a/packages/core/src/__tests__/store-create-intake-column.test.ts
+++ b/packages/core/src/__tests__/store-create-intake-column.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Task } from "../types.js";
+import { createTaskStoreTestHarness } from "./store-test-helpers.js";
+
+/*
+FNXC:CodingIdeasWorkflow 2026-07-04-11:30:
+Pin the createTask intake-column wiring: a task created against the Coding (Ideas) workflow (manual autoTriage:false intake) must land in the "ideas" column, not the legacy "triage" default, while the default Coding workflow keeps landing cards in "triage".
+*/
+describe("createTask intake-column wiring (Coding (Ideas))", () => {
+  const harness = createTaskStoreTestHarness();
+
+  beforeEach(harness.beforeEach);
+  afterEach(harness.afterEach);
+
+  it("lands a default-workflow task in triage (byte-identical regression guard)", async () => {
+    const store = harness.store();
+    const task = await store.createTask({ description: "default workflow task" });
+    expect(task.column).toBe("triage");
+  });
+
+  it("lands a Coding (Ideas) task in the ideas intake column when selected explicitly", async () => {
+    const store = harness.store();
+    const task = await store.createTask({
+      description: "ideas workflow task",
+      workflowId: "builtin:coding-ideas",
+    });
+    expect(task.column).toBe("ideas");
+  });
+
+  it("lands a Coding (Ideas) task in ideas when it is the project default workflow", async () => {
+    const store = harness.store();
+    await store.setDefaultWorkflowId("builtin:coding-ideas");
+    const task = await store.createTask({ description: "default ideas task" });
+    expect(task.column).toBe("ideas");
+  });
+
+  it("writes a bootstrap PROMPT.md for an ideas-column task (unplanned)", async () => {
+    const store = harness.store();
+    const task: Task = await store.createTask({
+      description: "ideas bootstrap prompt task",
+      workflowId: "builtin:coding-ideas",
+    });
+    const prompt = await readFile(
+      join(harness.rootDir(), ".fusion", "tasks", task.id, "PROMPT.md"),
+      "utf-8",
+    );
+    expect(prompt).toBe(`# ${task.id}\n\n${task.description}\n`);
+  });
+});

--- a/packages/core/src/builtin-coding-ideas-workflow-ir.ts
+++ b/packages/core/src/builtin-coding-ideas-workflow-ir.ts
@@ -1,0 +1,93 @@
+import type { WorkflowIr, WorkflowIrColumn, WorkflowIrV2 } from "./workflow-ir-types.js";
+import { parseWorkflowIr } from "./workflow-ir.js";
+import { BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR } from "./builtin-stepwise-final-review-coding-workflow-ir.js";
+import { BUILTIN_WORKFLOW_SETTINGS } from "./builtin-workflow-settings.js";
+
+/*
+FNXC:CodingIdeasWorkflow 2026-07-04-09:15:
+Operators need a manual-capture intake ("Ideas") in front of the default coding pipeline so they can park tasks without the engine auto-planning them. This workflow clones the current default Coding graph (stepwise execution + final review) and swaps the board columns to a five-stage Ideas → Todo → In-progress → In-review → Done shape.
+
+FNXC:CodingIdeasWorkflow 2026-07-04-09:18:
+The "Ideas" column is the intake column with autoTriage disabled. Tasks created into this workflow land there and are NOT picked up by the triage service until an operator moves them to "Todo" (the merged planner + capacity column). Planning then runs in place inside "Todo"; a "ready" badge distinguishes planned (real PROMPT.md) tasks from unplanned (bootstrap stub) ones while they wait for an in-progress slot. See createTask intake-column wiring (store.ts) and the triage todo-discovery extension (triage.ts).
+*/
+
+/** The board columns for the Coding (Ideas) workflow. The "ideas" intake carries
+ *  `autoTriage: false` so the engine's createTask intake-column wiring lands new
+ *  cards there and the triage service leaves them alone until they are promoted
+ *  into "todo". "todo" merges the legacy triage (planner) and todo (capacity
+ *  hold) stages into one agent-staffed column. */
+const CODING_IDEAS_COLUMNS: WorkflowIrColumn[] = [
+  {
+    id: "ideas",
+    name: "Ideas",
+    traits: [{ trait: "intake", config: { autoTriage: false } }],
+  },
+  {
+    id: "todo",
+    name: "Todo",
+    traits: [{ trait: "hold", config: { release: "capacity" } }, { trait: "reset-on-entry" }],
+  },
+  {
+    id: "in-progress",
+    name: "In progress",
+    traits: [
+      { trait: "wip", config: { limitSetting: "maxConcurrent", countPending: true } },
+      { trait: "abort-on-exit" },
+      { trait: "timing" },
+    ],
+  },
+  {
+    id: "in-review",
+    name: "In review",
+    traits: [{ trait: "merge-blocker" }, { trait: "human-review" }, { trait: "stall-detection" }, { trait: "merge" }],
+  },
+  { id: "done", name: "Done", traits: [{ trait: "complete" }] },
+  { id: "archived", name: "Archived", traits: [{ trait: "archived" }] },
+];
+
+/** Planning-stage node ids that sit in the legacy "triage" / "in-progress"
+ *  columns in the cloned default graph. They are re-homed to the merged "todo"
+ *  planner column so an agent is visibly working while the spec is produced. */
+const PLANNING_NODE_IDS: Record<string, true> = {
+  plan: true,
+  "plan-review": true,
+  "plan-replan": true,
+};
+
+const RAW_BUILTIN_CODING_IDEAS_WORKFLOW_IR: WorkflowIr = (() => {
+  const ir = JSON.parse(JSON.stringify(BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR)) as WorkflowIr;
+  ir.name = "builtin-coding-ideas";
+
+  const v2 = ir as WorkflowIrV2;
+  v2.columns = CODING_IDEAS_COLUMNS.map((column) => ({
+    ...column,
+    traits: column.traits.map((trait) => ({
+      ...trait,
+      config: trait.config ? { ...trait.config } : undefined,
+    })),
+  }));
+
+  /*
+  FNXC:CodingIdeasWorkflow 2026-07-04-09:30:
+  Re-home graph nodes to the new column shape: the start node becomes the "ideas" intake anchor; planning-stage nodes move to the merged "todo" column; every execution / review / merge / done node keeps its existing column id (in-progress / in-review / done), which still exists in the new column set. Unknown legacy columns (e.g. a leftover "triage" placement) default to "todo" so no node is ever left dangling in a column the workflow no longer declares.
+  */
+  const knownColumnIds = new Set(v2.columns.map((c) => c.id));
+  for (const node of v2.nodes) {
+    if (node.kind === "start") {
+      node.column = "ideas";
+      continue;
+    }
+    if (PLANNING_NODE_IDS[node.id]) {
+      node.column = "todo";
+      continue;
+    }
+    if (!node.column || !knownColumnIds.has(node.column)) {
+      node.column = "todo";
+    }
+  }
+
+  v2.settings = BUILTIN_WORKFLOW_SETTINGS;
+  return ir;
+})();
+
+export const BUILTIN_CODING_IDEAS_WORKFLOW_IR = parseWorkflowIr(RAW_BUILTIN_CODING_IDEAS_WORKFLOW_IR);

--- a/packages/core/src/builtin-workflows.ts
+++ b/packages/core/src/builtin-workflows.ts
@@ -1,4 +1,5 @@
 import { BUILTIN_CODING_WORKFLOW_IR } from "./builtin-coding-workflow-ir.js";
+import { BUILTIN_CODING_IDEAS_WORKFLOW_IR } from "./builtin-coding-ideas-workflow-ir.js";
 import { BUILTIN_LEAD_GENERATION_WORKFLOW_IR } from "./builtin-lead-generation-workflow-ir.js";
 import { BUILTIN_MARKETING_WORKFLOW_IR } from "./builtin-marketing-workflow-ir.js";
 import { BUILTIN_PR_WORKFLOW_IR } from "./builtin-pr-workflow-ir.js";
@@ -331,6 +332,42 @@ export const BUILTIN_WORKFLOWS: WorkflowDefinition[] = [
     description: "Default coding pipeline: plan steps, execute them one at a time, then run the optional final code review and merge.",
     kind: "workflow",
     ir: BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR,
+    layout: {
+      start: { x: 60, y: 160 },
+      plan: { x: 230, y: 160 },
+      "plan-review": { x: 400, y: 160 },
+      "plan-replan": { x: 400, y: 320 },
+      parse: { x: 570, y: 160 },
+      steps: { x: 740, y: 160 },
+      "browser-verification": { x: 910, y: 160 },
+      "browser-verification-remediation": { x: 910, y: 320 },
+      "code-review": { x: 1080, y: 160 },
+      "code-review-remediation": { x: 1080, y: 320 },
+      "completion-summary": { x: 1250, y: 160 },
+      "merge-gate": { x: 1420, y: 160 },
+      "branch-group-member-integration": { x: 1590, y: 80 },
+      "branch-group-promotion": { x: 1760, y: 80 },
+      "merge-attempt": { x: 1930, y: 160 },
+      "merge-retry": { x: 2100, y: 80 },
+      "recovery-router": { x: 2100, y: 240 },
+      "merge-manual-hold": { x: 1590, y: 240 },
+      "post-merge-verification": { x: 2270, y: 160 },
+      end: { x: 2440, y: 160 },
+    },
+    createdAt: BUILTIN_TS,
+    updatedAt: BUILTIN_TS,
+  },
+  /*
+   * FNXC:CodingIdeasWorkflow 2026-07-04-09:40:
+   * The Coding (Ideas) variant adds a manual "Ideas" intake in front of the default stepwise pipeline. New cards land in "ideas" (autoTriage off) and are not planned until an operator promotes them into the merged "todo" planner column; from there the graph is identical to the default Coding workflow.
+   */
+  {
+    id: "builtin:coding-ideas",
+    name: "Coding (Ideas)",
+    description:
+      "Capture-first coding pipeline: park ideas in a manual intake, then plan, execute per step, run the optional final code review, and merge.",
+    kind: "workflow",
+    ir: BUILTIN_CODING_IDEAS_WORKFLOW_IR,
     layout: {
       start: { x: 60, y: 160 },
       plan: { x: 230, y: 160 },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,7 @@ export type {
   EffectiveAgentResult,
 } from "./column-agent-resolver.js";
 export { BUILTIN_CODING_WORKFLOW_IR } from "./builtin-coding-workflow-ir.js";
+export { BUILTIN_CODING_IDEAS_WORKFLOW_IR } from "./builtin-coding-ideas-workflow-ir.js";
 export { PLAN_REVIEW_GROUP_ID } from "./builtin-plan-review-group.js";
 export { BUILTIN_MARKETING_WORKFLOW_IR } from "./builtin-marketing-workflow-ir.js";
 export {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -5060,15 +5060,13 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
     if (this.isWatching) this.taskCache.set(id, { ...task });
 
     /*
-    FNXC:CodingIdeasWorkflow 2026-07-04-10:10:
-    A freshly created task has no specification yet regardless of which intake/planning column it lands in (triage, ideas, or a merged todo). Use the bootstrap stub for every pre-execution column so the spec-detection helpers (isBootstrapPromptStub) treat the card as unplanned until triage replaces it with a real PROMPT.md. Execution/review/done/archived columns keep the generated specified prompt for the legacy direct-create paths.
+    FNXC:CodingIdeasWorkflow 2026-07-04-10:10 (revised):
+    A freshly created task needs the bootstrap stub only when it lands in a column the triage service will plan from — the legacy "triage" intake or a workflow's resolved manual intake (e.g. Coding (Ideas) → "ideas"). Gate on those two ids so legacy direct-create callers that pass an explicit column like "todo" still get the generated specified prompt. A task whose column is neither the entry column nor "triage" (custom hold/backlog columns, direct todo creates) keeps generateSpecifiedPrompt.
     */
-    const isPrePlanningColumn = task.column !== "in-progress"
-      && task.column !== "in-review"
-      && task.column !== "done"
-      && task.column !== "archived";
+    const isIntakeColumn = task.column === "triage"
+      || (options?.resolvedEntryColumn !== undefined && task.column === options.resolvedEntryColumn);
     const prompt = options?.promptOverride
-      ?? (isPrePlanningColumn
+      ?? (isIntakeColumn
         ? buildBootstrapPrompt(id, task.title, task.description)
         : this.generateSpecifiedPrompt(task));
     const validation = validateFileScopeInPromptContent(prompt);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -4639,6 +4639,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
     // When a project default workflow is configured, new tasks inherit it
     // (compiled to steps) ahead of the legacy default-on step behavior.
     let pendingWorkflowSelection: { workflowId: string; stepIds: string[] } | undefined;
+    let resolvedEntryColumn: string | undefined;
     /*
     FNXC:WorkflowCreation 2026-06-28-23:09:
     User-facing task creation can submit a selected workflowId and optional-group toggles together. The visible workflow selection is operator intent and must persist as task_workflow_selection; enabledWorkflowSteps only overrides that workflow's default optional-group seed.
@@ -4657,6 +4658,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
           ? (resolvedWorkflowSteps ?? [])
           : undefined;
         resolvedWorkflowSteps = explicitStepIds ?? selected.stepIds;
+        resolvedEntryColumn = selected.entryColumnId;
         pendingWorkflowSelection = {
           workflowId: selected.workflowId,
           stepIds: explicitStepIds ?? selected.stepIds,
@@ -4667,6 +4669,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
         const inherited = await this.materializeDefaultWorkflowSteps();
         if (inherited) {
           resolvedWorkflowSteps = inherited.stepIds;
+          resolvedEntryColumn = inherited.entryColumnId;
           pendingWorkflowSelection = inherited;
         }
       } catch (err) {
@@ -4708,7 +4711,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
           title,
           resolvedWorkflowSteps,
           taskId,
-          { invokeTaskCreatedHook: shouldInvokeTaskCreatedHook && !hasPendingSummarization, reservationCommit },
+          { invokeTaskCreatedHook: shouldInvokeTaskCreatedHook && !hasPendingSummarization, reservationCommit, resolvedEntryColumn },
         );
       },
     });
@@ -4833,6 +4836,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       : undefined;
 
     let pendingWorkflowSelection: { workflowId: string; stepIds: string[] } | undefined;
+    let resolvedEntryColumn: string | undefined;
     /*
     FNXC:WorkflowCreation 2026-06-28-23:09:
     Reserved-id task creation must match normal task creation: workflowId and enabledWorkflowSteps are independent create controls, so explicit optional toggles do not erase the selected workflow row.
@@ -4850,6 +4854,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
           ? (resolvedWorkflowSteps ?? [])
           : undefined;
         resolvedWorkflowSteps = explicitStepIds ?? selected.stepIds;
+        resolvedEntryColumn = selected.entryColumnId;
         pendingWorkflowSelection = {
           workflowId: selected.workflowId,
           stepIds: explicitStepIds ?? selected.stepIds,
@@ -4862,6 +4867,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
         const inherited = await this.materializeDefaultWorkflowSteps();
         if (inherited) {
           resolvedWorkflowSteps = inherited.stepIds;
+          resolvedEntryColumn = inherited.entryColumnId;
           pendingWorkflowSelection = inherited;
         }
       } catch (err) {
@@ -4893,14 +4899,13 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       resolvedWorkflowSteps = [];
     }
 
-    // U7c: selection seeds are optional-group node ids (not materialized
-    // `workflow_steps` rows), so a failed task creation strands nothing to clean.
     const createdTask: Task = await this._createTaskInternal(input, title, resolvedWorkflowSteps, id, {
       createdAt: options.createdAt,
       updatedAt: options.updatedAt,
       promptOverride: options.prompt,
       invokeTaskCreatedHook: options.invokeTaskCreatedHook,
       reservationCommit: options.reservationCommit,
+      resolvedEntryColumn,
     });
 
     // Record the inherited workflow selection now that the task row exists.
@@ -4974,6 +4979,11 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       promptOverride?: string;
       invokeTaskCreatedHook?: boolean;
       reservationCommit?: { reservationId: string; nodeId: string };
+      /*
+      FNXC:CodingIdeasWorkflow 2026-07-04-10:02:
+      The resolved workflow's intake column id. When the caller omits an explicit `input.column`, the task lands here instead of the legacy "triage" default so workflows with a manual intake (e.g. Coding (Ideas) → "ideas") capture new cards without auto-planning them. Defaults to "triage" when unset, preserving byte-identical behavior for the default workflow.
+      */
+      resolvedEntryColumn?: string;
     },
   ): Promise<Task> {
     const now = options?.createdAt ?? new Date().toISOString();
@@ -4999,7 +5009,7 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       branchContext: input.branchContext,
       autoMerge: input.autoMerge,
       autoMergeProvenance: input.autoMerge === undefined ? undefined : "user",
-      column: input.column || "triage",
+      column: input.column || options?.resolvedEntryColumn || "triage",
       dependencies: input.dependencies || [],
       breakIntoSubtasks: input.breakIntoSubtasks === true ? true : undefined,
       noCommitsExpected: input.noCommitsExpected === true ? true : undefined,
@@ -5049,8 +5059,16 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
     // Update cache if watcher is active
     if (this.isWatching) this.taskCache.set(id, { ...task });
 
+    /*
+    FNXC:CodingIdeasWorkflow 2026-07-04-10:10:
+    A freshly created task has no specification yet regardless of which intake/planning column it lands in (triage, ideas, or a merged todo). Use the bootstrap stub for every pre-execution column so the spec-detection helpers (isBootstrapPromptStub) treat the card as unplanned until triage replaces it with a real PROMPT.md. Execution/review/done/archived columns keep the generated specified prompt for the legacy direct-create paths.
+    */
+    const isPrePlanningColumn = task.column !== "in-progress"
+      && task.column !== "in-review"
+      && task.column !== "done"
+      && task.column !== "archived";
     const prompt = options?.promptOverride
-      ?? (task.column === "triage"
+      ?? (isPrePlanningColumn
         ? buildBootstrapPrompt(id, task.title, task.description)
         : this.generateSpecifiedPrompt(task));
     const validation = validateFileScopeInPromptContent(prompt);

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -1407,7 +1407,7 @@ function TaskCardComponent({
     || Boolean(task.blockedBy)
     || Boolean(task.overlapBlockedBy)
     || Boolean(fanout && fanout.totalCount > 0);
-  const showStartAction = task.column === "ideas" && Boolean(onMoveTask);
+  const showStartAction = taskColumnFlags?.intake === true && task.column !== "triage" && Boolean(onMoveTask);
   const shouldRenderActionRow = Boolean(onPromote) || showCreatePrQuickAction || showAddressPrFeedbackAction || showStartAction || (showInReviewMoveControl && !metaRowVisible);
 
   const renderInReviewMoveControl = () => (

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -1408,6 +1408,16 @@ function TaskCardComponent({
     || Boolean(task.overlapBlockedBy)
     || Boolean(fanout && fanout.totalCount > 0);
   const showStartAction = taskColumnFlags?.intake === true && task.column !== "triage" && Boolean(onMoveTask);
+  /*
+  FNXC:CodingIdeasWorkflow 2026-07-04-12:30:
+  The Start action promotes a card out of a manual intake into the workflow's first working column. Derive the target from the ordered workflow columns instead of hard-coding "todo" so a workflow whose intake feeds a differently-named stage transitions correctly. Falls back to "todo" when the column metadata is unavailable (e.g. the all-workflows board aggregate).
+  */
+  const startTargetColumn: ColumnId = useMemo(() => {
+    const next = taskMoveColumns?.find(
+      (c) => c.id !== task.column && !c.flags?.intake && !c.flags?.archived && !c.flags?.hiddenFromBoard,
+    );
+    return (next?.id ?? "todo") as ColumnId;
+  }, [taskMoveColumns, task.column]);
   const shouldRenderActionRow = Boolean(onPromote) || showCreatePrQuickAction || showAddressPrFeedbackAction || showStartAction || (showInReviewMoveControl && !metaRowVisible);
 
   const renderInReviewMoveControl = () => (
@@ -2191,14 +2201,14 @@ function TaskCardComponent({
     if (!onMoveTask || isStarting) return;
     setIsStarting(true);
     try {
-      await onMoveTask(task.id, "todo");
+      await onMoveTask(task.id, startTargetColumn);
       addToast(t("tasks.startedPlanning", "Started planning {{taskId}}", { taskId: task.id }), "success");
     } catch (err) {
       addToast(getErrorMessage(err), "error");
     } finally {
       setIsStarting(false);
     }
-  }, [addToast, isStarting, onMoveTask, t, task.id]);
+  }, [addToast, isStarting, onMoveTask, startTargetColumn, t, task.id]);
 
   const handleAddressPrFeedbackClick = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -777,6 +777,7 @@ function TaskCardComponent({
   const [isRetrying, setIsRetrying] = useState(false);
   const [isPrCreateOpen, setIsPrCreateOpen] = useState(false);
   const [isAddressingPrFeedback, setIsAddressingPrFeedback] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
   const [timeIndicatorNowMs, setTimeIndicatorNowMs] = useState(() => Date.now());
 
   const descTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -1406,7 +1407,8 @@ function TaskCardComponent({
     || Boolean(task.blockedBy)
     || Boolean(task.overlapBlockedBy)
     || Boolean(fanout && fanout.totalCount > 0);
-  const shouldRenderActionRow = Boolean(onPromote) || showCreatePrQuickAction || showAddressPrFeedbackAction || (showInReviewMoveControl && !metaRowVisible);
+  const showStartAction = task.column === "ideas" && Boolean(onMoveTask);
+  const shouldRenderActionRow = Boolean(onPromote) || showCreatePrQuickAction || showAddressPrFeedbackAction || showStartAction || (showInReviewMoveControl && !metaRowVisible);
 
   const renderInReviewMoveControl = () => (
     <div className="card-send-back" ref={sendBackRef}>
@@ -2184,6 +2186,19 @@ function TaskCardComponent({
     if (!onPromote || isPromoting) return;
     void onPromote(task.id);
   }, [isPromoting, onPromote, task.id]);
+  const handleStartClick = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (!onMoveTask || isStarting) return;
+    setIsStarting(true);
+    try {
+      await onMoveTask(task.id, "todo");
+      addToast(t("tasks.startedPlanning", "Started planning {{taskId}}", { taskId: task.id }), "success");
+    } catch (err) {
+      addToast(getErrorMessage(err), "error");
+    } finally {
+      setIsStarting(false);
+    }
+  }, [addToast, isStarting, onMoveTask, t, task.id]);
 
   const handleAddressPrFeedbackClick = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
@@ -2398,6 +2413,15 @@ function TaskCardComponent({
             className={`card-status-badge card-status-badge--${task.column}${isAwaitingApproval ? " awaiting-approval" : ""}${isAwaitingInput ? " awaiting-input" : ""}${ACTIVE_STATUSES.has(visualStatus) ? " pulsing" : ""}${isFailed ? " failed" : ""}${isStuck ? " stuck" : ""}`}
           >
             {isStuck ? t("tasks.stuck", "Stuck") : isAwaitingApproval ? t("tasks.awaitingApproval", "Awaiting Approval") : isAwaitingInput ? t("tasks.needsInput", "Needs input") : visualStatus === "merging-fix" ? t("tasks.statusMergingFix", "Merging fixes…") : getTaskStatusLabel(visualStatus, t)}
+          </span>
+        )}
+        {/*
+        FNXC:CodingIdeasWorkflow 2026-07-04-11:10:
+        In the merged planner/capacity "todo" column (Coding (Ideas)), a planned task with no active status is ready and waiting for an in-progress slot. Show a "Ready" badge so operators can distinguish planned cards from freshly promoted unplanned ones. Tasks still being planned surface the "planning" status badge above instead.
+        */}
+        {!isPaused && task.column === "todo" && !visualStatus && (task.steps?.length ?? 0) > 0 && (
+          <span className="card-status-badge card-status-badge--todo ready" data-testid={`card-ready-${task.id}`}>
+            {t("tasks.ready", "Ready")}
           </span>
         )}
         {hasInReviewStall && stallCopy && (
@@ -3036,6 +3060,20 @@ function TaskCardComponent({
               */}
               <Bot size={12} />
               {isAddressingPrFeedback ? t("tasks.addressingPrFeedback", "Addressing…") : t("tasks.addressPrFeedback", "Address PR feedback")}
+            </button>
+          )}
+          {showStartAction && (
+            <button
+              type="button"
+              className="card-promote-action card-send-back-btn"
+              data-testid={`card-start-${task.id}`}
+              title={t("tasks.startTask", "Start — plan this task")}
+              aria-label={t("tasks.startTask", "Start — plan this task")}
+              disabled={isStarting}
+              onClick={handleStartClick}
+            >
+              <Zap size={12} />
+              {isStarting ? t("tasks.starting", "Starting…") : t("tasks.start", "Start")}
             </button>
           )}
           {onPromote && (

--- a/packages/dashboard/src/routes/board-workflows.ts
+++ b/packages/dashboard/src/routes/board-workflows.ts
@@ -71,6 +71,7 @@ export interface BoardWorkflowsPayload {
 }
 
 const BUILTIN_WORKFLOW_COLUMN_LABELS: Record<string, string> = {
+  ideas: "Ideas",
   triage: "Triage",
   todo: "Todo",
   "in-progress": "In Progress",

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -2252,6 +2252,24 @@ export class Scheduler {
         reserveSlot: async (task): Promise<SlotReservation | null> => {
           let reservedScope = false;
 
+          /*
+          FNXC:CodingIdeasWorkflow 2026-07-04-12:10:
+          The workflow-column dispatch path is the only dispatcher when the flag is on, so the planning/bootstrap guards from the legacy todo filter must also apply here. A todo task being specified in place (status "planning") or still carrying the bootstrap stub PROMPT.md must not be released into an execution slot.
+          */
+          if (task.status === "planning") {
+            return null;
+          }
+          if (task.column === "todo") {
+            try {
+              const promptContent = await readFile(getPromptPath(this.store.getTasksDir(), task.id), "utf-8");
+              if (promptContent === buildBootstrapPrompt(task.id, task.title, task.description)) {
+                return null;
+              }
+            } catch {
+              // Missing prompt handled by filesystem validation below.
+            }
+          }
+
           const unmetDeps = getUnmetSchedulingDependencies(task, tasks, schedulingDependencyOptions);
           if (unmetDeps.length > 0) {
             await this.store.updateTask(task.id, {

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -14,6 +14,7 @@ import {
   type AgentStore,
   type Settings,
   TransitionRejectionError,
+  buildBootstrapPrompt,
 } from "@fusion/core";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -1403,8 +1404,28 @@ export class Scheduler {
         if (t.column !== "todo" || t.paused) return false;
         // Skip tasks with a recovery backoff that hasn't elapsed yet
         if (t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now) return false;
+        // FNXC:CodingIdeasWorkflow 2026-07-04-10:45: a todo task with status "planning" is being specified in place by the triage service (merged planner/capacity column in Coding (Ideas)); it must not be dispatched until planning finishes and the status clears.
+        if (t.status === "planning") return false;
         return true;
       });
+      /*
+      FNXC:CodingIdeasWorkflow 2026-07-04-10:46:
+      Exclude unplanned todo tasks whose PROMPT.md is still the bootstrap stub. In a merged planner/capacity column a freshly promoted card has no real spec yet; dispatching it would execute the stub. Normal-workflow todo tasks always carry a real spec (triage writes it before moving them to todo), so this filter is a no-op for them. This closes the gap between the operator promoting a card and the triage service picking it up.
+      */
+      todo = (
+        await Promise.all(
+          todo.map(async (t) => {
+            try {
+              const content = await readFile(getPromptPath(this.store.getTasksDir(), t.id), "utf-8");
+              if (content === buildBootstrapPrompt(t.id, t.title, t.description)) return null;
+            } catch {
+              // Missing prompt is handled by filesystem validation below; keep the candidate.
+            }
+            return t;
+          }),
+        )
+      ).filter((t): t is Task => t !== null);
+
 
       // Filter out tasks belonging to blocked missions
       if (todo.length > 0 && this.options.missionStore) {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -336,8 +336,13 @@ export class TriageProcessor {
   }
 
   private async clearStaleSpecifyingStatuses(): Promise<void> {
-    const tasks = await this.store.listTasks({ column: "triage", slim: true });
-    const stale = tasks.filter(
+    /*
+    FNXC:CodingIdeasWorkflow 2026-07-04-12:00:
+    In the merged planner/capacity "todo" column a task can carry status "planning" when the triage service is specifying it in place. A crash/restart before planning completes leaves that status set, so the startup sweep must clear it from BOTH triage and todo — otherwise a stale planning todo task permanently occupies a maxTriageConcurrent slot and blocks new triage work.
+    */
+    const triageTasks = await this.store.listTasks({ column: "triage", slim: true });
+    const todoTasks = await this.store.listTasks({ column: "todo", slim: true });
+    const stale = [...triageTasks, ...todoTasks].filter(
       (t) => t.status === "planning" && !this.processing.has(t.id),
     );
     for (const t of stale) {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -14,6 +14,7 @@ import {
   PLAN_REVIEW_GROUP_ID,
   TaskDeletedError,
   buildTriageMemoryInstructions,
+  buildBootstrapPrompt,
   getTaskDuplicateLineage,
   parseExplicitDuplicateMarker,
   resolveAgentPrompt,
@@ -788,7 +789,30 @@ export class TriageProcessor {
           // Skip tasks with a recovery backoff that hasn't elapsed yet
           && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),
       );
-      const triageTasks = sortTasksByPriorityThenAgeAndId(eligibleTriageTasks).sort((a, b) => {
+      /*
+      Workflows with a manual intake (e.g. Coding (Ideas)) merge the planner and capacity-hold stages into a single "todo" column. The triage service must also discover "todo" tasks whose PROMPT.md is still the bootstrap stub — they have been promoted out of the manual intake but not yet planned in place. Planned todo tasks carry a real spec and are left for the scheduler. The bootstrap-prompt file check is the ground-truth unplanned signal; it is false for every normal-workflow todo task because triage writes a real spec before it ever moves a card into todo.
+      */
+      const eligibleTodoTasksRaw = allTasks.filter(
+        (t) => t.column === "todo" && !this.processing.has(t.id) && !t.paused
+          && t.status !== "awaiting-approval"
+          && t.status !== "failed"
+          && t.status !== "stuck-killed"
+          && t.status !== "planning"
+          && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),
+      );
+      const eligibleTodoTasks: Task[] = [];
+      for (const todoTask of eligibleTodoTasksRaw) {
+        try {
+          const promptPath = join(this.rootDir, ".fusion", "tasks", todoTask.id, "PROMPT.md");
+          const content = await readFile(promptPath, "utf-8");
+          if (content === buildBootstrapPrompt(todoTask.id, todoTask.title, todoTask.description)) {
+            eligibleTodoTasks.push(todoTask);
+          }
+        } catch {
+          // Missing/unreadable prompt — skip; the scheduler's filesystem validation handles it.
+        }
+      }
+      const triageTasks = sortTasksByPriorityThenAgeAndId([...eligibleTriageTasks, ...eligibleTodoTasks]).sort((a, b) => {
         const priorityCmp = compareTaskPriority(a.priority, b.priority);
         if (priorityCmp !== 0) {
           return priorityCmp;
@@ -813,7 +837,7 @@ export class TriageProcessor {
       // Only planning tasks count against the triage limit; execution is governed by maxConcurrent.
       const maxTriageConcurrent = settings.maxTriageConcurrent ?? settings.maxConcurrent ?? 2;
       const planning = allTasks.filter(
-        (t) => t.column === "triage" && t.status === "planning" && !t.paused,
+        (t) => (t.column === "triage" || t.column === "todo") && t.status === "planning" && !t.paused,
       ).length;
       const activeAgents = planning;
 
@@ -2565,7 +2589,13 @@ export class TriageProcessor {
       }
     }
 
-    await this.store.moveTask(task.id, "todo");
+    /*
+    FNXC:CodingIdeasWorkflow 2026-07-04-10:35:
+    A task planned in place inside the merged "todo" column (Coding (Ideas) and any workflow with a manual intake) is already where it needs to be. Skipping the move avoids a redundant same-column transition that would re-run reset-on-entry and capacity trait hooks on a card that never left the column. Legacy triage tasks (column "triage") still move to "todo" as before.
+    */
+    if (task.column !== "todo") {
+      await this.store.moveTask(task.id, "todo");
+    }
 
     if (shouldApplyPromptDeclaredTitle && promptDeclaredTitle) {
       await this.store.updateTask(task.id, { title: promptDeclaredTitle });


### PR DESCRIPTION
## What

Adds a new built-in workflow **Coding (Ideas)** — a capture-first variant of the default coding pipeline that puts a manual **Ideas (no AI)** intake in front of a merged **Todo** (planner + capacity) column.

The board becomes five stages, each staffed by a distinct role:

```
Ideas (no AI)  →  Todo (planner)  →  In-progress (coder)  →  In-review (reviewer)  →  Done
```

## Why

The current board parks un-worked cards in a passive **Todo** column where no agent is active. Operators asked for a way to (1) capture ideas without the engine auto-planning them, and (2) collapse the triage/todo split so every visible column has an agent working it — planning now happens *in* Todo. A "Ready" badge distinguishes planned cards waiting for a capacity slot from freshly promoted unplanned ones.

## How it works

1. **Create** a task against Coding (Ideas) → it lands in **Ideas** (`autoTriage:false` intake). The triage service ignores it — no AI runs.
2. **Start** (button on the card, or drag) moves it to **Todo**. The triage poll discovers the unplanned card (bootstrap-stub PROMPT.md) and plans it in place.
3. While planning the card shows **Planning**; once the spec is written it shows **Ready** and waits for an in-progress slot under the normal capacity hold.
4. From Todo onward the graph is identical to the default Coding workflow (stepwise execution → optional code review → merge).

## Engine changes

| Surface | Change |
|---|---|
| `createTask` (`store.ts`) | Lands cards in the workflow's intake column (`resolvedEntryColumn`) instead of hardcoding `"triage"`. Default workflow is byte-identical (intake resolves to `"triage"`). Bootstrap-prompt check generalized to all pre-planning columns. |
| Triage poll (`triage.ts`) | Also discovers unplanned `todo` tasks (bootstrap-stub prompt); `finalizeApprovedTask` skips the redundant triage→todo move for in-place planning; planning-concurrency counter covers both columns. |
| Scheduler (`scheduler.ts`) | Skips `todo` tasks with `status:"planning"` or a bootstrap-stub prompt so unplanned cards are never dispatched. |
| TaskCard (`TaskCard.tsx`) | **Start** button on ideas cards; **Ready** badge on planned todo tasks. |
| Board (`board-workflows.ts`) | `ideas` column label. |

All engine changes are **gated** — they only affect workflows whose intake is not `"triage"`, so the default Coding workflow and every existing built-in are byte-identical in behavior.

## Tests

- `builtin-coding-ideas-workflow-ir.test.ts` *(new)* — column set, intake trait (`autoTriage:false`), merged todo traits, node re-homing (start→ideas, planning→todo), optional-group defaults, round-trip.
- `store-create-intake-column.test.ts` *(new)* — createTask lands in `ideas` for explicit + default selection, `triage` for the default workflow, writes a bootstrap prompt.
- Updated `builtin-workflows.test.ts` catalog-order assertion for the new entry.

## Verification

- Typecheck: core ✓ engine ✓ dashboard ✓
- Lint ✓ · Changeset format ✓ (`minor`)
- Merge gate (`test:gate`): 321 engine-core + 63 CI-shape ✓
- Regression suites: triage (39), concurrency (165), movement/migration/hooks (259), builtin workflows (65), store-create (54) — all green
- `verify:fast`: workspace build + CLI build + boot smoke (`fn --help` + real `/api/health`) ✓

## Changeset

`.changeset/fn-coding-ideas-workflow.md` — `@runfusion/fusion: minor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Coding (Ideas)” builtin workflow with an Ideas intake stage and merged planning flow.
  * Updated task cards to support a **Start** action and show a **Ready** badge for qualifying planning-stage tasks.

* **Bug Fixes**
  * Tasks created for the Ideas workflow now persist into the correct entry column and get the right prompt bootstrapping.
  * Scheduler and triage avoid promoting/releasing unplanned todo tasks that still contain the bootstrap prompt stub, and stale planning is cleaned up across the merged intake flow.

* **Tests**
  * Added coverage for the new builtin workflow IR and create-task intake wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->