### PR TITLE
Fix Dockerfile: add missing COPY line for plugins/fusion-plugin-linear-import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY plugins/examples/fusion-plugin-notification/package.json ./plugins/examples
 COPY plugins/examples/fusion-plugin-settings-demo/package.json ./plugins/examples/fusion-plugin-settings-demo/package.json
 COPY plugins/fusion-plugin-acp-runtime/package.json ./plugins/fusion-plugin-acp-runtime/package.json
 COPY plugins/fusion-plugin-compound-engineering/package.json ./plugins/fusion-plugin-compound-engineering/package.json
+COPY plugins/fusion-plugin-linear-import/package.json ./plugins/fusion-plugin-linear-import/package.json
 COPY plugins/fusion-plugin-paperclip-runtime/package.json ./plugins/fusion-plugin-paperclip-runtime/package.json
 COPY plugins/fusion-plugin-dependency-graph/package.json ./plugins/fusion-plugin-dependency-graph/package.json
 COPY plugins/fusion-plugin-cli-printing-press/package.json ./plugins/fusion-plugin-cli-printing-press/package.json


### PR DESCRIPTION
Fixes #1939.

Adds the single missing `COPY plugins/fusion-plugin-linear-import/package.json ./plugins/fusion-plugin-linear-import/package.json` line to the Dockerfile's pre-install COPY block.

## Root cause
Commit dfb6e5270de2fb84844b0680691e23c9883f7227 added `plugins/fusion-plugin-linear-import` as a new pnpm workspace member, but didn't add a matching Dockerfile COPY line for its package.json. As a result that member's devDependencies (`@types/node`, `@types/react`) are never installed inside the image, and the later `pnpm build` step fails with TS2688 once the compiler reaches that plugin.

## Fix
One line, alphabetically placed alongside the other `plugins/fusion-plugin-*` COPY lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container build setup to include an additional package manifest needed during image creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->