### PR TITLE
fix(docker): copy linear-import package.json before frozen install (fixes TS2688 build failure)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY plugins/fusion-plugin-whatsapp-chat/package.json ./plugins/fusion-plugin-wh
 COPY plugins/fusion-plugin-roadmap/package.json ./plugins/fusion-plugin-roadmap/package.json
 COPY plugins/fusion-plugin-even-realities-glasses/package.json ./plugins/fusion-plugin-even-realities-glasses/package.json
 COPY plugins/fusion-plugin-reports/package.json ./plugins/fusion-plugin-reports/package.json
+COPY plugins/fusion-plugin-linear-import/package.json ./plugins/fusion-plugin-linear-import/package.json
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
### Problem
`docker build` (and `docker compose up --build`) fails during the `RUN pnpm build` layer while compiling `plugins/fusion-plugin-linear-import`:

```
error TS2688: Cannot find type definition file for 'node'.
error TS2688: Cannot find type definition file for 'react'.
```

even though the prior `RUN pnpm install --frozen-lockfile` layer reports success.

### Root cause
The builder stage pre-copies each workspace package's `package.json` **before** `RUN pnpm install --frozen-lockfile` (a layer-caching optimization), then does `COPY . .` afterward. `pnpm-workspace.yaml` lists `plugins/fusion-plugin-linear-import` as a workspace member, but the Dockerfile's pre-copy list has a `COPY plugins/<name>/package.json` line for **every plugin except** `fusion-plugin-linear-import`.

Because that manifest is missing during the frozen-install layer, pnpm never links the plugin's devDependencies (`@types/node`, `@types/react`) into its resolution scope. When `pnpm build` later runs `tsc` for that package (its `tsconfig.json` uses `types: ["node", "react"]`), TypeScript can't find the type definitions — the `TS2688` failure above.

### Fix
Add the single missing pre-copy line so `fusion-plugin-linear-import`'s manifest is present during the install layer, exactly like every other workspace plugin:

```dockerfile
COPY plugins/fusion-plugin-linear-import/package.json ./plugins/fusion-plugin-linear-import/package.json
```

One-line, additive change; no behavior change beyond making the image build.

### Verification
- Confirmed the omission is present on `main` and at the latest release tag `v0.56.1`.
- With the line added, the pre-copied manifest set matches `pnpm-workspace.yaml`, so `pnpm install --frozen-lockfile` links `@types/node`/`@types/react` for the plugin and the `pnpm build` `tsc` step no longer reports `TS2688`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build setup to include an additional package manifest during installation, helping ensure the container build completes consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->