### PR TITLE
fix(dashboard): Memory view layout dead space, unlabeled toolbar, toggle alignment

### DIFF
--- a/.changeset/memory-view-polish.md
+++ b/.changeset/memory-view-polish.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Polish the Memory view: centered layout, labeled editor toolbar, aligned toggle rows.
+category: fix
+dev: MemoryView tabs get a 960px centered column; FileEditor instances pass forceToolbarActionsVisible; new i18n key memory.dreamsEnabledTooltip.

--- a/packages/dashboard/app/components/MemoryView.css
+++ b/packages/dashboard/app/components/MemoryView.css
@@ -59,6 +59,12 @@ After the header migrated to the shared .view-header (which is flex-shrink:0), t
   padding: 0 var(--space-lg) var(--space-lg);
 }
 
+/*
+FNXC:MemoryView 2026-07-10-14:30:
+First-run review on a wide desktop viewport: the Working Memory content hugged the left half of the view and the entire right half was empty background.
+Cap each tab pane to a readable content-column width and center it with auto inline margins, matching the app convention for wide layouts (e.g. .project-overview__body caps and centers its scroll body).
+The pane stays the scroll owner; width:100% keeps narrow/mobile viewports (max-width: 768px / max-height: 480px breakpoint) unchanged because the cap only bites above it.
+*/
 .memory-working-tab,
 .memory-insights-tab,
 .memory-engines-tab {
@@ -67,6 +73,9 @@ After the header migrated to the shared .view-header (which is flex-shrink:0), t
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  width: 100%;
+  max-width: 960px;
+  margin-inline: auto;
 }
 
 /*
@@ -433,6 +442,23 @@ The memory editor box is CAPPED to about a page (max-height: 60vh) so a long mem
   border-radius: var(--radius-md);
   background: var(--surface);
   padding: var(--space-sm) 0;
+}
+
+/*
+FNXC:MemoryView 2026-07-10-14:30:
+Shared layout for the automation checkbox rows ("Process dreams from daily memory", "Auto-summarize memory").
+Both rows must render identically: checkbox and label on one line, and the hint text indented to start where the label text starts (checkbox width 16px + the .checkbox-label gap), instead of hanging at the form-group edge with row-dependent spacing.
+Scoped under .memory-working-tab so these rules out-specify same-name form rules from SettingsModal.css (imported after this file).
+*/
+.memory-working-tab .memory-toggle-row .checkbox-label {
+  align-items: center;
+}
+
+.memory-working-tab .memory-toggle-row > small {
+  display: block;
+  margin-top: var(--space-xs);
+  margin-left: calc(16px + var(--space-sm));
+  color: var(--text-muted);
 }
 
 .memory-flex-spacer {

--- a/packages/dashboard/app/components/MemoryView.css
+++ b/packages/dashboard/app/components/MemoryView.css
@@ -62,8 +62,9 @@ After the header migrated to the shared .view-header (which is flex-shrink:0), t
 /*
 FNXC:MemoryView 2026-07-10-14:30:
 First-run review on a wide desktop viewport: the Working Memory content hugged the left half of the view and the entire right half was empty background.
-Cap each tab pane to a readable content-column width and center it with auto inline margins, matching the app convention for wide layouts (e.g. .project-overview__body caps and centers its scroll body).
-The pane stays the scroll owner; width:100% keeps narrow/mobile viewports (max-width: 768px / max-height: 480px breakpoint) unchanged because the cap only bites above it.
+
+FNXC:MemoryView 2026-07-10-18:45:
+Operator follow-up: the Memory tabs should use the FULL viewport width, not a centered 960px reading column — the editor benefits from every pixel. Each tab pane stretches to 100% and stays the scroll owner; the mobile breakpoint (max-width: 768px / max-height: 480px) is unaffected.
 */
 .memory-working-tab,
 .memory-insights-tab,
@@ -74,8 +75,6 @@ The pane stays the scroll owner; width:100% keeps narrow/mobile viewports (max-w
   flex-direction: column;
   overflow-y: auto;
   width: 100%;
-  max-width: 960px;
-  margin-inline: auto;
 }
 
 /*

--- a/packages/dashboard/app/components/MemoryView.tsx
+++ b/packages/dashboard/app/components/MemoryView.tsx
@@ -450,11 +450,17 @@ export function MemoryView({ projectId, addToast, onSendSelectionToTask }: Memor
                     <label>{selectedMemoryFile?.label || t("memory.editorLabel", "Memory Editor")}</label>
                     <small>{selectedLayerDescription}</small>
                     <div className="memory-editor-container">
+                      {/*
+                      FNXC:MemoryView 2026-07-10-14:30:
+                      First-run review: the FileEditor's collapsed toolbar rendered as an unlabeled empty bar with only a chevron above the editor, and a user asked "what is this button?".
+                      Force the toolbar actions (Edit/Preview/Wrap) to stay visible so the toolbar always shows labeled controls instead of a mystery chevron-only bar.
+                      */}
                       <FileEditor
                         content={selectedFileContent}
                         onChange={setSelectedFileContent}
                         readOnly={!isWritable}
                         filePath={selectedFilePath}
+                        forceToolbarActionsVisible
                         onSendSelectionToTask={onSendSelectionToTask}
                       />
                     </div>
@@ -501,9 +507,19 @@ export function MemoryView({ projectId, addToast, onSendSelectionToTask }: Memor
                 </div>
 
                 <div className="memory-config-section">
+                  {/*
+                  FNXC:MemoryView 2026-07-10-14:30:
+                  First-run review: the two automation checkbox rows ("Process dreams from daily memory" / "Auto-Summarize Memory") had inconsistent checkbox/label/hint alignment and mixed casing (sentence case vs Title Case).
+                  Both rows now share the .memory-toggle-row layout (hint indented under the label text, aligned past the checkbox) and use sentence-case labels.
+                  The dreams row also carries a hover tooltip (title attr) explaining the pipeline: daily notes are distilled into DREAMS.md and reusable lessons are promoted into MEMORY.md.
+                  */}
                   <div className="memory-settings-group">
-                    <div className="form-group">
-                      <label htmlFor="memoryDreamsEnabled" className="checkbox-label">
+                    <div className="form-group memory-toggle-row">
+                      <label
+                        htmlFor="memoryDreamsEnabled"
+                        className="checkbox-label"
+                        title={t("memory.dreamsEnabledTooltip", "Daily notes are distilled into DREAMS.md and reusable lessons are promoted into MEMORY.md.")}
+                      >
                         <input
                           id="memoryDreamsEnabled"
                           type="checkbox"
@@ -564,7 +580,7 @@ export function MemoryView({ projectId, addToast, onSendSelectionToTask }: Memor
                   </div>
 
                   <div className="memory-settings-group">
-                    <div className="form-group">
+                    <div className="form-group memory-toggle-row">
                       <label htmlFor="memoryAutoSummarizeEnabled" className="checkbox-label">
                         <input
                           id="memoryAutoSummarizeEnabled"
@@ -578,9 +594,9 @@ export function MemoryView({ projectId, addToast, onSendSelectionToTask }: Memor
                           }}
                           disabled={!memorySettingsDraft.memoryEnabled || settingsLoading}
                         />
-                        {t("memory.autoSummarizeLabel", "Auto-Summarize Memory")}
+                        {t("memory.autoSummarizeLabel", "Auto-summarize memory")}
                       </label>
-                      <small>{t("memory.autoSummarizeHint", "Automatically compact memory when it exceeds the threshold on a schedule")}</small>
+                      <small>{t("memory.autoSummarizeHint", "Automatically compacts memory when it exceeds the threshold on a schedule.")}</small>
                     </div>
 
                     {memorySettingsDraft.memoryEnabled && memorySettingsDraft.memoryAutoSummarizeEnabled && (
@@ -668,11 +684,16 @@ export function MemoryView({ projectId, addToast, onSendSelectionToTask }: Memor
               // Raw editor mode
               <div className="memory-insights-editor-layout">
                 <div className="memory-editor-container">
+                  {/*
+                  FNXC:MemoryView 2026-07-10-14:30:
+                  Same as the working-memory editor: keep toolbar actions visible so no unlabeled chevron-only bar renders above the raw insights editor.
+                  */}
                   <FileEditor
                     content={insightsEditorContent ?? ""}
                     onChange={setInsightsEditorContent}
                     readOnly={false}
                     filePath=".fusion/memory/INSIGHTS.md"
+                    forceToolbarActionsVisible
                     onSendSelectionToTask={onSendSelectionToTask}
                   />
                 </div>

--- a/packages/i18n/locales/en/app.json
+++ b/packages/i18n/locales/en/app.json
@@ -3403,8 +3403,8 @@
   },
   "memory": {
     "auditChecksTitle": "Audit Checks",
-    "autoSummarizeHint": "Automatically compact memory when it exceeds the threshold on a schedule",
-    "autoSummarizeLabel": "Auto-Summarize Memory",
+    "autoSummarizeHint": "Automatically compacts memory when it exceeds the threshold on a schedule.",
+    "autoSummarizeLabel": "Auto-summarize memory",
     "autoSummarizeScheduleHint": "Cron expression for auto-summarize schedule (default: daily at 3 AM)",
     "autoSummarizeScheduleLabel": "Schedule (cron)",
     "backendFile": "File (.fusion/memory/, agent/<agent-name>/memory/)",
@@ -3433,6 +3433,7 @@
     "dreamProcessingFailed": "Failed to run dream processing",
     "dreamsEnabledHint": "Turns daily notes into DREAMS.md and promotes reusable lessons into MEMORY.md.",
     "dreamsEnabledLabel": "Process dreams from daily memory",
+    "dreamsEnabledTooltip": "Daily notes are distilled into DREAMS.md and reusable lessons are promoted into MEMORY.md.",
     "dreamsScheduleHint": "Cron expression for dream processing.",
     "dreamsScheduleLabel": "Dream Schedule",
     "editorDefaultDescription": "Edits the selected memory file.",

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -3422,6 +3422,7 @@
     "dreamProcessingFailed": "Error al ejecutar el procesamiento de sueños",
     "dreamsEnabledHint": "Convierte las notas diarias en DREAMS.md y promueve las lecciones reutilizables en MEMORY.md.",
     "dreamsEnabledLabel": "Procesar sueños desde la memoria diaria",
+    "dreamsEnabledTooltip": "Las notas diarias se destilan en DREAMS.md y las lecciones reutilizables se promueven a MEMORY.md.",
     "dreamsScheduleHint": "Expresión cron para el procesamiento de sueños.",
     "dreamsScheduleLabel": "Programación de sueños",
     "editorDefaultDescription": "Edita el archivo de memoria seleccionado.",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -3422,6 +3422,7 @@
     "dreamProcessingFailed": "Échec du traitement des rêves",
     "dreamsEnabledHint": "Transforme les notes quotidiennes en DREAMS.md et promeut les leçons réutilisables dans MEMORY.md.",
     "dreamsEnabledLabel": "Traiter les rêves depuis la mémoire quotidienne",
+    "dreamsEnabledTooltip": "Les notes quotidiennes sont distillées dans DREAMS.md et les leçons réutilisables sont promues dans MEMORY.md.",
     "dreamsScheduleHint": "Expression cron pour le traitement des rêves.",
     "dreamsScheduleLabel": "Planification des rêves",
     "editorDefaultDescription": "Modifie le fichier mémoire sélectionné.",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -3422,6 +3422,7 @@
     "dreamProcessingFailed": "드림 처리 실행에 실패했습니다",
     "dreamsEnabledHint": "일일 메모를 DREAMS.md로 변환하고 재사용 가능한 교훈을 MEMORY.md로 승격합니다.",
     "dreamsEnabledLabel": "일일 메모리에서 드림 처리",
+    "dreamsEnabledTooltip": "일일 노트는 DREAMS.md로 정제되고 재사용 가능한 교훈은 MEMORY.md로 승격됩니다.",
     "dreamsScheduleHint": "드림 처리의 크론 표현식입니다.",
     "dreamsScheduleLabel": "드림 일정",
     "editorDefaultDescription": "선택한 메모리 파일을 편집합니다.",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -3422,6 +3422,7 @@
     "dreamProcessingFailed": "运行梦境处理失败",
     "dreamsEnabledHint": "将每日笔记转换为 DREAMS.md，并将可复用的经验提升到 MEMORY.md。",
     "dreamsEnabledLabel": "从每日记忆中处理梦境",
+    "dreamsEnabledTooltip": "每日笔记会被提炼到 DREAMS.md，可复用的经验会被提升到 MEMORY.md。",
     "dreamsScheduleHint": "梦境处理的 Cron 表达式。",
     "dreamsScheduleLabel": "梦境计划",
     "editorDefaultDescription": "编辑所选记忆文件。",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -3422,6 +3422,7 @@
     "dreamProcessingFailed": "執行夢境處理失敗",
     "dreamsEnabledHint": "將每日筆記轉換為 DREAMS.md，並將可重用的經驗提升至 MEMORY.md。",
     "dreamsEnabledLabel": "從每日記憶中處理夢境",
+    "dreamsEnabledTooltip": "每日筆記會被提煉到 DREAMS.md，可重複使用的經驗會被提升到 MEMORY.md。",
     "dreamsScheduleHint": "夢境處理的 Cron 表達式。",
     "dreamsScheduleLabel": "夢境排程",
     "editorDefaultDescription": "編輯所選記憶檔案。",


### PR DESCRIPTION
## What
First-run review feedback (Loom walkthrough) on the Memory view:
- **Dead space**: on wide viewports the Working Memory content hugged the left half, leaving the right half empty. Tabs now stretch to the full width of the view (initially shipped as a centered 960px column; widened to full width per operator follow-up).
- **Mystery control**: the unlabeled bar with a lone chevron above the editor was the FileEditor's collapsed toolbar. MemoryView now passes `forceToolbarActionsVisible` so the labeled actions (Edit/Preview, Wrap, Line #) always show.
- **Toggle rows**: 'Process dreams from daily memory' and 'Auto-Summarize Memory' had inconsistent alignment/casing. They now share one `.memory-toggle-row` layout, sentence case, and the dreams row has a tooltip explaining DREAMS.md/MEMORY.md promotion (new i18n key in all 6 locales).

## Verification
- `vitest run MemoryView.test.tsx SettingsModal.memory-css.test.ts SettingsModal.memory-editor.test.ts i18n-string-keys-not-objects.test.ts`: 4 files, 17 tests passed.
- `pnpm --filter @fusion/dashboard typecheck`: clean.
- Known pre-existing i18n parity failure (`chat.noMessage` missing in zh-CN) exists at main and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Polished the Memory view layout, including full-width tab panes on wide screens.
  * Ensured editor toolbar actions remain visibly labeled.
  * Refined automation toggle row alignment, spacing, and hint formatting.
  * Added a labeled Dreams tooltip and updated auto-summarize copy.

* **Localization**
  * Added/updated the new `memory.dreamsEnabledTooltip` string across English, Spanish, French, Korean, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots
| Before (Loom) | After |
|---|---|
| <img src="https://raw.githubusercontent.com/Runfusion/Fusion/assets/loom-review-2026-07/loom-review-2026-07/1987-before.png" width="420"> | <img src="https://raw.githubusercontent.com/Runfusion/Fusion/assets/loom-review-2026-07/loom-review-2026-07/1987-after-fullwidth.png" width="420"> |

Toggle rows after the alignment/casing pass:

<img src="https://raw.githubusercontent.com/Runfusion/Fusion/assets/loom-review-2026-07/loom-review-2026-07/1987-after-toggles-v2.png" width="600">