### PR TITLE
fix(FUX-039): add release changeset for runtime-fallback viewport hardening

### DIFF
--- a/.changeset/fux-039-runtime-fallback-review-polish.md
+++ b/.changeset/fux-039-runtime-fallback-review-polish.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Prevent redundant polling and a re-render loop in agent-card runtime-fallback badges.
+category: fix
+dev: AgentsView now caches one stable ref callback per viewport key (avoids an infinite re-render loop when IntersectionObserver is unavailable) and evicts it on unmount; the test-only toast-dedupe reset is guarded to a no-op in production builds.


### PR DESCRIPTION
## Summary

`003948033` ("harden runtime-fallback agent-card viewport gating") landed on `main` **without a changeset**, but it affects published `@runfusion/fusion`. This PR adds the missing patch changeset so the fix shows up in release notes.

## Context

Supersedes the now-closed #1963, whose code was fully redundant with `main` — all four FUX-039 findings plus every Greptile/CodeRabbit review comment already shipped via `003948033` and the preceding FUX-039 commits. The only remaining gap was this release-notes entry.

## What the changeset documents

- **summary (user-facing):** Prevent redundant polling and a re-render loop in agent-card runtime-fallback badges.
- **category:** `fix`
- **dev:** `AgentsView` caches one stable ref callback per viewport key (avoids an infinite re-render loop when `IntersectionObserver` is unavailable) and evicts it on unmount; the test-only toast-dedupe reset is guarded to a no-op in production builds.

## Status

- Diff: a single new file under `.changeset/`. No production code changes.
- Gate: ✅ green — Lint, Typecheck, Build, and Gate all pass on `d8ce3f408`.
- An earlier revision also trimmed `fn-7692`'s over-length summary to unblock the gate, but `main` since fixed that itself in `5815cd170`, so this branch was rebased to drop the now-redundant commit. The diff is now purely the FUX-039 changeset.

🤖 Generated with an autonomous coding agent
