### PR TITLE
fix(core): repair chat session thinkingLevel migration

### DIFF
--- a/packages/core/src/__tests__/db-migrate.test.ts
+++ b/packages/core/src/__tests__/db-migrate.test.ts
@@ -716,6 +716,40 @@ describe("schema migration", () => {
     db.close();
   });
 
+  it("repairs v140 chat_sessions tables missing thinkingLevel", () => {
+    const db = new Database(fusionDir);
+    db.exec("CREATE TABLE IF NOT EXISTS __meta (key TEXT PRIMARY KEY, value TEXT)");
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS chat_sessions (
+        id TEXT PRIMARY KEY,
+        agentId TEXT NOT NULL,
+        title TEXT,
+        status TEXT NOT NULL DEFAULT 'active',
+        projectId TEXT,
+        modelProvider TEXT,
+        modelId TEXT,
+        createdAt TEXT NOT NULL,
+        updatedAt TEXT NOT NULL,
+        cliSessionFile TEXT,
+        inFlightGeneration TEXT,
+        cliExecutorAdapterId TEXT
+      )
+    `);
+    db.exec("INSERT INTO __meta (key, value) VALUES ('schemaVersion', '140')");
+    db.exec("INSERT INTO __meta (key, value) VALUES ('lastModified', '1000')");
+    db.exec(`INSERT INTO chat_sessions (id, agentId, createdAt, updatedAt) VALUES ('chat-legacy', 'agent-1', '2026-07-11T03:40:00.000Z', '2026-07-11T03:40:00.000Z')`);
+
+    db.init();
+
+    const columns = db.prepare("PRAGMA table_info(chat_sessions)").all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toContain("thinkingLevel");
+    const row = db.prepare("SELECT id, thinkingLevel FROM chat_sessions WHERE id = 'chat-legacy'").get() as { id: string; thinkingLevel: string | null };
+    expect(row).toEqual({ id: "chat-legacy", thinkingLevel: null });
+    expect(db.getSchemaVersion()).toBe(SCHEMA_VERSION);
+
+    db.close();
+  });
+
   it("adds deletedAt column + index when migrating from schema version 86", () => {
     const db = new Database(fusionDir);
     db.exec("CREATE TABLE IF NOT EXISTS __meta (key TEXT PRIMARY KEY, value TEXT)");

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -184,7 +184,7 @@ export function isFts5CorruptionError(error: unknown): boolean {
 
 // ── Schema Definition ────────────────────────────────────────────────
 
-const SCHEMA_VERSION = 140;
+const SCHEMA_VERSION = 141;
 
 const TASKS_FTS_AUTOMERGE = 8;
 const TASKS_FTS_CRISISMERGE = 16;
@@ -1521,6 +1521,7 @@ export const MIGRATION_ONLY_TABLE_SCHEMAS: Record<string, Record<string, string>
     projectId: "TEXT",
     modelProvider: "TEXT",
     modelId: "TEXT",
+    thinkingLevel: "TEXT",
     createdAt: "TEXT NOT NULL",
     updatedAt: "TEXT NOT NULL",
     cliSessionFile: "TEXT",
@@ -5650,6 +5651,22 @@ export class Database {
        * Chat sessions store an optional per-session reasoning-effort level so model-loop chats can pass it as the engine `defaultThinkingLevel`; NULL means inherit the resolved project/global default.
        */
       this.applyMigration(140, () => {
+        if (this.hasTable("chat_sessions")) {
+          this.addColumnIfMissing("chat_sessions", "thinkingLevel", "TEXT");
+        }
+      });
+    }
+
+    if (version < 141) {
+      /*
+       * FNXC:Chat-ThinkingLevelRepair 2026-07-11-03:40:
+       * Some live project databases reached schemaVersion 140 without the
+       * chat_sessions.thinkingLevel column, which made POST /api/chat/sessions
+       * fail with "table chat_sessions has no column named thinkingLevel".
+       * Re-run the additive column repair under a fresh schema version so
+       * already-v140 databases converge instead of being skipped forever.
+       */
+      this.applyMigration(141, () => {
         if (this.hasTable("chat_sessions")) {
           this.addColumnIfMissing("chat_sessions", "thinkingLevel", "TEXT");
         }


### PR DESCRIPTION
## Summary
- bumps the project DB schema and re-runs the additive chat_sessions.thinkingLevel repair for databases already at v140
- includes thinkingLevel in the migration-only chat_sessions schema
- adds a regression test for v140 databases missing the column

## Test Plan
- corepack pnpm --filter @fusion/core exec vitest run src/__tests__/db-migrate.test.ts --silent=passed-only --reporter=dot
- corepack pnpm --filter @fusion/core build
- restarted atlas-notes loopback dashboard and verified GET /, /api/health, authenticated /api/tasks, DB schemaVersion=141 with chat_sessions.thinkingLevel, and final atlas_fusion_flow_watchdog.py silence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability for existing installations.
  * Automatically restores the missing `thinkingLevel` field in chat session data during initialization, including for databases previously stamped at an older schema version.
  * Preserves legacy records while completing schema upgrades successfully.
* **Tests**
  * Added a migration regression test covering `chat_sessions.thinkingLevel` on upgraded schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->