### PR TITLE
test: fix stale refinement-title assertions after FN-7165

### DIFF
--- a/packages/core/src/__tests__/store-comments.test.ts
+++ b/packages/core/src/__tests__/store-comments.test.ts
@@ -207,7 +207,9 @@ describe("TaskStore", () => {
       const allTasksAfter = await store.listTasks();
       expect(allTasksAfter).toHaveLength(allTasksBefore.length + 1);
 
-      const refinement = allTasksAfter.find((t) => t.id !== task.id && t.title?.includes("Refinement"));
+      // FN-7165 titles refinements as `${sourceId}: ${feedback}` (not "Refinement …"),
+      // so identify the new task by its feedback-derived title.
+      const refinement = allTasksAfter.find((t) => t.id !== task.id && t.title?.includes("Need to fix edge case"));
       expect(refinement).toBeDefined();
       expect(refinement?.column).toBe("triage");
       expect(refinement?.dependencies).toContain(task.id);
@@ -572,7 +574,9 @@ describe("TaskStore", () => {
       const allTasksAfter = await store.listTasks();
       expect(allTasksAfter).toHaveLength(allTasksBefore.length + 1);
 
-      const refinement = allTasksAfter.find((t) => t.id !== task.id && t.title?.includes("Refinement"));
+      // FN-7165 titles refinements as `${sourceId}: ${feedback}` (not "Refinement …"),
+      // so identify the new task by its feedback-derived title.
+      const refinement = allTasksAfter.find((t) => t.id !== task.id && t.title?.includes("Need to fix edge case"));
       expect(refinement).toBeDefined();
     });
 


### PR DESCRIPTION
## Problem

Two tests in `packages/core/src/__tests__/store-comments.test.ts` were failing on `main`:
- `addComment > creates refinement task when steering comment added to done task`
- `addComment > regular addComment on done task still creates refinement`

Both failed at `expect(refinement).toBeDefined()`.

## Root cause

The tests locate the auto-created refinement task with `t.title?.includes("Refinement")`. Commit `34efa8b89` (**FN-7165: title refinement tasks with source feedback**) intentionally changed refinement titles to `${sourceId}: ${feedback}` (per the encoded requirement at `store.ts` — "Refinement titles must encode the source task id followed by the operator-entered feedback for immediate traceability"). FN-7165 didn't update these two assertions, so they went stale.

The refinement task is still created correctly — the `expect(allTasksAfter).toHaveLength(before + 1)` assertion passes; only the identifying substring was outdated.

## Fix

Identify the refinement by its feedback-derived title (`"Need to fix edge case"`, the comment text each test posts), matching the FN-7165 format. The remaining assertions (created, `column === "triage"`, `dependencies` contains the source id) are unchanged. **Test-only change, no product behavior change.**

## Verification

`pnpm --filter @fusion/core exec vitest run src/__tests__/store-comments.test.ts` → 53/53 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)