### PR TITLE
fix: resolve main-branch CI test failures (planning checkpoint + cli flake quarantine)

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -42,7 +42,11 @@ const quarantinedCliTests: string[] = [
 
   FNXC:CliTests 2026-06-27-10:05:
   FN-7119 re-ran extension.test.ts twice with the exclude removed and the fn_delegate_task null-target symptom no longer reproduces at HEAD. Keep this list empty so delegate-task validation coverage stays active in the package lane.
+
+  FNXC:CliTests 2026-07-04-10:40:
+  FN-7447 re-quarantines extension.test.ts after its built-dist-barrel fn_task_list test (line ~3084) timed out at 5000ms in full-suite shard 4/4 (run 28697507894) while passing locally at ~1.2s and in 3 of the 4 surrounding CI runs. The root-cause invariant is the loaded-lane signature: in-test dist-barrel recompilation (vi.resetModules + vi.importActual of the full @fusion/core dist barrel + a fresh dynamic import of extension.js) inside the default 5s timeout is CPU-bound and degrades non-linearly under 4-shard CI contention. This is the same signature rescued in FN-6483/FN-6705/FN-6795/FN-6839; widening the timeout is forbidden by the flaky-test rule and removing the recompilation removes the test's only purpose, so the file is excluded per the deletion ratchet rather than re-attempting a fifth fixture rescue. Mirrors scripts/lib/test-quarantine.json; collateral is the ~68 otherwise-stable tests in this file, recoverable via rescue before the 2026-07-18 deletion deadline.
   */
+  "src/__tests__/extension.test.ts",
 ];
 
 export default defineConfig({

--- a/packages/dashboard/src/__tests__/session-reconnect.test.ts
+++ b/packages/dashboard/src/__tests__/session-reconnect.test.ts
@@ -11,7 +11,12 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { Database, TaskStore } from "@fusion/core";
+import {
+  Database,
+  TaskStore,
+  PLANNING_DEEPEN_CHECKPOINT_ID,
+  PLANNING_DEEPEN_PROCEED_OPTION_ID,
+} from "@fusion/core";
 import { createApiRoutes } from "../routes.js";
 import { request, get } from "../test-request.js";
 import { AiSessionStore, type AiSessionRow } from "../ai-session-store.js";
@@ -205,7 +210,15 @@ describe("session reconnect + replay", () => {
     const { sessionId } = await createSession("127.0.0.11", "Build reconnect tests", store, "/tmp/project");
     await submitResponse(sessionId, { "q-1": "medium" }, "/tmp/project");
     await submitResponse(sessionId, { "q-2": "none" }, "/tmp/project");
-
+    /*
+    FNXC:DashboardSessionTests 2026-07-04-10:30:
+    FN-7444 holds the completed planning summary behind a mandatory deepening checkpoint before finalization. The agent's third response returns a "complete" payload, which now sets a pending summary plus checkpoint question instead of finalizing. Respond with the reserved proceed option so finalizePendingSummary runs, session.summary is set, and the summary/complete events are buffered for SSE replay.
+    */
+    await submitResponse(
+      sessionId,
+      { [PLANNING_DEEPEN_CHECKPOINT_ID]: [PLANNING_DEEPEN_PROCEED_OPTION_ID] },
+      "/tmp/project",
+    );
     const firstStream = await get(app, `/api/planning/${sessionId}/stream?lastEventId=0`);
     expect(firstStream.status).toBe(200);
     const firstBody = String(firstStream.body);

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -1,4 +1,10 @@
 {
   "$comment": "Flaky-test quarantine ledger (deletion ratchet — see AGENTS.md 'Flaky tests: quarantine on sight' and docs/testing.md 'Quarantine ledger and the deletion ratchet'). A test observed failing without a corresponding real bug is quarantined ON SIGHT: add an entry here AND a matching one-line `exclude` entry in that package's vitest config, in the same commit. Every entry needs a non-empty `reason` (link the failing run) and a `quarantinedAt` date — the entry expires 14 days later, at which point the test file is DELETED unless someone rescues it with evidence it catches real regressions plus a root-cause fix (never appeasement). There is deliberately no loader module and no automation around this file: it is a dated record, the vitest config exclude is the mechanism, and the sweep is policy executed by whoever touches the suite.",
-  "entries": []
+  "entries": [
+    {
+      "file": "packages/cli/src/__tests__/extension.test.ts",
+      "reason": "Loaded-lane CI timeout: the dist-barrel fn_task_list test (extension.test.ts line ~3084) timed out at 5000ms in the full-suite shard 4/4 while passing locally in ~1.2s and in 3 of the 4 surrounding CI runs. Root-cause invariant: the test does in-test module recompilation (vi.resetModules + vi.importActual of the full @fusion/core dist barrel + a fresh dynamic import of extension.js) inside the default 5s test timeout; that work is CPU-bound and degrades non-linearly under 4-shard CI contention. This is the same loaded-lane signature rescued in FN-6483/FN-6705/FN-6795/FN-6839; widening the timeout is forbidden by the flaky-test rule and removing the recompilation removes the test's only purpose. The sibling source-@fusion/core test 'bounds large column-filtered listings' covers the identical truncation invariant, so the dist-barrel slice's marginal coverage is dist-resolution, which has been stable. Collateral: file-granular exclude also drops ~68 otherwise-stable tests in this file until a rescue. Failing run: https://github.com/Runfusion/Fusion/actions/runs/28697507894 (Test shard 4/4).",
+      "quarantinedAt": "2026-07-04"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Resolves the two failures from the full-suite run on `main` ([run 28697507894](https://github.com/Runfusion/Fusion/actions/runs/28697507894)).

### 1. dashboard `session-reconnect.test.ts` — real bug (deterministic)

The planning *"replays buffered events and supports reconnect catch-up"* test hung at the 15s timeout.

**Root cause:** FN-7444 (planning summary deepening checkpoint) now holds the completed planning summary behind a mandatory *"Would you like to go deeper?"* checkpoint question instead of finalizing when the agent returns a `"complete"` payload. `continueAgentConversation` calls `setPendingSummaryCheckpoint`, which sets `session.pendingSummary` + a checkpoint question and leaves `session.summary` undefined. The SSE stream route's summary-emit path is therefore never reached, so it subscribes waiting for a `"complete"` event that never arrives → 15s hang.

**Fix:** respond to the deepening checkpoint with the reserved proceed option (`PLANNING_DEEPEN_PROCEED_OPTION_ID`) so `finalizePendingSummary` runs, `session.summary` is set, and the summary/complete events are buffered for SSE replay.

- Reproduced locally: 15s timeout before, 4/4 green after.
- `routes-planning.test.ts`, `session-persistence-roundtrip.test.ts`, `session-reconnect.test.ts` → 116/116 green.

### 2. cli `extension.test.ts` — loaded-lane CI flake (quarantined on sight)

The built-dist-barrel `fn_task_list` test timed out at 5000ms in shard 4/4 while passing locally (~1.2s body) and in 3 of the 4 surrounding CI runs.

**Root cause:** in-test dist-barrel recompilation (`vi.resetModules` + `vi.importActual` of the full `@fusion/core` dist barrel + a fresh dynamic `import("../extension.js")`) inside the default 5s test timeout. That work is CPU-bound and degrades non-linearly under 4-shard CI contention — the same loaded-lane signature rescued in FN-6483 / FN-6705 / FN-6795 / FN-6839.

**Action:** quarantined on sight per the *Flaky Tests Are Quarantined on Sight* rule — ledger entry in `scripts/lib/test-quarantine.json` plus the matching `exclude` in `packages/cli/vitest.config.ts`, in the same commit. No widened timeout, no retries, no loosened assertions (all forbidden by the rule). The sibling source-`@fusion/core` test *"bounds large column-filtered listings"* covers the identical truncation invariant through source, so the dist-barrel slice's marginal coverage is dist-resolution, which has been stable.

⚠️ **Collateral:** the file-granular exclude also drops the ~68 otherwise-stable tests in `extension.test.ts` until a rescue before the 2026-07-18 deletion deadline. This matches the project's quarantine ratchet; the file has been rescued 4× before.

## Verification

- `packages/dashboard` `session-reconnect.test.ts` → 4/4 ✅
- `packages/dashboard` `routes-planning` + `session-persistence-roundtrip` + `session-reconnect` → 116/116 ✅
- `pnpm test:gate` (engine-core 321 + ci-shape 63) → ✅
- `pnpm test:gate` appeasement-check + changeset-format-check → ✅ (no changeset needed: test-only changes to a private package)
- cli `extension.test.ts` confirmed excluded post-quarantine.

## Notes

- No changeset: both changes are test-only and don't affect published `@runfusion/fusion` behavior.
- No production code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by keeping a known flaky CLI test out of the main run, reducing CI timeout-related failures.
  * Updated reconnect behavior coverage to better match event replay expectations after planning updates.
* **Tests**
  * Adjusted dashboard session reconnect tests to validate the full reconnect-and-replay flow more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->