### PR TITLE
fix: user-reported bugs — task API 500s, update EACCES, daemon restart, badge leak

### DIFF
--- a/.changeset/badge-snapshot-archive-eviction.md
+++ b/.changeset/badge-snapshot-archive-eviction.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Fix a slow dashboard memory leak where archived tasks were never evicted from the in-memory badge cache.
+category: performance
+dev: The badge-snapshot cache (packages/dashboard/src/server.ts) only removed a task on hard-delete, so archiving a task re-cached it via the task:updated listener and it was retained for the daemon's lifetime — unbounded growth over long uptimes with task churn. A new `isBadgeEligibleTask` predicate (column !== "archived") gates both the create and update listeners so archived tasks are evicted, matching the startup prime's `includeArchived:false`. An unarchive re-primes the entry.

--- a/.changeset/daemon-signal-nonzero-exit.md
+++ b/.changeset/daemon-signal-nonzero-exit.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Daemon exits non-zero on signal termination so Restart=on-failure restarts it after a memory-pressure kill.
+category: fix
+dev: `fn daemon` and `fn serve` (packages/cli/src/commands/daemon.ts, serve.ts) now exit with the POSIX 128+signal code (SIGTERM=143, SIGINT=130) on signal-initiated graceful shutdown instead of 0. Previously a memory-pressure SIGTERM produced exit 0, which `Restart=on-failure` treated as a clean stop, leaving the daemon dead. A deliberate `systemctl stop` still won't restart (systemd honors the requested inactive state regardless of exit code); a non-signal shutdown still exits 0. The interactive TUI launcher (`fn dashboard`) is intentionally unchanged — it has its own signal-name-keyed restart supervisor.

--- a/.changeset/task-api-500-diagnostics.md
+++ b/.changeset/task-api-500-diagnostics.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Server now logs the underlying stack behind an API 500 so opaque task-endpoint failures are diagnosable.
+category: fix
+dev: `rethrowAsApiError` (packages/dashboard/src/api-error.ts) now preserves the original error as Error `cause` instead of discarding it, and `sendErrorResponse`/the `/api` error boundary (packages/dashboard/src/server.ts) log the stack + cause chain for 5xx (not just the message). The client-facing body stays generic in production. Unblocks root-causing the reported "task write API returns 500 for every task" (GET/DELETE/PATCH/retry/archive/reset on /api/tasks/:id) whose cause was previously never recorded server-side.

--- a/.changeset/task-api-500-diagnostics.md
+++ b/.changeset/task-api-500-diagnostics.md
@@ -2,6 +2,6 @@
 "@runfusion/fusion": patch
 ---
 
-summary: Server now logs the underlying stack behind an API 500 so opaque task-endpoint failures are diagnosable.
+summary: Task API operations no longer fail with 500 when a task's PROMPT.md can't be read; server also logs 500 causes.
 category: fix
-dev: `rethrowAsApiError` (packages/dashboard/src/api-error.ts) now preserves the original error as Error `cause` instead of discarding it, and `sendErrorResponse`/the `/api` error boundary (packages/dashboard/src/server.ts) log the stack + cause chain for 5xx (not just the message). The client-facing body stays generic in production. Unblocks root-causing the reported "task write API returns 500 for every task" (GET/DELETE/PATCH/retry/archive/reset on /api/tasks/:id) whose cause was previously never recorded server-side.
+dev: getTask (the shared load for GET/DELETE/PATCH/retry/reset/archive) and the mutation helpers updateTaskUnlocked, updateStep, readPromptForArchive, and resetPromptCheckboxes (packages/core/src/store.ts) read PROMPT.md unguarded, so an unreadable file (root-owned from a prior `sudo` run → EACCES, PROMPT.md being a directory → EISDIR, transient FS error) 500'd every per-task op while the PROMPT.md-free board list/create kept working. These reads are now best-effort (degrade + log). Diagnosability: rethrowAsApiError preserves the original error as Error `cause` and the /api boundary logs stack + cause for 5xx (packages/dashboard/src/api-error.ts, server.ts); client body stays generic in production.

--- a/.changeset/update-now-eacces-guidance.md
+++ b/.changeset/update-now-eacces-guidance.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: "Update now" now explains permission (EACCES) failures and how to fix them instead of showing raw npm errors.
+category: fix
+dev: `performUpdateInstall` (packages/dashboard/src/update-check.ts) detects EACCES/EPERM install failures (by error code or stderr text) and returns actionable remediation — run `sudo fn update`, reinstall without sudo, or `brew upgrade fusion` for Homebrew installs — rather than the raw `npm error EACCES … rename '/usr/lib/node_modules/@runfusion/fusion'`. Occurs when Fusion was installed via `sudo npm i -g` (root-owned global dir); `--force` is not retried for this class since it cannot grant write permission.

--- a/packages/cli/src/commands/__tests__/daemon.test.ts
+++ b/packages/cli/src/commands/__tests__/daemon.test.ts
@@ -823,6 +823,22 @@ describe("runDaemon", () => {
     await triggerSignal("SIGINT");
   });
 
+  // FNXC:DaemonSignalExit 2026-07-10-14:00: a memory-pressure SIGTERM must exit
+  // non-zero (128+signal) so a `Restart=on-failure` supervisor restarts the
+  // daemon instead of treating the kill as a clean stop. Regression for the
+  // "daemon exits clean under memory pressure and isn't restarted" report.
+  it("exits 143 on SIGTERM-initiated shutdown", async () => {
+    await runDaemon({});
+    await triggerSignal("SIGTERM");
+    expect(process.exit).toHaveBeenCalledWith(143);
+  });
+
+  it("exits 130 on SIGINT-initiated shutdown", async () => {
+    await runDaemon({});
+    await triggerSignal("SIGINT");
+    expect(process.exit).toHaveBeenCalledWith(130);
+  });
+
   it("auto-loads installed plugins during startup", async () => {
     const { PluginLoader } = await import("@fusion/core");
 

--- a/packages/cli/src/commands/__tests__/serve.test.ts
+++ b/packages/cli/src/commands/__tests__/serve.test.ts
@@ -765,6 +765,22 @@ describe("runServe", () => {
     expect(mockSyncStartupModels).toHaveBeenCalledTimes(1);
   });
 
+  // FNXC:DaemonSignalExit 2026-07-10-16:00: `fn serve` must honor the same POSIX
+  // exit-code contract as `fn daemon` — a memory-pressure SIGTERM exits non-zero
+  // (143) so `Restart=on-failure` restarts it; SIGINT exits 130. Guards against
+  // the two headless-server paths regressing independently.
+  it("exits 143 on SIGTERM-initiated shutdown", async () => {
+    await runServe(0, {});
+    await triggerSignal("SIGTERM");
+    expect(process.exit).toHaveBeenCalledWith(143);
+  });
+
+  it("exits 130 on SIGINT-initiated shutdown", async () => {
+    await runServe(0, {});
+    await triggerSignal("SIGINT");
+    expect(process.exit).toHaveBeenCalledWith(130);
+  });
+
   it("registers built-in zai GLM-5.2 before refreshing models", async () => {
     await runServe(0, {});
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -962,7 +962,20 @@ export async function runDaemon(opts: DaemonOptions = {}) {
 
   let shuttingDown = false;
 
-  const shutdown = async () => {
+  /*
+  FNXC:DaemonSignalExit 2026-07-10-14:00:
+  When the host terminates the daemon under memory pressure it sends SIGTERM, which
+  this handler turns into a graceful shutdown. Exiting 0 on a signal made a
+  memory-pressure kill indistinguishable from a clean operator stop, so a
+  `Restart=on-failure` systemd unit treated it as success and left the daemon dead.
+  Exit with the POSIX 128+signal convention (SIGINT=130, SIGTERM=143) so
+  `Restart=on-failure` restarts an externally-killed daemon; a deliberate
+  `systemctl stop` still won't restart (systemd honors the requested inactive
+  state regardless of exit code). A non-signal shutdown() caller still exits 0.
+  */
+  const SIGNAL_EXIT_CODES: Record<string, number> = { SIGINT: 130, SIGTERM: 143 };
+
+  const shutdown = async (signal?: NodeJS.Signals) => {
     if (shuttingDown) return;
     shuttingDown = true;
 
@@ -1006,14 +1019,14 @@ export async function runDaemon(opts: DaemonOptions = {}) {
     }
 
     store.close();
-    process.exit(0);
+    process.exit(signal ? (SIGNAL_EXIT_CODES[signal] ?? 128) : 0);
   };
 
   process.on("SIGINT", () => {
-    void shutdown();
+    void shutdown("SIGINT");
   });
   process.on("SIGTERM", () => {
-    void shutdown();
+    void shutdown("SIGTERM");
   });
 
   // Ignore SIGHUP so the daemon survives SSH session disconnects

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1080,7 +1080,17 @@ export async function runServe(
 
   let shuttingDown = false;
 
-  const shutdown = async () => {
+  /*
+  FNXC:DaemonSignalExit 2026-07-10-14:00:
+  Same invariant as `fn daemon`: a memory-pressure SIGTERM must exit non-zero so a
+  `Restart=on-failure` supervisor restarts the server rather than treating the kill
+  as a clean stop. Exit 128+signal (SIGINT=130, SIGTERM=143); a non-signal caller
+  still exits 0. A deliberate `systemctl stop` won't restart regardless (systemd
+  honors the requested inactive state).
+  */
+  const SIGNAL_EXIT_CODES: Record<string, number> = { SIGINT: 130, SIGTERM: 143 };
+
+  const shutdown = async (signal?: NodeJS.Signals) => {
     if (shuttingDown) return;
     shuttingDown = true;
 
@@ -1151,14 +1161,14 @@ export async function runServe(
 
     stopDiagnosticInterval();
     store.close();
-    process.exit(0);
+    process.exit(signal ? (SIGNAL_EXIT_CODES[signal] ?? 128) : 0);
   };
 
   process.on("SIGINT", () => {
-    void shutdown();
+    void shutdown("SIGINT");
   });
   process.on("SIGTERM", () => {
-    void shutdown();
+    void shutdown("SIGTERM");
   });
 
   // Ignore SIGHUP so the server survives SSH session disconnects.

--- a/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
+++ b/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
@@ -57,18 +57,37 @@ describe("getTask PROMPT.md read resilience (task-write-API 500 regression)", ()
       expect(detail.id).toBe(task.id);
       expect(detail.prompt).toBe("");
 
+      // The board read paths must survive too — listTasks/searchTasks slim-sync
+      // steps from PROMPT.md for stepless tasks and would otherwise reject their
+      // Promise.all and 500 the whole board/search on one unreadable file.
+      const listed = await store.listTasks({ slim: true });
+      expect(listed.some((t) => t.id === task.id)).toBe(true);
+      const found = await store.searchTasks("unreadable", { slim: true });
+      expect(Array.isArray(found)).toBe(true);
+
       // The mutation path must stay usable too. These store methods back the
       // reported failing endpoints and each independently touches PROMPT.md:
-      //   PATCH  -> updateTask (title/description PROMPT.md heading sync)
-      //   archive-> archiveTask (readPromptForArchive)
+      //   PATCH   -> updateTask (title/description PROMPT.md heading sync)
+      //   reset   -> moveTask reopen-to-todo (resetPromptCheckboxes) + updateStep
+      //   archive -> archiveTask (readPromptForArchive)
+      //   delete  -> deleteTask
       // A read failure in that PROMPT.md work must not brick the DB mutation.
       await expect(store.updateTask(task.id, { title: "renamed with broken PROMPT.md" })).resolves.toBeTruthy();
       const afterMutation = await store.getTask(task.id);
       expect(afterMutation.title).toBe("renamed with broken PROMPT.md");
 
+      // reset path: advance the task then reopen to todo, which triggers
+      // resetPromptCheckboxes against the unreadable PROMPT.md. (New tasks start
+      // in `triage`, so step through todo → in-progress → todo.)
+      await expect(store.moveTask(task.id, "todo")).resolves.toBeTruthy();
+      await expect(store.moveTask(task.id, "in-progress")).resolves.toBeTruthy();
+      await expect(store.moveTask(task.id, "todo")).resolves.toBeTruthy();
+
       await expect(store.archiveTask(task.id)).resolves.toBeTruthy();
       const archived = await store.getTask(task.id);
       expect(archived.column).toBe("archived");
+
+      await expect(store.deleteTask(task.id)).resolves.toBeTruthy();
     } finally {
       await store.close();
     }

--- a/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
+++ b/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
@@ -76,6 +76,15 @@ describe("getTask PROMPT.md read resilience (task-write-API 500 regression)", ()
       const afterMutation = await store.getTask(task.id);
       expect(afterMutation.title).toBe("renamed with broken PROMPT.md");
 
+      // Atomicity: an *explicit* prompt write that can't hit disk (PROMPT.md is a
+      // directory → EISDIR) must reject AND leave the accompanying field change
+      // uncommitted — no partial commit of the row with a stale prompt.
+      await expect(
+        store.updateTask(task.id, { prompt: "new spec body", title: "atomic-should-not-apply" }),
+      ).rejects.toThrow();
+      const afterFailedPromptWrite = await store.getTask(task.id);
+      expect(afterFailedPromptWrite.title).toBe("renamed with broken PROMPT.md");
+
       // reset path: advance the task then reopen to todo, which triggers
       // resetPromptCheckboxes against the unreadable PROMPT.md. (New tasks start
       // in `triage`, so step through todo → in-progress → todo.)

--- a/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
+++ b/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
@@ -1,0 +1,76 @@
+/*
+FNXC:TaskDetailPromptResilience 2026-07-10-15:00:
+Symptom verification for the "task write API returns 500 for nearly everything" report:
+GET/DELETE/PATCH/retry/reset/archive on a task all 500'd for every task (healthy ones
+too) while the board list and create worked. Root cause: getTask — the shared load for
+the entire per-task API — reads PROMPT.md directly and unguarded, so any read failure
+(a root-owned PROMPT.md from a prior `sudo` run → EACCES, PROMPT.md being a directory →
+EISDIR, etc.) threw and bricked every per-task operation, whereas the slim board list
+never touches PROMPT.md.
+
+Original symptom: getTask throws on an unreadable PROMPT.md, 500ing all per-task ops.
+Exact reproduction: replace a task's PROMPT.md with a directory so readFile raises EISDIR.
+Assertion it is gone: getTask resolves with the row (prompt degraded to ""), and a
+representative mutation still succeeds — the per-task API is no longer bricked.
+*/
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of cleanupDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("getTask PROMPT.md read resilience (task-write-API 500 regression)", () => {
+  it("returns the task detail (and mutations still work) when PROMPT.md cannot be read", async () => {
+    const { TaskStore } = await import("../store.js");
+
+    const root = mkdtempSync(join(tmpdir(), "fn-task-detail-resilience-"));
+    cleanupDirs.push(root);
+
+    const store = new TaskStore(root);
+    await store.init();
+    try {
+      const task = await store.createTask({ description: "task whose PROMPT.md becomes unreadable" });
+
+      // Baseline: a healthy task detail loads and carries the prompt text.
+      const baseline = await store.getTask(task.id);
+      expect(baseline.id).toBe(task.id);
+      expect(typeof baseline.prompt).toBe("string");
+
+      // Make PROMPT.md unreadable deterministically: replace the file with a
+      // directory so `readFile` raises EISDIR (mirrors the EACCES a root-owned
+      // PROMPT.md produces, without depending on chmod/uid semantics).
+      const promptPath = join(root, ".fusion", "tasks", task.id, "PROMPT.md");
+      rmSync(promptPath, { force: true });
+      mkdirSync(promptPath, { recursive: true });
+      expect(existsSync(promptPath)).toBe(true);
+
+      // The read path (GET /api/tasks/:id) must NOT throw — it degrades to an
+      // empty prompt instead of 500ing.
+      const detail = await store.getTask(task.id);
+      expect(detail.id).toBe(task.id);
+      expect(detail.prompt).toBe("");
+
+      // The mutation path must stay usable too. These store methods back the
+      // reported failing endpoints and each independently touches PROMPT.md:
+      //   PATCH  -> updateTask (title/description PROMPT.md heading sync)
+      //   archive-> archiveTask (readPromptForArchive)
+      // A read failure in that PROMPT.md work must not brick the DB mutation.
+      await expect(store.updateTask(task.id, { title: "renamed with broken PROMPT.md" })).resolves.toBeTruthy();
+      const afterMutation = await store.getTask(task.id);
+      expect(afterMutation.title).toBe("renamed with broken PROMPT.md");
+
+      await expect(store.archiveTask(task.id)).resolves.toBeTruthy();
+      const archived = await store.getTask(task.id);
+      expect(archived.column).toBe("archived");
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
+++ b/packages/core/src/__tests__/task-detail-prompt-resilience.test.ts
@@ -83,6 +83,11 @@ describe("getTask PROMPT.md read resilience (task-write-API 500 regression)", ()
       await expect(store.moveTask(task.id, "in-progress")).resolves.toBeTruthy();
       await expect(store.moveTask(task.id, "todo")).resolves.toBeTruthy();
 
+      // Directly updating a step whose definition lives only in the unreadable
+      // PROMPT.md genuinely cannot succeed, but the error must name the real
+      // cause (PROMPT.md) rather than a misleading "task has 0 steps".
+      await expect(store.updateStep(task.id, 0, "in-progress")).rejects.toThrow(/PROMPT\.md/);
+
       await expect(store.archiveTask(task.id)).resolves.toBeTruthy();
       const archived = await store.getTask(task.id);
       expect(archived.column).toBe("archived");

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -6176,8 +6176,16 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
         return task;
       }
 
-      const steps = await this.parseStepsFromPrompt(task.id);
-      return steps.length > 0 ? { ...task, steps } : task;
+      // FNXC:TaskDetailPromptResilience 2026-07-10-16:00: an unreadable PROMPT.md
+      // must not reject this Promise.all and 500 the entire board list — degrade
+      // to the persisted (empty) steps and log, matching getTask.
+      try {
+        const steps = await this.parseStepsFromPrompt(task.id);
+        return steps.length > 0 ? { ...task, steps } : task;
+      } catch (err) {
+        storeLog.warn(`[task-detail] failed to sync steps from PROMPT.md for ${task.id} during listTasks: ${getErrorMessage(err)}`);
+        return task;
+      }
     }));
     const archivedTasks = includeArchived && (!columnFilter || columnFilter === "archived") ? this.archiveDb.list().map((entry) => this.archiveEntryToTask(entry, slim)) : [];
     // FNXC:BoardConsistency 2026-06-21-08:34: FN-6851's cache-sync fix is primary; listTasks still collapses duplicate storage sources so one task ID cannot render in two columns. Active SQLite rows are authoritative over archive snapshots.
@@ -6906,8 +6914,16 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
         return task;
       }
 
-      const steps = await this.parseStepsFromPrompt(task.id);
-      return steps.length > 0 ? { ...task, steps } : task;
+      // FNXC:TaskDetailPromptResilience 2026-07-10-16:00: an unreadable PROMPT.md
+      // must not reject this Promise.all and 500 the entire search — degrade to
+      // the persisted (empty) steps and log, matching getTask/listTasks.
+      try {
+        const steps = await this.parseStepsFromPrompt(task.id);
+        return steps.length > 0 ? { ...task, steps } : task;
+      } catch (err) {
+        storeLog.warn(`[task-detail] failed to sync steps from PROMPT.md for ${task.id} during searchTasks: ${getErrorMessage(err)}`);
+        return task;
+      }
     }));
     const archiveMatches = includeArchived
       ? this.archiveDb.search(trimmedQuery, limit >= 0 ? limit : 100).map((entry) => this.archiveEntryToTask(entry, slim))

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -9647,6 +9647,23 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       }
       task.updatedAt = new Date().toISOString();
 
+      // FNXC:TaskDetailPromptResilience 2026-07-10-17:00:
+      // Perform the explicit PROMPT.md write (and its File Scope validation) BEFORE
+      // committing the task row, so a failed write (EACCES/EISDIR/disk-full) or an
+      // invalid File Scope aborts the whole update atomically. Previously this ran
+      // AFTER the row/task.json commit, so a failed prompt write returned an error
+      // while the field changes stayed committed and PROMPT.md went stale — a
+      // partial commit. (This is the write counterpart to the read-resilience
+      // guards elsewhere in getTask/updateStep.)
+      if (updates.prompt !== undefined) {
+        const validation = validateFileScopeInPromptContent(updates.prompt);
+        if (validation.invalid.length > 0) {
+          throw new InvalidFileScopeError(id, validation.invalid);
+        }
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "PROMPT.md"), updates.prompt);
+      }
+
       // When runContext is provided, record audit event atomically with task mutation
       if (runContext) {
         await this.atomicWriteTaskJsonWithAudit(dir, task, {
@@ -9667,15 +9684,6 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
 
       // Update cache if watcher is active
       if (this.isWatching) this.taskCache.set(id, { ...task });
-
-      if (updates.prompt !== undefined) {
-        const validation = validateFileScopeInPromptContent(updates.prompt);
-        if (validation.invalid.length > 0) {
-          throw new InvalidFileScopeError(id, validation.invalid);
-        }
-        await mkdir(dir, { recursive: true });
-        await writeFile(join(dir, "PROMPT.md"), updates.prompt);
-      }
 
       // Sync PROMPT.md when title or description changes (but not when explicit
       // prompt update — that already wrote the new content above).

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -2436,7 +2436,15 @@ export class TaskStore extends EventEmitter<TaskStoreEvents> {
     if (!existsSync(promptPath)) {
       return undefined;
     }
-    return readFile(promptPath, "utf-8");
+    // FNXC:TaskDetailPromptResilience 2026-07-10-15:00: best-effort — an
+    // unreadable PROMPT.md must not fail archiving (a reported failing per-task
+    // op); the archive entry simply omits the prompt text.
+    try {
+      return await readFile(promptPath, "utf-8");
+    } catch (err) {
+      storeLog.warn(`[task-detail] failed to read PROMPT.md for archive of ${taskId}: ${getErrorMessage(err)}`);
+      return undefined;
+    }
   }
 
   private async buildArchivedAgentLogFields(
@@ -5533,15 +5541,34 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       // Derived at read time only; retrySummary is never persisted to SQLite.
       task.retrySummary = computeRetrySummary(task);
 
-      // Sync steps from PROMPT.md if task.steps is empty
+      /*
+      FNXC:TaskDetailPromptResilience 2026-07-10-15:00:
+      PROMPT.md is enrichment for the task detail (the `prompt` text and, when steps
+      are unpersisted, step-syncing) — NOT essential row data. getTask is the shared
+      load for the entire per-task API (GET/DELETE/PATCH/retry/reset/archive), so an
+      unguarded read/parse throw here turned every per-task operation into a 500 while
+      the PROMPT.md-free board list kept working — the reported "task write API returns
+      500 for every task". A read can fail for reasons unrelated to the row: a
+      root-owned PROMPT.md left by a prior `sudo` run (EACCES), PROMPT.md being a
+      directory (EISDIR), a symlink loop, or a transient FS error. Degrade to empty
+      prompt / unsynced steps and log, rather than bricking task management.
+      */
       if (task.steps.length === 0) {
-        task.steps = await this.parseStepsFromPrompt(id);
+        try {
+          task.steps = await this.parseStepsFromPrompt(id);
+        } catch (err) {
+          storeLog.warn(`[task-detail] failed to sync steps from PROMPT.md for ${id}: ${getErrorMessage(err)}`);
+        }
       }
 
       let prompt = "";
-      const promptPath = join(this.taskDir(id), "PROMPT.md");
-      if (existsSync(promptPath)) {
-        prompt = await readFile(promptPath, "utf-8");
+      try {
+        const promptPath = join(this.taskDir(id), "PROMPT.md");
+        if (existsSync(promptPath)) {
+          prompt = await readFile(promptPath, "utf-8");
+        }
+      } catch (err) {
+        storeLog.warn(`[task-detail] failed to read PROMPT.md for ${id}: ${getErrorMessage(err)}`);
       }
 
       return { ...task, prompt };
@@ -8340,11 +8367,18 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       return;
     }
 
-    const content = await readFile(promptPath, "utf-8");
-    const resetContent = content.replace(/^- \[x\]/gm, "- [ ]");
+    // FNXC:TaskDetailPromptResilience 2026-07-10-15:00: cosmetic checkbox reset —
+    // an unreadable/unwritable PROMPT.md must not fail the task reset itself (a
+    // reported failing per-task op); the DB reset already proceeded.
+    try {
+      const content = await readFile(promptPath, "utf-8");
+      const resetContent = content.replace(/^- \[x\]/gm, "- [ ]");
 
-    if (resetContent !== content) {
-      await writeFile(promptPath, resetContent, "utf-8");
+      if (resetContent !== content) {
+        await writeFile(promptPath, resetContent, "utf-8");
+      }
+    } catch (err) {
+      storeLog.warn(`[task-detail] failed to reset PROMPT.md checkboxes in ${dir}: ${getErrorMessage(err)}`);
     }
   }
 
@@ -9650,34 +9684,46 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       // task.json remains the canonical source for title/description fields.
       // PROMPT.md is only ever fully rewritten via explicit `updates.prompt`.
       if (updates.prompt === undefined && (updates.title !== undefined || updates.description !== undefined)) {
+        // FNXC:TaskDetailPromptResilience 2026-07-10-15:00:
+        // Keeping the human-visible PROMPT.md heading/mission in sync with
+        // task.json is cosmetic — the DB row (persisted above) is canonical. An
+        // unreadable/unwritable PROMPT.md (root-owned from a prior `sudo` run →
+        // EACCES, PROMPT.md being a directory → EISDIR, transient FS error) must
+        // NOT fail the update itself, or every title/description edit 500s
+        // exactly like the reported task-write-API failure. Best-effort: log and
+        // skip the sync on failure.
         const promptPath = join(dir, "PROMPT.md");
-        if (existsSync(promptPath)) {
-          const existingPrompt = await readFile(promptPath, "utf-8");
+        try {
+          if (existsSync(promptPath)) {
+            const existingPrompt = await readFile(promptPath, "utf-8");
 
-          if (isBootstrapPromptStub(existingPrompt, task.id, preUpdateTitle, preUpdateDescription)) {
-            const newPrompt = buildBootstrapPrompt(task.id, task.title, task.description);
-            await writeFile(promptPath, newPrompt);
-          } else {
-            // Real spec — surgical edits only. Each section we propagate to is
-            // edited in place; everything else (Review Level, Frontend UX
-            // Criteria, custom sections from triage) is preserved verbatim.
-            let next = existingPrompt;
-            if (updates.title !== undefined) {
-              // Match the existing heading style: triage emits
-              // `# Task: {id} - {title}`; createTask uses `# {id}: {title}`.
-              const triageStyle = /^#\s+Task:\s+[A-Z]+-\d+\s+-\s+/m.test(existingPrompt);
-              const heading = triageStyle
-                ? (task.title ? `Task: ${task.id} - ${task.title}` : `Task: ${task.id}`)
-                : (task.title ? `${task.id}: ${task.title}` : task.id);
-              next = rewriteHeadingLine(next, heading);
-            }
-            if (updates.description !== undefined) {
-              next = rewriteMissionSection(next, task.description);
-            }
-            if (next !== existingPrompt) {
-              await writeFile(promptPath, next);
+            if (isBootstrapPromptStub(existingPrompt, task.id, preUpdateTitle, preUpdateDescription)) {
+              const newPrompt = buildBootstrapPrompt(task.id, task.title, task.description);
+              await writeFile(promptPath, newPrompt);
+            } else {
+              // Real spec — surgical edits only. Each section we propagate to is
+              // edited in place; everything else (Review Level, Frontend UX
+              // Criteria, custom sections from triage) is preserved verbatim.
+              let next = existingPrompt;
+              if (updates.title !== undefined) {
+                // Match the existing heading style: triage emits
+                // `# Task: {id} - {title}`; createTask uses `# {id}: {title}`.
+                const triageStyle = /^#\s+Task:\s+[A-Z]+-\d+\s+-\s+/m.test(existingPrompt);
+                const heading = triageStyle
+                  ? (task.title ? `Task: ${task.id} - ${task.title}` : `Task: ${task.id}`)
+                  : (task.title ? `${task.id}: ${task.title}` : task.id);
+                next = rewriteHeadingLine(next, heading);
+              }
+              if (updates.description !== undefined) {
+                next = rewriteMissionSection(next, task.description);
+              }
+              if (next !== existingPrompt) {
+                await writeFile(promptPath, next);
+              }
             }
           }
+        } catch (err) {
+          storeLog.warn(`[task-detail] failed to sync PROMPT.md heading for ${task.id}: ${getErrorMessage(err)}`);
         }
       }
 
@@ -9900,8 +9946,15 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
 
       // Auto-initialize steps from PROMPT.md if empty. Bypassed for graph-source
       // writes (U6/KTD-3): the graph owns explicit indices pinned at expansion.
+      // FNXC:TaskDetailPromptResilience 2026-07-10-15:00: step auto-init is
+      // best-effort — an unreadable PROMPT.md must not fail updateStep (on the
+      // reported reset path); proceed with the persisted (empty) steps.
       if (task.steps.length === 0 && !graphSource) {
-        task.steps = await this.parseStepsFromPrompt(id);
+        try {
+          task.steps = await this.parseStepsFromPrompt(id);
+        } catch (err) {
+          storeLog.warn(`[task-detail] failed to auto-init steps from PROMPT.md for ${id}: ${getErrorMessage(err)}`);
+        }
       }
 
       // Initialize log array if missing (for legacy tasks)

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -9965,11 +9965,17 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       // FNXC:TaskDetailPromptResilience 2026-07-10-15:00: step auto-init is
       // best-effort — an unreadable PROMPT.md must not fail updateStep (on the
       // reported reset path); proceed with the persisted (empty) steps.
+      let promptStepsUnavailable: string | undefined;
       if (task.steps.length === 0 && !graphSource) {
         try {
           task.steps = await this.parseStepsFromPrompt(id);
         } catch (err) {
-          storeLog.warn(`[task-detail] failed to auto-init steps from PROMPT.md for ${id}: ${getErrorMessage(err)}`);
+          // Remember WHY steps couldn't be resolved so the range check below
+          // attributes the failure to the unreadable PROMPT.md rather than a
+          // misleading "0 steps". A step defined only in an unreadable PROMPT.md
+          // genuinely cannot be updated — but the error should say so.
+          promptStepsUnavailable = getErrorMessage(err);
+          storeLog.warn(`[task-detail] failed to auto-init steps from PROMPT.md for ${id}: ${promptStepsUnavailable}`);
         }
       }
 
@@ -9979,6 +9985,14 @@ ${TASK_UPSERT_SQL_ASSIGNMENTS}
       }
 
       if (stepIndex < 0 || stepIndex >= task.steps.length) {
+        // FNXC:TaskDetailPromptResilience 2026-07-10-16:30: when the range failure
+        // is caused by an unreadable PROMPT.md (not a genuinely stepless task),
+        // surface the real cause instead of a confusing "task has 0 steps".
+        if (promptStepsUnavailable !== undefined && task.steps.length === 0) {
+          throw new Error(
+            `Cannot update step ${stepIndex} for ${id}: its steps are defined in PROMPT.md, which could not be read (${promptStepsUnavailable}).`,
+          );
+        }
         throw new Error(
           `Step ${stepIndex} out of range (task has ${task.steps.length} steps)`,
         );

--- a/packages/dashboard/src/__tests__/badge-snapshot-eviction.test.ts
+++ b/packages/dashboard/src/__tests__/badge-snapshot-eviction.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isBadgeEligibleTask } from "../server.js";
+
+/*
+FNXC:BadgeSnapshotEviction 2026-07-10-15:00:
+Regression for the slow badge-cache memory leak: archived tasks were re-cached on
+task:updated but only evicted on hard-delete, so they accumulated for the daemon's
+lifetime. The badge cache is board-scoped — archived tasks must be ineligible so both
+the create and update listeners evict rather than retain them.
+*/
+describe("isBadgeEligibleTask", () => {
+  it("excludes archived tasks from the live-board badge cache", () => {
+    expect(isBadgeEligibleTask({ column: "archived" })).toBe(false);
+  });
+
+  it("includes tasks on any live board column", () => {
+    for (const column of ["todo", "in-progress", "in-review", "done"] as const) {
+      expect(isBadgeEligibleTask({ column })).toBe(true);
+    }
+  });
+});

--- a/packages/dashboard/src/__tests__/update-check.test.ts
+++ b/packages/dashboard/src/__tests__/update-check.test.ts
@@ -260,6 +260,25 @@ describe("update-check", () => {
     expect(execFake).toHaveBeenCalledTimes(1);
   });
 
+  // FNXC:UpdateInstallPermissions 2026-07-10-16:00: an Intel-macOS Homebrew install
+  // resolves through `/usr/local/Cellar/…` (not `/usr/local/Homebrew/`), so the
+  // remediation must recommend `brew upgrade`, not the npm/sudo guidance.
+  it("performUpdateInstall recommends brew for an Intel-macOS Homebrew install path", async () => {
+    const originalArgv1 = process.argv[1];
+    process.argv[1] = "/usr/local/Cellar/fusion/0.57.0/bin/fn";
+    try {
+      const execFake = vi.fn().mockRejectedValue(
+        Object.assign(new Error("EACCES"), { code: "EACCES", stderr: "npm error EACCES" }),
+      );
+      const result = await performUpdateInstall("1.0.0", "2.0.0", { exec: execFake, fusionDir });
+      expect(result.updated).toBe(false);
+      expect(result.error).toMatch(/brew upgrade fusion/);
+      expect(result.error).not.toMatch(/sudo npm/);
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
+  });
+
   describe("frequency", () => {
     beforeEach(() => {
       __resetStartupRefreshFlag();

--- a/packages/dashboard/src/__tests__/update-check.test.ts
+++ b/packages/dashboard/src/__tests__/update-check.test.ts
@@ -227,6 +227,39 @@ describe("update-check", () => {
     expect(execFake).toHaveBeenCalledTimes(1);
   });
 
+  // FNXC:UpdateInstallPermissions 2026-07-10-14:00: a root-owned global dir
+  // (from `sudo npm i -g`) makes the non-root in-app updater fail with EACCES/
+  // EPERM. It must surface actionable remediation, not raw npm stderr, and must
+  // NOT retry with --force (which cannot grant write permission).
+  it("performUpdateInstall returns actionable guidance on an EACCES permission failure", async () => {
+    const execFake = vi.fn().mockRejectedValue(
+      Object.assign(new Error("EACCES"), {
+        code: "EACCES",
+        stderr: "npm error EACCES: permission denied, rename '/usr/lib/node_modules/@runfusion/fusion'",
+      }),
+    );
+
+    const result = await performUpdateInstall("1.0.0", "2.0.0", { exec: execFake, fusionDir });
+    expect(result.updated).toBe(false);
+    expect(result.error).toMatch(/EACCES\/EPERM|not writable|sudo/i);
+    // Must not fall through to raw npm stderr, and must not retry with --force.
+    expect(result.error).not.toContain("rename '/usr/lib/node_modules");
+    expect(execFake).toHaveBeenCalledTimes(1);
+  });
+
+  it("performUpdateInstall detects EPERM from stderr text without an error code", async () => {
+    const execFake = vi.fn().mockRejectedValue(
+      Object.assign(new Error("install failed"), {
+        stderr: "npm error code EPERM\nnpm error operation not permitted",
+      }),
+    );
+
+    const result = await performUpdateInstall("1.0.0", "2.0.0", { exec: execFake, fusionDir });
+    expect(result.updated).toBe(false);
+    expect(result.error).toMatch(/not writable|sudo/i);
+    expect(execFake).toHaveBeenCalledTimes(1);
+  });
+
   describe("frequency", () => {
     beforeEach(() => {
       __resetStartupRefreshFlag();

--- a/packages/dashboard/src/api-error.ts
+++ b/packages/dashboard/src/api-error.ts
@@ -9,6 +9,15 @@ export interface ApiErrorResponse {
 export interface SendErrorOptions {
   details?: Record<string, unknown>;
   logger?: RuntimeLogger;
+  /*
+  FNXC:ApiErrorDiagnostics 2026-07-10-14:00:
+  The original thrown error behind a 5xx. When present, its stack (and any `cause`
+  chain) is logged so server-side 500s are root-causable. Previously only the error
+  *message* was logged and `rethrowAsApiError` discarded the stack, leaving the
+  full-TaskDetail 500s on /api/tasks/:id (GET/DELETE/PATCH/retry/archive/reset)
+  untraceable across releases.
+  */
+  error?: unknown;
 }
 
 export class ApiError extends Error {
@@ -16,12 +25,19 @@ export class ApiError extends Error {
   public readonly details?: Record<string, unknown>;
   public readonly isOperational: boolean;
 
-  constructor(statusCode: number, message: string, details?: Record<string, unknown>) {
+  constructor(statusCode: number, message: string, details?: Record<string, unknown>, cause?: unknown) {
     super(message);
     this.name = "ApiError";
     this.statusCode = statusCode;
     this.details = details;
     this.isOperational = true;
+    // FNXC:ApiErrorDiagnostics 2026-07-10-14:00: preserve the wrapped error's
+    // stack/chain via Error `cause` so the boundary can log where the 500 came
+    // from (assigned directly rather than via super(message,{cause}) to stay
+    // independent of the compiled lib target).
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
   }
 }
 
@@ -34,11 +50,17 @@ export function sendErrorResponse(
   if (statusCode >= 500) {
     const request = res.req;
     const logger = options?.logger ?? createRuntimeLogger("api:error");
+    // FNXC:ApiErrorDiagnostics 2026-07-10-14:00: log the underlying stack and
+    // cause (not just the message) so a 500 can be traced to its origin.
+    const originalError = options?.error;
+    const cause = originalError instanceof Error ? (originalError as { cause?: unknown }).cause : undefined;
     logger.error("Request failed", {
       method: request?.method,
       path: request?.originalUrl ?? request?.path,
       statusCode,
       message,
+      stack: originalError instanceof Error ? originalError.stack : undefined,
+      cause: cause instanceof Error ? (cause.stack ?? cause.message) : cause !== undefined ? String(cause) : undefined,
     });
   }
 
@@ -63,16 +85,16 @@ export function catchHandler(fn: AsyncHandler): RequestHandler {
       }
 
       if (error instanceof ApiError) {
-        sendErrorResponse(res, error.statusCode, error.message, { details: error.details });
+        sendErrorResponse(res, error.statusCode, error.message, { details: error.details, error });
         return;
       }
 
       if (error instanceof Error) {
-        sendErrorResponse(res, 500, error.message);
+        sendErrorResponse(res, 500, error.message, { error });
         return;
       }
 
-      sendErrorResponse(res, 500, "Internal server error");
+      sendErrorResponse(res, 500, "Internal server error", { error });
     }
   };
 }

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -1930,13 +1930,22 @@ export function createServer(store: TaskStore, options?: ServerOptions): ReturnT
   // API Error Handling Middleware - MUST be after API routes but before SPA fallback
   // This ensures API errors return JSON instead of falling through to the SPA fallback (which returns HTML)
    
+  /*
+  FNXC:ApiErrorDiagnostics 2026-07-10-14:00:
+  The /api error boundary is the chokepoint for every unhandled per-request error.
+  It must LOG the underlying error (stack + cause), not just echo a message, so a
+  500 is root-causable server-side — the reported "task write API returns 500 for
+  every task" was undiagnosable because the wrapped error's origin was never
+  recorded. The client-facing body stays generic in production (avoid leaking
+  internals); pass `error: err` so sendErrorResponse logs the stack/cause.
+  */
   app.use("/api", (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
     if (res.headersSent) {
       return;
     }
 
     if (err instanceof ApiError) {
-      sendErrorResponse(res, err.statusCode, err.message, { details: err.details });
+      sendErrorResponse(res, err.statusCode, err.message, { details: err.details, error: err });
       return;
     }
 
@@ -1948,7 +1957,7 @@ export function createServer(store: TaskStore, options?: ServerOptions): ReturnT
           ? err.message
           : fallbackMessage;
 
-    sendErrorResponse(res, 500, message);
+    sendErrorResponse(res, 500, message, { error: err });
   });
 
   if (!isHeadless) {

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -2445,6 +2445,14 @@ export function setupBadgeWebSocket(
 
     const onTaskUpdated = (task: Task) => {
       const cacheKey = `${scopeKey}:${task.id}`;
+      // FNXC:BadgeSnapshotEviction 2026-07-10-15:00: evict (not re-cache) when a
+      // task is archived off the live board, and skip the publish so peers don't
+      // re-cache it. An unarchive re-emits task:updated with a live column and
+      // re-primes the entry. See isBadgeEligibleTask.
+      if (!isBadgeEligibleTask(task)) {
+        badgeSnapshots.delete(cacheKey);
+        return;
+      }
       const previousSnapshot = badgeSnapshots.get(cacheKey);
       const nextSnapshot: BadgeSnapshot = {
         prInfo: task.prInfo ?? null,
@@ -2480,6 +2488,13 @@ export function setupBadgeWebSocket(
 
     const onTaskCreated = (task: Task) => {
       const cacheKey = `${scopeKey}:${task.id}`;
+      // FNXC:BadgeSnapshotEviction 2026-07-10-15:00: an already-archived task
+      // (e.g. restored/imported into the archive) must not seed the live-board
+      // badge cache — same eligibility rule as the update listener.
+      if (!isBadgeEligibleTask(task)) {
+        badgeSnapshots.delete(cacheKey);
+        return;
+      }
       badgeSnapshots.set(cacheKey, {
         prInfo: task.prInfo ?? null,
         issueInfo: task.issueInfo ?? null,
@@ -2601,6 +2616,19 @@ export function setupBadgeWebSocket(
     dashboardApp.badgeWsManager = null;
     dashboardApp.__fnWebSocketsAttached = false;
   });
+}
+
+/*
+FNXC:BadgeSnapshotEviction 2026-07-10-15:00:
+The in-memory badge-snapshot cache is keyed by task id and only ever removed a task
+on hard-delete, so archived tasks accumulated for the daemon's whole lifetime — a slow
+memory leak on long-running servers with task churn. Badge snapshots are only needed for
+tasks visible on the live board; archived tasks leave it. This predicate is the single
+eligibility rule used by both the create and update listeners (and mirrored by the
+startup prime's `includeArchived:false`). Exported for unit coverage of the invariant.
+*/
+export function isBadgeEligibleTask(task: Pick<Task, "column">): boolean {
+  return task.column !== "archived";
 }
 
 /** Compare two badge snapshots for equality */

--- a/packages/dashboard/src/update-check.ts
+++ b/packages/dashboard/src/update-check.ts
@@ -1,5 +1,5 @@
 import { exec } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -131,12 +131,30 @@ function detectRunningBinaryPath(): string | null {
   return typeof process.execPath === "string" ? process.execPath : null;
 }
 
+/*
+FNXC:UpdateInstallPermissions 2026-07-10-16:00:
+Detect a Homebrew-managed install so the remediation says `brew upgrade` rather than
+the npm/sudo guidance. Formulae live under a Cellar and are symlinked into bin — on
+Apple Silicon everything is under `/opt/homebrew/`, but on Intel macOS the bin symlink
+is `/usr/local/bin/fn` -> `/usr/local/Cellar/...` (and `/usr/local/Homebrew/` is only
+brew's own git repo, not where formulae install). So resolve the symlink and match the
+real Cellar/opt install roots — checking only `/usr/local/Homebrew/` missed Intel Macs.
+`/usr/local/bin` is deliberately NOT matched: it is shared with npm-global bins.
+*/
 function isHomebrewInstall(binaryPath: string | null): boolean {
   if (!binaryPath) return false;
-  return (
-    binaryPath.startsWith("/opt/homebrew/") ||
-    binaryPath.startsWith("/usr/local/Homebrew/") ||
-    binaryPath.startsWith("/home/linuxbrew/")
+  let resolved = binaryPath;
+  try {
+    resolved = realpathSync(binaryPath);
+  } catch {
+    // Unresolvable symlink/path — fall back to the raw path.
+  }
+  return [binaryPath, resolved].some((p) =>
+    p.startsWith("/opt/homebrew/") ||     // Apple Silicon (bin, opt, Cellar)
+    p.startsWith("/usr/local/Cellar/") || // Intel formula install root
+    p.startsWith("/usr/local/opt/") ||    // Intel formula opt symlinks
+    p.includes("/Homebrew/") ||           // brew's own repo checkout
+    p.startsWith("/home/linuxbrew/"),     // Linuxbrew
   );
 }
 

--- a/packages/dashboard/src/update-check.ts
+++ b/packages/dashboard/src/update-check.ts
@@ -105,6 +105,57 @@ function getInstallErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/*
+FNXC:UpdateInstallPermissions 2026-07-10-14:00:
+The in-app "Update now" button runs `npm install -g @runfusion/fusion@latest` as the
+(typically non-root) dashboard process. When Fusion was installed via `sudo npm i -g`,
+the global package dir is root-owned, so npm's rename() fails with EACCES/EPERM and the
+button ALWAYS fails. Previously the raw npm stderr was surfaced with no explanation.
+Detect the permission class and return an actionable remediation instead of a cryptic
+EACCES, mirroring the CLI's Homebrew-path awareness. (`--force` cannot grant write
+permission, so we do not retry it for this class — unlike bin-collision errors.)
+*/
+function isPermissionInstallError(error: unknown): boolean {
+  const installError = error as InstallError & { code?: string };
+  if (installError?.code === "EACCES" || installError?.code === "EPERM") return true;
+  const message = [installError?.message, installError?.stderr, installError?.stdout]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .join("\n");
+  return /\bEACCES\b|\bEPERM\b|permission denied|operation not permitted/i.test(message);
+}
+
+/** Best-effort path of the running Fusion binary, used to tailor remediation. */
+function detectRunningBinaryPath(): string | null {
+  const argvPath = process.argv[1];
+  if (typeof argvPath === "string" && argvPath.length > 0) return argvPath;
+  return typeof process.execPath === "string" ? process.execPath : null;
+}
+
+function isHomebrewInstall(binaryPath: string | null): boolean {
+  if (!binaryPath) return false;
+  return (
+    binaryPath.startsWith("/opt/homebrew/") ||
+    binaryPath.startsWith("/usr/local/Homebrew/") ||
+    binaryPath.startsWith("/home/linuxbrew/")
+  );
+}
+
+function getPermissionRemediationMessage(binaryPath: string | null): string {
+  if (isHomebrewInstall(binaryPath)) {
+    return (
+      "Update failed: this Fusion install is managed by Homebrew and cannot be updated with npm. " +
+      "Update it from a terminal with: brew upgrade fusion"
+    );
+  }
+  return (
+    "Update failed: the global npm directory is not writable by the Fusion process (EACCES/EPERM). " +
+    "This happens when Fusion was installed with `sudo npm i -g`, leaving a root-owned package directory " +
+    "that the dashboard (running as a normal user) cannot replace. Update from a terminal instead:\n" +
+    "  • sudo fn update  (or: sudo npm i -g @runfusion/fusion@latest)\n" +
+    "  • or reinstall without sudo so the global directory is user-owned"
+  );
+}
+
 function getInstallOptions(): { timeout: number; maxBuffer: number } {
   return {
     timeout: INSTALL_TIMEOUT_MS,
@@ -169,6 +220,18 @@ export async function performUpdateInstall(
       updated: true,
     };
   } catch (error) {
+    // FNXC:UpdateInstallPermissions 2026-07-10-14:00: a root-owned global dir
+    // (from `sudo npm i -g`) yields EACCES/EPERM the non-root updater cannot
+    // recover from — return actionable guidance rather than raw npm stderr.
+    if (isPermissionInstallError(error)) {
+      return {
+        currentVersion,
+        latestVersion,
+        updated: false,
+        error: getPermissionRemediationMessage(detectRunningBinaryPath()),
+      };
+    }
+
     if (!isBinCollisionInstallError(error)) {
       return {
         currentVersion,


### PR DESCRIPTION
Addresses four user-reported bugs from a batch report. Each was investigated to root cause before fixing; two reported items were found to be working-as-designed and are noted below rather than changed.

## Fixes

### #5 — Task write API returned 500 for nearly everything
`GET/DELETE/PATCH/retry/reset/archive` on `/api/tasks/:id` 500'd for **every** task (healthy ones too) while the board list and create worked.

**Root cause (reproduced):** `getTask` — the shared load for the entire per-task API — plus the mutation helpers `updateTaskUnlocked`, `updateStep`, `readPromptForArchive`, and `resetPromptCheckboxes` read `PROMPT.md` **unguarded**. An unreadable file (root-owned from a prior `sudo` install → EACCES, PROMPT.md being a directory → EISDIR, a transient FS error) threw and bricked every per-task op, whereas the PROMPT.md-free board list/create kept working. These reads are now **best-effort** (degrade + log; the DB row is canonical).

**Diagnosability:** `rethrowAsApiError` now preserves the original error as Error `cause`, and the `/api` error boundary logs stack + cause for 5xx (client body stays generic in production) — previously the underlying cause was never recorded, which is why this survived four releases.

Symptom-verification test forces EISDIR and asserts `getTask`/`updateTask`/`archiveTask` still succeed.

### #9 — In-app "Update now" failed with EACCES
When Fusion was installed via `sudo npm i -g`, the root-owned global dir made the non-root updater fail with a raw `npm error EACCES … rename '/usr/lib/node_modules/@runfusion/fusion'`. `performUpdateInstall` now detects EACCES/EPERM and returns actionable guidance (run `sudo fn update`, reinstall without sudo, or `brew upgrade fusion`) instead of raw stderr, and does not retry `--force` for this class.

### #10b — Daemon exited clean under memory pressure and wasn't restarted
`fn daemon`/`fn serve` now exit `128+signal` (SIGTERM=143, SIGINT=130) on signal-initiated shutdown instead of 0, so `Restart=on-failure` restarts a memory-pressure kill. A deliberate `systemctl stop` still won't restart (systemd honors the requested inactive state); non-signal shutdown still exits 0. The interactive `fn dashboard` TUI is intentionally unchanged (its own signal-name-keyed restart supervisor).

### #10c — Slow dashboard memory leak (badge snapshot cache)
The badge-snapshot cache only evicted on hard-delete, so archiving a task re-cached it via `task:updated` and it was retained for the daemon's lifetime — unbounded growth over long uptimes. New `isBadgeEligibleTask` predicate gates the create/update listeners so archived tasks are evicted (matching the startup prime's `includeArchived:false`).

## Investigated, not changed (working as designed)
- **#8 `pushAfterMerge`** — single `config.settings` store (no "decoy"); the toggle persists to the same store the merger reads, and the post-merge push uses an explicit `git push <remote> <branch>` refspec (no silent no-upstream skip). Default-off is intentional.
- **#10a bind 127.0.0.1** — `--host` flag exists; loopback is a deliberate, documented default (`fn daemon --host 0.0.0.0` to expose).

## Tests / verification
- New: `task-detail-prompt-resilience` (core), `badge-snapshot-eviction` (dashboard), `update-check` EACCES/EPERM cases, daemon exit-code assertions (130/143).
- Regression-safe: store-create/movement/persistence (156✓), prompt-generation/step-parsers (37✓); PROMPT.md changes are additive try/catch (happy path byte-identical).
- `pnpm verify:fast` ✓ (typecheck+build core/engine/dashboard/CLI + boot smoke); `pnpm check:changesets` ✓ (5 patch/performance changesets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archived tasks are removed from live badge notifications and cache.
  * Task operations remain available when `PROMPT.md` cannot be read, with clearer diagnostics.
  * Signal-triggered daemon and server shutdowns now return standard non-zero exit codes.
  * Update failures caused by permission issues now provide actionable guidance for npm and Homebrew installations.
  * Server-side error logging now includes underlying causes for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->