### PR TITLE
fix(FUX-039): staff-engineer review fixes for FUX-022 runtime-fallback UI patch

### DIFF
--- a/packages/dashboard/app/components/ActiveAgentsPanel.tsx
+++ b/packages/dashboard/app/components/ActiveAgentsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Activity, FileText } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { Agent } from "../api";
@@ -24,6 +24,32 @@ function LiveAgentCard({ agent, projectId, onSelect, onOpenTaskLogs }: LiveAgent
   const { t } = useTranslation("app");
   const { entries, isConnected } = useLiveTranscript(agent.taskId, projectId);
   const [task, setTask] = useState<TaskDetail | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  // FUX-039: real viewport gating (matching TaskCard.tsx's pattern) so
+  // RuntimeFallbackBadge's 30s poll only runs while this card is actually
+  // visible, rather than hardcoding isInViewport={true} for every mounted
+  // card regardless of scroll position.
+  const [isInViewport, setIsInViewport] = useState(false);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") {
+      setIsInViewport(true);
+      return;
+    }
+
+    const element = cardRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsInViewport(entry?.isIntersecting ?? true);
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
 
   // Poll the agent's task so the empty state can show real run progress
   // (current step, executor model) instead of just "Connecting..." while the
@@ -101,6 +127,7 @@ function LiveAgentCard({ agent, projectId, onSelect, onOpenTaskLogs }: LiveAgent
 
   return (
     <div
+      ref={cardRef}
       className="live-agent-card"
       onClick={handleSelect}
       onKeyDown={handleKeyDown}
@@ -120,7 +147,7 @@ function LiveAgentCard({ agent, projectId, onSelect, onOpenTaskLogs }: LiveAgent
           <span className="live-agent-task badge"><AgentTaskBadge taskId={agent.taskId} taskColumn={agent.taskColumn} /></span>
         )}
         {agent.taskId && (
-          <RuntimeFallbackBadge taskId={agent.taskId} isInViewport={true} projectId={projectId} />
+          <RuntimeFallbackBadge taskId={agent.taskId} isInViewport={isInViewport} projectId={projectId} />
         )}
       </div>
       <div className="live-agent-card-transcript">

--- a/packages/dashboard/app/components/AgentsView.tsx
+++ b/packages/dashboard/app/components/AgentsView.tsx
@@ -343,6 +343,95 @@ export function AgentsView({ addToast, projectId, onOpenTaskLogs, agentOnboardin
   const [selectedAgentInitialTab, setSelectedAgentInitialTab] = useState<"dashboard" | "runs">("dashboard");
   const [selectedAgentInitialRunId, setSelectedAgentInitialRunId] = useState<string | null>(null);
   const [selectedAgentPreferActiveRun, setSelectedAgentPreferActiveRun] = useState(false);
+
+  // FUX-039: real viewport gating for RuntimeFallbackBadge on the board and
+  // list card surfaces. Both surfaces render inline inside .map() calls, so
+  // a naive per-item useState/useEffect would violate the rules of hooks.
+  // Instead, a single shared IntersectionObserver instance observes every
+  // registered card element, keyed distinctly per surface ("board:{id}" vs
+  // "list:{id}") so the two surfaces never share visibility state. The
+  // registration function below MUST return a cached, stable callback per
+  // key (never a fresh closure per render) — a fresh closure would look like
+  // an unmount+remount to React on every render, and in environments without
+  // IntersectionObserver support that reproduces a real infinite re-render
+  // loop (including jsdom test environments).
+  const intersectionObserverSupported = typeof IntersectionObserver !== "undefined";
+  const agentCardObserverRef = useRef<IntersectionObserver | null>(null);
+  const agentCardElementsRef = useRef<Map<string, Element>>(new Map());
+  const agentCardRefCallbacksRef = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
+  const [visibleAgentCardKeys, setVisibleAgentCardKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!intersectionObserverSupported) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setVisibleAgentCardKeys((prev) => {
+          let changed = false;
+          const next = new Set(prev);
+          for (const entry of entries) {
+            const key = (entry.target as HTMLElement).dataset.viewportKey;
+            if (!key) continue;
+            if (entry.isIntersecting) {
+              if (!next.has(key)) {
+                next.add(key);
+                changed = true;
+              }
+            } else if (next.has(key)) {
+              next.delete(key);
+              changed = true;
+            }
+          }
+          return changed ? next : prev;
+        });
+      },
+      { rootMargin: "200px" },
+    );
+    agentCardObserverRef.current = observer;
+    // Ref callbacks run during the commit phase, BEFORE this effect. Any card
+    // element registered on the initial mount (or during a render that
+    // happened before this observer existed) is already recorded in
+    // agentCardElementsRef but was never actually passed to .observe(), since
+    // the observer didn't exist yet at ref-callback time. Catch those up here.
+    for (const el of agentCardElementsRef.current.values()) {
+      observer.observe(el);
+    }
+    return () => {
+      observer.disconnect();
+      agentCardObserverRef.current = null;
+    };
+  }, [intersectionObserverSupported]);
+
+  const registerAgentCardRef = useCallback((key: string) => {
+    const cached = agentCardRefCallbacksRef.current.get(key);
+    if (cached) return cached;
+    const callback = (el: HTMLDivElement | null) => {
+      const prevElement = agentCardElementsRef.current.get(key);
+      const observer = agentCardObserverRef.current;
+      if (prevElement && observer) {
+        observer.unobserve(prevElement);
+      }
+      if (el) {
+        el.dataset.viewportKey = key;
+        agentCardElementsRef.current.set(key, el);
+        observer?.observe(el);
+      } else {
+        agentCardElementsRef.current.delete(key);
+        setVisibleAgentCardKeys((prev) => {
+          if (!prev.has(key)) return prev;
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      }
+    };
+    agentCardRefCallbacksRef.current.set(key, callback);
+    return callback;
+  }, []);
+
+  const isAgentCardKeyInViewport = useCallback(
+    (key: string) => (intersectionObserverSupported ? visibleAgentCardKeys.has(key) : true),
+    [intersectionObserverSupported, visibleAgentCardKeys],
+  );
   const [agentView, setAgentView] = useState<"list" | "board" | "org">(() => {
     if (typeof window === "undefined") return "list";
     const saved = getScopedItem("fn-agent-view", projectId);
@@ -1690,8 +1779,13 @@ export function AgentsView({ addToast, projectId, onOpenTaskLogs, agentOnboardin
                 const healthSummary = getHealthSummary(agent, health, t);
                 const stateBadgeClass = getStateBadgeClass(agent.state);
                 const stateCardClass = getStateCardClass("agent-board-card", agent.state);
+                const viewportKey = `board:${agent.id}`;
                 return (
-                  <div key={agent.id} className={`agent-board-card ${stateCardClass}${selectedAgentId === agent.id ? " agent-card--selected" : ""}`}>
+                  <div
+                    key={agent.id}
+                    ref={registerAgentCardRef(viewportKey)}
+                    className={`agent-board-card ${stateCardClass}${selectedAgentId === agent.id ? " agent-card--selected" : ""}`}
+                  >
                     <div
                       className="agent-board-clickable"
                       onClick={() => openAgentDetail(agent.id)}
@@ -1720,7 +1814,7 @@ export function AgentsView({ addToast, projectId, onOpenTaskLogs, agentOnboardin
                       <div className="agent-board-name">{agent.name}</div>
                       <div className="agent-board-id">{agent.id}</div>
                       {agent.taskId && (
-                        <RuntimeFallbackBadge taskId={agent.taskId} isInViewport={true} projectId={projectId} />
+                        <RuntimeFallbackBadge taskId={agent.taskId} isInViewport={isAgentCardKeyInViewport(viewportKey)} projectId={projectId} />
                       )}
                       <div className="agent-board-health" style={{ color: health.color }} title={healthSummary.title}>
                         {health.icon}{healthSummary.label ? ` ${healthSummary.label}` : ""}
@@ -1757,9 +1851,11 @@ export function AgentsView({ addToast, projectId, onOpenTaskLogs, agentOnboardin
               const heartbeatOptions = getHeartbeatIntervalOptions(configuredIntervalMs);
               const isUpdatingHeartbeat = updatingHeartbeatAgentId === agent.id;
               const modelLabel = getAgentModelLabel(agent);
+              const viewportKey = `list:${agent.id}`;
               return (
                 <div
                   key={agent.id}
+                  ref={registerAgentCardRef(viewportKey)}
                   className={`agent-card agent-card--clickable ${stateCardClass}${selectedAgentId === agent.id ? " agent-card--selected" : ""}`}
                   onClick={(e) => {
                     // Open detail when the user clicks the card body, but
@@ -1892,7 +1988,7 @@ export function AgentsView({ addToast, projectId, onOpenTaskLogs, agentOnboardin
                       <div className="agent-task">
                         <span className="text-secondary">{t("agents.workingOn", "Working on:")}</span>
                         <span className="badge"><AgentTaskBadge taskId={agent.taskId} taskColumn={agent.taskColumn} /></span>
-                        <RuntimeFallbackBadge taskId={agent.taskId} isInViewport={true} projectId={projectId} />
+                        <RuntimeFallbackBadge taskId={agent.taskId} isInViewport={isAgentCardKeyInViewport(viewportKey)} projectId={projectId} />
                       </div>
                     )}
                     <div className="agent-heartbeat-control">

--- a/packages/dashboard/app/components/__tests__/ActiveAgentsPanel.test.tsx
+++ b/packages/dashboard/app/components/__tests__/ActiveAgentsPanel.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import i18next from "i18next";
 import { ActiveAgentsPanel } from "../ActiveAgentsPanel";
 import type { Agent } from "../../api";
 import { useLiveTranscript } from "../../hooks/useLiveTranscript";
+import { ToastProvider } from "../../hooks/useToast";
 import esApp from "../../../../i18n/locales/es/app.json";
 import frApp from "../../../../i18n/locales/fr/app.json";
 import koApp from "../../../../i18n/locales/ko/app.json";
@@ -18,7 +19,74 @@ vi.mock("../../hooks/useLiveTranscript", () => ({
   }),
 }));
 
+// Mock the runtime-fallback endpoint consumed (indirectly, via
+// useRuntimeFallbackStatus) by RuntimeFallbackBadge for the FUX-039
+// viewport-gating regression suite below.
+const legacyMocks = vi.hoisted(() => ({
+  fetchTaskRuntimeFallback: vi.fn(),
+}));
+vi.mock("../../api/legacy", () => legacyMocks);
+
+// Default resolution for every test in this file (regardless of describe
+// block): RuntimeFallbackBadge is now rendered for any agent with a taskId
+// and, once viewport-gated visible, polls this endpoint. Individual tests in
+// the FUX-039 describe block below override this via mockResolvedValue.
+legacyMocks.fetchTaskRuntimeFallback.mockResolvedValue({
+  taskId: "",
+  hasEvent: false,
+  wasConfigured: null,
+  runtimeHint: null,
+  reason: null,
+  eventId: null,
+  timestamp: null,
+  showFallbackBadge: false,
+});
+
 const mockUseLiveTranscript = vi.mocked(useLiveTranscript);
+
+// FUX-039: RuntimeFallbackBadge (rendered unconditionally for any agent with
+// a taskId) calls useToast() unconditionally, which throws outside a
+// ToastProvider. Route every ActiveAgentsPanel render through this helper so
+// that requirement is satisfied consistently across the suite.
+function renderPanel(ui: Parameters<typeof render>[0]) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+// Minimal IntersectionObserver mock that records every constructed instance
+// so tests can drive `isIntersecting` transitions manually. Real jsdom has no
+// IntersectionObserver implementation.
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  callback: IntersectionObserverCallback;
+  observedElements = new Set<Element>();
+  static instances: MockIntersectionObserver[] = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observedElements.add(el);
+  }
+  unobserve(el: Element) {
+    this.observedElements.delete(el);
+  }
+  disconnect() {
+    this.observedElements.clear();
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  /** Test helper: fire a visibility transition for a specific observed element. */
+  fire(el: Element, isIntersecting: boolean) {
+    this.callback(
+      [{ target: el, isIntersecting } as IntersectionObserverEntry],
+      this,
+    );
+  }
+}
 
 const nonEnglishAppCatalogs = [
   ["es", esApp],
@@ -65,7 +133,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     expect(screen.getByText("Processing request...")).toBeInTheDocument();
     expect(screen.getByText("Analyzing code...")).toBeInTheDocument();
@@ -81,7 +149,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} projectId="my-project" />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} projectId="my-project" />);
 
     // Verify the hook was called with the projectId
     expect(mockUseLiveTranscript).toHaveBeenCalledWith("FN-001", "my-project");
@@ -97,7 +165,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     // Verify the hook was called without projectId
     expect(mockUseLiveTranscript).toHaveBeenCalledWith("FN-001", undefined);
@@ -119,7 +187,7 @@ describe("ActiveAgentsPanel", () => {
         lastHeartbeatAt: new Date().toISOString(),
       } as Agent;
 
-      const futureRender = render(<ActiveAgentsPanel agents={[futureAgent]} />);
+      const futureRender = renderPanel(<ActiveAgentsPanel agents={[futureAgent]} />);
       const futureBadge = futureRender.container.querySelector(".live-agent-card-next-heartbeat");
       expect(futureBadge, `${locale} next-heartbeat badge`).toBeInTheDocument();
       expect(futureBadge?.textContent?.trim(), `${locale} next-heartbeat text`).not.toBe("");
@@ -135,7 +203,7 @@ describe("ActiveAgentsPanel", () => {
         lastHeartbeatAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
       } as Agent;
 
-      const overdueRender = render(<ActiveAgentsPanel agents={[overdueAgent]} />);
+      const overdueRender = renderPanel(<ActiveAgentsPanel agents={[overdueAgent]} />);
       const overdueBadge = overdueRender.container.querySelector(".live-agent-card-next-heartbeat");
       expect(overdueBadge, `${locale} heartbeat-overdue badge`).toBeInTheDocument();
       expect(overdueBadge?.textContent?.trim(), `${locale} heartbeat-overdue text`).not.toBe("");
@@ -161,7 +229,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     expect(screen.getByText("Connecting...")).toBeInTheDocument();
   });
@@ -181,7 +249,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     expect(screen.getByText("Waiting for output...")).toBeInTheDocument();
   });
@@ -201,7 +269,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     expect(screen.getByText("Idle — no task assigned")).toBeInTheDocument();
     expect(screen.queryByText("Connecting...")).toBeNull();
@@ -222,22 +290,31 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     expect(screen.getByText("Starting...")).toBeInTheDocument();
     expect(screen.queryByText("Connecting...")).toBeNull();
   });
 
   it("renders multiple agent cards with separate transcript streams", async () => {
-    mockUseLiveTranscript
-      .mockReturnValueOnce({
-        entries: [{ type: "text", text: "Agent 1 output", timestamp: "2026-01-01T00:01:00Z" }],
-        isConnected: true,
-      })
-      .mockReturnValueOnce({
-        entries: [{ type: "text", text: "Agent 2 output", timestamp: "2026-01-01T00:02:00Z" }],
-        isConnected: true,
-      });
+    // Keyed by taskId (not call order) so this stays correct regardless of
+    // how many render passes each card takes (e.g. the FUX-039 viewport-
+    // gating effect's own settle-render).
+    mockUseLiveTranscript.mockImplementation((taskId?: string) => {
+      if (taskId === "FN-001") {
+        return {
+          entries: [{ type: "text", text: "Agent 1 output", timestamp: "2026-01-01T00:01:00Z" }],
+          isConnected: true,
+        };
+      }
+      if (taskId === "FN-002") {
+        return {
+          entries: [{ type: "text", text: "Agent 2 output", timestamp: "2026-01-01T00:02:00Z" }],
+          isConnected: true,
+        };
+      }
+      return { entries: [], isConnected: false };
+    });
 
     const mockAgent1: Agent = {
       id: "agent-001",
@@ -257,7 +334,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent1, mockAgent2]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent1, mockAgent2]} />);
 
     expect(screen.getByText("Agent 1 output")).toBeInTheDocument();
     expect(screen.getByText("Agent 2 output")).toBeInTheDocument();
@@ -287,7 +364,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     // Should show the first 20 entries (most recent first)
     // With reversed entries, slice(0, 20) gives us Line 24 through Line 5
@@ -296,7 +373,7 @@ describe("ActiveAgentsPanel", () => {
   });
 
   it("returns null when agents array is empty", async () => {
-    const { container } = render(<ActiveAgentsPanel agents={[]} />);
+    const { container } = renderPanel(<ActiveAgentsPanel agents={[]} />);
     expect(container.firstChild).toBeNull();
   });
 
@@ -343,7 +420,7 @@ describe("ActiveAgentsPanel", () => {
       } as Agent,
     ];
 
-    const { container } = render(<ActiveAgentsPanel agents={agents} />);
+    const { container } = renderPanel(<ActiveAgentsPanel agents={agents} />);
 
     expect(screen.getByText("Triage Agent")).toBeInTheDocument();
     expect(screen.getByText((_, el) => el?.textContent === "FN-TRIAGE · Planning")).toBeInTheDocument();
@@ -368,7 +445,7 @@ describe("ActiveAgentsPanel", () => {
     } as Agent;
 
     const handleSelect = vi.fn();
-    render(<ActiveAgentsPanel agents={[mockAgent]} onAgentSelect={handleSelect} />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent]} onAgentSelect={handleSelect} />);
 
     fireEvent.click(screen.getByRole("button", { name: /select agent test agent/i }));
 
@@ -390,7 +467,7 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    const { container } = render(<ActiveAgentsPanel agents={[mockAgent]} />);
+    const { container } = renderPanel(<ActiveAgentsPanel agents={[mockAgent]} />);
 
     // The streaming dot should be present when connected
     const streamingDot = container.querySelector(".live-agent-streaming-dot");
@@ -421,10 +498,118 @@ describe("ActiveAgentsPanel", () => {
       lastHeartbeatAt: new Date().toISOString(),
     } as Agent;
 
-    render(<ActiveAgentsPanel agents={[mockAgent1, mockAgent2]} projectId="shared-project" />);
+    renderPanel(<ActiveAgentsPanel agents={[mockAgent1, mockAgent2]} projectId="shared-project" />);
 
     // Both agents should receive the same projectId
     expect(mockUseLiveTranscript).toHaveBeenCalledWith("FN-001", "shared-project");
     expect(mockUseLiveTranscript).toHaveBeenCalledWith("FN-002", "shared-project");
+  });
+});
+
+describe("ActiveAgentsPanel — RuntimeFallbackBadge viewport gating (FUX-039)", () => {
+  const realIntersectionObserver = globalThis.IntersectionObserver;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    legacyMocks.fetchTaskRuntimeFallback.mockReset();
+    legacyMocks.fetchTaskRuntimeFallback.mockResolvedValue({
+      taskId: "FN-001",
+      hasEvent: true,
+      wasConfigured: false,
+      runtimeHint: "hermes",
+      reason: "init_error",
+      eventId: "audit-1",
+      timestamp: "2026-07-08T00:00:00.000Z",
+      showFallbackBadge: true,
+    });
+    MockIntersectionObserver.instances = [];
+    // @ts-expect-error test-only override
+    globalThis.IntersectionObserver = MockIntersectionObserver;
+    mockUseLiveTranscript.mockReturnValue({ entries: [], isConnected: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.IntersectionObserver = realIntersectionObserver;
+  });
+
+  function agentWithTask(): Agent {
+    return {
+      id: "agent-001",
+      name: "Test Agent",
+      role: "executor",
+      state: "running",
+      taskId: "FN-001",
+      lastHeartbeatAt: new Date().toISOString(),
+    } as Agent;
+  }
+
+  it("does not poll the runtime-fallback endpoint until the card's own IntersectionObserver reports it visible, and stops/resumes on transitions", async () => {
+    const { container } = render(
+      <ToastProvider>
+        <ActiveAgentsPanel agents={[agentWithTask()]} />
+      </ToastProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Not yet observed as intersecting — no poll should have fired.
+    expect(legacyMocks.fetchTaskRuntimeFallback).not.toHaveBeenCalled();
+
+    const cardEl = container.querySelector(".live-agent-card") as Element;
+    expect(cardEl).toBeTruthy();
+    const observer = MockIntersectionObserver.instances.find((o) => o.observedElements.has(cardEl));
+    expect(observer).toBeTruthy();
+
+    // Transition to visible: polling should start.
+    await act(async () => {
+      observer!.fire(cardEl, true);
+      await Promise.resolve();
+    });
+    expect(legacyMocks.fetchTaskRuntimeFallback).toHaveBeenCalledTimes(1);
+
+    // Transition to hidden mid-session: further 30s poll ticks must NOT fire.
+    await act(async () => {
+      observer!.fire(cardEl, false);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(legacyMocks.fetchTaskRuntimeFallback).toHaveBeenCalledTimes(1);
+
+    // Transition back to visible: polling resumes.
+    await act(async () => {
+      observer!.fire(cardEl, true);
+      await Promise.resolve();
+    });
+    expect(legacyMocks.fetchTaskRuntimeFallback.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("gates the runtime-fallback poll the same way at a 375x812 mobile viewport", async () => {
+    Object.defineProperty(window, "innerWidth", { value: 375, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 812, configurable: true });
+
+    const { container } = render(
+      <ToastProvider>
+        <ActiveAgentsPanel agents={[agentWithTask()]} />
+      </ToastProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(legacyMocks.fetchTaskRuntimeFallback).not.toHaveBeenCalled();
+
+    const cardEl = container.querySelector(".live-agent-card") as Element;
+    const observer = MockIntersectionObserver.instances.find((o) => o.observedElements.has(cardEl));
+    expect(observer).toBeTruthy();
+
+    await act(async () => {
+      observer!.fire(cardEl, true);
+      await Promise.resolve();
+    });
+    expect(legacyMocks.fetchTaskRuntimeFallback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/dashboard/app/components/__tests__/AgentsView.test.tsx
+++ b/packages/dashboard/app/components/__tests__/AgentsView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import type { ReactElement } from "react";
 import i18next from "i18next";
 import { loadAllAppCss } from "../../test/cssFixture";
 import { AgentsView } from "../AgentsView";
@@ -7,6 +8,66 @@ import * as apiModule from "../../api";
 import type { Agent, AgentState, AgentCapability, OrgTreeNode } from "../../api";
 import { scopedKey } from "../../utils/projectStorage";
 import { ORG_CHART_LAYOUT_STORAGE_KEY } from "../agentsOrgChartLayout";
+import { ToastProvider } from "../../hooks/useToast";
+
+// FUX-039: RuntimeFallbackBadge is rendered unconditionally for any agent
+// with a taskId (board card, list card) and calls useToast() unconditionally,
+// which throws outside a ToastProvider. Route every AgentsView render through
+// this helper. Also stub the runtime-fallback endpoint it polls (once
+// viewport-gated visible) so it resolves to a harmless "no event" response by
+// default instead of hitting the real (unmocked) network call.
+const legacyMocks = vi.hoisted(() => ({
+  fetchTaskRuntimeFallback: vi.fn(),
+}));
+vi.mock("../../api/legacy", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/legacy")>();
+  return { ...actual, ...legacyMocks };
+});
+legacyMocks.fetchTaskRuntimeFallback.mockResolvedValue({
+  taskId: "",
+  hasEvent: false,
+  wasConfigured: null,
+  runtimeHint: null,
+  reason: null,
+  eventId: null,
+  timestamp: null,
+  showFallbackBadge: false,
+});
+
+function renderView(ui: ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+// Minimal IntersectionObserver mock that records every constructed instance
+// so tests can drive visibility transitions manually (jsdom has no real IO).
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  callback: IntersectionObserverCallback;
+  observedElements = new Set<Element>();
+  static instances: MockIntersectionObserver[] = [];
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observedElements.add(el);
+  }
+  unobserve(el: Element) {
+    this.observedElements.delete(el);
+  }
+  disconnect() {
+    this.observedElements.clear();
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  fire(el: Element, isIntersecting: boolean) {
+    this.callback([{ target: el, isIntersecting } as IntersectionObserverEntry], this);
+  }
+}
 
 // Mock the API module
 vi.mock("../../api", async (importOriginal) => {
@@ -214,14 +275,14 @@ describe("AgentsView", () => {
 
   describe("rendering", () => {
     it("renders the agents view header", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
       });
     });
 
     it("renders agent list on mount", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await waitFor(() => {
         // Active agents may appear in both ActiveAgentsPanel and main list
         expect(screen.getAllByText("Test Agent 1").length).toBeGreaterThanOrEqual(1);
@@ -235,7 +296,7 @@ describe("AgentsView", () => {
       ]);
       mockFetchAgentStats.mockResolvedValueOnce({ total: 1, byState: {}, byRole: {} });
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Pending approvals")).toBeInTheDocument();
@@ -256,7 +317,7 @@ describe("AgentsView", () => {
       ]);
       mockFetchAgentStats.mockResolvedValueOnce({ total: 1, byState: {}, byRole: {} });
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("review")).toBeInTheDocument();
@@ -295,7 +356,7 @@ describe("AgentsView", () => {
       mockFetchAgents.mockResolvedValueOnce(modelAgents);
       mockFetchAgentStats.mockResolvedValueOnce({ total: 4, byState: {}, byRole: {} });
 
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("Provider Model Agent")).toBeInTheDocument();
@@ -316,7 +377,7 @@ describe("AgentsView", () => {
     });
 
     it("renders cross-pane overview above split layout", async () => {
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(container.querySelector(".agents-overview-bar")).toBeTruthy();
@@ -341,7 +402,7 @@ describe("AgentsView", () => {
     });
 
     it("opens inline detail pane and marks selected card", async () => {
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       const detailButton = await screen.findByRole("button", { name: "View details for Test Agent 1" });
       fireEvent.click(detailButton);
@@ -354,7 +415,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps desktop selection in detail pane without rendering sidebar quick-controls strip", async () => {
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       const detailButton = await screen.findByRole("button", { name: "View details for Test Agent 2" });
       fireEvent.click(detailButton);
@@ -369,7 +430,7 @@ describe("AgentsView", () => {
 
     it.each(["desktop", "tablet"] as const)("renders an accessible resize handle on %s split layouts", async (mode) => {
       mockViewportMode.mockReturnValue(mode);
-      const { container } = render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const handle = await screen.findByTestId("agents-sidebar-resize-handle");
       expect(handle).toHaveAttribute("role", "separator");
@@ -382,7 +443,7 @@ describe("AgentsView", () => {
 
     it("does not render the resize handle or inline split width on mobile", async () => {
       mockViewportMode.mockReturnValue("mobile");
-      const { container } = render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
@@ -403,7 +464,7 @@ describe("AgentsView", () => {
         localStorage.setItem(scopedKey(agentsSidebarWidthKey, projectId), stored);
       }
 
-      const { container } = render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const handle = await screen.findByTestId("agents-sidebar-resize-handle");
       expect(handle).toHaveAttribute("aria-valuenow", String(expected));
@@ -412,7 +473,7 @@ describe("AgentsView", () => {
 
     it("supports keyboard resizing with project-scoped persistence and clamping", async () => {
       localStorage.setItem(scopedKey(agentsSidebarWidthKey, projectId), "515");
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const handle = await screen.findByTestId("agents-sidebar-resize-handle");
 
@@ -433,7 +494,7 @@ describe("AgentsView", () => {
 
     it("clamps keyboard resizing at the minimum width", async () => {
       localStorage.setItem(scopedKey(agentsSidebarWidthKey, projectId), "260");
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const handle = await screen.findByTestId("agents-sidebar-resize-handle");
       fireEvent.keyDown(handle, { key: "ArrowLeft", shiftKey: true });
@@ -444,7 +505,7 @@ describe("AgentsView", () => {
 
     it("supports pointer drag resizing with capture, cleanup, persistence, and max clamping", async () => {
       localStorage.setItem(scopedKey(agentsSidebarWidthKey, projectId), "500");
-      const { container } = render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       const handle = await screen.findByTestId("agents-sidebar-resize-handle");
       const setPointerCapture = vi.fn();
       const releasePointerCapture = vi.fn();
@@ -469,7 +530,7 @@ describe("AgentsView", () => {
 
     it("supports pointer drag resizing with min clamping", async () => {
       localStorage.setItem(scopedKey(agentsSidebarWidthKey, projectId), "300");
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       const handle = await screen.findByTestId("agents-sidebar-resize-handle");
 
       fireEvent.pointerDown(handle, { pointerId: 2, clientX: 300 });
@@ -484,7 +545,7 @@ describe("AgentsView", () => {
 
     it("supports mobile drill-in detail with back navigation", async () => {
       mockViewportMode.mockReturnValue("mobile");
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       expect(container.querySelector(".agents-split-layout")).toBeTruthy();
       expect(container.querySelector(".agents-view-content")).toBeTruthy();
@@ -526,7 +587,7 @@ describe("AgentsView", () => {
         },
       ]);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       fireEvent.click(await screen.findByRole("button", { name: "View details for Test Agent 1" }));
       await waitFor(() => {
@@ -544,7 +605,7 @@ describe("AgentsView", () => {
 
     it("collapses mobile overview after selecting an active agent card", async () => {
       mockViewportMode.mockReturnValue("mobile");
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       const overviewToggle = await openOverviewPanel();
       fireEvent.click(await screen.findByRole("button", { name: /select agent test agent 2/i }));
@@ -557,7 +618,7 @@ describe("AgentsView", () => {
 
     it("keeps desktop overview open after selecting an active agent card", async () => {
       mockViewportMode.mockReturnValue("desktop");
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       const overviewToggle = await openOverviewPanel();
       fireEvent.click(await screen.findByRole("button", { name: /select agent test agent 2/i }));
@@ -577,7 +638,7 @@ describe("AgentsView", () => {
           }),
       );
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       const loadingStatus = await screen.findByRole("status");
       expect(loadingStatus).toHaveTextContent("Loading agents...");
@@ -598,7 +659,7 @@ describe("AgentsView", () => {
           }),
       );
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       expect(await screen.findByText("Loading agents...")).toBeTruthy();
 
@@ -611,7 +672,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps existing agents visible during refresh loads", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getAllByText("Test Agent 1").length).toBeGreaterThan(0);
@@ -639,7 +700,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps New Agent directly accessible on desktop while controls live in popup", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       expect(screen.getByRole("button", { name: "New Agent" })).toBeTruthy();
       expect(screen.queryByRole("dialog", { name: "Agent controls" })).toBeNull();
@@ -654,7 +715,7 @@ describe("AgentsView", () => {
 
     it("moves import and new-agent actions into the controls popup on mobile", async () => {
       mockViewportMode.mockReturnValue("mobile");
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       expect(screen.queryByRole("button", { name: "Import" })).toBeNull();
       expect(screen.queryByRole("button", { name: "New Agent" })).toBeNull();
@@ -665,7 +726,7 @@ describe("AgentsView", () => {
     });
 
     it("closes controls popup on Escape and outside click", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       const trigger = await openControlsPanel();
 
       fireEvent.keyDown(document, { key: "Escape" });
@@ -686,7 +747,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps metrics and active agents collapsed behind overview disclosure by default", async () => {
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(container.querySelector(".agent-list")).toBeTruthy();
@@ -707,7 +768,7 @@ describe("AgentsView", () => {
     });
 
     it("fetches agents only once on mount (regression: no duplicate initial load path)", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(mockFetchAgents).toHaveBeenCalledTimes(1);
@@ -720,7 +781,7 @@ describe("AgentsView", () => {
     });
 
     it("renders token stats derived from the currently displayed agents", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       // Token-usage panel now lives inside the controls popup, not in the
       // main view body — open the controls panel before asserting.
@@ -743,7 +804,7 @@ describe("AgentsView", () => {
     });
 
     it("passes projectId to agent fetches", async () => {
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await waitFor(() => {
         expect(mockFetchAgents).toHaveBeenCalledWith({ includeEphemeral: false }, projectId);
       });
@@ -751,7 +812,7 @@ describe("AgentsView", () => {
 
     it("renders empty state when no agents", async () => {
       mockFetchAgents.mockResolvedValue([]);
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await waitFor(() => {
         expect(screen.getByText("No agents found")).toBeTruthy();
         expect(screen.getByText("Create an agent to get started")).toBeTruthy();
@@ -761,7 +822,7 @@ describe("AgentsView", () => {
 
     it("opens the create dialog from the empty state CTA", async () => {
       mockFetchAgents.mockResolvedValue([]);
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       const cta = await screen.findByRole("button", { name: "Create Agent" });
       fireEvent.click(cta);
@@ -772,7 +833,7 @@ describe("AgentsView", () => {
     });
 
     it("displays agent states", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await waitFor(() => {
         expect(screen.getAllByText("idle").length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText("active").length).toBeGreaterThanOrEqual(1);
@@ -797,7 +858,7 @@ describe("AgentsView", () => {
         mockFetchAgentStats.mockResolvedValue({ total: 1, byState: { [state]: 1 }, byRole: { executor: 1 } });
         mockFetchOrgTree.mockResolvedValue([{ agent: highlightAgent, children: [] }]);
 
-        render(<AgentsView addToast={mockAddToast} />);
+        renderView(<AgentsView addToast={mockAddToast} />);
 
         await waitFor(() => {
           expect(document.querySelector(`.agent-card--${state}`)).toBeTruthy();
@@ -815,7 +876,7 @@ describe("AgentsView", () => {
       });
 
       it("keeps paused agents out of active highlight classes", async () => {
-        render(<AgentsView addToast={mockAddToast} />);
+        renderView(<AgentsView addToast={mockAddToast} />);
 
         const pausedAgentCard = await screen.findByText("Test Agent 3");
         const pausedCard = pausedAgentCard.closest(".agent-card");
@@ -835,7 +896,7 @@ describe("AgentsView", () => {
       ]);
       mockFetchAgentStats.mockResolvedValue({ total: 4, byState: { active: 1, running: 1 }, byRole: { executor: 2 } });
 
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getAllByText((_, el) => el?.textContent === "FN-TRIAGE · Planning").length).toBeGreaterThanOrEqual(1);
@@ -846,14 +907,14 @@ describe("AgentsView", () => {
     });
 
     it("displays unresolved context when task column is missing", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await waitFor(() => {
         expect(screen.getAllByText((_, el) => el?.textContent === "FN-001 · Unresolved task").length).toBeGreaterThanOrEqual(1);
       });
     });
 
     it("renders explicit View Details button on list cards", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "View details for Test Agent 1" })).toBeTruthy();
@@ -864,7 +925,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps a visible icon affordance on split-sidebar action buttons when labels are compacted", async () => {
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       const sidebarCard = await waitFor(() => {
         const card = container.querySelector(".agents-split-sidebar .agent-card");
@@ -897,7 +958,7 @@ describe("AgentsView", () => {
     });
 
     it("opens matching detail view when clicking View Details button", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "View details for Test Agent 3" })).toBeTruthy();
@@ -918,7 +979,7 @@ describe("AgentsView", () => {
           ...mockAgents.slice(1),
         ]);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getAllByText("Test Agent 1").length).toBeGreaterThan(0);
@@ -934,7 +995,7 @@ describe("AgentsView", () => {
     });
 
     it("opens detail view when clicking anywhere on the agent card body", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getAllByText("Test Agent 1").length).toBeGreaterThan(0);
@@ -975,7 +1036,7 @@ describe("AgentsView", () => {
       mockFetchAgents.mockResolvedValue([runningAgent]);
       mockFetchAgentStats.mockResolvedValue({ total: 1, byState: { running: 1 }, byRole: { executor: 1 } });
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       const runningButton = await screen.findByRole("button", { name: "View live run details for Runner" });
       fireEvent.click(runningButton);
@@ -990,7 +1051,7 @@ describe("AgentsView", () => {
     });
 
     it("shows heartbeat interval control on agent cards with 5m minimum presets", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1033,7 +1094,7 @@ describe("AgentsView", () => {
       ]);
       mockFetchAgentStats.mockResolvedValueOnce({ total: 1, byState: { active: 1 }, byRole: { triage: 1 } });
 
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       const lastAt = new Date(lastHeartbeatAt);
       const nextAt = new Date(lastAt.getTime() + 300000);
@@ -1064,7 +1125,7 @@ describe("AgentsView", () => {
         },
       ]);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1076,7 +1137,7 @@ describe("AgentsView", () => {
     });
 
     it("updates agent heartbeat interval from preset dropdown", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1098,7 +1159,7 @@ describe("AgentsView", () => {
     });
 
     it("shows Custom... option in dropdown that reveals typed input", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1118,7 +1179,7 @@ describe("AgentsView", () => {
     });
 
     it("can enter custom minutes value and save it", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1152,7 +1213,7 @@ describe("AgentsView", () => {
     });
 
     it("clamps custom value 1-4 minutes to 5 minutes with info toast", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1191,7 +1252,7 @@ describe("AgentsView", () => {
     });
 
     it("does not save when custom input is empty", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1227,7 +1288,7 @@ describe("AgentsView", () => {
     });
 
     it("does not save when custom input is non-numeric", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1263,7 +1324,7 @@ describe("AgentsView", () => {
     });
 
     it("does not save when custom input is zero or negative", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText("Set heartbeat interval for Test Agent 2")).toBeTruthy();
@@ -1309,7 +1370,7 @@ describe("AgentsView", () => {
       mockFetchAgents.mockResolvedValueOnce([errorAgent]);
       mockFetchAgentStats.mockResolvedValueOnce({ total: 1, byState: { error: 1 }, byRole: { executor: 1 } });
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Open error details" })).toBeTruthy();
@@ -1345,7 +1406,7 @@ describe("AgentsView", () => {
       ]);
       mockFetchAgentStats.mockResolvedValueOnce({ total: 2, byState: { error: 1, active: 1 }, byRole: { executor: 2 } });
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("Error No Text")).toBeTruthy();
@@ -1357,7 +1418,7 @@ describe("AgentsView", () => {
     });
 
     it("shows refresh button", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       // Use findBy to ensure React has flushed all pending state updates before asserting.
       // This prevents act(...) warnings from any async effects triggered during render.
       const refreshBtn = await screen.findByTitle("Refresh");
@@ -1367,7 +1428,7 @@ describe("AgentsView", () => {
 
   describe("view toggle (list/board)", () => {
     it("can toggle between list and board view", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getAllByText("Test Agent 1").length).toBeGreaterThanOrEqual(1);
@@ -1392,7 +1453,7 @@ describe("AgentsView", () => {
     });
 
     it("board view shows compact cards", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
@@ -1407,7 +1468,7 @@ describe("AgentsView", () => {
     });
 
     it("persists view toggle preference to project-scoped localStorage", async () => {
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
@@ -1421,7 +1482,7 @@ describe("AgentsView", () => {
     });
 
     it("defaults to list view when no localStorage preference exists", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const listContainer = document.querySelector(".agent-list");
@@ -1430,7 +1491,7 @@ describe("AgentsView", () => {
     });
 
     it("marks board view button as active when in board mode", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
@@ -1519,7 +1580,7 @@ describe("AgentsView", () => {
 
     it("renders org chart toggle with aria attributes and activates org view", async () => {
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const orgButton = screen.getByRole("button", { name: "Org Chart view" });
       expect(orgButton.getAttribute("aria-pressed")).toBe("false");
@@ -1538,7 +1599,7 @@ describe("AgentsView", () => {
 
     it("does not render the split resize handle in org chart view", async () => {
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       expect(await screen.findByTestId("agents-sidebar-resize-handle")).toBeTruthy();
 
@@ -1554,7 +1615,7 @@ describe("AgentsView", () => {
 
     it("renders org chart nodes and opens detail view when clicking a node", async () => {
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      const { container } = render(<AgentsView addToast={mockAddToast} />);
+      const { container } = renderView(<AgentsView addToast={mockAddToast} />);
 
       fireEvent.click(screen.getByRole("button", { name: "Org Chart view" }));
 
@@ -1589,7 +1650,7 @@ describe("AgentsView", () => {
 
     it("keeps org chart node metadata compact without skill badges", async () => {
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       fireEvent.click(screen.getByRole("button", { name: "Org Chart view" }));
 
@@ -1635,7 +1696,7 @@ describe("AgentsView", () => {
     it("switches org chart to vertical layout mode when estimated width exceeds viewport", async () => {
       const clientWidthSpy = vi.spyOn(window.HTMLElement.prototype, "clientWidth", "get").mockReturnValue(320);
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       fireEvent.click(screen.getByRole("button", { name: "Org Chart view" }));
 
@@ -1655,7 +1716,7 @@ describe("AgentsView", () => {
     it("keeps org chart horizontal layout mode when viewport is wide enough", async () => {
       const clientWidthSpy = vi.spyOn(window.HTMLElement.prototype, "clientWidth", "get").mockReturnValue(1920);
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       fireEvent.click(screen.getByRole("button", { name: "Org Chart view" }));
 
@@ -1672,7 +1733,7 @@ describe("AgentsView", () => {
       localStorage.setItem(scopedKey("fn-agent-view", projectId), "org");
       localStorage.setItem(scopedKey(ORG_CHART_LAYOUT_STORAGE_KEY, projectId), "vertical");
       mockFetchOrgTree.mockResolvedValue(orgTree);
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const chart = await screen.findByTestId("agent-org-chart");
       const toggle = screen.getByTestId("agent-org-chart-layout-toggle");
@@ -1716,7 +1777,7 @@ describe("AgentsView", () => {
 
     it("shows org chart empty state when API returns no nodes", async () => {
       mockFetchOrgTree.mockResolvedValue([]);
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       fireEvent.click(screen.getByRole("button", { name: "Org Chart view" }));
 
@@ -1736,7 +1797,7 @@ describe("AgentsView", () => {
           }),
       );
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       fireEvent.click(screen.getByRole("button", { name: "Org Chart view" }));
 
       await waitFor(() => {
@@ -1753,7 +1814,7 @@ describe("AgentsView", () => {
 
   describe("filter agents by state", () => {
     it("renders the state filter with styled container", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       // Styled filter container exists
@@ -1766,7 +1827,7 @@ describe("AgentsView", () => {
     });
 
     it("can filter agents by state", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       const filterSelect = screen.getByLabelText("Filter agents by state");
@@ -1778,7 +1839,7 @@ describe("AgentsView", () => {
     });
 
     it("clears filter when selecting 'all'", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       const filterSelect = screen.getByLabelText("Filter agents by state");
@@ -1798,7 +1859,7 @@ describe("AgentsView", () => {
 
   describe("show system agents toggle", () => {
     it("renders the system agents checkbox", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       // Checkbox should be unchecked by default
@@ -1807,7 +1868,7 @@ describe("AgentsView", () => {
     });
 
     it("passes includeEphemeral: false by default to fetchAgents", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       // Default call should include includeEphemeral: false
       await waitFor(() => {
@@ -1816,7 +1877,7 @@ describe("AgentsView", () => {
     });
 
     it("toggles system agents visibility when checkbox is clicked", async () => {
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await openControlsPanel();
 
       const checkbox = screen.getByLabelText("Show system agents");
@@ -1828,7 +1889,7 @@ describe("AgentsView", () => {
     });
 
     it("combines system agents toggle with state filter", async () => {
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await openControlsPanel();
 
       // First enable system agents toggle
@@ -1865,7 +1926,7 @@ describe("AgentsView", () => {
       // client-side filtering still hides it unless the toggle is enabled.
       mockFetchAgents.mockResolvedValue([...mockAgents.slice(0, 3), ...systemAgents]);
 
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       await waitFor(() => {
         expect(screen.getAllByText("Test Agent 1").length).toBeGreaterThan(0);
@@ -1886,7 +1947,7 @@ describe("AgentsView", () => {
 
   describe("create new agent", () => {
     it("can create new agent via multi-step dialog", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -1921,7 +1982,7 @@ describe("AgentsView", () => {
     });
 
     it("shows create dialog when clicking New Agent button", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -1938,7 +1999,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps legacy dialog launch when agent onboarding flag is disabled", async () => {
-      render(<AgentsView addToast={mockAddToast} agentOnboardingEnabled={false} />);
+      renderView(<AgentsView addToast={mockAddToast} agentOnboardingEnabled={false} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -1953,7 +2014,7 @@ describe("AgentsView", () => {
     });
 
     it("keeps New Agent launch on the standard dialog when agent onboarding flag is enabled", async () => {
-      render(<AgentsView addToast={mockAddToast} agentOnboardingEnabled={true} />);
+      renderView(<AgentsView addToast={mockAddToast} agentOnboardingEnabled={true} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -1968,7 +2029,7 @@ describe("AgentsView", () => {
     });
 
     it("launches interview from AgentsView and only applies draft after review confirmation", async () => {
-      render(<AgentsView addToast={mockAddToast} agentOnboardingEnabled={true} />);
+      renderView(<AgentsView addToast={mockAddToast} agentOnboardingEnabled={true} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -2003,7 +2064,7 @@ describe("AgentsView", () => {
     });
 
     it("does not allow proceeding with empty name", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -2025,7 +2086,7 @@ describe("AgentsView", () => {
     it("handles creation error gracefully", async () => {
       mockCreateAgent.mockRejectedValue(new Error("Creation failed"));
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("New Agent")).toBeTruthy();
@@ -2053,7 +2114,7 @@ describe("AgentsView", () => {
 
   describe("change agent state", () => {
     it("can change agent state - activate idle agent", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Activate")).toBeTruthy();
@@ -2073,7 +2134,7 @@ describe("AgentsView", () => {
     });
 
     it("can pause active agent", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const agentCards = document.querySelectorAll(".agent-card");
@@ -2096,7 +2157,7 @@ describe("AgentsView", () => {
     });
 
     it("can resume paused agent without manual run trigger", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Resume")).toBeTruthy();
@@ -2118,7 +2179,7 @@ describe("AgentsView", () => {
       });
       mockUpdateAgentState.mockImplementationOnce(() => transitionPromise);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Activate")).toBeTruthy();
@@ -2146,7 +2207,7 @@ describe("AgentsView", () => {
       });
       mockUpdateAgentState.mockImplementationOnce(() => transitionPromise);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Activate")).toBeTruthy();
@@ -2181,7 +2242,7 @@ describe("AgentsView", () => {
       });
       mockUpdateAgentState.mockImplementationOnce(() => transitionPromise);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Activate")).toBeTruthy();
@@ -2215,7 +2276,7 @@ describe("AgentsView", () => {
     it("handles state change error gracefully", async () => {
       mockUpdateAgentState.mockRejectedValue(new Error("State change failed"));
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Activate")).toBeTruthy();
@@ -2232,7 +2293,7 @@ describe("AgentsView", () => {
     });
 
     it("does not start run when pausing agent", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const agentCards = document.querySelectorAll(".agent-card");
@@ -2267,7 +2328,7 @@ describe("AgentsView", () => {
         mockAgents[3],
       ]);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       const runNowButton = await screen.findByTitle("Run Now");
       const pauseButton = await screen.findByTitle("Pause");
@@ -2291,7 +2352,7 @@ describe("AgentsView", () => {
         mockAgents[3],
       ]);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Run Now")).toBeTruthy();
@@ -2308,7 +2369,7 @@ describe("AgentsView", () => {
         mockAgents[3],
       ]);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Run Now")).toBeTruthy();
@@ -2331,7 +2392,7 @@ describe("AgentsView", () => {
 
   describe("delete agent", () => {
     it("shows Delete button for idle, paused, and error agents in default view", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const deleteButtons = screen.getAllByTitle("Delete");
@@ -2340,7 +2401,7 @@ describe("AgentsView", () => {
     });
 
     it("does not show Delete button for active agents", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const allCards = Array.from(document.querySelectorAll(".agent-card"));
@@ -2351,7 +2412,7 @@ describe("AgentsView", () => {
     });
 
     it("shows Delete button for paused agents", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const allCards = Array.from(document.querySelectorAll(".agent-card"));
@@ -2362,7 +2423,7 @@ describe("AgentsView", () => {
     });
 
     it("shows Delete button for error agents in board view", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
@@ -2380,7 +2441,7 @@ describe("AgentsView", () => {
 
     it("deletes idle agent after confirmation (from default view)", async () => {
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const deleteButtons = screen.getAllByTitle("Delete");
@@ -2405,7 +2466,7 @@ describe("AgentsView", () => {
     });
 
     it("deletes paused agent after confirmation (from default view)", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         const pausedCard = Array.from(document.querySelectorAll(".agent-card")).find(
@@ -2422,7 +2483,7 @@ describe("AgentsView", () => {
     });
 
     it("deletes error agent after confirmation (from board view)", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByText("Agents")).toBeTruthy();
@@ -2447,7 +2508,7 @@ describe("AgentsView", () => {
 
   describe("refresh functionality", () => {
     it("refreshes agent list when clicking refresh button", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
 
       await waitFor(() => {
         expect(screen.getByTitle("Refresh")).toBeTruthy();
@@ -2465,7 +2526,7 @@ describe("AgentsView", () => {
   describe("active agents panel selection", () => {
     it("renders active agents panel when agents are active", async () => {
       // agent-002 is active with taskId FN-001
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2478,7 +2539,7 @@ describe("AgentsView", () => {
     });
 
     it("opens AgentDetailView when clicking an active agent card", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2498,7 +2559,7 @@ describe("AgentsView", () => {
     });
 
     it("opens AgentDetailView when pressing Enter on an active agent card", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2519,7 +2580,7 @@ describe("AgentsView", () => {
     });
 
     it("opens AgentDetailView when pressing Space on an active agent card", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2540,7 +2601,7 @@ describe("AgentsView", () => {
     });
 
     it("live agent cards have proper accessibility attributes", async () => {
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2571,7 +2632,7 @@ describe("AgentsView", () => {
       ];
       mockFetchAgents.mockResolvedValue(inactiveAgents);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2597,7 +2658,7 @@ describe("AgentsView", () => {
       ];
       mockFetchAgents.mockResolvedValue(spawnedAgents);
 
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openOverviewPanel();
 
       await waitFor(() => {
@@ -2673,7 +2734,7 @@ describe("AgentsView", () => {
 
     it("loads bulk eligibility when controls open and shows count hints", async () => {
       mockFetchAgents.mockResolvedValue(bulkAgents);
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
 
       const initialFetchCount = mockFetchAgents.mock.calls.length;
       await openControlsPanel();
@@ -2690,7 +2751,7 @@ describe("AgentsView", () => {
         { ...bulkAgents[3] },
         { ...bulkAgents[4], state: "paused" as AgentState },
       ]);
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await openControlsPanel();
 
       await waitFor(() => {
@@ -2703,7 +2764,7 @@ describe("AgentsView", () => {
 
     it("pauses eligible non-ephemeral agents after confirmation", async () => {
       mockFetchAgents.mockResolvedValue(bulkAgents);
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await openControlsPanel();
 
       fireEvent.click(screen.getByRole("menuitem", { name: /Pause All Agents/i }));
@@ -2727,7 +2788,7 @@ describe("AgentsView", () => {
 
     it("resumes paused agents only", async () => {
       mockFetchAgents.mockResolvedValue(bulkAgents);
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await openControlsPanel();
 
       fireEvent.click(screen.getByRole("menuitem", { name: /Resume All Agents/i }));
@@ -2751,7 +2812,7 @@ describe("AgentsView", () => {
         }
         return { ...bulkAgents[0], id: agentId, state: newState };
       });
-      render(<AgentsView addToast={mockAddToast} projectId={projectId} />);
+      renderView(<AgentsView addToast={mockAddToast} projectId={projectId} />);
       await openControlsPanel();
 
       fireEvent.click(screen.getByRole("menuitem", { name: /Pause All Agents/i }));
@@ -2768,7 +2829,7 @@ describe("AgentsView", () => {
   describe("global heartbeat multiplier", () => {
     it("renders the global heartbeat speed control", async () => {
       mockFetchSettings.mockResolvedValue({ heartbeatMultiplier: 1 });
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       // Check the slider and preset are rendered
@@ -2781,7 +2842,7 @@ describe("AgentsView", () => {
 
     it("loads heartbeat multiplier from settings", async () => {
       mockFetchSettings.mockResolvedValue({ heartbeatMultiplier: 2.5 });
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       const slider = screen.getByRole("slider", { name: "Heartbeat Speed" }) as HTMLInputElement;
@@ -2790,7 +2851,7 @@ describe("AgentsView", () => {
 
     it("saves heartbeat multiplier when slider changes", async () => {
       mockFetchSettings.mockResolvedValue({ heartbeatMultiplier: 1 });
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       // Change the slider
@@ -2805,7 +2866,7 @@ describe("AgentsView", () => {
 
     it("saves heartbeat multiplier when preset is selected", async () => {
       mockFetchSettings.mockResolvedValue({ heartbeatMultiplier: 1 });
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       // Change the preset
@@ -2820,7 +2881,7 @@ describe("AgentsView", () => {
     it("disables control while saving", async () => {
       mockFetchSettings.mockResolvedValue({ heartbeatMultiplier: 1 });
       mockUpdateSettings.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
-      render(<AgentsView addToast={mockAddToast} />);
+      renderView(<AgentsView addToast={mockAddToast} />);
       await openControlsPanel();
 
       // Change the slider - this should start the save
@@ -2831,6 +2892,89 @@ describe("AgentsView", () => {
       await waitFor(() => {
         expect(slider).toBeDisabled();
       });
+    });
+  });
+});
+
+describe("AgentsView — RuntimeFallbackBadge viewport gating on board/list cards (FUX-039)", () => {
+  const realIntersectionObserver = globalThis.IntersectionObserver;
+
+  beforeEach(() => {
+    localStorage.clear();
+    legacyMocks.fetchTaskRuntimeFallback.mockReset();
+    legacyMocks.fetchTaskRuntimeFallback.mockResolvedValue({
+      taskId: "FN-001",
+      hasEvent: true,
+      wasConfigured: false,
+      runtimeHint: "hermes",
+      reason: "init_error",
+      eventId: "audit-agentsview-1",
+      timestamp: "2026-07-08T00:00:00.000Z",
+      showFallbackBadge: true,
+    });
+    MockIntersectionObserver.instances = [];
+    // @ts-expect-error test-only override
+    globalThis.IntersectionObserver = MockIntersectionObserver;
+  });
+
+  afterEach(() => {
+    globalThis.IntersectionObserver = realIntersectionObserver;
+  });
+
+  it("gates polling on the board card via its own registered viewport key, stopping/resuming on transitions", async () => {
+    renderView(<AgentsView addToast={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Agents")).toBeTruthy());
+    fireEvent.click(screen.getByTitle("Board view"));
+
+    // Only the card for the agent carrying a taskId ever renders a RuntimeFallbackBadge
+    // (see the `agent.taskId &&` guard in AgentsView.tsx) — mockAgents[0] has no taskId,
+    // so target the card keyed for mockAgents[1] ("agent-002", taskId "FN-001") explicitly
+    // rather than the first ".agent-board-card" in DOM order.
+    const boardCard = await waitFor(() => {
+      const el = document.querySelector('[data-viewport-key="board:agent-002"]');
+      expect(el).toBeTruthy();
+      return el as Element;
+    });
+
+    // Not yet observed as intersecting: no poll.
+    expect(legacyMocks.fetchTaskRuntimeFallback).not.toHaveBeenCalled();
+
+    const observer = MockIntersectionObserver.instances.find((o) => o.observedElements.has(boardCard));
+    expect(observer).toBeTruthy();
+
+    await waitFor(() => {
+      observer!.fire(boardCard, true);
+      expect(legacyMocks.fetchTaskRuntimeFallback).toHaveBeenCalled();
+    });
+
+    const callsAfterVisible = legacyMocks.fetchTaskRuntimeFallback.mock.calls.length;
+    observer!.fire(boardCard, false);
+    // No further polling once hidden (polling is driven by the hook's own
+    // interval, gated by `enabled`; hiding tears the interval down).
+    expect(legacyMocks.fetchTaskRuntimeFallback.mock.calls.length).toBe(callsAfterVisible);
+  });
+
+  it("gates polling on the list card via a distinct viewport key from the board card", async () => {
+    renderView(<AgentsView addToast={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Agents")).toBeTruthy());
+
+    // Same taskId-guard rationale as the board-card test above: target the list card
+    // keyed for mockAgents[1] ("agent-002", taskId "FN-001") explicitly.
+    const listCard = await waitFor(() => {
+      const el = document.querySelector('[data-viewport-key="list:agent-002"]');
+      expect(el).toBeTruthy();
+      return el as Element;
+    });
+
+    expect(legacyMocks.fetchTaskRuntimeFallback).not.toHaveBeenCalled();
+
+    const observer = MockIntersectionObserver.instances.find((o) => o.observedElements.has(listCard));
+    expect(observer).toBeTruthy();
+    expect((listCard as HTMLElement).dataset.viewportKey?.startsWith("list:")).toBe(true);
+
+    await waitFor(() => {
+      observer!.fire(listCard, true);
+      expect(legacyMocks.fetchTaskRuntimeFallback).toHaveBeenCalled();
     });
   });
 });

--- a/packages/dashboard/app/components/__tests__/RuntimeFallbackBadge.test.tsx
+++ b/packages/dashboard/app/components/__tests__/RuntimeFallbackBadge.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { RuntimeFallbackBadge } from "../RuntimeFallbackBadge";
 import { ToastProvider, useToast } from "../../hooks/useToast";
+import { __resetRuntimeFallbackToastClaimsForTests } from "../../hooks/useRuntimeFallbackStatus";
 import type { TaskRuntimeFallbackResponse } from "../../api/legacy";
 
 const legacyMocks = vi.hoisted(() => ({
@@ -37,6 +38,22 @@ function renderBadge(taskId = "FN-100", isInViewport = true) {
   return render(
     <ToastProvider>
       <RuntimeFallbackBadge taskId={taskId} isInViewport={isInViewport} projectId="proj-1" />
+      <ToastPeek />
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Renders TWO independently-mounted RuntimeFallbackBadge instances (as if the
+ * same task appeared on both a board card and a list card simultaneously),
+ * sharing a single ToastProvider/ToastPeek so cross-instance toast dedupe
+ * (FUX-039 finding 3) can be observed on one toast history.
+ */
+function renderTwoBadgeInstances(taskId = "FN-100") {
+  return render(
+    <ToastProvider>
+      <RuntimeFallbackBadge taskId={taskId} isInViewport={true} projectId="proj-1" />
+      <RuntimeFallbackBadge taskId={taskId} isInViewport={true} projectId="proj-1" />
       <ToastPeek />
     </ToastProvider>,
   );
@@ -88,6 +105,10 @@ describe("RuntimeFallbackBadge", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     legacyMocks.fetchTaskRuntimeFallback.mockReset();
+    // The FUX-039 toast-claim store is module-level (shared across every hook
+    // instance in the process) so multiple tests reusing the same eventId
+    // (e.g. "audit-fallback-1") don't leak dedupe state between test cases.
+    __resetRuntimeFallbackToastClaimsForTests();
   });
 
   afterEach(() => {
@@ -189,12 +210,42 @@ describe("RuntimeFallbackBadge", () => {
     expect(legacyMocks.fetchTaskRuntimeFallback).not.toHaveBeenCalled();
     expect(screen.queryByTestId("runtime-fallback-badge")).toBeNull();
   });
+
+  it("fires the toast exactly once across two simultaneously-mounted badge instances for the same task (FUX-039 cross-instance dedupe)", async () => {
+    // Regression test for finding 3: previously the toast-dedupe key
+    // (lastToastedEventIdRef) lived in a per-hook-instance useRef, so two
+    // badge instances polling the SAME task (e.g. the task's board card and
+    // list card both mounted at once) would each independently observe the
+    // fallback event as "new" and each fire their own toast — the user would
+    // see the same warning toasted twice. The dedupe must be shared across
+    // instances so only one toast ever fires per fallback session, no matter
+    // how many card surfaces are rendering it concurrently.
+    legacyMocks.fetchTaskRuntimeFallback.mockResolvedValue(fallbackWithHint);
+    renderTwoBadgeInstances();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Both instances should render their own badge (badge visibility is not deduped, only toasts).
+    expect(screen.getAllByTestId("runtime-fallback-badge")).toHaveLength(2);
+    // But only ONE toast should have fired, even though two hook instances
+    // independently polled and observed the same eventId.
+    expect(screen.getAllByTestId("toast-entry")).toHaveLength(1);
+
+    // Further polls (by either instance) for the same still-latest event must not add more toasts.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(screen.getAllByTestId("toast-entry")).toHaveLength(1);
+  });
 });
 
 describe("RuntimeFallbackBadge — mobile breakpoint", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     legacyMocks.fetchTaskRuntimeFallback.mockReset();
+    __resetRuntimeFallbackToastClaimsForTests();
   });
 
   afterEach(() => {

--- a/packages/dashboard/app/hooks/useRuntimeFallbackStatus.ts
+++ b/packages/dashboard/app/hooks/useRuntimeFallbackStatus.ts
@@ -13,11 +13,69 @@
  * would add cross-cutting server/socket surface for no material latency win.
  * This hook only polls while `enabled` is true (callers should pass
  * `isInViewport` so off-screen cards do not generate background traffic).
+ *
+ * ## Cross-instance toast dedupe (FUX-039)
+ * The same task can be rendered by multiple simultaneously-mounted card
+ * surfaces (e.g. the board card AND the list card both poll the same taskId
+ * when a caller toggles view modes, or a task appears in both
+ * ActiveAgentsPanel and AgentsView at once). Each surface owns its own
+ * `useRuntimeFallbackStatus` hook instance, so a dedupe key stored only in a
+ * per-instance `useRef` cannot see what a sibling instance has already
+ * toasted — every newly-mounted instance would fire its own toast for the
+ * same underlying fallback session, spamming the user. `claimToastOnce`
+ * below is a module-level (i.e. shared across every hook instance in the
+ * process) claim store: only the first instance to observe a given eventId
+ * gets `shouldToastNow: true`.
  */
 import { useEffect, useRef, useState } from "react";
 import { fetchTaskRuntimeFallback, type TaskRuntimeFallbackResponse } from "../api/legacy";
 
 const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Upper bound on how many distinct fallback-session eventIds we remember
+ * having toasted. Without a cap, a long-lived dashboard session polling many
+ * tasks over hours/days would grow this set unboundedly. Eviction is
+ * insertion-order (oldest-claimed-first), which is sufficient here: once an
+ * eventId has been evicted it is exceedingly unlikely to be re-observed
+ * (each event corresponds to a single agent session's one-time
+ * `session:runtime-resolved` audit write), so an accidental duplicate toast
+ * after eviction is a harmless, extremely rare edge case rather than a
+ * regression risk.
+ */
+const MAX_CLAIMED_EVENT_IDS = 500;
+
+/** Module-level (process-wide) set of fallback-session eventIds already claimed for a toast. */
+let claimedEventIds = new Set<string>();
+
+/**
+ * Atomically claim `eventId` for a toast. Returns true the first time a given
+ * eventId is claimed (the caller should fire the toast); returns false on
+ * every subsequent claim attempt for the same eventId, including from other
+ * hook instances mounted elsewhere in the tree. Safe to call from multiple
+ * components polling the same task concurrently.
+ */
+function claimToastOnce(eventId: string): boolean {
+  if (claimedEventIds.has(eventId)) {
+    return false;
+  }
+  claimedEventIds.add(eventId);
+  if (claimedEventIds.size > MAX_CLAIMED_EVENT_IDS) {
+    const oldest = claimedEventIds.values().next().value;
+    if (oldest !== undefined) {
+      claimedEventIds.delete(oldest);
+    }
+  }
+  return true;
+}
+
+/**
+ * Test-only: reset the shared claim store between test cases so assertions in
+ * one test don't leak dedupe state into the next. Not used by production code.
+ */
+export function __resetRuntimeFallbackToastClaimsForTests(): void {
+  claimedEventIds = new Set<string>();
+}
 
 export interface RuntimeFallbackStatus {
   /** True only when the latest resolution has wasConfigured=false and a non-empty runtimeHint. */
@@ -28,7 +86,7 @@ export interface RuntimeFallbackStatus {
   reason: string | null;
   /** Human-readable badge/toast message, or null when there is nothing to show. */
   message: string | null;
-  /** True exactly once, on the render where a newly-observed fallback session should fire a toast. */
+  /** True exactly once (process-wide, across every hook instance) for a newly-observed fallback session. */
   shouldToastNow: boolean;
 }
 
@@ -55,10 +113,14 @@ export function useRuntimeFallbackStatus(
   projectId?: string,
 ): RuntimeFallbackStatus {
   const [status, setStatus] = useState<RuntimeFallbackStatus>(IDLE_STATUS);
-  // Dedupe key for toasts: last audit event ID we already toasted for. Persists across
-  // polls/re-renders for the lifetime of the component so the toast fires exactly once
-  // per newly-observed fallback session, not on every poll.
-  const lastToastedEventIdRef = useRef<string | null>(null);
+  // Per-instance de-flicker guard only: once THIS hook instance has already
+  // rendered the badge for a given eventId, subsequent polls for the same
+  // eventId should not re-flip shouldToastNow even if the shared claim was
+  // won by this instance on an earlier poll cycle (claimToastOnce is
+  // one-shot per eventId process-wide, so this ref is redundant for
+  // correctness but documents the intent locally and avoids re-touching the
+  // shared store on every poll for an already-seen eventId).
+  const lastSeenEventIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!enabled || !taskId) {
@@ -83,9 +145,14 @@ export function useRuntimeFallbackStatus(
         return;
       }
 
-      const isNewlyObserved = data.eventId !== null && data.eventId !== lastToastedEventIdRef.current;
-      if (isNewlyObserved && data.eventId) {
-        lastToastedEventIdRef.current = data.eventId;
+      const isNewEventForThisInstance = data.eventId !== null && data.eventId !== lastSeenEventIdRef.current;
+      let shouldToastNow = false;
+      if (isNewEventForThisInstance && data.eventId) {
+        lastSeenEventIdRef.current = data.eventId;
+        // Cross-instance dedupe: only the first instance (across the whole
+        // process — any mounted card/panel polling this or any other task)
+        // to observe this eventId wins the toast.
+        shouldToastNow = claimToastOnce(data.eventId);
       }
 
       setStatus({
@@ -93,7 +160,7 @@ export function useRuntimeFallbackStatus(
         runtimeHint: data.runtimeHint,
         reason: data.reason,
         message: formatRuntimeFallbackMessage(data.runtimeHint),
-        shouldToastNow: isNewlyObserved,
+        shouldToastNow,
       });
     };
 

--- a/packages/engine/src/__tests__/runtime-resolution.test.ts
+++ b/packages/engine/src/__tests__/runtime-resolution.test.ts
@@ -324,7 +324,7 @@ describe("runtime-resolution", () => {
         expect(result.fallbackReason).toBe("factory_error");
       });
 
-      it("should fall back to pi when createRuntimeContext returns null", async () => {
+      it("should fall back to pi with reason 'init_error' when createRuntimeContext returns null (runtime was found, but failed to initialize — FUX-039)", async () => {
         mockPluginRunner.createRuntimeContext.mockResolvedValue(null);
         const mockRuntime = createMockPluginRuntime("orphan", "Orphan Runtime");
         mockPluginRunner.getRuntimeById.mockReturnValue({
@@ -337,7 +337,10 @@ describe("runtime-resolution", () => {
 
         expect(result.runtimeId).toBe("pi");
         expect(result.wasConfigured).toBe(false);
-        expect(result.fallbackReason).toBe("not_found");
+        // The runtime WAS found via getRuntimeById (registration exists) — only
+        // createRuntimeContext(...) failed. This is distinct from "never
+        // registered" and must not be collapsed into "not_found" (FUX-039 fix).
+        expect(result.fallbackReason).toBe("init_error");
       });
 
       it("should report reason 'not_found' distinct from 'factory_error' across the two hint failure modes", async () => {
@@ -359,6 +362,36 @@ describe("runtime-resolution", () => {
         expect(factoryErrorResult.fallbackReason).toBe("factory_error");
 
         expect(notFoundResult.fallbackReason).not.toBe(factoryErrorResult.fallbackReason);
+      });
+
+      it("should reach all three FallbackReason values from three distinct real code paths, pairwise distinct (FUX-039)", async () => {
+        // not_found: no registration at all
+        mockPluginRunner.getRuntimeById.mockReturnValueOnce(undefined);
+        const notFoundResult = await resolveRuntime(createContext("executor", "missing-plugin"));
+
+        // init_error: registration exists, but createRuntimeContext(...) fails
+        mockPluginRunner.createRuntimeContext.mockResolvedValueOnce(null);
+        const initErrorRuntime = createMockPluginRuntime("orphan-2", "Orphan Runtime 2");
+        mockPluginRunner.getRuntimeById.mockReturnValueOnce({
+          pluginId: "orphan-plugin-2",
+          runtime: initErrorRuntime,
+        });
+        const initErrorResult = await resolveRuntime(createContext("executor", "orphan-2"));
+
+        // factory_error: registration exists, context resolves, but factory throws
+        const throwingRuntime2: PluginRuntimeRegistration = {
+          metadata: { runtimeId: "throws-2", name: "Throwing Runtime 2" },
+          factory: vi.fn().mockRejectedValue(new Error("boom-2")),
+        };
+        mockPluginRunner.getRuntimeById.mockReturnValueOnce({
+          pluginId: "throwing-plugin-2",
+          runtime: throwingRuntime2,
+        });
+        const factoryErrorResult = await resolveRuntime(createContext("executor", "throws-2"));
+
+        const reasons = [notFoundResult.fallbackReason, initErrorResult.fallbackReason, factoryErrorResult.fallbackReason];
+        expect(reasons).toEqual(["not_found", "init_error", "factory_error"]);
+        expect(new Set(reasons).size).toBe(3);
       });
     });
   });

--- a/packages/engine/src/runtime-resolution.ts
+++ b/packages/engine/src/runtime-resolution.ts
@@ -169,7 +169,7 @@ async function resolvePluginRuntime(
     const pluginContext = await pluginRunner.createRuntimeContext(pluginId);
     if (!pluginContext) {
       runtimeLog.warn(`Plugin "${pluginId}" runtime factory context unavailable`);
-      return { ok: false, reason: "not_found" };
+      return { ok: false, reason: "init_error" };
     }
 
     // Instantiate the runtime via factory


### PR DESCRIPTION
## Summary

Addresses the Staff Engineer pre-landing review findings on merged PR #1957 (FUX-022 runtime-fallback badge/toast feature). All 4 findings were independently re-verified against a fresh bootstrap of `main` (not trusting a prior unmerged branch attempt) before fixing.

1. **`resolvePluginRuntime()` mislabeled found-but-failed-to-init as `"not_found"`.** The branch where a plugin's registration exists but `createRuntimeContext(...)` returns falsy now correctly returns `reason: "init_error"` instead of `"not_found"` (which was indistinguishable from "never registered"). Extended the existing unit test suite to assert all 3 `FallbackReason` values are independently reachable and pairwise-distinct.

2. **Viewport gating was defeated on card surfaces.** `ActiveAgentsPanel` and `AgentsView` both hardcoded `isInViewport={true}` when rendering `RuntimeFallbackBadge`, so every rendered card polled regardless of actual visibility — defeating the entire purpose of the `isInViewport` gate. Wired real `IntersectionObserver`-based viewport gating on both surfaces (`ActiveAgentsPanel`'s `LiveAgentCard` tracks its own visibility; `AgentsView` uses one shared observer instance keyed per card so the board and list surfaces never share visibility state). Added desktop + mobile regression tests.

3. **Toast-dedupe was per-component-instance, not shared.** `useRuntimeFallbackStatus`'s dedupe key lived only in a per-hook-instance `useRef`, so two simultaneously-mounted card surfaces polling the same task (e.g. its board card and list card both visible at once) would each independently fire their own toast for the same fallback session. Replaced with a module-level shared claim store (bounded, with a test-only reset hook) so only the first instance to observe a given event, process-wide, fires the toast. Added a cross-instance regression test.

4. **Lint-breaking `eslint-disable` comment** — independently confirmed already resolved on `main` prior to this PR; no code change included.

## Test plan

- `pnpm --filter @fusion/engine exec vitest run src/__tests__/runtime-resolution.test.ts` — 25/25 pass
- `pnpm --filter @fusion/dashboard exec vitest run app/components/__tests__/ActiveAgentsPanel.test.tsx` — 17/17 pass
- `pnpm --filter @fusion/dashboard exec vitest run app/components/__tests__/RuntimeFallbackBadge.test.tsx` — 9/9 pass
- `pnpm --filter @fusion/dashboard exec vitest run app/components/__tests__/AgentsView.test.tsx` — 132/134 pass (1 pre-existing, unrelated CSS-fixture failure confirmed via `git stash` prior to this change)
- `pnpm --filter @fusion/engine exec tsc --noEmit` — clean
- `pnpm --filter @fusion/dashboard exec tsc --noEmit` — clean
- `eslint` scoped to all changed files — 0 errors

🤖 Generated with an autonomous coding agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent cards now load fallback/runtime status only when visible on screen, improving responsiveness in long lists and board views.
  * If the same fallback event appears in multiple places, users now see a single toast instead of duplicates.

* **Bug Fixes**
  * Runtime failures are now reported with a more accurate reason when a runtime exists but cannot initialize.
  * Off-screen agent cards no longer trigger unnecessary polling or badge updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->