### PR TITLE
fix: restore full-suite green — i18n parity (FN-7658) + chat core mock (FN-7675) + verification-followup-dedup (FN-7658)

### DIFF
--- a/.changeset/fn-7692-merger-confirmation-copy.md
+++ b/.changeset/fn-7692-merger-confirmation-copy.md
@@ -2,6 +2,6 @@
 "@runfusion/fusion": patch
 ---
 
-summary: Fix misleading merger "awaiting-confirmation" copy that claimed a hard block when auto-merge advances the merge automatically.
+summary: Fix merger awaiting-confirmation copy that implied a hard block when auto-merge proceeds automatically.
 category: fix
 dev: `decidePlannerRecovery` now accepts an additive `autoMergeWillProceed` flag (threaded from `allowsAutoMergeProcessing` in `PlannerRecoveryController.tick`) that only shapes the confirmation `reason` string; no gating/behavior change to `action`/`requiresConfirmation`/`sideEffectClass`.

--- a/packages/dashboard/src/__tests__/chat.test.ts
+++ b/packages/dashboard/src/__tests__/chat.test.ts
@@ -26,6 +26,8 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 // Mock @fusion/core to prevent cascade loading of real fs modules
 vi.mock("@fusion/core", () => ({
   summarizeTitle: vi.fn(),
+  // FNXC:DashboardChatTests 2026-07-08-12:00: FN-7675 added FUSION_RUNTIME_SELF_AWARENESS to chat.ts's @fusion/core imports (CHAT_SYSTEM_PROMPT embeds it). The hand-written core mock must stub it so chat.js loads; importOriginal is intentionally avoided to prevent the real fs cascade this mock exists to block.
+  FUSION_RUNTIME_SELF_AWARENESS: "",
   AgentStore: vi.fn(),
   ChatStore: vi.fn(),
   registerTraitHookImpl: vi.fn(),

--- a/packages/engine/src/__tests__/reliability-interactions/verification-followup-dedup.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/verification-followup-dedup.test.ts
@@ -195,6 +195,11 @@ describe("reliability interactions: verification follow-up dedup", () => {
   it("remains additive with FN-4892 same-agent duplicate intake", async () => {
     const fx = await createStore();
     fixtures.push(fx);
+    /*
+    FNXC:ReliabilityTests 2026-07-08-12:30:
+    FN-7658 gated same-agent duplicate auto-archiving behind autoArchiveDuplicateTasksEnabled (default false → flag-in-place in triage). This test asserts the ARCHIVE path is additive with verification follow-up dedup, so opt into the legacy archive behavior explicitly rather than asserting the new flag-in-place default.
+    */
+    await fx.store.updateSettings({ autoArchiveDuplicateTasksEnabled: true });
     const source = {
       sourceType: "api" as const,
       sourceAgentId: "agent-1",

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -6526,6 +6526,8 @@
       "addIgnoredPath": "",
       "archiveAgentLog": "",
       "archiveCompletedTasksAfterDays": "",
+      "autoArchiveDuplicateTasks": "",
+      "autoArchiveDuplicateTasksHelp": "",
       "backlogNoTaskAutoClaimIsExecutorOnly": "",
       "browse": "",
       "closeParenPeriod": "",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -6526,6 +6526,8 @@
       "addIgnoredPath": "",
       "archiveAgentLog": "",
       "archiveCompletedTasksAfterDays": "",
+      "autoArchiveDuplicateTasks": "",
+      "autoArchiveDuplicateTasksHelp": "",
       "backlogNoTaskAutoClaimIsExecutorOnly": "",
       "browse": "",
       "closeParenPeriod": "",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -6526,6 +6526,8 @@
       "addIgnoredPath": "",
       "archiveAgentLog": "",
       "archiveCompletedTasksAfterDays": "",
+      "autoArchiveDuplicateTasks": "",
+      "autoArchiveDuplicateTasksHelp": "",
       "backlogNoTaskAutoClaimIsExecutorOnly": "",
       "browse": "",
       "closeParenPeriod": "",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -6526,6 +6526,8 @@
       "addIgnoredPath": "",
       "archiveAgentLog": "",
       "archiveCompletedTasksAfterDays": "",
+      "autoArchiveDuplicateTasks": "",
+      "autoArchiveDuplicateTasksHelp": "",
       "backlogNoTaskAutoClaimIsExecutorOnly": "",
       "browse": "",
       "closeParenPeriod": "",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -6526,6 +6526,8 @@
       "addIgnoredPath": "",
       "archiveAgentLog": "",
       "archiveCompletedTasksAfterDays": "",
+      "autoArchiveDuplicateTasks": "",
+      "autoArchiveDuplicateTasksHelp": "",
       "backlogNoTaskAutoClaimIsExecutorOnly": "",
       "browse": "",
       "closeParenPeriod": "",


### PR DESCRIPTION
## Summary

Follow-up to #1947. The full-suite on `main` is still red on 3 surfaces introduced by post-#1947 commits. This PR fixes the two real test failures and the i18n parity gap.

## Fixes
- **i18n key parity (FN-7658)** — `settings.scheduling.autoArchiveDuplicateTasks` + `...Help` were added to `en` but not the 5 non-en catalogs, breaking the i18n parity gate (`parity.test.ts`, `i18n-gate-coverage.test.ts`). Added the 2 keys (empty-string per the untranslated-entry convention) to `zh-CN`, `zh-TW`, `fr`, `es`, `ko` in `packages/i18n/locales` (the single source of truth; `dashboard/app/locales` is gitignored and synced in CI).
- **chat.test.ts (FN-7675)** — `chat.ts` now imports `FUSION_RUNTIME_SELF_AWARENESS` from `@fusion/core` (CHAT_SYSTEM_PROMPT embeds it); the hand-written core mock didn't stub it, so the module failed to load. Added a stub (importOriginal intentionally avoided to preserve the fs-cascade block).
- **verification-followup-dedup.test.ts (FN-7658)** — the "remains additive with FN-4892 same-agent duplicate intake" test asserts the ARCHIVE path, but FN-7658 made same-agent auto-archiving opt-in (`autoArchiveDuplicateTasksEnabled` defaults false → flag-in-place in triage). The test now opts into the legacy archive behavior it asserts.

## Note on shard-2 engine[2/2] timeout
The full-suite shard 2 times out on `@fusion/engine [2/2]` (watchdog 900s). Locally `[2/2]` runs in ~96s and is green (the lone `provider-registration.test.ts` failure is local-only `pi-ai@0.79.9` staleness — the lockfile pins `0.80.3` which exports `/compat`, so CI resolves it). The `verification-followup-dedup` failure above is the only real `[2/2]` defect; this PR fixes it. If the CI timeout persists it's aggregate real-git load, which I'll address separately (not a code bug).

## Verification
- i18n `parity` + `i18n-gate-coverage`: 7/7 ✅
- `chat.test.ts`: 14/14 ✅
- `verification-followup-dedup`: 5/5 ✅
- engine `--shard=2/2` (excluding the local-staleness file): 363 files / 4483 tests ✅ in ~96s

No production behavior change; no changeset needed (i18n catalog + test-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduling settings for automatic duplicate-task archiving, including label and help text entries (currently placeholders) across Spanish, French, Korean, Simplified Chinese, and Traditional Chinese.
* **Bug Fixes**
  * Updated “awaiting confirmation” merger messaging to better reflect when auto-merge proceeds automatically.
* **Tests**
  * Updated reliability interaction tests to explicitly opt into legacy duplicate-task archiving behavior.
  * Adjusted chat-related tests by extending the runtime mock to satisfy a new core import requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->