### PR TITLE
fix(dashboard): Artifacts 'Add comment' did nothing — trigger teleported mid-press

### DIFF
--- a/.changeset/artifacts-add-comment-active-transform.md
+++ b/.changeset/artifacts-add-comment-active-transform.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Fix the Artifacts preview "Add comment" button doing nothing when clicked, and label the preview as read-only.
+category: fix
+dev: The global `.btn:active { transform: scale(0.97) }` press feedback replaced the selection-comment trigger's positioning translate while the mouse was held, moving the button out from under the cursor so `click` never fired. `.selection-comment-trigger:active` now restates the translate (desktop and mobile), covering DocumentsView and FileEditor surfaces. The Artifacts project-file preview header also gains a `documents.readOnly` badge.

--- a/packages/dashboard/app/components/DocumentsView.css
+++ b/packages/dashboard/app/components/DocumentsView.css
@@ -318,6 +318,19 @@ Artifacts controls are the first page content below the shared header, so add a 
   flex: 1;
 }
 
+/*
+FNXC:ArtifactsView 2026-07-10-16:10:
+Subtle view-only indicator for the project-file preview header; muted so it informs without competing with the Plain/Markdown toggle. Shared markup serves desktop and mobile.
+*/
+.documents-readonly-badge {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
 .documents-content-viewer-text {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);

--- a/packages/dashboard/app/components/DocumentsView.tsx
+++ b/packages/dashboard/app/components/DocumentsView.tsx
@@ -744,6 +744,16 @@ export function DocumentsView({ projectId, addToast, onOpenDetail, onOpenArtifac
                     <div className="documents-content-viewer">
                       <div className="documents-content-header">
                         <p className="documents-file-path-header">{selectedFile.path}</p>
+                        {/*
+                        FNXC:ArtifactsView 2026-07-10-16:10:
+                        First-run review feedback: the Artifacts preview pane did not communicate whether documents are editable. This pane is view-only (there is no editor here — editing happens elsewhere, e.g. the workspace FileEditor), so a persistent Read-only badge states that explicitly on both desktop and mobile. Select-to-comment still works and is the intended interaction.
+                        */}
+                        <span
+                          className="documents-readonly-badge badge"
+                          title={t("documents.readOnlyHint", "This preview is read-only. Select text to comment and send it to a new task.")}
+                        >
+                          {t("documents.readOnly", "Read-only")}
+                        </span>
                         <button
                           className="btn btn-sm document-mode-toggle"
                           onClick={() => setRenderProjectMarkdown((prev) => !prev)}

--- a/packages/dashboard/app/components/SelectionCommentPopover.css
+++ b/packages/dashboard/app/components/SelectionCommentPopover.css
@@ -12,6 +12,24 @@
   white-space: nowrap;
 }
 
+/*
+FNXC:ArtifactsView 2026-07-10-16:05:
+The "Add comment" trigger is positioned entirely by its transform translate. The global
+`.btn:active { transform: scale(0.97) }` press feedback REPLACED that translate while the
+mouse button was held, teleporting the trigger about half its width right and one spacing
+unit down between mousedown and mouseup, so the browser never dispatched `click` on the
+button and the comment composer silently never opened (user-reported no-op while viewing a
+markdown file in the Artifacts view; reproduced with real mouse events — jsdom clicks
+cannot catch this).
+Every :active override here must restate the positioning translate alongside the press
+feedback so the trigger stays under the cursor for the whole press. This one shared rule
+covers all popover surfaces: DocumentsView project-file preview (plain and markdown) and
+FileEditor (editor and preview), desktop and mobile.
+*/
+.selection-comment-trigger:active {
+  transform: translate(-50%, calc(-1 * var(--space-xl))) scale(0.97);
+}
+
 .selection-comment-panel {
   width: min(var(--selection-comment-panel-width, calc(var(--space-2xl) * 12)), calc(100vw - (var(--space-lg) * 2)));
   transform: translate(-50%, var(--space-xs));
@@ -60,6 +78,16 @@
 
   .selection-comment-trigger {
     transform: translate(-50%, calc(-1 * var(--space-2xl)));
+  }
+
+  /*
+  FNXC:ArtifactsView 2026-07-10-16:05:
+  Mobile uses a taller lift, so its :active rule must restate the mobile translate too —
+  otherwise the desktop :active rule (space-xl) would snap the pressed trigger to the
+  desktop offset and reintroduce the missed-click no-op on touch/landscape-phone widths.
+  */
+  .selection-comment-trigger:active {
+    transform: translate(-50%, calc(-1 * var(--space-2xl))) scale(0.97);
   }
 
   .selection-comment-actions {

--- a/packages/dashboard/app/components/SelectionCommentPopover.css
+++ b/packages/dashboard/app/components/SelectionCommentPopover.css
@@ -30,8 +30,26 @@ FileEditor (editor and preview), desktop and mobile.
   transform: translate(-50%, calc(-1 * var(--space-xl))) scale(0.97);
 }
 
+/*
+FNXC:ArtifactsView 2026-07-10-18:20:
+The composer panel carries the shared `.card` class, and `.card { position: relative }` loads AFTER
+this file in the bundle, so at equal specificity it silently replaced the panel's `position: fixed`.
+The panel then flowed inside `.documents-content-viewer` with the left/top vars applied as relative
+offsets — rendering clipped at the bottom-right of the viewport nowhere near the selection.
+`.selection-comment-panel.card` (0,2,0) makes the fixed positioning immune to bundle order.
+The `left` clamp keeps the whole panel inside the viewport on every width: it accounts for half the
+panel width (the panel is centered on the selection via translate(-50%)), and the `top` clamp stops
+a selection near the bottom of the viewport from pushing the composer off-screen.
+*/
+.selection-comment-panel.card {
+  position: fixed;
+}
+
 .selection-comment-panel {
-  width: min(var(--selection-comment-panel-width, calc(var(--space-2xl) * 12)), calc(100vw - (var(--space-lg) * 2)));
+  --scp-width: min(var(--selection-comment-panel-width, calc(var(--space-2xl) * 12)), calc(100vw - (var(--space-lg) * 2)));
+  width: var(--scp-width);
+  left: clamp(calc(var(--space-lg) + (var(--scp-width) / 2)), var(--selection-comment-left), calc(100vw - var(--space-lg) - (var(--scp-width) / 2)));
+  top: min(var(--selection-comment-top), calc(100vh - var(--space-lg) - 20rem));
   transform: translate(-50%, var(--space-xs));
   padding: var(--space-md);
   display: flex;
@@ -71,8 +89,13 @@ FileEditor (editor and preview), desktop and mobile.
 }
 
 @media (max-width: 768px) {
-  .selection-comment-trigger,
-  .selection-comment-panel {
+  /*
+  FNXC:ArtifactsView 2026-07-10-18:20:
+  Only the trigger keeps the simple center-point clamp here — the panel's base rule already applies
+  a width-aware clamp on all viewports, and re-declaring `left` in this later block would override
+  it with a clamp that lets half the panel hang past the edge.
+  */
+  .selection-comment-trigger {
     left: max(var(--space-lg), min(var(--selection-comment-left), calc(100vw - var(--space-lg))));
   }
 

--- a/packages/dashboard/app/components/SelectionCommentPopover.tsx
+++ b/packages/dashboard/app/components/SelectionCommentPopover.tsx
@@ -87,7 +87,14 @@ export function SelectionCommentPopover({
 
   useEffect(() => {
     if (!expanded) return;
-    textareaRef.current?.focus();
+    /*
+    FNXC:ArtifactsView 2026-07-10-18:20:
+    The panel is position:fixed, so the default focus scroll-into-view is meaningless for it — but
+    the browser still scrolled the underlying preview pane, yanking the selected content out of
+    view the moment the composer opened. preventScroll keeps the pane exactly where the user
+    selected the text.
+    */
+    textareaRef.current?.focus({ preventScroll: true });
   }, [expanded]);
 
   const setPanelExpanded = useCallback((open: boolean) => {

--- a/packages/dashboard/app/components/__tests__/DocumentsView.test.tsx
+++ b/packages/dashboard/app/components/__tests__/DocumentsView.test.tsx
@@ -567,6 +567,24 @@ describe("DocumentsView", () => {
     expect(await screen.findByText(/Hello docs/)).toBeInTheDocument();
   });
 
+  /*
+  FNXC:ArtifactsView 2026-07-10-16:20:
+  First-run review: the preview pane did not communicate that it is view-only. The Read-only
+  badge must render with the preview header in BOTH render modes (plain and markdown) — the
+  header markup is shared between desktop and mobile layouts.
+  */
+  it("shows a Read-only badge in the project file preview header in plain and markdown modes", async () => {
+    render(<DocumentsView addToast={addToast} onOpenDetail={onOpenDetail} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open README.md" }));
+    await screen.findByText(/Hello docs/);
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /switch to markdown/i }));
+    await screen.findByText("Hello docs");
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
+  });
+
   it("sends selected plain project file preview text to a new task description", async () => {
     mockSelectionRect();
     const onSendSelectionToTask = vi.fn();

--- a/packages/dashboard/app/components/__tests__/SelectionCommentPopover.test.tsx
+++ b/packages/dashboard/app/components/__tests__/SelectionCommentPopover.test.tsx
@@ -104,6 +104,35 @@ describe("SelectionCommentPopover", () => {
     expect(activeBlocks.length, "both desktop and mobile need an :active override that restates the translate").toBeGreaterThanOrEqual(2);
   });
 
+  /*
+  FNXC:ArtifactsView 2026-07-10-18:20:
+  Regression guard for the composer-panel drift: the panel carries the shared `.card` class, and
+  `.card { position: relative }` loads after this stylesheet, so a bare `.selection-comment-panel`
+  rule lost `position: fixed` to bundle order and the panel rendered clipped at the viewport's
+  bottom-right, far from the selection. The fixed positioning must live on a selector that
+  out-specifies `.card` regardless of order, and the panel's `left` must be a width-aware clamp so
+  a selection near a viewport edge cannot push half the panel off-screen.
+  */
+  it("keeps the composer panel fixed-positioned over .card and clamps it inside the viewport", () => {
+    const css = readFileSync(join(__dirname, "..", "SelectionCommentPopover.css"), "utf8");
+    const uncommented = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+    const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+    const blocks = [...uncommented.matchAll(rulePattern)].map((m) => ({ selector: m[1].trim(), block: m[2] }));
+
+    const fixedOverCard = blocks.find(({ selector, block }) =>
+      selector.split(",").some((part) => {
+        const s = part.trim();
+        return s.includes(".selection-comment-panel") && s.includes(".card");
+      }) && /position\s*:\s*fixed/.test(block));
+    expect(fixedOverCard, "a .selection-comment-panel selector compounded with .card must restate position: fixed").toBeTruthy();
+
+    const panelBlocks = blocks.filter(({ selector }) => selector.split(",").some((p) => p.trim() === ".selection-comment-panel"));
+    const clampBlock = panelBlocks.find(({ block }) => /left\s*:\s*clamp\(/.test(block));
+    expect(clampBlock, "panel must declare a width-aware left clamp").toBeTruthy();
+    expect(clampBlock!.block, "left clamp must account for half the panel width").toContain("--scp-width) / 2");
+  });
+
   it("uses a longer markdown fence when the snippet contains backticks", () => {
     expect(composeSelectionCommentDescription({
       filePath: "README.md",

--- a/packages/dashboard/app/components/__tests__/SelectionCommentPopover.test.tsx
+++ b/packages/dashboard/app/components/__tests__/SelectionCommentPopover.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { SelectionCommentPopover, composeSelectionCommentDescription } from "../SelectionCommentPopover";
@@ -63,6 +65,43 @@ describe("SelectionCommentPopover", () => {
     expect(onOpenChange).toHaveBeenCalledWith(true);
     expect(onOpenChange).toHaveBeenLastCalledWith(false);
     expect(screen.getByRole("button", { name: /add a comment/i })).toBeInTheDocument();
+  });
+
+  /*
+  FNXC:ArtifactsView 2026-07-10-16:20:
+  Regression guard for the "Add comment does nothing" bug: the trigger is positioned solely
+  by its transform translate, and the global `.btn:active { transform: scale(0.97) }` press
+  feedback replaced it while pressed, moving the button out from under the cursor so `click`
+  never fired. jsdom cannot reproduce hit-testing, so this invariant is asserted on the CSS:
+  every `.selection-comment-trigger` transform rule — base AND :active, desktop AND mobile —
+  must include the `translate(-50%` positioning component. The popover is shared by
+  DocumentsView (plain + markdown preview) and FileEditor (editor + preview), so this one
+  stylesheet invariant covers all surfaces.
+  */
+  it("keeps the positioning translate in every trigger transform, including :active press state", () => {
+    const css = readFileSync(join(__dirname, "..", "SelectionCommentPopover.css"), "utf8");
+    const uncommented = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+    // Collect the declaration block of every rule whose selector list targets the trigger.
+    const triggerBlocks: Array<{ selector: string; block: string }> = [];
+    const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+    for (const match of uncommented.matchAll(rulePattern)) {
+      const selector = match[1].trim();
+      if (selector.split(",").some((part) => part.trim().startsWith(".selection-comment-trigger"))) {
+        triggerBlocks.push({ selector, block: match[2] });
+      }
+    }
+
+    const transformBlocks = triggerBlocks.filter(({ block }) => /transform\s*:/.test(block));
+    // Base + :active on desktop, base + :active in the mobile media query.
+    expect(transformBlocks.length).toBeGreaterThanOrEqual(4);
+
+    for (const { selector, block } of transformBlocks) {
+      expect(block, `trigger transform for "${selector}" must keep the positioning translate`).toContain("translate(-50%");
+    }
+
+    const activeBlocks = transformBlocks.filter(({ selector }) => selector.includes(":active"));
+    expect(activeBlocks.length, "both desktop and mobile need an :active override that restates the translate").toBeGreaterThanOrEqual(2);
   });
 
   it("uses a longer markdown fence when the snippet contains backticks", () => {

--- a/packages/i18n/locales/en/app.json
+++ b/packages/i18n/locales/en/app.json
@@ -2250,6 +2250,8 @@
     "projectFiles": "project files",
     "projectFilesTab": "Project Files",
     "projectMarkdownFilesLabel": "Project markdown files",
+    "readOnly": "Read-only",
+    "readOnlyHint": "This preview is read-only. Select text to comment and send it to a new task.",
     "resultCount_one": "{{count}} result{{plural}}",
     "resultCount_other": "{{count}} result{{plural}}",
     "retry": "Retry",

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -2281,7 +2281,9 @@
     "closeLightbox": "Close artifact preview",
     "expandArtifact": "Expand {{title}}",
     "expandArtifactHint": "Click to expand",
-    "lightboxLabel": "Artifact media preview"
+    "lightboxLabel": "Artifact media preview",
+    "readOnly": "",
+    "readOnlyHint": ""
   },
   "droidCli": {
     "active": "Activo",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -2281,7 +2281,9 @@
     "closeLightbox": "Close artifact preview",
     "expandArtifact": "Expand {{title}}",
     "expandArtifactHint": "Click to expand",
-    "lightboxLabel": "Artifact media preview"
+    "lightboxLabel": "Artifact media preview",
+    "readOnly": "",
+    "readOnlyHint": ""
   },
   "droidCli": {
     "active": "Actif",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -2281,7 +2281,9 @@
     "closeLightbox": "Close artifact preview",
     "expandArtifact": "Expand {{title}}",
     "expandArtifactHint": "Click to expand",
-    "lightboxLabel": "Artifact media preview"
+    "lightboxLabel": "Artifact media preview",
+    "readOnly": "",
+    "readOnlyHint": ""
   },
   "droidCli": {
     "active": "활성",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -2281,7 +2281,9 @@
     "closeLightbox": "Close artifact preview",
     "expandArtifact": "Expand {{title}}",
     "expandArtifactHint": "Click to expand",
-    "lightboxLabel": "Artifact media preview"
+    "lightboxLabel": "Artifact media preview",
+    "readOnly": "",
+    "readOnlyHint": ""
   },
   "droidCli": {
     "active": "活跃",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -2281,7 +2281,9 @@
     "closeLightbox": "Close artifact preview",
     "expandArtifact": "Expand {{title}}",
     "expandArtifactHint": "Click to expand",
-    "lightboxLabel": "Artifact media preview"
+    "lightboxLabel": "Artifact media preview",
+    "readOnly": "",
+    "readOnlyHint": ""
   },
   "droidCli": {
     "active": "活躍",


### PR DESCRIPTION
## What
First-run review feedback (Loom walkthrough): selecting text in an Artifacts/Documents preview and pressing 'Add comment' did nothing.

**Root cause**: the selection-comment trigger is a `position: fixed` button positioned entirely by its CSS transform (`translate(-50%, …)`). The global press-feedback rule `.btn:active { transform: scale(0.97) }` has higher specificity, so during the press the positioning translate was *replaced* by the scale — the button teleported ~half its width away while the mouse was down, mouseup landed elsewhere, and `click` never fired on the button. Proven against a real browser via CDP (rect jumped x 590→652 mid-press; event log showed mousedown on trigger, mouseup on the underlying `<pre>`). jsdom tests were green because jsdom does no hit-testing.

**Fix**: `.selection-comment-trigger:active` restates the positioning translate alongside `scale(0.97)` for both desktop and mobile offsets — one shared fix covering every popover surface (DocumentsView plain + markdown previews, FileEditor editor + preview). Validated live: drag-select → click now opens the composer and the comment flows to 'Send to new task'.

Also: document previews now show a subtle **Read-only** badge (with a hint that selecting text creates a comment/task), addressing the reviewer's confusion about whether artifacts are editable. The popover isn't rendered in Task Documents/Artifacts tabs, so no dead affordance existed there.


**Second fix in this PR — composer panel drift**: the panel carries the shared `.card` class, and `.card { position: relative }` loads after the popover stylesheet, so bundle order silently stripped the panel's `position: fixed` — it flowed inside the documents viewer and rendered clipped at the bottom-right of the viewport, far from the selection. Now `.selection-comment-panel.card` restates fixed positioning immune to bundle order, the panel's `left` is a width-aware clamp (it can never hang past a viewport edge), `top` clamps near the bottom, and the textarea focuses with `preventScroll` so opening the composer no longer scrolls the selected text out of view. CSS-invariant regression test added.

## Verification
- `vitest run SelectionCommentPopover.test.tsx DocumentsView.test.tsx`: 2 files, 27 tests passed — includes a CSS-invariant regression test (every trigger transform block keeps `translate(-50%`) and Read-only badge tests for both preview modes.
- `tsc --noEmit` (both dashboard tsconfigs) exit 0; eslint clean.
- Live end-to-end repro + fix validation in a real browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
| Before (Loom): 'Add comment' did nothing | After: trigger stays put, click lands |
|---|---|
| <img src="https://raw.githubusercontent.com/Runfusion/Fusion/assets/loom-review-2026-07/loom-review-2026-07/1991-before.png" width="420"> | <img src="https://raw.githubusercontent.com/Runfusion/Fusion/assets/loom-review-2026-07/loom-review-2026-07/1991-after-trigger.png" width="420"> |

Composer opening centered under the selection (position fix in this PR) (also note the new READ-ONLY badge in the preview header above):

<img src="https://raw.githubusercontent.com/Runfusion/Fusion/assets/loom-review-2026-07/loom-review-2026-07/1991-after-composer-v2.png" width="600">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Artifacts preview’s **Add comment** button so clicks register reliably on desktop and mobile.
  * Kept the comment trigger positioned under the cursor while pressed.
  * Prevented the preview from scrolling when opening the comment composer.
  * Improved comment panel positioning across viewport sizes.

* **New Features**
  * Added a persistent **Read-only** badge and explanatory tooltip to project file previews.
  * Added supporting localization strings for read-only previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->