### PR TITLE
fix(engine): persist push-after-merge failures instead of dropping them

### DIFF
--- a/packages/engine/src/__tests__/merger-prompt-and-utils.test.ts
+++ b/packages/engine/src/__tests__/merger-prompt-and-utils.test.ts
@@ -467,6 +467,26 @@ describe("push-after-merge", () => {
     expect(result.pushedToRemote).toBe(false);
     expect(result.pushError).toContain("permission denied");
     expect(store.moveTask).toHaveBeenCalledWith("FN-050", "done");
+
+    // FN-7625: a failed push must not vanish silently — it needs a persisted
+    // audit event and a task log entry, not just a process-wide log line.
+    expect(store.recordRunAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: "git",
+        mutationType: "push:origin",
+        target: "FN-050",
+        metadata: expect.objectContaining({
+          outcome: "failed",
+          remote: "origin",
+          stderrPreview: expect.stringContaining("permission denied"),
+        }),
+      }),
+    );
+    expect(store.logEntry).toHaveBeenCalledWith(
+      "FN-050",
+      expect.stringContaining("Push to remote failed after merge"),
+      "PushToRemoteFailed",
+    );
   });
 
   it.each([undefined, "", "   "])("FN-7490 falls back to origin and integration branch for empty pushRemote %s", async (pushRemote) => {

--- a/packages/engine/src/merger.ts
+++ b/packages/engine/src/merger.ts
@@ -10874,6 +10874,21 @@ export async function aiMergeTask(
         }
       } else {
         mergerLog.warn(`${taskId}: push to remote failed: ${pushResult.error}`);
+        await audit.git({
+          type: "push:origin",
+          target: taskId,
+          metadata: {
+            integrationBranch: mergeTarget.branch,
+            remote: settings.pushRemote || "origin",
+            outcome: "failed",
+            stderrPreview: pushResult.error,
+          },
+        }).catch(() => undefined);
+        await store.logEntry(
+          taskId,
+          `Push to remote failed after merge — task marked done anyway; local main may diverge from origin: ${pushResult.error}`,
+          "PushToRemoteFailed",
+        ).catch(() => undefined);
       }
       result.pushedToRemote = pushResult.pushed;
       if (pushResult.error) {
@@ -10883,6 +10898,21 @@ export async function aiMergeTask(
       mergerLog.error(`${taskId}: push to remote error: ${err.message}`);
       result.pushedToRemote = false;
       result.pushError = err.message;
+      await audit.git({
+        type: "push:origin",
+        target: taskId,
+        metadata: {
+          integrationBranch: mergeTarget.branch,
+          remote: settings.pushRemote || "origin",
+          outcome: "failed",
+          stderrPreview: err.message,
+        },
+      }).catch(() => undefined);
+      await store.logEntry(
+        taskId,
+        `Push to remote threw after merge — task marked done anyway; local main may diverge from origin: ${err.message}`,
+        "PushToRemoteFailed",
+      ).catch(() => undefined);
     }
   }
 


### PR DESCRIPTION
## Summary

In direct-merge mode (`mergeStrategy: direct` + `pushAfterMerge: true`), when the post-merge `git push` to origin fails or throws, `aiMergeTask` in `packages/engine/src/merger.ts` only logged the failure to the process-wide `mergerLog` and set a transient field (`result.pushedToRemote` / `result.pushError`) on the local `MergeResult` object — neither of which is persisted anywhere. The task was still unconditionally marked done/merged.

Because nothing durable recorded the failure, a diverging local `main` could go unnoticed indefinitely. This is exactly the mechanism that let a local `main` drift 162 commits behind `origin/main` in our deployment before it was caught by hand.

## Fix

Both push-failure branches (the non-throwing `else` and the throwing `catch`) now also:

- call `audit.git({ type: "push:origin", ... })`, activating the existing-but-previously-unused `"push:origin"` `GitMutationType` in the run-audit schema (populated with `remote`, `integrationBranch`, `outcome: "failed"`, `stderrPreview`)
- call `store.logEntry(taskId, ..., "PushToRemoteFailed")` so the failure is visible on the task itself, not just in an ephemeral process log

Both calls are wrapped in `.catch(() => undefined)` — they're best-effort recording, not new failure paths, so a problem persisting the failure record can't abort the outer merge flow. Task-completion behavior (mark done even when the push failed) is intentionally unchanged; this fix is about visibility, not about blocking completion.

## Test plan

- [x] Added assertions to the existing `merger-prompt-and-utils.test.ts` test `"records push error but still completes merge when push fails"`, asserting `store.recordRunAuditEvent` and `store.logEntry` are called with the expected shape
- [x] `npx vitest run src/__tests__/merger-prompt-and-utils.test.ts` — 35 passed
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of merge completion when pushing changes to the remote repository fails.
  * Failures are now consistently recorded and surfaced with clearer error logging, making it easier to identify when a push did not succeed after a merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->