### PR TITLE
test: fix TaskCard/GraphTaskNode useToast + TaskDetailModal CSS selector-list regex (round 3)

### DIFF
--- a/packages/dashboard/app/components/__tests__/TaskCard.badge-height.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.badge-height.test.tsx
@@ -29,6 +29,13 @@ vi.mock("../ProviderIcon", () => ({
 vi.mock("../../hooks/useTaskDiffStats", () => ({
   useTaskDiffStats: () => ({ stats: null, loading: false }),
 }));
+vi.mock("../../hooks/useToast", () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+    toasts: [],
+  }),
+}));
 
 const noop = () => {};
 

--- a/packages/dashboard/app/components/__tests__/TaskCard.badge-wrap.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.badge-wrap.test.tsx
@@ -36,6 +36,13 @@ vi.mock("../PluginSlot", () => ({
 vi.mock("../../hooks/useTaskDiffStats", () => ({
   useTaskDiffStats: () => ({ stats: null, loading: false }),
 }));
+vi.mock("../../hooks/useToast", () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+    toasts: [],
+  }),
+}));
 
 const noop = () => {};
 

--- a/packages/dashboard/app/components/__tests__/TaskCard.footer-wrap.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.footer-wrap.test.tsx
@@ -60,6 +60,13 @@ vi.mock("../../api", () => ({
 vi.mock("../../hooks/useConfirm", () => ({
   useConfirm: () => ({ confirm: vi.fn(async () => true) }),
 }));
+vi.mock("../../hooks/useToast", () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+    toasts: [],
+  }),
+}));
 
 const noop = () => {};
 

--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.github-tracking-header.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.github-tracking-header.test.tsx
@@ -35,14 +35,18 @@ describe("FN-4224 GitHub tracking header layout", () => {
 
     const css = loadAllAppCss();
 
+    /*
+    FNXC:TaskDetailCSS 2026-07-08-13:00:
+    The github/gitlab tracking header rules were consolidated into a shared selector list (.detail-github-tracking-section .detail-source-header, .detail-gitlab-tracking-section .detail-source-header {…}), so the selector is no longer immediately followed by `{`. Allow the selector list (comma + sibling selector) between the tracked selector and the brace via [^{]* while still pinning the layout contract (flex-wrap/align-items/min-width).
+    */
     expect(css).toMatch(
-      /\.detail-github-tracking-section\s+\.detail-source-header\s*\{[^}]*flex-wrap:\s*nowrap;[^}]*align-items:\s*center;[^}]*min-width:\s*0;/,
+      /\.detail-github-tracking-section\s+\.detail-source-header[^{]*\{[^}]*flex-wrap:\s*nowrap;[^}]*align-items:\s*center;[^}]*min-width:\s*0;/,
     );
     expect(css).toMatch(
-      /\.detail-github-tracking-section\s+\.detail-source-summary\s*\{[^}]*flex:\s*1 1 auto;[^}]*flex-wrap:\s*nowrap;[^}]*min-width:\s*0;/,
+      /\.detail-github-tracking-section\s+\.detail-source-summary[^{]*\{[^}]*flex:\s*1 1 auto;[^}]*flex-wrap:\s*nowrap;[^}]*min-width:\s*0;/,
     );
     expect(css).toMatch(
-      /@media[^{]*\(max-width:\s*768px\)[^{]*\{[\s\S]*?\.detail-github-tracking-section\s+\.detail-source-header\s*\{[^}]*flex-wrap:\s*nowrap;[^}]*min-width:\s*0;[^}]*\}[\s\S]*?\.detail-github-tracking-section\s+\.detail-source-summary\s*\{[^}]*flex:\s*1 1 auto;[^}]*flex-wrap:\s*nowrap;[^}]*min-width:\s*0;[^}]*\}/,
+      /@media[^{]*\(max-width:\s*768px\)[^{]*\{[\s\S]*?\.detail-github-tracking-section\s+\.detail-source-header[^{]*\{[^}]*flex-wrap:\s*nowrap;[^}]*min-width:\s*0;[^}]*\}[\s\S]*?\.detail-github-tracking-section\s+\.detail-source-summary[^{]*\{[^}]*flex:\s*1 1 auto;[^}]*flex-wrap:\s*nowrap;[^}]*min-width:\s*0;[^}]*\}/,
     );
   });
 });

--- a/packages/engine/src/__tests__/step-session-executor.test.ts
+++ b/packages/engine/src/__tests__/step-session-executor.test.ts
@@ -1399,7 +1399,15 @@ describe("StepSessionExecutor", () => {
         agentStore: { saveRun } as any,
       } as any);
 
-      const results = await executor.executeAll();
+      // FNXC:EngineTests 2026-07-09-06:00:
+      // executeAll retries the failing step 3× with sleep() delays between attempts. With
+      // useFakeTimers({ shouldAdvanceTime: true }) these sleeps advance REAL wall-clock time if
+      // the test awaits executeAll directly (was 22.6s, ballooning under CI load and busting the
+      // shard-2 watchdog). Fast-forward the retry sleeps via fake timers like the sibling retry
+      // tests below, so the loop completes in milliseconds.
+      const resultsPromise = executor.executeAll();
+      await vi.advanceTimersByTimeAsync(60_000);
+      const results = await resultsPromise;
 
       expect(results).toEqual([{ stepIndex: 0, success: false, error: "boom", retries: 3, tokenUsage: undefined }]);
       const terminalRun = saveRun.mock.calls.at(-1)?.[0];

--- a/plugins/fusion-plugin-dependency-graph/src/__tests__/GraphTaskNode.drag.test.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/__tests__/GraphTaskNode.drag.test.tsx
@@ -3,6 +3,13 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type React from "react";
 import type { Task } from "@fusion/core";
 import { GraphTaskNode } from "../GraphTaskNode";
+/*
+FNXC:DependencyGraphTests 2026-07-08-13:10:
+GraphTaskNode renders the REAL TaskCard; TaskCard's RuntimeFallbackBadge calls the dashboard's useToast() hook, and this file has no ToastProvider. Mock useToast (same as the dashboard's own TaskCard.test.tsx) to avoid "useToast must be used within ToastProvider".
+*/
+vi.mock("@fusion/dashboard/app/hooks/useToast", () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn(), toasts: [] }),
+}));
 
 function task(id = "FN-1"): Task {
   return { id, description: id, column: "todo", dependencies: [], steps: [], currentStep: 0, log: [] } as Task;

--- a/plugins/fusion-plugin-dependency-graph/src/__tests__/GraphTaskNode.test.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/__tests__/GraphTaskNode.test.tsx
@@ -3,6 +3,13 @@ import type { Task } from "@fusion/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TaskCard } from "@fusion/dashboard/app/components/TaskCard";
 import { GraphTaskNode } from "../GraphTaskNode";
+/*
+FNXC:DependencyGraphTests 2026-07-08-13:10:
+GraphTaskNode renders the REAL TaskCard (to verify prop pass-through), and TaskCard now renders RuntimeFallbackBadge which calls the dashboard's useToast() hook. This file has no ToastProvider, so mock useToast the same way the dashboard's own TaskCard.test.tsx does to avoid "useToast must be used within ToastProvider".
+*/
+vi.mock("@fusion/dashboard/app/hooks/useToast", () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn(), toasts: [] }),
+}));
 
 function createTask(overrides: Partial<Task> = {}): Task {
   return {


### PR DESCRIPTION
## Summary

Round 3 of full-suite greening on `main`. The post-#1965 full-suite still failed on 6 UI/CSS test files in shards 3+4 (pre-existing test-drift from recent UI commits, surfaced after the chat/i18n fixes landed). All fixed.

## Fixes (all test-only; no production change)
- **TaskCard badge/footer tests** (`TaskCard.badge-height`, `TaskCard.badge-wrap`, `TaskCard.footer-wrap`) — `RuntimeFallbackBadge` now calls the dashboard `useToast()` hook, but these suites render `<TaskCard>` without a `ToastProvider`. Added the `useToast` mock (same pattern as the sibling `TaskCard.test.tsx` and `PlanningModeModal` suites).
- **`TaskDetailModal.github-tracking-header`** — the github/gitlab tracking header CSS rules were consolidated into a shared selector list (`.detail-github-tracking-section .detail-source-header, .detail-gitlab-tracking-section .detail-source-header {…}`), so the test's `\s*\{` (selector immediately followed by `{`) no longer matched. Updated the 3 CSS regexes to `[^{]*\{` to tolerate the selector list while still pinning the layout contract.
- **`GraphTaskNode` tests** (`fusion-plugin-dependency-graph`) — same `useToast` issue: `GraphTaskNode` renders the REAL `TaskCard` (to verify prop pass-through, unlike sibling suites that mock it), hitting `RuntimeFallbackBadge`→`useToast`. Added the `@fusion/dashboard/app/hooks/useToast` mock to both files.

## Note on shard-2 engine[2/2]
Shard 2 still times out (watchdog 900s) on `@fusion/engine [2/2]`. This is the engine-reliability real-git tier running single-threaded under 4-shard concurrent load — locally `[2/2]` is ~96s and green. It's slow-test-debt / CI-load, not a code bug in these commits; I'm investigating the specific slow/hanging file separately (the silent CI reporter hides it).

## Verification
- TaskCard badge/footer: 14/14 ✅
- TaskDetailModal.github-tracking-header: 1/1 ✅
- GraphTaskNode + GraphTaskNode.drag: 29/29 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Stabilized several dashboard and dependency-graph test suites by mocking toast behavior to prevent provider-related failures.
  * Improved robustness of task card and graph node interaction tests.
  * Updated task detail modal CSS/layout assertions to better align with current responsive styling and selector patterns.
  * Reduced test flakiness for step-session retry timing by using controlled fake-timer advancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->