### PR TITLE
feat(compound-engineering): clarify the pipeline flow

### DIFF
--- a/.changeset/artifacts-doc-editing-and-comment-fix.md
+++ b/.changeset/artifacts-doc-editing-and-comment-fix.md
@@ -2,6 +2,6 @@
 "@runfusion/fusion": minor
 ---
 
-summary: Task documents and project files are now editable in the Artifacts view, task documents render markdown by default, and the select-to-comment "Add comment" button works again.
+summary: Edit task documents and project files in Artifacts, with Markdown previews and working add-comment controls.
 category: feature
 dev: DocumentsView embeds the shared CodeMirror FileEditor for task-document (PUT /tasks/:id/documents/:key) and project-file (project workspace file API) edits. The Add comment no-op was a CSS bundle-order regression — `.btn:active` out-ordered the equal-specificity trigger rule; the `:active` rules now use `.btn.selection-comment-trigger` (0,3,0) with a test asserting the prefix.

--- a/.changeset/clean-compound-pipeline.md
+++ b/.changeset/clean-compound-pipeline.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": minor
+---
+
+summary: Clarify Compound Engineering progress and preserve one plan from brainstorm through delivery.
+category: feature
+dev: Adds a stage rail, safer session controls, explicit choice confirmation, and terminal Work progression.

--- a/.changeset/clean-compound-pipeline.md
+++ b/.changeset/clean-compound-pipeline.md
@@ -2,6 +2,6 @@
 "@runfusion/fusion": minor
 ---
 
-summary: Clarify Compound Engineering progress and preserve one plan from brainstorm through delivery.
+summary: Support repeatable Compound Engineering cycles with project-scoped progress and artifact collections.
 category: feature
-dev: Adds a stage rail, safer session controls, explicit choice confirmation, and terminal Work progression.
+dev: Adds collection-aware stages, safer session controls, explicit choice confirmation, and terminal Work progression.

--- a/.changeset/clean-compound-pipeline.md
+++ b/.changeset/clean-compound-pipeline.md
@@ -2,6 +2,6 @@
 "@runfusion/fusion": minor
 ---
 
-summary: Support repeatable Compound Engineering cycles with project-scoped progress and artifact collections.
+summary: Guide repeatable Compound Engineering cycles from product grounding through reusable learnings.
 category: feature
-dev: Adds collection-aware stages, safer session controls, explicit choice confirmation, and terminal Work progression.
+dev: Adds project-scoped sessions, collection-aware stages, Work quality gates, and terminal Compound progression.

--- a/docs/screenshots/compound-engineering/pipeline-desktop.png
+++ b/docs/screenshots/compound-engineering/pipeline-desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6c218824cbd21ec36305437e2adc5c810163ab25cd28fdee705bb12ddf48b93
-size 270173
+oid sha256:06d35e52a88966234de0aef50cc471a474a80422789cfaba5e3b8133f189e2d8
+size 251273

--- a/docs/screenshots/compound-engineering/pipeline-desktop.png
+++ b/docs/screenshots/compound-engineering/pipeline-desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e4dc3baed78f895c3a954ade947e3ee211da7612b6f1693127f8f67f74689a3
+size 234370

--- a/docs/screenshots/compound-engineering/pipeline-desktop.png
+++ b/docs/screenshots/compound-engineering/pipeline-desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e4dc3baed78f895c3a954ade947e3ee211da7612b6f1693127f8f67f74689a3
-size 234370
+oid sha256:a6c218824cbd21ec36305437e2adc5c810163ab25cd28fdee705bb12ddf48b93
+size 270173

--- a/docs/screenshots/compound-engineering/pipeline-mobile.png
+++ b/docs/screenshots/compound-engineering/pipeline-mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bbcbf6767d6982ebb4340498396dc1453eb2e7458c3f0877c20d7a4f5ece9d3
-size 95990
+oid sha256:5ddba7235bdf54679910eae60d9716ea631fec8ef5e0a8be651e197fca243225
+size 98300

--- a/docs/screenshots/compound-engineering/pipeline-mobile.png
+++ b/docs/screenshots/compound-engineering/pipeline-mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e1320ecaac17cc84399f7cf58de13df5100175dd57e34fd1d6c0039e630f487
-size 90474
+oid sha256:9bbcbf6767d6982ebb4340498396dc1453eb2e7458c3f0877c20d7a4f5ece9d3
+size 95990

--- a/docs/screenshots/compound-engineering/pipeline-mobile.png
+++ b/docs/screenshots/compound-engineering/pipeline-mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e1320ecaac17cc84399f7cf58de13df5100175dd57e34fd1d6c0039e630f487
+size 90474

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/session-routes.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/session-routes.test.ts
@@ -133,6 +133,20 @@ describe("session routes (polling transport)", () => {
     expect(sessions.map((s) => s.stage).sort()).toEqual(["brainstorm", "plan"]);
   });
 
+  it("GET /sessions scopes every session consumer to the requested project", async () => {
+    const { getCeSessionStore } = await import("../session/session-store.js");
+    const store = getCeSessionStore(h.ctx);
+    const projectA = store.create({ stage: "brainstorm", projectId: "project-a" });
+    store.create({ stage: "plan", projectId: "project-b" });
+    store.create({ stage: "debug" });
+
+    const res = await call("GET", "/sessions", { params: {}, query: { projectId: "project-a" } }, h.ctx);
+
+    expect(res.status).toBe(200);
+    const sessions = (res.body as { sessions: Array<{ id: string; projectId: string | null }> }).sessions;
+    expect(sessions).toEqual([expect.objectContaining({ id: projectA.id, projectId: "project-a" })]);
+  });
+
   it("GET /sessions keeps error, interrupted, awaiting_input, active, and completed rows independently manageable", async () => {
     const { getCeSessionStore } = await import("../session/session-store.js");
     const store = getCeSessionStore(h.ctx);

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/session-store.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/session-store.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { CeSessionStore, STALE_INTERVAL_MULTIPLE } from "../session/session-store.js";
+import { CeSessionStore, PlanHandoffClaimError, STALE_INTERVAL_MULTIPLE } from "../session/session-store.js";
 import { ensureCeSchema } from "../schema.js";
 import { makeHarness, type TestHarness } from "./_harness.js";
 
@@ -28,6 +28,10 @@ describe("ensureCeSchema", () => {
         "lastActivityAt",
       ]),
     );
+    const claimsTable = h.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ce_plan_handoff_claims'")
+      .get() as { name: string } | undefined;
+    expect(claimsTable?.name).toBe("ce_plan_handoff_claims");
   });
 });
 
@@ -103,6 +107,18 @@ describe("multi-session independence + delete", () => {
     expect(store.get(c.id)).toBeDefined();
     // Deleting a missing row reports false, no throw.
     expect(store.delete(b.id)).toBe(false);
+  });
+
+  it("atomically claims a requirements artifact for one Plan session and releases it on discard", () => {
+    const store = new CeSessionStore(h.db);
+    const artifactPath = "docs/plans/2026-07-11-001-topic-plan.md";
+    const first = store.createWithPlanHandoffClaim({ stage: "plan", projectId: "p1" }, artifactPath);
+
+    expect(() => store.createWithPlanHandoffClaim({ stage: "plan", projectId: "p1" }, artifactPath)).toThrow(PlanHandoffClaimError);
+    expect(store.delete(first.id)).toBe(true);
+
+    const retry = store.createWithPlanHandoffClaim({ stage: "plan", projectId: "p1" }, artifactPath);
+    expect(retry.artifactPath).toBe(artifactPath);
   });
 });
 

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/stage-registry.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/stage-registry.test.ts
@@ -1,17 +1,28 @@
 import { describe, expect, it } from "vitest";
 import * as LucideIcons from "lucide-react";
-import { getStage, listStages } from "../session/stage-registry.js";
+import { getStage, listPipelineStages, listStages } from "../session/stage-registry.js";
 import { nextStageAfter } from "../sync/reconciler.js";
 
 describe("compound engineering stage registry", () => {
-  it("keeps the linear pipeline order unchanged and appends debug at the tail", () => {
+  it("keeps debug launchable while excluding it from the automatic pipeline", () => {
     const stageIds = listStages().map((stage) => stage.stageId);
+    const pipelineStageIds = listPipelineStages().map((stage) => stage.stageId);
 
     expect(stageIds.slice(0, 5)).toEqual(["strategy", "ideate", "brainstorm", "plan", "work"]);
     expect(stageIds.at(-1)).toBe("debug");
     expect(stageIds.filter((stageId) => stageId === "debug")).toHaveLength(1);
     expect(stageIds.indexOf("plan")).toBeLessThan(stageIds.indexOf("work"));
     expect(stageIds.indexOf("work")).toBeLessThan(stageIds.indexOf("debug"));
+    expect(pipelineStageIds).toEqual(["strategy", "ideate", "brainstorm", "plan", "work"]);
+  });
+
+  it("advances through every automatic transition and treats work as terminal", () => {
+    expect(nextStageAfter("strategy")).toBe("ideate");
+    expect(nextStageAfter("ideate")).toBe("brainstorm");
+    expect(nextStageAfter("brainstorm")).toBe("plan");
+    expect(nextStageAfter("plan")).toBe("work");
+    expect(nextStageAfter("work")).toBeUndefined();
+    expect(nextStageAfter("debug")).toBeUndefined();
   });
 
   it("aliases brainstorm to unified docs/plans artifacts without renaming the stage or skill", () => {
@@ -42,6 +53,7 @@ describe("compound engineering stage registry", () => {
       artifactGlob: "docs/debug/**/*.md",
       icon: "Bug",
       label: "Debug",
+      participatesInPipeline: false,
     });
     expect((LucideIcons as unknown as Record<string, unknown>)[stage!.icon]).toBeTruthy();
   });

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/stage-registry.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/stage-registry.test.ts
@@ -8,20 +8,21 @@ describe("compound engineering stage registry", () => {
     const stageIds = listStages().map((stage) => stage.stageId);
     const pipelineStageIds = listPipelineStages().map((stage) => stage.stageId);
 
-    expect(stageIds.slice(0, 5)).toEqual(["strategy", "ideate", "brainstorm", "plan", "work"]);
+    expect(stageIds.slice(0, 6)).toEqual(["strategy", "ideate", "brainstorm", "plan", "work", "compound"]);
     expect(stageIds.at(-1)).toBe("debug");
     expect(stageIds.filter((stageId) => stageId === "debug")).toHaveLength(1);
     expect(stageIds.indexOf("plan")).toBeLessThan(stageIds.indexOf("work"));
-    expect(stageIds.indexOf("work")).toBeLessThan(stageIds.indexOf("debug"));
-    expect(pipelineStageIds).toEqual(["strategy", "ideate", "brainstorm", "plan", "work"]);
+    expect(stageIds.indexOf("compound")).toBeLessThan(stageIds.indexOf("debug"));
+    expect(pipelineStageIds).toEqual(["brainstorm", "plan", "work", "compound"]);
   });
 
-  it("advances through every automatic transition and treats work as terminal", () => {
-    expect(nextStageAfter("strategy")).toBe("ideate");
-    expect(nextStageAfter("ideate")).toBe("brainstorm");
+  it("advances through delivery into compounding and treats compound as terminal", () => {
+    expect(nextStageAfter("strategy")).toBeUndefined();
+    expect(nextStageAfter("ideate")).toBeUndefined();
     expect(nextStageAfter("brainstorm")).toBe("plan");
     expect(nextStageAfter("plan")).toBe("work");
-    expect(nextStageAfter("work")).toBeUndefined();
+    expect(nextStageAfter("work")).toBe("compound");
+    expect(nextStageAfter("compound")).toBeUndefined();
     expect(nextStageAfter("debug")).toBeUndefined();
   });
 
@@ -47,7 +48,7 @@ describe("compound engineering stage registry", () => {
 
     expect(stage).toMatchObject({
       stageId: "debug",
-      order: 600,
+      order: 700,
       skillId: "ce-debug",
       artifactLocation: "docs/debug/",
       artifactGlob: "docs/debug/**/*.md",

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/stage-skill-loading.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/stage-skill-loading.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CreateInteractiveAiSessionFactory } from "@fusion/core";
 import { CeOrchestrator, warnIfStageSkillMissing } from "../session/orchestrator.js";
+import { getCeSessionStore } from "../session/session-store.js";
 import { listStages } from "../session/stage-registry.js";
 import { makeHarness, makeScriptedSession, type TestHarness } from "./_harness.js";
 
@@ -64,6 +65,120 @@ describe("CE stage skill loading session options", () => {
       );
     } finally {
       rmSync(missingRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("enriches a completed brainstorm artifact in place when plan starts for the same project", async () => {
+    const capturedOptions: Parameters<CreateInteractiveAiSessionFactory>[0][] = [];
+    const factory: CreateInteractiveAiSessionFactory = vi.fn(async (options) => {
+      capturedOptions.push(options);
+      const artifact = options.requestedSkillNames?.includes("ce-brainstorm")
+        ? "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: requirements-only\n---\n# Requirements\n"
+        : "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: implementation-ready\nexecution: code\n---\n# Plan\n";
+      return { session: makeScriptedSession([{ type: "complete", data: { artifact } }]) };
+    });
+    const orch = new CeOrchestrator({ ctx: h.ctx, createInteractiveAiSession: factory, projectRoot: h.projectRoot });
+
+    const brainstorm = await orch.start("brainstorm", { openingMessage: "Frame it", projectId: "project-a" });
+    const plan = await orch.start("plan", { openingMessage: "Plan it", projectId: "project-a" });
+
+    expect(plan.session.artifactPath).toBe(brainstorm.session.artifactPath);
+    expect(readFileSync(plan.session.artifactPath!, "utf8")).toContain("artifact_readiness: implementation-ready");
+    expect(capturedOptions[1].systemPrompt).toContain(brainstorm.session.artifactPath!);
+    expect(capturedOptions[1].systemPrompt).toContain("enrich that exact artifact in place");
+  });
+
+  it("uses the explicitly selected brainstorm predecessor when several are complete", async () => {
+    const factory: CreateInteractiveAiSessionFactory = vi.fn(async (options) => {
+      const artifact = options.requestedSkillNames?.includes("ce-brainstorm")
+        ? "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: requirements-only\n---\n# Requirements\n"
+        : "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: implementation-ready\n---\n# Plan\n";
+      return { session: makeScriptedSession([{ type: "complete", data: { artifact } }]) };
+    });
+    const orch = new CeOrchestrator({ ctx: h.ctx, createInteractiveAiSession: factory, projectRoot: h.projectRoot });
+    const older = await orch.start("brainstorm", { openingMessage: "Older", projectId: "project-a" });
+    const newer = await orch.start("brainstorm", { openingMessage: "Newer", projectId: "project-a" });
+
+    const plan = await orch.start("plan", {
+      openingMessage: "Plan the selected requirements",
+      projectId: "project-a",
+      sourceSessionId: older.session.id,
+    });
+
+    expect(plan.session.artifactPath).toBe(older.session.artifactPath);
+    expect(readFileSync(older.session.artifactPath!, "utf8")).toContain("implementation-ready");
+    expect(readFileSync(newer.session.artifactPath!, "utf8")).toContain("requirements-only");
+  });
+
+  it("does not reuse an already implementation-ready brainstorm artifact", async () => {
+    const factory: CreateInteractiveAiSessionFactory = vi.fn(async (options) => {
+      const artifact = options.requestedSkillNames?.includes("ce-brainstorm")
+        ? "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: requirements-only\n---\n# Requirements\n"
+        : "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: implementation-ready\n---\n# Plan\n";
+      return { session: makeScriptedSession([{ type: "complete", data: { artifact } }]) };
+    });
+    const orch = new CeOrchestrator({ ctx: h.ctx, createInteractiveAiSession: factory, projectRoot: h.projectRoot });
+    const brainstorm = await orch.start("brainstorm", { openingMessage: "Frame it", projectId: "project-a" });
+    const firstPlan = await orch.start("plan", { openingMessage: "Plan it", projectId: "project-a" });
+    const finalized = readFileSync(firstPlan.session.artifactPath!, "utf8");
+
+    const secondPlan = await orch.start("plan", { openingMessage: "Plan again", projectId: "project-a" });
+
+    expect(secondPlan.session.artifactPath).not.toBe(brainstorm.session.artifactPath);
+    expect(readFileSync(brainstorm.session.artifactPath!, "utf8")).toBe(finalized);
+  });
+
+  it("preserves requirements when Plan completion is not implementation-ready", async () => {
+    const factory: CreateInteractiveAiSessionFactory = vi.fn(async (options) => {
+      const artifact = options.requestedSkillNames?.includes("ce-brainstorm")
+        ? "---\nartifact_contract: ce-unified-plan/v1\nartifact_readiness: requirements-only\n---\n# Requirements\n"
+        : "# malformed plan";
+      return { session: makeScriptedSession([{ type: "complete", data: { artifact } }]) };
+    });
+    const orch = new CeOrchestrator({ ctx: h.ctx, createInteractiveAiSession: factory, projectRoot: h.projectRoot });
+    const brainstorm = await orch.start("brainstorm", { openingMessage: "Frame it", projectId: "project-a" });
+    const original = readFileSync(brainstorm.session.artifactPath!, "utf8");
+
+    const plan = await orch.start("plan", { openingMessage: "Plan it", projectId: "project-a" });
+
+    expect(plan.session.status).toBe("error");
+    expect(readFileSync(brainstorm.session.artifactPath!, "utf8")).toBe(original);
+  });
+
+  it("does not reuse a brainstorm artifact from another project", async () => {
+    const factory: CreateInteractiveAiSessionFactory = vi.fn(async (options) => ({
+      session: makeScriptedSession([{
+        type: "complete",
+        data: { artifact: `# ${options.requestedSkillNames?.[0]}` },
+      }]),
+    }));
+    const orch = new CeOrchestrator({ ctx: h.ctx, createInteractiveAiSession: factory, projectRoot: h.projectRoot });
+
+    const brainstorm = await orch.start("brainstorm", { openingMessage: "Frame it", projectId: "project-a" });
+    const plan = await orch.start("plan", { openingMessage: "Plan it", projectId: "project-b" });
+
+    expect(plan.session.artifactPath).not.toBe(brainstorm.session.artifactPath);
+  });
+
+  it("rejects persisted brainstorm handoffs outside docs/plans", async () => {
+    const outsideRoot = mkdtempSync(join(tmpdir(), "ce-outside-plan-"));
+    const outsideArtifact = join(outsideRoot, "requirements.md");
+    writeFileSync(outsideArtifact, "do not overwrite", "utf8");
+    const store = getCeSessionStore(h.ctx);
+    const seeded = store.create({ stage: "brainstorm", projectId: "project-a", artifactPath: outsideArtifact });
+    store.update(seeded.id, { status: "completed" });
+    const factory: CreateInteractiveAiSessionFactory = vi.fn(async () => ({
+      session: makeScriptedSession([{ type: "complete", data: { artifact: "# Safe plan" } }]),
+    }));
+    const orch = new CeOrchestrator({ ctx: h.ctx, createInteractiveAiSession: factory, projectRoot: h.projectRoot });
+
+    try {
+      const plan = await orch.start("plan", { openingMessage: "Plan it", projectId: "project-a" });
+
+      expect(plan.session.artifactPath).not.toBe(outsideArtifact);
+      expect(readFileSync(outsideArtifact, "utf8")).toBe("do not overwrite");
+    } finally {
+      rmSync(outsideRoot, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/sync.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/sync.test.ts
@@ -183,8 +183,25 @@ describe("U8 reconciler (convergence + outbound)", () => {
     expect(state.currentStage).toBe("work");
   });
 
-  it("completing work terminates the automatic pipeline without creating a debug task", async () => {
+  it("completing work advances to Compound without creating a debug task", async () => {
     const { cePipelineId, task } = await landPipeline("work");
+    const before = await taskStore.listTasks();
+
+    await moveTo(task.id, "done");
+    const result = await reconcileCePipelines(ctx);
+
+    expect(result.advanced).toBe(1);
+    expect(result.tasksCreated).toBe(1);
+    expect(getCePipelineStore(ctx).getState(cePipelineId)).toMatchObject({
+      currentStage: "compound",
+      status: "awaiting_board",
+    });
+    expect(await taskStore.listTasks()).toHaveLength(before.length + 1);
+    expect(getCePipelineStore(ctx).listByPipeline(cePipelineId).some((link) => link.ceStageId === "debug")).toBe(false);
+  });
+
+  it("completing Compound closes the delivery loop without creating another task", async () => {
+    const { cePipelineId, task } = await landPipeline("compound");
     const before = await taskStore.listTasks();
 
     await moveTo(task.id, "done");
@@ -193,11 +210,10 @@ describe("U8 reconciler (convergence + outbound)", () => {
     expect(result.advanced).toBe(1);
     expect(result.tasksCreated).toBe(0);
     expect(getCePipelineStore(ctx).getState(cePipelineId)).toMatchObject({
-      currentStage: "work",
+      currentStage: "compound",
       status: "completed",
     });
     expect(await taskStore.listTasks()).toHaveLength(before.length);
-    expect(getCePipelineStore(ctx).listByPipeline(cePipelineId).some((link) => link.ceStageId === "debug")).toBe(false);
   });
 
   it("outbound: advancing the pipeline propagates a NEW next-stage board task", async () => {

--- a/plugins/fusion-plugin-compound-engineering/src/__tests__/sync.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/__tests__/sync.test.ts
@@ -183,6 +183,23 @@ describe("U8 reconciler (convergence + outbound)", () => {
     expect(state.currentStage).toBe("work");
   });
 
+  it("completing work terminates the automatic pipeline without creating a debug task", async () => {
+    const { cePipelineId, task } = await landPipeline("work");
+    const before = await taskStore.listTasks();
+
+    await moveTo(task.id, "done");
+    const result = await reconcileCePipelines(ctx);
+
+    expect(result.advanced).toBe(1);
+    expect(result.tasksCreated).toBe(0);
+    expect(getCePipelineStore(ctx).getState(cePipelineId)).toMatchObject({
+      currentStage: "work",
+      status: "completed",
+    });
+    expect(await taskStore.listTasks()).toHaveLength(before.length);
+    expect(getCePipelineStore(ctx).listByPipeline(cePipelineId).some((link) => link.ceStageId === "debug")).toBe(false);
+  });
+
   it("outbound: advancing the pipeline propagates a NEW next-stage board task", async () => {
     const { cePipelineId, task } = await landPipeline("plan");
     const before = (await taskStore.listTasks()).length;

--- a/plugins/fusion-plugin-compound-engineering/src/artifacts/__tests__/discovery.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/artifacts/__tests__/discovery.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as realFs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { registerStage } from "../../session/stage-registry.js";
+import { registerStage, unregisterStage } from "../../session/stage-registry.js";
 
 // Mock node:fs so we can observe/inject behaviour around readFileSync and
 // accessSync without relying on vi.spyOn (ESM namespace exports are not
@@ -40,6 +40,7 @@ describe("discoverArtifacts", () => {
 
   afterEach(() => {
     if (root) rmSync(root, { recursive: true, force: true });
+    unregisterStage("publish-check");
     readFileHook = undefined;
     accessHook = undefined;
     vi.restoreAllMocks();
@@ -52,6 +53,8 @@ describe("discoverArtifacts", () => {
     mkdirSync(join(root, "docs/ideation"), { recursive: true });
     writeFileSync(join(root, "docs/ideation/a.md"), "ideation a");
     writeFileSync(join(root, "docs/ideation/b.md"), "ideation b");
+    mkdirSync(join(root, "docs/brainstorms"), { recursive: true });
+    writeFileSync(join(root, "docs/brainstorms/requirements.md"), "requirements");
     mkdirSync(join(root, "docs/plans"), { recursive: true });
     writeFileSync(join(root, "docs/plans/plan1.md"), "plan 1");
     mkdirSync(join(root, "docs/work"), { recursive: true });
@@ -64,20 +67,21 @@ describe("discoverArtifacts", () => {
     const result = discoverArtifacts(root);
     const byStage = Object.fromEntries(result.groups.map((g) => [g.stage, g]));
 
-    expect(result.totalArtifacts).toBe(8);
+    expect(result.totalArtifacts).toBe(9);
     expect(result.totalErrors).toBe(0);
     expect(byStage.strategy.entries).toHaveLength(1);
     expect(byStage.concepts.entries).toHaveLength(1);
     expect(byStage.ideate.entries).toHaveLength(2);
     expect(byStage.plan.entries).toHaveLength(1);
     expect(byStage.plan.entries[0]).toMatchObject({ path: "docs/plans/plan1.md" });
-    expect(byStage.plan.label).toBe("Brainstorm / Plan");
+    expect(byStage.brainstorm.entries).toHaveLength(1);
+    expect(byStage.plan.label).toBe("Plan");
     expect(byStage.work.entries[0]).toMatchObject({ path: "docs/work/work.md" });
     expect(byStage.debug.entries[0]).toMatchObject({ path: "docs/debug/debug.md" });
     expect(byStage.solution.entries).toHaveLength(1);
     // Every group present is flagged present.
     expect(byStage.ideate.present).toBe(true);
-    expect(byStage.brainstorm).toBeUndefined();
+    expect(byStage.brainstorm.entries[0]).toMatchObject({ path: "docs/brainstorms/requirements.md" });
     // All entries are artifacts in the happy path.
     expect(result.groups.flatMap((g) => g.entries).every((e) => e.kind === "artifact")).toBe(true);
   });
@@ -112,7 +116,7 @@ describe("discoverArtifacts", () => {
     expect(populated.map((g) => g.stage).sort()).toEqual(["plan", "strategy"]);
     expect(empty.length).toBeGreaterThan(0);
     // Empty groups are still present in the result so the hub can render them.
-    expect(result.groups).toHaveLength(7);
+    expect(result.groups).toHaveLength(8);
   });
 
   it("returns an all-empty result when nothing is present (first-run)", () => {

--- a/plugins/fusion-plugin-compound-engineering/src/artifacts/__tests__/discovery.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/artifacts/__tests__/discovery.test.ts
@@ -78,7 +78,7 @@ describe("discoverArtifacts", () => {
     expect(byStage.plan.label).toBe("Plan");
     expect(byStage.work.entries[0]).toMatchObject({ path: "docs/work/work.md" });
     expect(byStage.debug.entries[0]).toMatchObject({ path: "docs/debug/debug.md" });
-    expect(byStage.solution.entries).toHaveLength(1);
+    expect(byStage.compound.entries).toHaveLength(1);
     // Every group present is flagged present.
     expect(byStage.ideate.present).toBe(true);
     expect(byStage.brainstorm.entries[0]).toMatchObject({ path: "docs/brainstorms/requirements.md" });

--- a/plugins/fusion-plugin-compound-engineering/src/artifacts/__tests__/discovery.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/artifacts/__tests__/discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as realFs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { registerStage } from "../../session/stage-registry.js";
 
 // Mock node:fs so we can observe/inject behaviour around readFileSync and
 // accessSync without relying on vi.spyOn (ESM namespace exports are not
@@ -44,35 +45,39 @@ describe("discoverArtifacts", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns grouped artifacts from legacy brainstorm and unified plan locations (happy path)", () => {
+  it("returns registry-backed pipeline artifacts plus explicit knowledge collections", () => {
     root = makeRepo();
     writeFileSync(join(root, "STRATEGY.md"), "# Strategy");
     writeFileSync(join(root, "CONCEPTS.md"), "# Concepts");
     mkdirSync(join(root, "docs/ideation"), { recursive: true });
     writeFileSync(join(root, "docs/ideation/a.md"), "ideation a");
     writeFileSync(join(root, "docs/ideation/b.md"), "ideation b");
-    mkdirSync(join(root, "docs/brainstorms"), { recursive: true });
-    writeFileSync(join(root, "docs/brainstorms/x.md"), "brainstorm x");
     mkdirSync(join(root, "docs/plans"), { recursive: true });
     writeFileSync(join(root, "docs/plans/plan1.md"), "plan 1");
+    mkdirSync(join(root, "docs/work"), { recursive: true });
+    writeFileSync(join(root, "docs/work/work.md"), "work");
+    mkdirSync(join(root, "docs/debug"), { recursive: true });
+    writeFileSync(join(root, "docs/debug/debug.md"), "debug");
     mkdirSync(join(root, "docs/solutions"), { recursive: true });
     writeFileSync(join(root, "docs/solutions/sol.md"), "solution");
 
     const result = discoverArtifacts(root);
     const byStage = Object.fromEntries(result.groups.map((g) => [g.stage, g]));
 
-    expect(result.totalArtifacts).toBe(7);
+    expect(result.totalArtifacts).toBe(8);
     expect(result.totalErrors).toBe(0);
     expect(byStage.strategy.entries).toHaveLength(1);
     expect(byStage.concepts.entries).toHaveLength(1);
-    expect(byStage.ideation.entries).toHaveLength(2);
-    expect(byStage.brainstorm.entries).toHaveLength(1);
-    expect(byStage.brainstorm.entries[0]).toMatchObject({ path: "docs/brainstorms/x.md" });
+    expect(byStage.ideate.entries).toHaveLength(2);
     expect(byStage.plan.entries).toHaveLength(1);
     expect(byStage.plan.entries[0]).toMatchObject({ path: "docs/plans/plan1.md" });
+    expect(byStage.plan.label).toBe("Brainstorm / Plan");
+    expect(byStage.work.entries[0]).toMatchObject({ path: "docs/work/work.md" });
+    expect(byStage.debug.entries[0]).toMatchObject({ path: "docs/debug/debug.md" });
     expect(byStage.solution.entries).toHaveLength(1);
     // Every group present is flagged present.
-    expect(byStage.ideation.present).toBe(true);
+    expect(byStage.ideate.present).toBe(true);
+    expect(byStage.brainstorm).toBeUndefined();
     // All entries are artifacts in the happy path.
     expect(result.groups.flatMap((g) => g.entries).every((e) => e.kind === "artifact")).toBe(true);
   });
@@ -107,7 +112,7 @@ describe("discoverArtifacts", () => {
     expect(populated.map((g) => g.stage).sort()).toEqual(["plan", "strategy"]);
     expect(empty.length).toBeGreaterThan(0);
     // Empty groups are still present in the result so the hub can render them.
-    expect(result.groups).toHaveLength(6);
+    expect(result.groups).toHaveLength(7);
   });
 
   it("returns an all-empty result when nothing is present (first-run)", () => {
@@ -118,10 +123,8 @@ describe("discoverArtifacts", () => {
     expect(result.groups.every((g) => g.entries.length === 0 && !g.present)).toBe(true);
   });
 
-  it("classifies unified plan readiness metadata while keeping legacy files valid without frontmatter", () => {
+  it("classifies both readiness states in the single unified plan collection", () => {
     root = makeRepo();
-    mkdirSync(join(root, "docs/brainstorms"), { recursive: true });
-    writeFileSync(join(root, "docs/brainstorms/legacy.md"), "# Legacy brainstorm");
     mkdirSync(join(root, "docs/plans"), { recursive: true });
     writeFileSync(
       join(root, "docs/plans/requirements.md"),
@@ -133,18 +136,10 @@ describe("discoverArtifacts", () => {
     );
 
     const result = discoverArtifacts(root);
-    const brainstorm = result.groups.find((g) => g.stage === "brainstorm")!;
     const plan = result.groups.find((g) => g.stage === "plan")!;
-    const legacy = brainstorm.entries[0];
     const requirementsOnly = plan.entries.find((e) => e.name === "requirements.md");
     const implementationReady = plan.entries.find((e) => e.name === "implementation.md");
 
-    expect(legacy).toMatchObject({
-      kind: "artifact",
-      artifactContract: null,
-      artifactReadiness: null,
-      productContractSource: null,
-    });
     expect(requirementsOnly).toMatchObject({
       kind: "artifact",
       artifactContract: "ce-unified-plan/v1",
@@ -277,6 +272,26 @@ describe("discoverArtifacts", () => {
     writeFileSync(join(root, "secrets.md"), "secret");
 
     expect(readArtifactById(root, "plan:../../secrets.md")).toBeUndefined();
+  });
+
+  it("discovers artifacts for a runtime-registered stage", () => {
+    registerStage({
+      stageId: "publish-check",
+      order: 550,
+      skillId: "ce-publish-check",
+      artifactLocation: "docs/publish-check/",
+      icon: "FileCheck",
+      label: "Publish Check",
+    });
+    root = makeRepo();
+    mkdirSync(join(root, "docs/publish-check"), { recursive: true });
+    writeFileSync(join(root, "docs/publish-check/result.md"), "# Ready");
+
+    const result = discoverArtifacts(root);
+    expect(result.groups.find((group) => group.stage === "publish-check")).toMatchObject({
+      label: "Publish Check",
+      entries: [expect.objectContaining({ path: "docs/publish-check/result.md" })],
+    });
   });
 });
 

--- a/plugins/fusion-plugin-compound-engineering/src/artifacts/discovery.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/artifacts/discovery.ts
@@ -65,7 +65,7 @@ function stageLocations(): ConventionalLocation[] {
     const path = definition.artifactLocation.replace(/\/$/, "");
     return {
       stage: definition.stageId,
-      label: definition.label,
+      label: definition.stageId === "compound" ? "Learnings" : definition.label,
       path,
       kind: definition.artifactLocation.endsWith("/") ? "directory" : "file",
     };
@@ -76,7 +76,6 @@ function conventionalLocations(): ConventionalLocation[] {
   return [
     ...stageLocations(),
     { stage: "brainstorm", label: "Brainstorms", path: "docs/brainstorms", kind: "directory" },
-    { stage: "solution", label: "Solutions", path: "docs/solutions", kind: "directory" },
     { stage: "concepts", label: "Concepts", path: "CONCEPTS.md", kind: "file" },
   ];
 }

--- a/plugins/fusion-plugin-compound-engineering/src/artifacts/discovery.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/artifacts/discovery.ts
@@ -55,14 +55,17 @@ interface ConventionalLocation {
  */
 /*
 FNXC:CompoundEngineeringArtifacts 2026-07-10-12:00:
-The artifact hub must follow registered stage output locations so Work and Debug remain discoverable as the pipeline evolves. Brainstorm and Plan share one durable docs/plans collection; exposing the removed docs/brainstorms location or two groups for the same path misrepresents the unified-plan contract.
+The artifact hub must follow registered stage output locations so Work and Debug remain discoverable as the pipeline evolves.
+
+FNXC:CompoundEngineeringArtifacts 2026-07-10-23:40:
+The upstream Compound Engineering workflow writes repeatable requirements documents to docs/brainstorms and implementation plans to docs/plans. Discovery must retain the dedicated requirements history while also supporting requirements-only unified plans produced by newer in-place handoffs.
 */
 function stageLocations(): ConventionalLocation[] {
   return listStages().filter((definition) => definition.stageId !== "brainstorm").map((definition) => {
     const path = definition.artifactLocation.replace(/\/$/, "");
     return {
       stage: definition.stageId,
-      label: definition.stageId === "plan" ? "Brainstorm / Plan" : definition.label,
+      label: definition.label,
       path,
       kind: definition.artifactLocation.endsWith("/") ? "directory" : "file",
     };
@@ -72,6 +75,7 @@ function stageLocations(): ConventionalLocation[] {
 function conventionalLocations(): ConventionalLocation[] {
   return [
     ...stageLocations(),
+    { stage: "brainstorm", label: "Brainstorms", path: "docs/brainstorms", kind: "directory" },
     { stage: "solution", label: "Solutions", path: "docs/solutions", kind: "directory" },
     { stage: "concepts", label: "Concepts", path: "CONCEPTS.md", kind: "file" },
   ];

--- a/plugins/fusion-plugin-compound-engineering/src/artifacts/discovery.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/artifacts/discovery.ts
@@ -10,6 +10,7 @@ import {
   realpathSync,
 } from "node:fs";
 import { isAbsolute, join, relative, sep } from "node:path";
+import { listStages } from "../session/stage-registry.js";
 
 /**
  * CE artifact discovery (U3).
@@ -21,17 +22,19 @@ import { isAbsolute, join, relative, sep } from "node:path";
  * them. An artifact that cannot be read or is malformed is represented as an
  * `error` entry rather than crashing the scan or being silently dropped.
  *
- * Locations (per the plan): STRATEGY.md, docs/ideation/, docs/brainstorms/,
- * docs/plans/, docs/solutions/, CONCEPTS.md.
+ * Stage locations come from the registry. Solutions and Concepts remain
+ * explicit knowledge collections because they are not interactive stages.
  */
 
 export type CeArtifactStage =
   | "strategy"
-  | "ideation"
-  | "brainstorm"
+  | "ideate"
   | "plan"
+  | "work"
+  | "debug"
   | "solution"
-  | "concepts";
+  | "concepts"
+  | (string & {});
 
 /** Whether a conventional location is a single file or a directory of files. */
 type LocationKind = "file" | "directory";
@@ -50,14 +53,31 @@ interface ConventionalLocation {
  * scanner reads ONLY these paths (and, for directories, their immediate `.md`
  * children). Nothing outside this list is opened.
  */
-export const CONVENTIONAL_LOCATIONS: readonly ConventionalLocation[] = [
-  { stage: "strategy", label: "Strategy", path: "STRATEGY.md", kind: "file" },
-  { stage: "ideation", label: "Ideation", path: "docs/ideation", kind: "directory" },
-  { stage: "brainstorm", label: "Brainstorms", path: "docs/brainstorms", kind: "directory" },
-  { stage: "plan", label: "Plans", path: "docs/plans", kind: "directory" },
-  { stage: "solution", label: "Solutions", path: "docs/solutions", kind: "directory" },
-  { stage: "concepts", label: "Concepts", path: "CONCEPTS.md", kind: "file" },
-];
+/*
+FNXC:CompoundEngineeringArtifacts 2026-07-10-12:00:
+The artifact hub must follow registered stage output locations so Work and Debug remain discoverable as the pipeline evolves. Brainstorm and Plan share one durable docs/plans collection; exposing the removed docs/brainstorms location or two groups for the same path misrepresents the unified-plan contract.
+*/
+function stageLocations(): ConventionalLocation[] {
+  return listStages().filter((definition) => definition.stageId !== "brainstorm").map((definition) => {
+    const path = definition.artifactLocation.replace(/\/$/, "");
+    return {
+      stage: definition.stageId,
+      label: definition.stageId === "plan" ? "Brainstorm / Plan" : definition.label,
+      path,
+      kind: definition.artifactLocation.endsWith("/") ? "directory" : "file",
+    };
+  });
+}
+
+function conventionalLocations(): ConventionalLocation[] {
+  return [
+    ...stageLocations(),
+    { stage: "solution", label: "Solutions", path: "docs/solutions", kind: "directory" },
+    { stage: "concepts", label: "Concepts", path: "CONCEPTS.md", kind: "file" },
+  ];
+}
+
+export const CONVENTIONAL_LOCATIONS: readonly ConventionalLocation[] = conventionalLocations();
 
 /** A discovered, readable artifact. */
 export interface CeArtifact {
@@ -376,7 +396,7 @@ function discoverLocation(root: string, loc: ConventionalLocation): CeArtifactGr
  */
 export function discoverArtifacts(projectRoot: string): DiscoveryResult {
   const root = projectRoot;
-  const groups = CONVENTIONAL_LOCATIONS.map((loc) => discoverLocation(root, loc));
+  const groups = conventionalLocations().map((loc) => discoverLocation(root, loc));
   let totalArtifacts = 0;
   let totalErrors = 0;
   for (const g of groups) {
@@ -402,7 +422,7 @@ export function readArtifactById(
   if (sepIdx <= 0) return undefined;
   const stage = id.slice(0, sepIdx) as CeArtifactStage;
   const relPath = id.slice(sepIdx + 1);
-  const loc = CONVENTIONAL_LOCATIONS.find((l) => l.stage === stage);
+  const loc = conventionalLocations().find((l) => l.stage === stage);
   if (!loc) return undefined;
 
   const locationAbs = join(projectRoot, loc.path);

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CeFlow.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CeFlow.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { Trash2 } from "lucide-react";
 import type { PlanningQuestion } from "@fusion/core";
 import type { CeActivityTurn, CeConversationTurn, CeSession } from "../session/session-store.js";
+import { getStage } from "../session/stage-registry.js";
 import { canRenderRichly } from "./ce-question-support.js";
 
 /**
@@ -38,6 +39,27 @@ export interface CeFlowProps {
   onCancel?: () => void;
   /** Back to the launcher. */
   onClose?: () => void;
+  /** Open the completed stage artifact. */
+  onOpenArtifact?: (artifactPath: string) => void;
+  /** Pipeline stage available after this session. Debug is intentionally manual-only. */
+  nextStageId?: string;
+  /** Start the next pipeline stage. */
+  onStartNextStage?: (stageId: string) => void;
+}
+
+/*
+FNXC:CompoundEngineeringFlow 2026-07-10-22:51:
+The active flow uses registry labels, explicit choice confirmation, secondary optional guidance, accessible async status announcements, and hierarchical recovery/completion actions. Debug remains a manual investigation and must never appear as automatic next-stage progression.
+*/
+
+function humanizeIdentifier(value: string): string {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function stageLabel(stageId: string): string {
+  return getStage(stageId)?.label ?? humanizeIdentifier(stageId);
 }
 
 // ── Transcript parsing ───────────────────────────────────────────────────────
@@ -270,6 +292,7 @@ function RichQuestion({
   onAnswer: (questionId: string, response: unknown) => void;
 }) {
   const [text, setText] = useState("");
+  const [single, setSingle] = useState<string | null>(null);
   const [multi, setMulti] = useState<string[]>([]);
 
   const submit = (response: unknown) => onAnswer(question.id, response);
@@ -326,22 +349,36 @@ function RichQuestion({
       ) : null}
 
       {question.type === "single_select" ? (
-        <ul className="ce-flow-options" data-testid="ce-flow-single">
-          {(question.options ?? []).map((opt) => (
-            <li key={opt.id}>
-              <button
-                type="button"
-                className="ce-flow-option btn"
-                data-option={opt.id}
-                disabled={disabled}
-                onClick={() => submit(opt.id)}
-              >
-                <span className="ce-flow-option-label">{opt.label}</span>
-                {opt.description ? <span className="ce-flow-option-desc">{opt.description}</span> : null}
-              </button>
-            </li>
-          ))}
-        </ul>
+        <div className="ce-flow-choice-group" data-testid="ce-flow-single">
+          <ul className="ce-flow-options" aria-label={question.question}>
+            {(question.options ?? []).map((opt) => (
+              <li key={opt.id}>
+                <button
+                  type="button"
+                  className={`ce-flow-option btn${single === opt.id ? " is-selected" : ""}`}
+                  data-option={opt.id}
+                  disabled={disabled}
+                  aria-pressed={single === opt.id}
+                  onClick={() => setSingle(opt.id)}
+                >
+                  <span className="ce-flow-option-label">{opt.label}</span>
+                  {opt.description ? <span className="ce-flow-option-desc">{opt.description}</span> : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="btn btn-primary ce-flow-choice-submit"
+            data-testid="ce-flow-single-submit"
+            disabled={disabled || single === null}
+            onClick={() => {
+              if (single !== null) submit(single);
+            }}
+          >
+            Confirm choice
+          </button>
+        </div>
       ) : null}
 
       {question.type === "multi_select" ? (
@@ -350,7 +387,7 @@ function RichQuestion({
           data-testid="ce-flow-multi"
           onSubmit={(e) => {
             e.preventDefault();
-            submit(multi);
+            if (multi.length > 0) submit(multi);
           }}
         >
           <ul>
@@ -377,7 +414,12 @@ function RichQuestion({
               );
             })}
           </ul>
-          <button type="submit" className="btn btn-primary" data-testid="ce-flow-multi-submit" disabled={disabled}>
+          <button
+            type="submit"
+            className="btn btn-primary ce-flow-choice-submit"
+            data-testid="ce-flow-multi-submit"
+            disabled={disabled || multi.length === 0}
+          >
             Confirm selection
           </button>
         </form>
@@ -483,9 +525,10 @@ function QuestionPanel({
         <DegradedQuestion question={question} disabled={disabled} onAnswer={onAnswer} />
       )}
       {showGuidance ? (
-        <div className="ce-flow-guidance" data-testid="ce-flow-guidance">
+        <details className="ce-flow-guidance ce-flow-progressive-disclosure" data-testid="ce-flow-guidance">
+          <summary className="ce-flow-guidance-summary">Add guidance (optional)</summary>
           <label className="ce-flow-guidance-label" htmlFor="ce-flow-guidance-input">
-            Steer in your own words (optional — attached to your answer, or sent on its own)
+            Attach context to your answer, or send guidance on its own
           </label>
           <div className="ce-flow-guidance-row">
             <textarea
@@ -508,7 +551,7 @@ function QuestionPanel({
               Send guidance
             </button>
           </div>
-        </div>
+        </details>
       ) : null}
     </div>
   );
@@ -517,7 +560,18 @@ function QuestionPanel({
 // ── Flow surface ─────────────────────────────────────────────────────────────
 
 export function CeFlow(props: CeFlowProps) {
-  const { session, busy, error, onAnswer, onResume, onCancel, onClose } = props;
+  const {
+    session,
+    busy,
+    error,
+    onAnswer,
+    onResume,
+    onCancel,
+    onClose,
+    onOpenArtifact,
+    nextStageId,
+    onStartNextStage,
+  } = props;
 
   const question = session?.currentQuestion ?? undefined;
 
@@ -539,13 +593,15 @@ export function CeFlow(props: CeFlowProps) {
   const recoverable = status === "interrupted" || status === "error";
   const cancellable = status === "launching" || status === "active" || status === "awaiting_input";
   const working = status === "active" || status === "launching";
+  const currentStageLabel = stageLabel(session.stage);
+  const automaticNextStageId = nextStageId && nextStageId !== "debug" && session.stage !== "debug" ? nextStageId : undefined;
 
   return (
     <div className="ce-flow card" data-testid="ce-flow" data-status={status} data-stage={session.stage}>
       <header className="ce-flow-header">
-        <h3>{session.stage}</h3>
-        <span className="ce-flow-status" data-testid="ce-flow-status">
-          {status.replace("_", " ")}
+        <h3>{currentStageLabel}</h3>
+        <span className="ce-flow-status" data-testid="ce-flow-status" role="status" aria-live="polite" aria-atomic="true">
+          {humanizeIdentifier(status)}
         </span>
         {onCancel && cancellable ? (
           <button
@@ -570,7 +626,7 @@ export function CeFlow(props: CeFlowProps) {
       <Transcript history={session.conversationHistory} />
 
       {working || (busy && status !== "awaiting_input") ? (
-        <div className="ce-flow-working" data-testid="ce-flow-thinking">
+        <div className="ce-flow-working" data-testid="ce-flow-thinking" role="status" aria-live="polite" aria-atomic="false">
           <p className="ce-flow-working-label">
             <span className="ce-flow-pulse" aria-hidden="true" />
             Agent working…
@@ -588,11 +644,11 @@ export function CeFlow(props: CeFlowProps) {
       ) : null}
 
       {status === "awaiting_input" && question ? (
-        <QuestionPanel question={question} disabled={Boolean(busy)} onAnswer={onAnswer} />
+        <QuestionPanel key={question.id} question={question} disabled={Boolean(busy)} onAnswer={onAnswer} />
       ) : null}
 
       {recoverable ? (
-        <div className="ce-flow-recover" data-testid="ce-flow-recover">
+        <div className="ce-flow-recover ce-flow-action-state" data-testid="ce-flow-recover">
           <p className="ce-flow-error" role="alert">
             Session {status}{session.error ? `: ${session.error}` : ""}.
           </p>
@@ -605,13 +661,29 @@ export function CeFlow(props: CeFlowProps) {
       ) : null}
 
       {settledTerminal ? (
-        <div className="ce-flow-complete" data-testid="ce-flow-complete">
-          <p>Stage complete.</p>
+        <div className="ce-flow-complete ce-flow-action-state" data-testid="ce-flow-complete" role="status" aria-live="polite">
+          <p>{currentStageLabel} complete.</p>
           {session.artifactPath ? (
             <p className="ce-flow-artifact-path" data-testid="ce-flow-artifact-path">
               Artifact: {session.artifactPath}
             </p>
           ) : null}
+          <div className="ce-flow-complete-actions">
+            {session.artifactPath && onOpenArtifact ? (
+              <button type="button" className="btn" onClick={() => onOpenArtifact(session.artifactPath!)}>
+                Open artifact
+              </button>
+            ) : null}
+            {automaticNextStageId && onStartNextStage ? (
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => onStartNextStage(automaticNextStageId)}
+              >
+                Start {stageLabel(automaticNextStageId)}
+              </button>
+            ) : null}
+          </div>
         </div>
       ) : null}
     </div>

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.css
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.css
@@ -83,6 +83,20 @@ The shared ViewHeader sits directly above plugin content, so the body needs top 
   gap: var(--space-sm);
 }
 
+/* Strategy is one durable upstream anchor; keep it as a compact row while repeatable workflow outputs retain collection cards. */
+.ce-group[data-layout="singleton"] {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.3fr) minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--space-lg);
+  padding-block: var(--space-sm);
+}
+
+.ce-group[data-layout="singleton"] .ce-artifact-list {
+  min-width: 0;
+}
+
 .ce-group[data-empty="true"] {
   color: var(--text-muted);
 }
@@ -177,6 +191,11 @@ The shared ViewHeader sits directly above plugin content, so the body needs top 
 .ce-view[data-mobile="true"] .ce-view-body {
   width: 100%;
   padding: var(--space-sm);
+}
+
+.ce-view[data-mobile="true"] .ce-group[data-layout="singleton"] {
+  grid-template-columns: 1fr;
+  row-gap: var(--space-xs);
 }
 
 .ce-view[data-mobile="true"] .ce-groups {

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.css
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.css
@@ -719,3 +719,67 @@ The shared ViewHeader sits directly above plugin content, so the body needs top 
 .ce-flow-complete p {
   margin: 0;
 }
+
+/*
+FNXC:CompoundEngineeringUI 2026-07-10-12:10:
+The pipeline overview must communicate progression and the next useful action at a glance on desktop and mobile. Use a connected, restrained stage rail, a single high-signal resume row, and progressive disclosure for session management; avoid nested cards and oversized dashboard typography.
+*/
+.ce-pipeline { display: flex; flex-direction: column; gap: var(--space-md); }
+.ce-pipeline-header { display: flex; align-items: flex-end; justify-content: space-between; gap: var(--space-md); }
+.ce-pipeline-header h2 { margin: 0; font-size: 1rem; font-weight: 650; }
+.ce-pipeline-header p { margin: calc(var(--space-xs) / 2) 0 0; color: var(--text-muted); font-size: 0.78rem; }
+.ce-investigate { display: inline-flex; align-items: center; gap: var(--space-xs); flex: none; }
+.ce-stage-rail { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); list-style: none; margin: 0; padding: 0; }
+.ce-stage-step { position: relative; min-width: 0; border-block: 1px solid var(--border); border-left: 1px solid var(--border); background: var(--surface); }
+.ce-stage-step:first-child { border-radius: var(--radius-md) 0 0 var(--radius-md); }
+.ce-stage-step:last-child { border-right: 1px solid var(--border); border-radius: 0 var(--radius-md) var(--radius-md) 0; }
+.ce-stage-step::after { position: absolute; z-index: 2; top: calc(var(--space-lg) + 1px); right: calc(var(--space-xs) * -1); width: calc(var(--space-sm) - 2px); height: calc(var(--space-sm) - 2px); border-top: 1px solid var(--border); border-right: 1px solid var(--border); background: inherit; content: ""; transform: rotate(45deg); }
+.ce-stage-step:last-child::after { display: none; }
+.ce-stage-main { display: flex; width: 100%; min-height: calc(var(--space-2xl) * 2.25); align-items: flex-start; gap: var(--space-sm); border: 0; background: transparent; color: inherit; cursor: pointer; padding: var(--space-md); text-align: left; }
+.ce-stage-main:hover:not(:disabled), .ce-stage-main:focus-visible { background: var(--card-hover); }
+.ce-stage-main:focus-visible { position: relative; z-index: 3; outline: 2px solid var(--color-info); outline-offset: -2px; }
+.ce-stage-icon { display: grid; width: calc(var(--space-lg) + var(--space-xs)); height: calc(var(--space-lg) + var(--space-xs)); flex: none; place-items: center; border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted); }
+.ce-stage-step[data-status="complete"] .ce-stage-icon { border-color: color-mix(in srgb, var(--color-success) 45%, var(--border)); color: var(--color-success); }
+.ce-stage-step[data-status="active"] .ce-stage-icon, .ce-stage-step[data-status="needs-input"] .ce-stage-icon { border-color: var(--color-info); background: color-mix(in srgb, var(--color-info) 12%, var(--surface)); color: var(--color-info); }
+.ce-stage-step[data-status="needs-input"] .ce-stage-status { color: var(--color-warning); }
+.ce-stage-copy { display: flex; min-width: 0; flex-direction: column; gap: calc(var(--space-xs) / 2); }
+.ce-stage-copy strong { overflow: hidden; font-size: 0.86rem; text-overflow: ellipsis; white-space: nowrap; }
+.ce-stage-status { color: var(--text-muted); font-size: 0.7rem; }
+.ce-stage-artifact { display: flex; width: calc(100% - var(--space-lg)); min-width: 0; align-items: center; gap: var(--space-xs); margin: 0 var(--space-sm) var(--space-sm); border: 0; background: transparent; color: var(--text-dim); cursor: pointer; font: inherit; font-size: 0.68rem; text-align: left; }
+.ce-stage-artifact span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ce-stage-artifact.is-empty { cursor: default; }
+.ce-resume-banner { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: var(--space-sm); width: 100%; border: 1px solid color-mix(in srgb, var(--color-info) 35%, var(--border)); border-radius: var(--radius-md); background: color-mix(in srgb, var(--color-info) 6%, var(--surface)); color: inherit; cursor: pointer; padding: var(--space-sm) var(--space-md); text-align: left; }
+.ce-resume-banner:hover, .ce-resume-banner:focus-visible { border-color: var(--color-info); }
+.ce-resume-banner > span:not(.ce-resume-icon) { display: flex; min-width: 0; flex-direction: column; gap: calc(var(--space-xs) / 2); }
+.ce-resume-banner strong { font-size: 0.84rem; }
+.ce-resume-banner small { overflow: hidden; color: var(--text-muted); font-size: 0.72rem; text-overflow: ellipsis; white-space: nowrap; }
+.ce-resume-icon { display: grid; width: calc(var(--space-lg) + var(--space-xs)); height: calc(var(--space-lg) + var(--space-xs)); place-items: center; border-radius: 50%; background: var(--color-info); color: var(--surface); }
+.ce-readiness { width: max-content; margin-top: calc(var(--space-xs) / 2); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text-muted); font-size: 0.65rem; padding: 1px var(--space-xs); }
+.ce-readiness-implementation-ready { border-color: color-mix(in srgb, var(--color-success) 40%, var(--border)); color: var(--color-success); }
+.ce-flow-choice-group { display: flex; flex-direction: column; align-items: flex-start; gap: var(--space-md); }
+.ce-flow-option.is-selected { border-color: var(--color-info); background: color-mix(in srgb, var(--color-info) 9%, var(--surface)); }
+.ce-flow-choice-submit { min-width: calc(var(--space-2xl) * 3); }
+.ce-flow-progressive-disclosure { border-top: 1px solid var(--border); padding-top: var(--space-sm); }
+.ce-flow-guidance-summary { width: max-content; color: var(--text-muted); cursor: pointer; font-size: 0.76rem; font-weight: 600; }
+.ce-flow-progressive-disclosure[open] .ce-flow-guidance-summary { margin-bottom: var(--space-sm); color: var(--text); }
+.ce-flow-action-state { display: flex; min-height: calc(var(--space-2xl) * 3); flex: 1 1 auto; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-md); text-align: center; }
+.ce-flow-action-state > p { max-width: 34rem; }
+.ce-flow-complete-actions { display: flex; flex-wrap: wrap; justify-content: center; gap: var(--space-sm); }
+.ce-flow[data-status="awaiting_input"] .ce-flow-question-panel { border-color: color-mix(in srgb, var(--color-info) 40%, var(--border)); }
+.ce-flow[data-status="active"] .ce-flow-status, .ce-flow[data-status="launching"] .ce-flow-status { color: var(--color-info); }
+.ce-sessions { border-top: 1px solid var(--border); padding-top: var(--space-sm); }
+.ce-sessions-summary { display: flex; align-items: center; justify-content: space-between; color: var(--text-muted); cursor: pointer; font-size: 0.8rem; font-weight: 600; padding: var(--space-xs) 0; }
+.ce-sessions[open] .ce-sessions-summary { margin-bottom: var(--space-sm); }
+.ce-discard-confirm { display: flex; align-items: center; gap: var(--space-xs); margin-left: auto; }
+
+@media (max-width: 768px) {
+  .ce-pipeline-header { align-items: center; }
+  .ce-stage-rail { grid-template-columns: 1fr; }
+  .ce-stage-step, .ce-stage-step:first-child, .ce-stage-step:last-child { border: 1px solid var(--border); border-bottom: 0; border-radius: 0; }
+  .ce-stage-step:first-child { border-radius: var(--radius-md) var(--radius-md) 0 0; }
+  .ce-stage-step:last-child { border-bottom: 1px solid var(--border); border-radius: 0 0 var(--radius-md) var(--radius-md); }
+  .ce-stage-step::after { display: none; }
+  .ce-stage-main { min-height: auto; align-items: center; padding: var(--space-sm) var(--space-md); }
+  .ce-stage-artifact { margin-left: calc(var(--space-2xl) + var(--space-xs)); }
+  .ce-discard-confirm { flex-wrap: wrap; justify-content: flex-end; }
+}

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.css
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.css
@@ -132,6 +132,11 @@ The shared ViewHeader sits directly above plugin content, so the body needs top 
   gap: calc(var(--space-sm) - var(--space-xs) / 2);
 }
 
+/* Keep multi-run histories scannable; older artifacts remain available on demand. */
+.ce-group-more { border-top: 1px solid var(--border); padding-top: var(--space-xs); }
+.ce-group-more summary { color: var(--text-muted); cursor: pointer; font-size: 0.74rem; font-weight: 600; }
+.ce-group-more[open] summary { margin-bottom: var(--space-xs); color: var(--text); }
+
 .ce-artifact {
   display: flex;
   align-items: center;
@@ -748,21 +753,30 @@ The pipeline overview must communicate progression and the next useful action at
 .ce-pipeline-header h2 { margin: 0; font-size: 1rem; font-weight: 650; }
 .ce-pipeline-header p { margin: calc(var(--space-xs) / 2) 0 0; color: var(--text-muted); font-size: 0.78rem; }
 .ce-investigate { display: inline-flex; align-items: center; gap: var(--space-xs); flex: none; }
-.ce-stage-rail { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); list-style: none; margin: 0; padding: 0; }
+.ce-pipeline-block { display: flex; flex-direction: column; gap: var(--space-xs); }
+.ce-pipeline-block-heading { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-md); }
+.ce-pipeline-block-heading h3 { margin: 0; font-size: 0.78rem; font-weight: 650; }
+.ce-pipeline-block-heading span { color: var(--text-dim); font-size: 0.7rem; }
+.ce-stage-rail { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); list-style: none; margin: 0; padding: 0; }
+.ce-stage-rail[data-count="2"] { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.ce-stage-rail[data-count="4"] { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 .ce-stage-step { position: relative; min-width: 0; border-block: 1px solid var(--border); border-left: 1px solid var(--border); background: var(--surface); }
 .ce-stage-step:first-child { border-radius: var(--radius-md) 0 0 var(--radius-md); }
 .ce-stage-step:last-child { border-right: 1px solid var(--border); border-radius: 0 var(--radius-md) var(--radius-md) 0; }
 .ce-stage-step::after { position: absolute; z-index: 2; top: calc(var(--space-lg) + 1px); right: calc(var(--space-xs) * -1); width: calc(var(--space-sm) - 2px); height: calc(var(--space-sm) - 2px); border-top: 1px solid var(--border); border-right: 1px solid var(--border); background: inherit; content: ""; transform: rotate(45deg); }
 .ce-stage-step:last-child::after { display: none; }
-.ce-stage-main { display: flex; width: 100%; min-height: calc(var(--space-2xl) * 2.25); align-items: flex-start; gap: var(--space-sm); border: 0; background: transparent; color: inherit; cursor: pointer; padding: var(--space-md); text-align: left; }
+.ce-stage-main { display: flex; width: 100%; min-height: calc(var(--space-2xl) * 2.65); align-items: flex-start; gap: var(--space-sm); border: 0; background: transparent; color: inherit; cursor: pointer; padding: var(--space-md); text-align: left; }
 .ce-stage-main:hover:not(:disabled), .ce-stage-main:focus-visible { background: var(--card-hover); }
 .ce-stage-main:focus-visible { position: relative; z-index: 3; outline: 2px solid var(--color-info); outline-offset: -2px; }
 .ce-stage-icon { display: grid; width: calc(var(--space-lg) + var(--space-xs)); height: calc(var(--space-lg) + var(--space-xs)); flex: none; place-items: center; border: 1px solid var(--border); border-radius: 50%; color: var(--text-muted); }
-.ce-stage-step[data-status="complete"] .ce-stage-icon { border-color: color-mix(in srgb, var(--color-success) 45%, var(--border)); color: var(--color-success); }
+.ce-stage-step[data-status="current"] .ce-stage-icon,
+.ce-stage-step[data-status="history"] .ce-stage-icon,
+.ce-stage-step[data-status="last-run-complete"] .ce-stage-icon { border-color: color-mix(in srgb, var(--color-success) 45%, var(--border)); color: var(--color-success); }
 .ce-stage-step[data-status="active"] .ce-stage-icon, .ce-stage-step[data-status="needs-input"] .ce-stage-icon { border-color: var(--color-info); background: color-mix(in srgb, var(--color-info) 12%, var(--surface)); color: var(--color-info); }
 .ce-stage-step[data-status="needs-input"] .ce-stage-status { color: var(--color-warning); }
 .ce-stage-copy { display: flex; min-width: 0; flex-direction: column; gap: calc(var(--space-xs) / 2); }
 .ce-stage-copy strong { overflow: hidden; font-size: 0.86rem; text-overflow: ellipsis; white-space: nowrap; }
+.ce-stage-purpose { color: var(--text-muted); font-size: 0.7rem; line-height: 1.25; }
 .ce-stage-status { color: var(--text-muted); font-size: 0.7rem; }
 .ce-stage-artifact { display: flex; width: calc(100% - var(--space-lg)); min-width: 0; align-items: center; gap: var(--space-xs); margin: 0 var(--space-sm) var(--space-sm); border: 0; background: transparent; color: var(--text-dim); cursor: pointer; font: inherit; font-size: 0.68rem; text-align: left; }
 .ce-stage-artifact span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -793,7 +807,8 @@ The pipeline overview must communicate progression and the next useful action at
 
 @media (max-width: 768px) {
   .ce-pipeline-header { align-items: center; }
-  .ce-stage-rail { grid-template-columns: 1fr; }
+  .ce-stage-rail,
+  .ce-stage-rail[data-count] { grid-template-columns: 1fr; }
   .ce-stage-step, .ce-stage-step:first-child, .ce-stage-step:last-child { border: 1px solid var(--border); border-bottom: 0; border-radius: 0; }
   .ce-stage-step:first-child { border-radius: var(--radius-md) var(--radius-md) 0 0; }
   .ce-stage-step:last-child { border-bottom: 1px solid var(--border); border-radius: 0 0 var(--radius-md) var(--radius-md); }

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
@@ -170,15 +170,18 @@ function SessionsPanel({
 }
 
 function nextPipelineStageId(stageId: string): string | undefined {
+  if (stageId === "strategy" || stageId === "ideate") return "brainstorm";
   const stages = listPipelineStages();
   const index = stages.findIndex((stage) => stage.stageId === stageId);
   return index >= 0 ? stages[index + 1]?.stageId : undefined;
 }
 
-type RailStatus = "Not started" | "Active" | "Needs input" | "Complete";
+type RailStatus = "Not started" | "Active" | "Needs input" | "Last run complete" | "History" | "Current";
 
 function artifactsForStage(stageId: string, groups: CeArtifactGroup[]): CeArtifactEntry[] {
-  const entries = groups.find((group) => group.stage === stageId)?.entries ?? [];
+  const entries = groups.find((group) => group.stage === stageId)?.entries
+    ?? (stageId === "compound" ? groups.find((group) => group.stage === "solution")?.entries : undefined)
+    ?? [];
   if (stageId === "brainstorm") {
     const unifiedEntries = groups.find((group) => group.stage === "plan")?.entries ?? [];
     return [...entries, ...unifiedEntries.filter((entry) => (
@@ -200,16 +203,87 @@ function railStatus(stageId: string, sessions: CeSession[], artifact?: CeArtifac
   const latest = sessions.find((session) => session.stage === stageId);
   if (latest?.status === "awaiting_input") return "Needs input";
   if (latest?.status === "active" || latest?.status === "launching") return "Active";
-  if (latest?.status === "completed" || artifact?.kind === "artifact") return "Complete";
+  if (latest?.status === "completed") return "Last run complete";
+  if (artifact?.kind === "artifact") return stageId === "strategy" ? "Current" : "History";
   return "Not started";
+}
+
+const STAGE_PURPOSE: Record<string, string> = {
+  strategy: "Set the product direction",
+  ideate: "Explore high-leverage ideas",
+  brainstorm: "Define what to build",
+  plan: "Decide how to build it",
+  work: "Build, simplify, and review",
+  compound: "Save reusable learnings",
+};
+
+function StageRail({
+  stages,
+  groups,
+  sessions,
+  disabled,
+  openFile,
+  onLaunch,
+  onOpenSession,
+}: {
+  stages: CeStageDefinition[];
+  groups: CeArtifactGroup[];
+  sessions: CeSession[];
+  disabled: boolean;
+  openFile?: PluginDashboardViewContext["openFile"];
+  onLaunch: (stage: CeStageDefinition) => void;
+  onOpenSession: (session: CeSession) => void;
+}) {
+  return (
+    <ol className="ce-stage-rail" data-count={stages.length}>
+      {stages.map((stage) => {
+        const artifacts = artifactsForStage(stage.stageId, groups);
+        const artifact = artifacts[0];
+        const stageSessions = sessions.filter((session) => session.stage === stage.stageId);
+        const latestSession = stageSessions[0];
+        const status = railStatus(stage.stageId, sessions, artifact);
+        const Icon = resolveIcon(stage.icon);
+        return (
+          <li key={stage.stageId} className="ce-stage-step" data-status={status.toLowerCase().replaceAll(" ", "-")}>
+            <button
+              type="button"
+              className="ce-stage-main"
+              data-testid="ce-pipeline-stage"
+              data-stage={stage.stageId}
+              disabled={disabled}
+              onClick={() => latestSession && !TERMINAL.has(latestSession.status) ? onOpenSession(latestSession) : onLaunch(stage)}
+            >
+              <span className="ce-stage-icon"><Icon size={17} aria-hidden="true" /></span>
+              <span className="ce-stage-copy">
+                <strong>{stage.label}</strong>
+                {STAGE_PURPOSE[stage.stageId] ? <span className="ce-stage-purpose">{STAGE_PURPOSE[stage.stageId]}</span> : null}
+                <span className="ce-stage-status">
+                  {status} · {stageSessions.length} {stageSessions.length === 1 ? "run" : "runs"} · {artifacts.length} {artifacts.length === 1 ? "artifact" : "artifacts"}
+                </span>
+              </span>
+            </button>
+            {artifact?.kind === "artifact" ? (
+              <button type="button" className="ce-stage-artifact" onClick={() => openFile?.(artifact.path, { workspace: "project" })}>
+                <LucideIcons.FileText size={13} aria-hidden="true" />
+                <span>{artifact.name}</span>
+              </button>
+            ) : <span className="ce-stage-artifact is-empty">No artifact yet</span>}
+          </li>
+        );
+      })}
+    </ol>
+  );
 }
 
 /**
  * FNXC:CompoundEngineeringUI 2026-07-10-12:00:
- * Operators need the five-stage compounding loop as the overview's primary navigation. Stages report repeatable run and artifact collections instead of implying one permanent completion; Strategy remains the upstream singleton anchor, while Debug remains a separate investigation action because it is not pipeline progression.
+ * Operators need the optional foundation plus four-stage delivery loop as the overview's primary navigation. Stages report repeatable run and artifact collections instead of implying one permanent completion; Strategy remains the upstream singleton anchor, while Debug remains a separate investigation action because it is not pipeline progression.
  *
  * FNXC:CompoundEngineeringUI 2026-07-10-23:40:
- * Compound Engineering follows the upstream repeatable loop: brainstorm requirements, plan implementation, work, review, compound, then repeat with better context. Brainstorm and Plan therefore expose collection counts and latest activity over multiple unified-plan files rather than a single artifact slot.
+ * Compound Engineering follows the upstream repeatable loop: brainstorm requirements, plan implementation, work through built-in simplification and review, compound the learning, then repeat with better context. Brainstorm and Plan therefore expose collection counts and latest activity over multiple unified-plan files rather than a single artifact slot.
+ *
+ * FNXC:CompoundEngineeringUI 2026-07-11-00:02:
+ * Strategy and Ideate are optional foundation work, not mandatory delivery gates. Visually separate them from the Brainstorm -> Plan -> Work -> Compound loop, and state that Work owns simplification and review so users do not repeat quality stages manually.
  */
 function PipelineOverview({
   groups,
@@ -226,14 +300,16 @@ function PipelineOverview({
   onLaunch: (stage: CeStageDefinition) => void;
   onOpenSession: (session: CeSession) => void;
 }) {
-  const stages = listPipelineStages();
+  const stages = listStages().filter((stage) => stage.stageId !== "debug");
+  const foundationStages = stages.filter((stage) => stage.stageId === "strategy" || stage.stageId === "ideate");
+  const deliveryStages = stages.filter((stage) => stage.stageId !== "strategy" && stage.stageId !== "ideate");
   const debug = getStage("debug");
   return (
     <section className="ce-pipeline" data-testid="ce-pipeline">
       <header className="ce-pipeline-header">
         <div>
-          <h2>Pipeline</h2>
-          <p>Move from direction to delivered work.</p>
+          <h2>Compound Engineering</h2>
+          <p>Plan deeply, ship carefully, and save what you learn.</p>
         </div>
         {debug ? (
           <button type="button" className="btn ce-investigate" data-testid="ce-investigate" disabled={disabled} onClick={() => onLaunch(debug)}>
@@ -241,42 +317,14 @@ function PipelineOverview({
           </button>
         ) : null}
       </header>
-      <ol className="ce-stage-rail">
-        {stages.map((stage) => {
-          const artifacts = artifactsForStage(stage.stageId, groups);
-          const artifact = artifacts[0];
-          const stageSessions = sessions.filter((session) => session.stage === stage.stageId);
-          const latestSession = stageSessions[0];
-          const status = railStatus(stage.stageId, sessions, artifact);
-          const Icon = resolveIcon(stage.icon);
-          return (
-            <li key={stage.stageId} className="ce-stage-step" data-status={status.toLowerCase().replace(" ", "-")}>
-              <button
-                type="button"
-                className="ce-stage-main"
-                data-testid="ce-pipeline-stage"
-                data-stage={stage.stageId}
-                disabled={disabled}
-                onClick={() => latestSession && !TERMINAL.has(latestSession.status) ? onOpenSession(latestSession) : onLaunch(stage)}
-              >
-                <span className="ce-stage-icon"><Icon size={17} aria-hidden="true" /></span>
-                <span className="ce-stage-copy">
-                  <strong>{stage.label}</strong>
-                  <span className="ce-stage-status">
-                    {status} · {stageSessions.length} {stageSessions.length === 1 ? "run" : "runs"} · {artifacts.length} {artifacts.length === 1 ? "artifact" : "artifacts"}
-                  </span>
-                </span>
-              </button>
-              {artifact?.kind === "artifact" ? (
-                <button type="button" className="ce-stage-artifact" onClick={() => openFile?.(artifact.path, { workspace: "project" })}>
-                  <LucideIcons.FileText size={13} aria-hidden="true" />
-                  <span>{artifact.name}</span>
-                </button>
-              ) : <span className="ce-stage-artifact is-empty">No artifact yet</span>}
-            </li>
-          );
-        })}
-      </ol>
+      <div className="ce-pipeline-block">
+        <div className="ce-pipeline-block-heading"><h3>Foundation</h3><span>Optional grounding</span></div>
+        <StageRail stages={foundationStages} groups={groups} sessions={sessions} disabled={disabled} openFile={openFile} onLaunch={onLaunch} onOpenSession={onOpenSession} />
+      </div>
+      <div className="ce-pipeline-block">
+        <div className="ce-pipeline-block-heading"><h3>Delivery loop</h3><span>Repeat for each meaningful change</span></div>
+        <StageRail stages={deliveryStages} groups={groups} sessions={sessions} disabled={disabled} openFile={openFile} onLaunch={onLaunch} onOpenSession={onOpenSession} />
+      </div>
     </section>
   );
 }
@@ -302,11 +350,11 @@ function EmptyState({ onStart }: { onStart: () => void }) {
       <h3>Start your compounding pipeline</h3>
       <p>
         No compound-engineering artifacts found yet. Compound Engineering tracks the documents your
-        pipeline produces — strategy, ideation, brainstorms, plans, solutions, and concepts — as you
+        workflow produces — strategy, ideation, brainstorms, plans, work logs, learnings, and concepts — as you
         move through each stage.
       </p>
       <p className="ce-empty-hint">
-        Begin with a stage and its artifact will appear here, grouped and traceable.
+        Start with Brainstorm when the problem is still fuzzy, Plan when requirements are settled, or Debug for broken behavior.
       </p>
       <button type="button" className="btn btn-primary" data-testid="ce-start-action" onClick={onStart}>
         Start a stage
@@ -376,8 +424,14 @@ function StageGroup({
   selectedId?: string;
   openFile?: PluginDashboardViewContext["openFile"];
 }) {
+  /*
+   * FNXC:CompoundEngineeringUI 2026-07-11-00:06:
+   * Brainstorm and Plan are repeatable collections that can contain dozens of artifacts. Keep the four newest visible for scanning and disclose the full history on demand so power does not overwhelm the default view.
+   */
   const empty = group.entries.length === 0;
   const singleton = group.stage === "strategy";
+  const visibleEntries = group.entries.slice(0, 4);
+  const remainingEntries = group.entries.slice(4);
   return (
     <section className="ce-group card" data-testid="ce-group" data-stage={group.stage} data-layout={singleton ? "singleton" : "collection"} data-empty={empty ? "true" : "false"}>
       <header className="ce-group-header">
@@ -390,7 +444,7 @@ function StageGroup({
         </p>
       ) : (
         <ul className="ce-artifact-list">
-          {group.entries.map((entry) => (
+          {visibleEntries.map((entry) => (
             <ArtifactRow
               key={entry.id}
               entry={entry}
@@ -401,14 +455,34 @@ function StageGroup({
           ))}
         </ul>
       )}
+      {remainingEntries.length > 0 ? (
+        <details className="ce-group-more">
+          <summary>Show all {group.entries.length}</summary>
+          <ul className="ce-artifact-list">
+            {remainingEntries.map((entry) => (
+              <ArtifactRow
+                key={entry.id}
+                entry={entry}
+                onSelect={onSelect}
+                selected={selectedId === entry.id}
+                openFile={openFile}
+              />
+            ))}
+          </ul>
+        </details>
+      ) : null}
     </section>
   );
 }
 
 function artifactDisplayGroups(groups: CeArtifactGroup[]): CeArtifactGroup[] {
   const conventionalBrainstorms = groups.find((group) => group.stage === "brainstorm");
+  const hasCompoundGroup = groups.some((group) => group.stage === "compound");
   return groups.flatMap((group) => {
     if (group.stage === "brainstorm") return [];
+    if (group.stage === "solution") {
+      return hasCompoundGroup ? [] : [{ ...group, stage: "compound", label: "Learnings" }];
+    }
     if (group.stage !== "plan") return [group];
     const brainstorms = group.entries.filter((entry) => (
       entry.kind === "artifact"
@@ -641,7 +715,7 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
         ) : null}
 
         {launcherOpen ? (
-          <StageLauncher stages={listPipelineStages()} disabled={ceSession.busy} onLaunch={onLaunch} />
+          <StageLauncher stages={listStages().filter((stage) => stage.stageId !== "debug")} disabled={ceSession.busy} onLaunch={onLaunch} />
         ) : null}
 
         <SessionsPanel

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
@@ -1,5 +1,5 @@
 import "./CompoundEngineeringView.css";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import * as LucideIcons from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { PluginDashboardViewContext } from "@fusion/dashboard/app/plugins/types";
@@ -9,7 +9,7 @@ import { useViewportMode } from "./hooks/useViewportMode.js";
 import { useCeSession, type CeSessionSubscribe } from "./hooks/useCeSession.js";
 import { useCeSessions, type CeSessionsSubscribe } from "./hooks/useCeSessions.js";
 import { CeFlow } from "./CeFlow.js";
-import { getStage, listStages, type CeStageDefinition } from "../session/stage-registry.js";
+import { getStage, listPipelineStages, listStages, type CeStageDefinition } from "../session/stage-registry.js";
 import type { CeArtifactEntry, CeArtifactGroup } from "../artifacts/discovery.js";
 import type { CeSession, CeSessionStatus } from "../session/session-store.js";
 
@@ -94,13 +94,14 @@ function SessionsPanel({
   onCancel: (session: CeSession) => void;
   onDiscard: (session: CeSession) => void;
 }) {
+  const [discardCandidate, setDiscardCandidate] = useState<string>();
   if (sessions.length === 0) return null;
   return (
-    <section className="ce-sessions card" data-testid="ce-sessions">
-      <header className="ce-group-header">
-        <h3>Sessions</h3>
+    <details className="ce-sessions" data-testid="ce-sessions">
+      <summary className="ce-sessions-summary">
+        <span>Session history</span>
         <span className="ce-group-count">{sessions.length}</span>
-      </header>
+      </summary>
       <ul className="ce-sessions-list">
         {sessions.map((s) => {
           const stageLabel = getStage(s.stage)?.label ?? s.stage;
@@ -127,15 +128,26 @@ function SessionsPanel({
                 <span className="ce-session-updated">{new Date(s.updatedAt).toLocaleString()}</span>
               </button>
               {TERMINAL.has(s.status) ? (
-                <button
-                  type="button"
-                  className="btn ce-session-discard"
-                  data-testid="ce-session-discard"
-                  disabled={disabled}
-                  onClick={() => onDiscard(s)}
-                >
-                  Discard
-                </button>
+                discardCandidate === s.id ? (
+                  <span className="ce-discard-confirm" data-testid="ce-discard-confirm">
+                    <button type="button" className="btn ce-session-discard" disabled={disabled} onClick={() => onDiscard(s)}>
+                      Delete permanently
+                    </button>
+                    <button type="button" className="btn" disabled={disabled} onClick={() => setDiscardCandidate(undefined)}>
+                      Keep
+                    </button>
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    className="btn ce-session-discard"
+                    data-testid="ce-session-discard"
+                    disabled={disabled}
+                    onClick={() => setDiscardCandidate(s.id)}
+                  >
+                    Discard
+                  </button>
+                )
               ) : (
                 <button
                   type="button"
@@ -146,13 +158,118 @@ function SessionsPanel({
                   aria-label="Cancel session"
                   title="Cancel session"
                 >
-                  <LucideIcons.Trash2 size={16} aria-hidden="true" />
+                  <LucideIcons.CircleStop size={16} aria-hidden="true" />
                 </button>
               )}
             </li>
           );
         })}
       </ul>
+    </details>
+  );
+}
+
+function nextPipelineStageId(stageId: string): string | undefined {
+  const stages = listPipelineStages();
+  const index = stages.findIndex((stage) => stage.stageId === stageId);
+  return index >= 0 ? stages[index + 1]?.stageId : undefined;
+}
+
+type RailStatus = "Not started" | "Active" | "Needs input" | "Complete";
+
+function artifactForStage(stageId: string, groups: CeArtifactGroup[]): CeArtifactEntry | undefined {
+  const groupId = stageId === "brainstorm" ? "plan" : stageId;
+  const entries = groups.find((group) => group.stage === groupId)?.entries ?? [];
+  if (stageId === "brainstorm") {
+    return entries.find((entry) => (
+      entry.kind === "artifact"
+      && entry.artifactContract === "ce-unified-plan/v1"
+      && (entry.artifactReadiness === "requirements-only" || entry.artifactReadiness === "implementation-ready")
+    ));
+  }
+  if (stageId === "plan") {
+    return entries.find((entry) => (
+      entry.kind === "artifact"
+      && (entry.artifactReadiness === "implementation-ready" || !entry.artifactReadiness)
+    ));
+  }
+  return entries.find((entry) => entry.kind === "artifact");
+}
+
+function railStatus(stageId: string, sessions: CeSession[], artifact?: CeArtifactEntry): RailStatus {
+  const latest = sessions.find((session) => session.stage === stageId);
+  if (latest?.status === "awaiting_input") return "Needs input";
+  if (latest?.status === "active" || latest?.status === "launching") return "Active";
+  if (latest?.status === "completed" || artifact?.kind === "artifact") return "Complete";
+  return "Not started";
+}
+
+/**
+ * FNXC:CompoundEngineeringUI 2026-07-10-12:00:
+ * Operators need the five-stage compounding pipeline as the overview's primary navigation. Each stage shows actionable state and its latest durable artifact, while Debug remains a separate investigation action because it is not pipeline progression.
+ */
+function PipelineOverview({
+  groups,
+  sessions,
+  disabled,
+  openFile,
+  onLaunch,
+  onOpenSession,
+}: {
+  groups: CeArtifactGroup[];
+  sessions: CeSession[];
+  disabled: boolean;
+  openFile?: PluginDashboardViewContext["openFile"];
+  onLaunch: (stage: CeStageDefinition) => void;
+  onOpenSession: (session: CeSession) => void;
+}) {
+  const stages = listPipelineStages();
+  const debug = getStage("debug");
+  return (
+    <section className="ce-pipeline" data-testid="ce-pipeline">
+      <header className="ce-pipeline-header">
+        <div>
+          <h2>Pipeline</h2>
+          <p>Move from direction to delivered work.</p>
+        </div>
+        {debug ? (
+          <button type="button" className="btn ce-investigate" data-testid="ce-investigate" disabled={disabled} onClick={() => onLaunch(debug)}>
+            <LucideIcons.Bug size={16} aria-hidden="true" /> Investigate
+          </button>
+        ) : null}
+      </header>
+      <ol className="ce-stage-rail">
+        {stages.map((stage) => {
+          const artifact = artifactForStage(stage.stageId, groups);
+          const latestSession = sessions.find((session) => session.stage === stage.stageId);
+          const status = railStatus(stage.stageId, sessions, artifact);
+          const Icon = resolveIcon(stage.icon);
+          return (
+            <li key={stage.stageId} className="ce-stage-step" data-status={status.toLowerCase().replace(" ", "-")}>
+              <button
+                type="button"
+                className="ce-stage-main"
+                data-testid="ce-pipeline-stage"
+                data-stage={stage.stageId}
+                disabled={disabled}
+                onClick={() => latestSession && !TERMINAL.has(latestSession.status) ? onOpenSession(latestSession) : onLaunch(stage)}
+              >
+                <span className="ce-stage-icon"><Icon size={17} aria-hidden="true" /></span>
+                <span className="ce-stage-copy">
+                  <strong>{stage.label}</strong>
+                  <span className="ce-stage-status">{status}</span>
+                </span>
+              </button>
+              {artifact?.kind === "artifact" ? (
+                <button type="button" className="ce-stage-artifact" onClick={() => openFile?.(artifact.path, { workspace: "project" })}>
+                  <LucideIcons.FileText size={13} aria-hidden="true" />
+                  <span>{artifact.name}</span>
+                </button>
+              ) : <span className="ce-stage-artifact is-empty">No artifact yet</span>}
+            </li>
+          );
+        })}
+      </ol>
     </section>
   );
 }
@@ -213,10 +330,20 @@ function ArtifactRow({
       </li>
     );
   }
+  const readinessLabel = entry.artifactReadiness === "requirements-only"
+    ? "Requirements"
+    : entry.artifactReadiness === "implementation-ready"
+      ? "Implementation ready"
+      : entry.artifactReadiness;
   return (
     <li className={`ce-artifact${selected ? " is-selected" : ""}`} data-testid="ce-artifact">
       <button type="button" className="ce-artifact-btn" onClick={() => onSelect(entry.id)}>
         <span className="ce-artifact-name">{entry.name}</span>
+        {entry.artifactReadiness ? (
+          <span className={`ce-readiness ce-readiness-${entry.artifactReadiness}`}>
+            {readinessLabel}
+          </span>
+        ) : null}
         <span className="ce-artifact-path">{entry.path}</span>
       </button>
       <button
@@ -295,6 +422,8 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
       });
   }, [subscribePluginEvents]);
   const ceSession = useCeSession(subscribe ? { subscribe } : {});
+  const activeSession = ceSession.session;
+  const openSession = ceSession.open;
   // Session list refresh: ANY CE push event means some session changed.
   const subscribeList = useMemo<CeSessionsSubscribe | undefined>(() => {
     if (!subscribePluginEvents) return undefined;
@@ -308,6 +437,14 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
   const [launcherOpen, setLauncherOpen] = useState(false);
   const [sessionActionBusy, setSessionActionBusy] = useState(false);
 
+  const setSessionUrl = useCallback((value?: string) => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (value) url.searchParams.set("ceSession", value);
+    else url.searchParams.delete("ceSession");
+    window.history.replaceState(window.history.state, "", url);
+  }, []);
+
   const totalArtifacts = result?.totalArtifacts ?? 0;
   const totalErrors = result?.totalErrors ?? 0;
   const hasAnything = totalArtifacts > 0 || totalErrors > 0;
@@ -319,20 +456,24 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
   const onStart = () => setLauncherOpen(true);
 
   const onLaunch = useCallback(
-    (stage: CeStageDefinition) => {
+    (stage: CeStageDefinition, sourceSessionId?: string) => {
       setLauncherOpen(false);
       void ceSession
-        .start(stage.stageId, { message: `Start the ${stage.label} stage.`, projectId })
-        .then(() => ceSessions.refresh());
+        .start(stage.stageId, { message: `Start the ${stage.label} stage.`, projectId, sourceSessionId })
+        .then((session) => {
+          if (session) setSessionUrl(session.id);
+          return ceSessions.refresh();
+        });
     },
-    [ceSession, ceSessions, projectId],
+    [ceSession, ceSessions, projectId, setSessionUrl],
   );
 
   const onOpenSession = useCallback(
     (s: CeSession) => {
-      void ceSession.open(s.id, { projectId });
+      setSessionUrl(s.id);
+      void openSession(s.id, { projectId });
     },
-    [ceSession, projectId],
+    [openSession, projectId, setSessionUrl],
   );
 
   const onCancelSession = useCallback(
@@ -341,11 +482,14 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
       void ceSessions
         .cancel(s.id)
         .then(() => {
-          if (ceSession.session?.id === s.id) ceSession.reset();
+          if (ceSession.session?.id === s.id) {
+            ceSession.reset();
+            setSessionUrl();
+          }
         })
         .finally(() => setSessionActionBusy(false));
     },
-    [ceSession, ceSessions],
+    [ceSession, ceSessions, setSessionUrl],
   );
 
   const onDiscardSession = useCallback(
@@ -360,8 +504,22 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
   // it keeps running server-side and stays reachable from the sessions panel.
   const onCloseFlow = useCallback(() => {
     ceSession.reset();
+    setSessionUrl();
     void ceSessions.refresh();
-  }, [ceSession, ceSessions]);
+  }, [ceSession, ceSessions, setSessionUrl]);
+
+  const resumableSession = useMemo(() => {
+    return ceSessions.sessions.find(
+      (session) => session.status === "active" || session.status === "awaiting_input" || session.status === "launching",
+    );
+  }, [ceSessions.sessions]);
+
+  useEffect(() => {
+    if (activeSession || ceSessions.loading || ceSessions.sessions.length === 0 || typeof window === "undefined") return;
+    const sessionId = new URL(window.location.href).searchParams.get("ceSession");
+    const session = ceSessions.sessions.find((candidate) => candidate.id === sessionId);
+    if (session) void openSession(session.id, { projectId });
+  }, [activeSession, ceSessions.loading, ceSessions.sessions, openSession, projectId]);
 
   // Once a session is active here, the flow renderer owns the surface until
   // closed — but the sessions panel stays visible so other sessions remain
@@ -393,6 +551,12 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
             onResume={ceSession.resume}
             onCancel={() => onCancelSession(ceSession.session!)}
             onClose={onCloseFlow}
+            onOpenArtifact={openFile ? (path) => openFile(path, { workspace: "project" }) : undefined}
+            nextStageId={nextPipelineStageId(ceSession.session.stage)}
+            onStartNextStage={(stageId) => {
+              const stage = getStage(stageId);
+              if (stage) onLaunch(stage, ceSession.session!.id);
+            }}
           />
         </div>
       </div>
@@ -421,8 +585,28 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
       />
 
       <div className="ce-view-body">
+        <PipelineOverview
+          groups={result?.groups ?? []}
+          sessions={ceSessions.sessions}
+          disabled={ceSession.busy || sessionActionBusy}
+          openFile={openFile}
+          onLaunch={onLaunch}
+          onOpenSession={onOpenSession}
+        />
+
+        {resumableSession ? (
+          <button type="button" className="ce-resume-banner" data-testid="ce-resume-latest" onClick={() => onOpenSession(resumableSession)}>
+            <span className="ce-resume-icon"><LucideIcons.Play size={16} aria-hidden="true" /></span>
+            <span>
+              <strong>{resumableSession.status === "awaiting_input" ? "Input needed" : "Resume active session"}</strong>
+              <small>{getStage(resumableSession.stage)?.label ?? resumableSession.stage} · Updated {new Date(resumableSession.updatedAt).toLocaleString()}</small>
+            </span>
+            <LucideIcons.ChevronRight size={17} aria-hidden="true" />
+          </button>
+        ) : null}
+
         {launcherOpen ? (
-          <StageLauncher stages={stages} disabled={ceSession.busy} onLaunch={onLaunch} />
+          <StageLauncher stages={listPipelineStages()} disabled={ceSession.busy} onLaunch={onLaunch} />
         ) : null}
 
         <SessionsPanel

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/CompoundEngineeringView.tsx
@@ -177,23 +177,23 @@ function nextPipelineStageId(stageId: string): string | undefined {
 
 type RailStatus = "Not started" | "Active" | "Needs input" | "Complete";
 
-function artifactForStage(stageId: string, groups: CeArtifactGroup[]): CeArtifactEntry | undefined {
-  const groupId = stageId === "brainstorm" ? "plan" : stageId;
-  const entries = groups.find((group) => group.stage === groupId)?.entries ?? [];
+function artifactsForStage(stageId: string, groups: CeArtifactGroup[]): CeArtifactEntry[] {
+  const entries = groups.find((group) => group.stage === stageId)?.entries ?? [];
   if (stageId === "brainstorm") {
-    return entries.find((entry) => (
+    const unifiedEntries = groups.find((group) => group.stage === "plan")?.entries ?? [];
+    return [...entries, ...unifiedEntries.filter((entry) => (
       entry.kind === "artifact"
       && entry.artifactContract === "ce-unified-plan/v1"
-      && (entry.artifactReadiness === "requirements-only" || entry.artifactReadiness === "implementation-ready")
-    ));
+      && (entry.artifactReadiness === "requirements-only" || !entry.productContractSource || entry.productContractSource === "ce-brainstorm")
+    ))];
   }
   if (stageId === "plan") {
-    return entries.find((entry) => (
+    return entries.filter((entry) => (
       entry.kind === "artifact"
       && (entry.artifactReadiness === "implementation-ready" || !entry.artifactReadiness)
     ));
   }
-  return entries.find((entry) => entry.kind === "artifact");
+  return entries.filter((entry) => entry.kind === "artifact");
 }
 
 function railStatus(stageId: string, sessions: CeSession[], artifact?: CeArtifactEntry): RailStatus {
@@ -206,7 +206,10 @@ function railStatus(stageId: string, sessions: CeSession[], artifact?: CeArtifac
 
 /**
  * FNXC:CompoundEngineeringUI 2026-07-10-12:00:
- * Operators need the five-stage compounding pipeline as the overview's primary navigation. Each stage shows actionable state and its latest durable artifact, while Debug remains a separate investigation action because it is not pipeline progression.
+ * Operators need the five-stage compounding loop as the overview's primary navigation. Stages report repeatable run and artifact collections instead of implying one permanent completion; Strategy remains the upstream singleton anchor, while Debug remains a separate investigation action because it is not pipeline progression.
+ *
+ * FNXC:CompoundEngineeringUI 2026-07-10-23:40:
+ * Compound Engineering follows the upstream repeatable loop: brainstorm requirements, plan implementation, work, review, compound, then repeat with better context. Brainstorm and Plan therefore expose collection counts and latest activity over multiple unified-plan files rather than a single artifact slot.
  */
 function PipelineOverview({
   groups,
@@ -240,8 +243,10 @@ function PipelineOverview({
       </header>
       <ol className="ce-stage-rail">
         {stages.map((stage) => {
-          const artifact = artifactForStage(stage.stageId, groups);
-          const latestSession = sessions.find((session) => session.stage === stage.stageId);
+          const artifacts = artifactsForStage(stage.stageId, groups);
+          const artifact = artifacts[0];
+          const stageSessions = sessions.filter((session) => session.stage === stage.stageId);
+          const latestSession = stageSessions[0];
           const status = railStatus(stage.stageId, sessions, artifact);
           const Icon = resolveIcon(stage.icon);
           return (
@@ -257,7 +262,9 @@ function PipelineOverview({
                 <span className="ce-stage-icon"><Icon size={17} aria-hidden="true" /></span>
                 <span className="ce-stage-copy">
                   <strong>{stage.label}</strong>
-                  <span className="ce-stage-status">{status}</span>
+                  <span className="ce-stage-status">
+                    {status} · {stageSessions.length} {stageSessions.length === 1 ? "run" : "runs"} · {artifacts.length} {artifacts.length === 1 ? "artifact" : "artifacts"}
+                  </span>
                 </span>
               </button>
               {artifact?.kind === "artifact" ? (
@@ -370,8 +377,9 @@ function StageGroup({
   openFile?: PluginDashboardViewContext["openFile"];
 }) {
   const empty = group.entries.length === 0;
+  const singleton = group.stage === "strategy";
   return (
-    <section className="ce-group card" data-testid="ce-group" data-stage={group.stage} data-empty={empty ? "true" : "false"}>
+    <section className="ce-group card" data-testid="ce-group" data-stage={group.stage} data-layout={singleton ? "singleton" : "collection"} data-empty={empty ? "true" : "false"}>
       <header className="ce-group-header">
         <h3>{group.label}</h3>
         <span className="ce-group-count">{group.entries.length}</span>
@@ -395,6 +403,33 @@ function StageGroup({
       )}
     </section>
   );
+}
+
+function artifactDisplayGroups(groups: CeArtifactGroup[]): CeArtifactGroup[] {
+  const conventionalBrainstorms = groups.find((group) => group.stage === "brainstorm");
+  return groups.flatMap((group) => {
+    if (group.stage === "brainstorm") return [];
+    if (group.stage !== "plan") return [group];
+    const brainstorms = group.entries.filter((entry) => (
+      entry.kind === "artifact"
+      && entry.artifactContract === "ce-unified-plan/v1"
+      && entry.artifactReadiness === "requirements-only"
+    ));
+    const plans = group.entries.filter((entry) => (
+      entry.kind === "error"
+      || (entry.artifactReadiness !== "requirements-only")
+    ));
+    return [
+      {
+        ...(conventionalBrainstorms ?? group),
+        stage: "brainstorm",
+        label: "Brainstorms",
+        present: Boolean(conventionalBrainstorms?.present || brainstorms.length > 0),
+        entries: [...(conventionalBrainstorms?.entries ?? []), ...brainstorms],
+      },
+      { ...group, label: "Plans", entries: plans },
+    ];
+  });
 }
 
 export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
@@ -647,7 +682,7 @@ export function CompoundEngineeringView(props: CompoundEngineeringViewProps) {
 
         {result && hasAnything ? (
           <div className="ce-groups" data-partial={isPartial ? "true" : "false"}>
-            {result.groups.map((group) => (
+            {artifactDisplayGroups(result.groups).map((group) => (
               <StageGroup
                 key={group.stage}
                 group={group}

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CeFlow.test.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CeFlow.test.tsx
@@ -96,7 +96,7 @@ describe("CeFlow — rich question rendering + submit", () => {
     expect(onAnswer).toHaveBeenCalledWith("q-text", "ship faster");
   });
 
-  it("renders + submits a single_select question", () => {
+  it("selects a single_select answer and submits only after explicit confirmation", () => {
     const onAnswer = vi.fn();
     const q: PlanningQuestion = {
       id: "q-single",
@@ -109,7 +109,33 @@ describe("CeFlow — rich question rendering + submit", () => {
     };
     render(<CeFlow session={makeSession({ currentQuestion: q })} onAnswer={onAnswer} />);
     fireEvent.click(screen.getByText("Beta"));
+    expect(onAnswer).not.toHaveBeenCalled();
+    expect(screen.getByText("Beta").closest("button")).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(screen.getByRole("button", { name: "Confirm choice" }));
     expect(onAnswer).toHaveBeenCalledWith("q-single", "b");
+  });
+
+  it("resets local answer state when the session advances to another question", () => {
+    const onAnswer = vi.fn();
+    const first: PlanningQuestion = {
+      id: "q-first",
+      type: "single_select",
+      question: "First choice",
+      options: [{ id: "shared", label: "First shared option" }],
+    };
+    const second: PlanningQuestion = {
+      id: "q-second",
+      type: "single_select",
+      question: "Second choice",
+      options: [{ id: "shared", label: "Second shared option" }],
+    };
+    const { rerender } = render(<CeFlow session={makeSession({ currentQuestion: first })} onAnswer={onAnswer} />);
+    fireEvent.click(screen.getByText("First shared option"));
+    expect(screen.getByTestId("ce-flow-single-submit")).toBeEnabled();
+
+    rerender(<CeFlow session={makeSession({ currentQuestion: second })} onAnswer={onAnswer} />);
+    expect(screen.getByText("Second shared option").closest("button")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("ce-flow-single-submit")).toBeDisabled();
   });
 
   it("renders + submits a multi_select question", () => {
@@ -130,6 +156,21 @@ describe("CeFlow — rich question rendering + submit", () => {
     fireEvent.click(boxes[2]);
     fireEvent.click(screen.getByTestId("ce-flow-multi-submit"));
     expect(onAnswer).toHaveBeenCalledWith("q-multi", ["g1", "g3"]);
+  });
+
+  it("does not submit an empty multi_select", () => {
+    const onAnswer = vi.fn();
+    const question: PlanningQuestion = {
+      id: "q-multi",
+      type: "multi_select",
+      question: "Which goals?",
+      options: [{ id: "g1", label: "Speed" }],
+    };
+    render(<CeFlow session={makeSession({ currentQuestion: question })} onAnswer={onAnswer} />);
+    const submit = screen.getByTestId("ce-flow-multi-submit");
+    expect(submit).toBeDisabled();
+    fireEvent.click(submit);
+    expect(onAnswer).not.toHaveBeenCalled();
   });
 
   it("renders + submits a confirm question (both branches)", () => {
@@ -204,6 +245,8 @@ describe("CeFlow — steering (guidance channel)", () => {
       target: { value: "focus on mobile" },
     });
     fireEvent.click(screen.getByText("Beta"));
+    expect(onAnswer).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm choice" }));
     expect(onAnswer).toHaveBeenCalledWith("q-steer", { value: "b", comment: "focus on mobile" });
   });
 
@@ -223,6 +266,7 @@ describe("CeFlow — steering (guidance channel)", () => {
     const onAnswer = vi.fn();
     render(<CeFlow session={makeSession({ currentQuestion: q })} onAnswer={onAnswer} />);
     fireEvent.click(screen.getByText("Alpha"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm choice" }));
     expect(onAnswer).toHaveBeenCalledWith("q-steer", "a");
   });
 
@@ -399,6 +443,14 @@ describe("CeFlow — Q&A transcript rendering", () => {
 });
 
 describe("CeFlow — lifecycle surfaces", () => {
+  it("renders the registry label and exposes async state through polite live regions", () => {
+    render(<CeFlow session={makeSession({ stage: "brainstorm", status: "active" })} onAnswer={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: "Brainstorm" })).toBeInTheDocument();
+    expect(screen.getByTestId("ce-flow-status")).toHaveAttribute("role", "status");
+    expect(screen.getByTestId("ce-flow-status")).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByTestId("ce-flow-thinking")).toHaveAttribute("role", "status");
+  });
+
   it("shows the working pane while a turn runs", () => {
     render(<CeFlow session={makeSession({ status: "active", currentQuestion: null })} busy onAnswer={vi.fn()} />);
     expect(screen.getByTestId("ce-flow-thinking")).toBeInTheDocument();
@@ -456,5 +508,36 @@ describe("CeFlow — lifecycle surfaces", () => {
     );
     fireEvent.click(screen.getByTestId("ce-flow-resume"));
     expect(onResume).toHaveBeenCalled();
+  });
+
+  it("offers artifact and next-stage actions after completion", () => {
+    const onOpenArtifact = vi.fn();
+    const onStartNextStage = vi.fn();
+    render(
+      <CeFlow
+        session={makeSession({ status: "completed", stage: "plan", artifactPath: "/repo/docs/plans/x.md" })}
+        onAnswer={vi.fn()}
+        onOpenArtifact={onOpenArtifact}
+        nextStageId="work"
+        onStartNextStage={onStartNextStage}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open artifact" }));
+    expect(onOpenArtifact).toHaveBeenCalledWith("/repo/docs/plans/x.md");
+    fireEvent.click(screen.getByRole("button", { name: "Start Work" }));
+    expect(onStartNextStage).toHaveBeenCalledWith("work");
+    expect(screen.getByTestId("ce-flow-complete")).toHaveAttribute("role", "status");
+  });
+
+  it("keeps Debug outside automatic next-stage completion actions", () => {
+    render(
+      <CeFlow
+        session={makeSession({ status: "completed", stage: "work" })}
+        onAnswer={vi.fn()}
+        nextStageId="debug"
+        onStartNextStage={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /start debug/i })).not.toBeInTheDocument();
   });
 });

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { DiscoveryResult } from "../../artifacts/discovery.js";
 
 // Mock the network layer so the view renders from seeded discovery results.
@@ -54,10 +54,11 @@ function mkCeSession(over: Partial<CeSession>): CeSession {
 const ALL_STAGES: Array<{ stage: DiscoveryResult["groups"][number]["stage"]; label: string }> = [
   { stage: "strategy", label: "Strategy" },
   { stage: "ideate", label: "Ideate" },
-  { stage: "plan", label: "Brainstorm / Plan" },
+  { stage: "brainstorm", label: "Brainstorms" },
+  { stage: "plan", label: "Plan" },
   { stage: "work", label: "Work" },
   { stage: "debug", label: "Debug" },
-  { stage: "solution", label: "Solutions" },
+  { stage: "compound", label: "Learnings" },
   { stage: "concepts", label: "Concepts" },
 ];
 
@@ -155,6 +156,52 @@ describe("CompoundEngineeringView", () => {
     expect(plans.querySelectorAll('[data-testid="ce-artifact"]')).toHaveLength(2);
   });
 
+  it("keeps long artifact histories collapsed after the four newest entries", async () => {
+    listArtifacts.mockResolvedValue(
+      makeResult({
+        plan: Array.from({ length: 6 }, (_, index) => ({
+          kind: "artifact" as const,
+          id: `plan:docs/plans/${index}.md`,
+          stage: "plan",
+          path: `docs/plans/${index}.md`,
+          name: `${index}.md`,
+          size: 5,
+          updatedAt: 6 - index,
+        })),
+      }),
+    );
+
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    const plans = await screen.findByRole("heading", { name: "Plans" });
+    const group = plans.closest<HTMLElement>("[data-testid='ce-group']")!;
+    expect(group.querySelectorAll("[data-testid='ce-artifact']")).toHaveLength(6);
+    const disclosure = within(group).getByText("Show all 6").closest("details")!;
+    expect(disclosure).not.toHaveAttribute("open");
+    fireEvent.click(within(group).getByText("Show all 6"));
+    expect(disclosure).toHaveAttribute("open");
+  });
+
+  it("normalizes legacy solution groups into Compound learnings", async () => {
+    const result = makeResult({});
+    result.groups = result.groups.filter((group) => group.stage !== "compound");
+    result.groups.push({
+      stage: "solution",
+      label: "Solutions",
+      present: true,
+      entries: [{ kind: "artifact", id: "solution:docs/solutions/learned.md", stage: "solution", path: "docs/solutions/learned.md", name: "learned.md", size: 5, updatedAt: 1 }],
+    });
+    result.totalArtifacts = 1;
+    listArtifacts.mockResolvedValue(result);
+
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    expect(await screen.findByRole("heading", { name: "Learnings" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Solutions" })).not.toBeInTheDocument();
+    const compound = screen.getAllByTestId("ce-pipeline-stage").find((node) => node.getAttribute("data-stage") === "compound");
+    expect(compound).toHaveTextContent("1 artifact");
+  });
+
   it("opens an artifact in the built-in file viewer via context.openFile", async () => {
     const openFile = vi.fn();
     listArtifacts.mockResolvedValue(
@@ -243,7 +290,10 @@ describe("CompoundEngineeringView", () => {
     expect(rows[1].querySelector("[data-testid='ce-session-cancel']")).toBeInTheDocument();
     expect(rows[2].querySelector("[data-testid='ce-session-cancel']")).not.toBeInTheDocument();
     expect(screen.getByTestId("ce-resume-latest")).toHaveTextContent(/input needed/i);
-    expect(screen.getAllByTestId("ce-pipeline-stage")).toHaveLength(5);
+    expect(screen.getAllByTestId("ce-pipeline-stage")).toHaveLength(6);
+    expect(screen.getByText("Foundation")).toBeInTheDocument();
+    expect(screen.getByText("Delivery loop")).toBeInTheDocument();
+    expect(screen.getByText("Build, simplify, and review")).toBeInTheDocument();
   });
 
   it("renders no cancel affordance for an empty sessions list", async () => {
@@ -289,6 +339,19 @@ describe("CompoundEngineeringView", () => {
     await screen.findByTestId("ce-empty-state");
     expect(screen.getByTestId("ce-sessions")).toBeInTheDocument();
     expect(deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("hands optional foundation sessions directly into Brainstorm", async () => {
+    const strategy = mkCeSession({ id: "strategy-done", stage: "strategy", status: "completed" });
+    listArtifacts.mockResolvedValue(makeResult({}));
+    listSessions.mockResolvedValue([strategy]);
+    getSession.mockResolvedValue(strategy);
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    fireEvent.click((await screen.findAllByTestId("ce-session-open"))[0]);
+
+    expect(await screen.findByRole("button", { name: "Start Brainstorm" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Start Ideate" })).not.toBeInTheDocument();
   });
 
   it("cancels an in-flight session via the list", async () => {
@@ -356,7 +419,7 @@ describe("CompoundEngineeringView", () => {
     await waitFor(() => expect(screen.queryByTestId("ce-sessions")).not.toBeInTheDocument());
   });
 
-  it("shows unified plan readiness and derives rail completion from artifacts", async () => {
+  it("shows unified plan readiness and distinguishes artifact history from completed runs", async () => {
     listArtifacts.mockResolvedValue(makeResult({
       plan: [{
         kind: "artifact",
@@ -374,9 +437,9 @@ describe("CompoundEngineeringView", () => {
 
     expect(await screen.findByText("Implementation ready")).toBeInTheDocument();
     const plan = screen.getAllByTestId("ce-pipeline-stage").find((node) => node.getAttribute("data-stage") === "plan")!;
-    expect(plan).toHaveTextContent("Complete");
+    expect(plan).toHaveTextContent("History");
     const brainstorm = screen.getAllByTestId("ce-pipeline-stage").find((node) => node.getAttribute("data-stage") === "brainstorm")!;
-    expect(brainstorm).toHaveTextContent("Complete");
+    expect(brainstorm).toHaveTextContent("History");
   });
 
   it("keeps Plan incomplete when only a requirements artifact exists", async () => {
@@ -396,7 +459,7 @@ describe("CompoundEngineeringView", () => {
     render(<CompoundEngineeringView projectId="p1" enabledOverride />);
 
     const stages = await screen.findAllByTestId("ce-pipeline-stage");
-    expect(stages.find((node) => node.getAttribute("data-stage") === "brainstorm")).toHaveTextContent("Complete");
+    expect(stages.find((node) => node.getAttribute("data-stage") === "brainstorm")).toHaveTextContent("History");
     expect(stages.find((node) => node.getAttribute("data-stage") === "plan")).toHaveTextContent("Not started");
   });
 

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
@@ -130,6 +130,29 @@ describe("CompoundEngineeringView", () => {
     // Populated groups render artifacts; empty ones render an empty hint.
     expect(screen.getAllByTestId("ce-artifact")).toHaveLength(2);
     expect(screen.getAllByTestId("ce-group-empty").length).toBeGreaterThan(0);
+    expect(document.querySelector('.ce-groups [data-stage="strategy"]')).toHaveAttribute("data-layout", "singleton");
+  });
+
+  it("presents brainstorm and plan artifacts as repeatable collections", async () => {
+    listArtifacts.mockResolvedValue(
+      makeResult({
+        plan: [
+          { kind: "artifact", id: "plan:docs/plans/requirements.md", stage: "plan", path: "docs/plans/requirements.md", name: "requirements.md", size: 5, updatedAt: 3, artifactContract: "ce-unified-plan/v1", artifactReadiness: "requirements-only", productContractSource: "ce-brainstorm" },
+          { kind: "artifact", id: "plan:docs/plans/ready.md", stage: "plan", path: "docs/plans/ready.md", name: "ready.md", size: 5, updatedAt: 2, artifactContract: "ce-unified-plan/v1", artifactReadiness: "implementation-ready", productContractSource: "ce-brainstorm" },
+          { kind: "artifact", id: "plan:docs/plans/legacy.md", stage: "plan", path: "docs/plans/legacy.md", name: "legacy.md", size: 5, updatedAt: 1 },
+        ],
+      }),
+    );
+
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    await screen.findByTestId("ce-summary");
+    const brainstorms = document.querySelector('.ce-groups [data-stage="brainstorm"]')!;
+    const plans = document.querySelector('.ce-groups [data-stage="plan"]')!;
+    expect(brainstorms).toHaveTextContent("Brainstorms");
+    expect(brainstorms.querySelectorAll('[data-testid="ce-artifact"]')).toHaveLength(1);
+    expect(plans).toHaveTextContent("Plans");
+    expect(plans.querySelectorAll('[data-testid="ce-artifact"]')).toHaveLength(2);
   });
 
   it("opens an artifact in the built-in file viewer via context.openFile", async () => {

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/CompoundEngineeringView.test.tsx
@@ -14,6 +14,9 @@ const cancelSession = vi.fn(async (_id: string, _projectId?: string): Promise<Ce
 const getSession = vi.fn(async (_id: string, _projectId?: string): Promise<CeSession> => {
   throw new Error("getSession mock not configured");
 });
+const startSession = vi.fn(async (_stage: string, _opts?: unknown): Promise<CeSession> => {
+  throw new Error("startSession mock not configured");
+});
 vi.mock("../hooks/api.js", () => ({
   listArtifacts: (projectId?: string) => listArtifacts(projectId),
   getArtifactPreviewUrl: (id: string) => `/preview/${id}`,
@@ -21,7 +24,7 @@ vi.mock("../hooks/api.js", () => ({
   deleteSession: (id: string, projectId?: string) => deleteSession(id, projectId),
   cancelSession: (id: string, projectId?: string) => cancelSession(id, projectId),
   getSession: (id: string, projectId?: string) => getSession(id, projectId),
-  startSession: vi.fn(),
+  startSession: (stage: string, opts?: unknown) => startSession(stage, opts),
   answerSession: vi.fn(),
   resumeSession: vi.fn(),
 }));
@@ -50,9 +53,10 @@ function mkCeSession(over: Partial<CeSession>): CeSession {
 
 const ALL_STAGES: Array<{ stage: DiscoveryResult["groups"][number]["stage"]; label: string }> = [
   { stage: "strategy", label: "Strategy" },
-  { stage: "ideation", label: "Ideation" },
-  { stage: "brainstorm", label: "Brainstorms" },
-  { stage: "plan", label: "Plans" },
+  { stage: "ideate", label: "Ideate" },
+  { stage: "plan", label: "Brainstorm / Plan" },
+  { stage: "work", label: "Work" },
+  { stage: "debug", label: "Debug" },
   { stage: "solution", label: "Solutions" },
   { stage: "concepts", label: "Concepts" },
 ];
@@ -77,6 +81,7 @@ function makeResult(overrides: Partial<Record<DiscoveryResult["groups"][number][
 
 describe("CompoundEngineeringView", () => {
   beforeEach(() => {
+    window.history.replaceState({}, "", "/");
     __test_clearArtifactsCache();
     listArtifacts.mockReset();
     listSessions.mockReset();
@@ -86,6 +91,7 @@ describe("CompoundEngineeringView", () => {
     cancelSession.mockReset();
     cancelSession.mockImplementation(async (id: string, projectId?: string) => mkCeSession({ id, projectId: projectId ?? null, status: "interrupted", error: "Cancelled by user" }));
     getSession.mockReset();
+    startSession.mockReset();
   });
 
   afterEach(() => vi.clearAllMocks());
@@ -213,6 +219,8 @@ describe("CompoundEngineeringView", () => {
     expect(rows[0].querySelector("[data-testid='ce-session-cancel']")).toBeInTheDocument();
     expect(rows[1].querySelector("[data-testid='ce-session-cancel']")).toBeInTheDocument();
     expect(rows[2].querySelector("[data-testid='ce-session-cancel']")).not.toBeInTheDocument();
+    expect(screen.getByTestId("ce-resume-latest")).toHaveTextContent(/input needed/i);
+    expect(screen.getAllByTestId("ce-pipeline-stage")).toHaveLength(5);
   });
 
   it("renders no cancel affordance for an empty sessions list", async () => {
@@ -283,13 +291,30 @@ describe("CompoundEngineeringView", () => {
     await screen.findByTestId("ce-sessions");
     fireEvent.click(screen.getByTestId("ce-session-open"));
     await screen.findByTestId("ce-flow");
+    expect(new URLSearchParams(window.location.search).get("ceSession")).toBe("flow");
     listSessions.mockResolvedValue([mkCeSession({ id: "flow", stage: "plan", status: "interrupted", error: "Cancelled by user" })]);
     fireEvent.click(screen.getByTestId("ce-flow-cancel"));
 
     await waitFor(() => expect(cancelSession).toHaveBeenCalledWith("flow", "p1"));
     await waitFor(() => expect(screen.queryByTestId("ce-flow")).not.toBeInTheDocument());
+    expect(new URLSearchParams(window.location.search).has("ceSession")).toBe(false);
     expect(screen.getByTestId("ce-sessions")).toBeInTheDocument();
     expect(screen.getByTestId("ce-session-discard")).toBeInTheDocument();
+  });
+
+  it("writes a newly launched session to the URL", async () => {
+    listArtifacts.mockResolvedValue(makeResult({}));
+    startSession.mockResolvedValue(mkCeSession({ id: "new-strategy", stage: "strategy", status: "active" }));
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    fireEvent.click(await screen.findByTestId("ce-start-action"));
+    const strategy = (await screen.findAllByTestId("ce-launcher-stage")).find(
+      (node) => node.getAttribute("data-stage") === "strategy",
+    )!;
+    fireEvent.click(strategy);
+
+    await screen.findByTestId("ce-flow");
+    expect(new URLSearchParams(window.location.search).get("ceSession")).toBe("new-strategy");
   });
 
   it("discards a terminal session via the list", async () => {
@@ -300,9 +325,56 @@ describe("CompoundEngineeringView", () => {
     await screen.findByTestId("ce-sessions");
     listSessions.mockResolvedValue([]);
     fireEvent.click(screen.getByTestId("ce-session-discard"));
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(screen.getByTestId("ce-discard-confirm")).toHaveTextContent(/delete permanently/i);
+    fireEvent.click(screen.getByRole("button", { name: "Delete permanently" }));
 
     await waitFor(() => expect(deleteSession).toHaveBeenCalledWith("done", "p1"));
     await waitFor(() => expect(screen.queryByTestId("ce-sessions")).not.toBeInTheDocument());
+  });
+
+  it("shows unified plan readiness and derives rail completion from artifacts", async () => {
+    listArtifacts.mockResolvedValue(makeResult({
+      plan: [{
+        kind: "artifact",
+        id: "plan:docs/plans/ready.md",
+        stage: "plan",
+        path: "docs/plans/ready.md",
+        name: "ready.md",
+        size: 10,
+        updatedAt: 2,
+        artifactContract: "ce-unified-plan/v1",
+        artifactReadiness: "implementation-ready",
+      }],
+    }));
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    expect(await screen.findByText("Implementation ready")).toBeInTheDocument();
+    const plan = screen.getAllByTestId("ce-pipeline-stage").find((node) => node.getAttribute("data-stage") === "plan")!;
+    expect(plan).toHaveTextContent("Complete");
+    const brainstorm = screen.getAllByTestId("ce-pipeline-stage").find((node) => node.getAttribute("data-stage") === "brainstorm")!;
+    expect(brainstorm).toHaveTextContent("Complete");
+  });
+
+  it("keeps Plan incomplete when only a requirements artifact exists", async () => {
+    listArtifacts.mockResolvedValue(makeResult({
+      plan: [{
+        kind: "artifact",
+        id: "plan:docs/plans/requirements.md",
+        stage: "plan",
+        path: "docs/plans/requirements.md",
+        name: "requirements.md",
+        size: 10,
+        updatedAt: 2,
+        artifactContract: "ce-unified-plan/v1",
+        artifactReadiness: "requirements-only",
+      }],
+    }));
+    render(<CompoundEngineeringView projectId="p1" enabledOverride />);
+
+    const stages = await screen.findAllByTestId("ce-pipeline-stage");
+    expect(stages.find((node) => node.getAttribute("data-stage") === "brainstorm")).toHaveTextContent("Complete");
+    expect(stages.find((node) => node.getAttribute("data-stage") === "plan")).toHaveTextContent("Not started");
   });
 
   it("does not fetch when the viewport-gated flag is disabled", async () => {

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/StageLauncher.test.tsx
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/StageLauncher.test.tsx
@@ -47,24 +47,24 @@ function mkSession(over: Partial<CeSession>): CeSession {
 }
 
 describe("Stage launcher (R4)", () => {
-  it("lists exactly the registered stages", async () => {
+  it("keeps pipeline stages in the launcher and Debug as a separate investigation action", async () => {
     render(<CompoundEngineeringView enabledOverride projectId="p1" />);
     // Empty-state start affordance opens the launcher.
     await waitFor(() => screen.getByTestId("ce-empty-state"));
     fireEvent.click(screen.getByTestId("ce-start-action"));
 
     const tiles = await screen.findAllByTestId("ce-launcher-stage");
-    const expected = listStages();
+    const expected = listStages().filter((stage) => stage.stageId !== "debug");
     expect(tiles).toHaveLength(expected.length);
     const renderedStages = tiles.map((t) => t.getAttribute("data-stage")).sort();
     expect(renderedStages).toEqual(expected.map((s) => s.stageId).sort());
     // And the labels match the registry.
     for (const stage of expected) {
-      expect(screen.getByText(stage.label)).toBeInTheDocument();
+      expect(screen.getAllByText(stage.label).length).toBeGreaterThan(0);
     }
     const debugTiles = tiles.filter((t) => t.getAttribute("data-stage") === "debug");
-    expect(debugTiles).toHaveLength(1);
-    expect(debugTiles[0]).toHaveTextContent("Debug");
+    expect(debugTiles).toHaveLength(0);
+    expect(screen.getByTestId("ce-investigate")).toHaveTextContent("Investigate");
     expect((LucideIcons as unknown as Record<string, unknown>)[getStage("debug")!.icon]).toBeTruthy();
   });
 

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/browser-boundary.test.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/__tests__/browser-boundary.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const DASHBOARD_ENTRY_FILES = ["../CeFlow.tsx", "../CompoundEngineeringView.tsx"];
+
+describe("Compound Engineering dashboard browser boundary", () => {
+  it("does not import server-only plugin modules into browser entry files", () => {
+    /*
+    FNXC:CompoundEngineeringUI 2026-07-10-23:10:
+    Dashboard entry modules must stay browser-safe. Importing the server reconciler pulls node:crypto through pipeline-store and crashes the live plugin view even when TypeScript and jsdom tests pass.
+    */
+    for (const relativePath of DASHBOARD_ENTRY_FILES) {
+      const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+      expect(source).not.toMatch(/from\s+["']\.\.\/sync\//);
+      expect(source).not.toMatch(/from\s+["']node:/);
+    }
+  });
+});

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/api.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/api.ts
@@ -50,12 +50,12 @@ export function getArtifactPreviewUrl(id: string, projectId?: string): string {
 /** Start a stage session. Returns the freshly-created session (after one turn). */
 export async function startSession(
   stage: string,
-  opts: { message?: string; projectId?: string } = {},
+  opts: { message?: string; projectId?: string; sourceSessionId?: string } = {},
 ): Promise<CeSession> {
   const data = await request<{ session: CeSession }>(`/sessions`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ stage, message: opts.message ?? "", projectId: opts.projectId }),
+    body: JSON.stringify({ stage, message: opts.message ?? "", projectId: opts.projectId, sourceSessionId: opts.sourceSessionId }),
   });
   return data.session;
 }

--- a/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/useCeSession.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/dashboard/hooks/useCeSession.ts
@@ -61,7 +61,7 @@ export interface UseCeSessionResult {
   /** True while a request (start/answer/resume) is in flight. */
   busy: boolean;
   error?: string;
-  start(stage: string, opts?: { message?: string; projectId?: string }): Promise<void>;
+  start(stage: string, opts?: { message?: string; projectId?: string; sourceSessionId?: string }): Promise<CeSession | undefined>;
   /** Adopt an EXISTING session (e.g. from the session list) as the active one. */
   open(sessionId: string, opts?: { projectId?: string }): Promise<void>;
   answer(questionId: string, response: unknown): Promise<void>;
@@ -116,8 +116,10 @@ export function useCeSession(options: UseCeSessionOptions = {}): UseCeSessionRes
       try {
         const next = await op();
         apply(next);
+        return next;
       } catch (err) {
         if (mounted.current) setError(err instanceof Error ? err.message : String(err));
+        return undefined;
       } finally {
         if (mounted.current) setBusy(false);
       }
@@ -126,7 +128,7 @@ export function useCeSession(options: UseCeSessionOptions = {}): UseCeSessionRes
   );
 
   const start = useCallback(
-    (stage: string, opts: { message?: string; projectId?: string } = {}) => {
+    (stage: string, opts: { message?: string; projectId?: string; sourceSessionId?: string } = {}) => {
       projectIdRef.current = opts.projectId;
       return run(() => transport.start(stage, opts));
     },
@@ -137,27 +139,27 @@ export function useCeSession(options: UseCeSessionOptions = {}): UseCeSessionRes
   // as this hook's active session. Like start(), it pins the projectId used for
   // every subsequent call — the session row lives in that project's store.
   const open = useCallback(
-    (sessionId: string, opts: { projectId?: string } = {}) => {
+    async (sessionId: string, opts: { projectId?: string } = {}) => {
       projectIdRef.current = opts.projectId;
       sessionIdRef.current = sessionId;
-      return run(() => transport.get(sessionId, opts.projectId));
+      await run(() => transport.get(sessionId, opts.projectId));
     },
     [run, transport],
   );
 
   const answer = useCallback(
-    (questionId: string, response: unknown) => {
+    async (questionId: string, response: unknown) => {
       const id = sessionIdRef.current;
-      if (!id) return Promise.resolve();
-      return run(() => transport.answer(id, questionId, response, projectIdRef.current));
+      if (!id) return;
+      await run(() => transport.answer(id, questionId, response, projectIdRef.current));
     },
     [run, transport],
   );
 
-  const resume = useCallback(() => {
+  const resume = useCallback(async () => {
     const id = sessionIdRef.current;
-    if (!id) return Promise.resolve();
-    return run(() => transport.resume(id, projectIdRef.current));
+    if (!id) return;
+    await run(() => transport.resume(id, projectIdRef.current));
   }, [run, transport]);
 
   const reset = useCallback(() => {

--- a/plugins/fusion-plugin-compound-engineering/src/index.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/index.ts
@@ -46,7 +46,7 @@ export {
   CE_PLUGIN_ID,
   CE_WORK_SOURCE_TYPE,
 } from "./session/orchestrator.js";
-export { getStage, listStages, registerStage } from "./session/stage-registry.js";
+export { getStage, listPipelineStages, listStages, registerStage } from "./session/stage-registry.js";
 export {
   settingsSchema,
   getDefaultProvider,

--- a/plugins/fusion-plugin-compound-engineering/src/routes/session-routes.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/routes/session-routes.ts
@@ -59,6 +59,7 @@ export function createSessionRoutes(): PluginRouteDefinition[] {
           const result = await orch.start(stageId, {
             openingMessage,
             projectId: asString(body?.projectId) ?? null,
+            sourceSessionId: asString(body?.sourceSessionId),
             detach: true,
           });
           return { status: 201, body: { session: result.session } };

--- a/plugins/fusion-plugin-compound-engineering/src/routes/session-routes.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/routes/session-routes.ts
@@ -138,13 +138,18 @@ export function createSessionRoutes(): PluginRouteDefinition[] {
     {
       method: "GET",
       path: "/sessions",
-      description: "List CE sessions (optionally filtered by status/stage).",
+      description: "List CE sessions (optionally filtered by project/status/stage).",
       handler: async (req: unknown, ctx: PluginContext): Promise<PluginRouteResponse> => {
         recoverStaleSessionsForContext(ctx, { reason: "route" });
         const query = (req as RouteRequest).query ?? {};
         const status = asCeSessionStatus(typeof query.status === "string" ? query.status : undefined);
         const stage = typeof query.stage === "string" ? query.stage : undefined;
-        const sessions = getCeSessionStore(ctx).list({ status, stage });
+        const projectId = typeof query.projectId === "string" ? query.projectId : undefined;
+        /*
+        FNXC:CompoundEngineering 2026-07-10-23:40:
+        Dashboard session collections must be scoped at the route/store boundary so resume, URL restoration, stage state, and history cannot expose another project's Compound Engineering runs.
+        */
+        const sessions = getCeSessionStore(ctx).list({ status, stage, projectId });
         return { status: 200, body: { sessions } };
       },
     },

--- a/plugins/fusion-plugin-compound-engineering/src/schema.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/schema.ts
@@ -68,6 +68,16 @@ export function ensureCeSchema(db: Database): void {
     CREATE INDEX IF NOT EXISTS idxCeSessionsProject
       ON ce_sessions(projectId, updatedAt DESC, id);
 
+    CREATE TABLE IF NOT EXISTS ce_plan_handoff_claims (
+      artifactPath TEXT PRIMARY KEY,
+      sessionId TEXT NOT NULL UNIQUE,
+      projectId TEXT,
+      createdAt TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idxCePlanHandoffClaimsSession
+      ON ce_plan_handoff_claims(sessionId);
+
     CREATE TABLE IF NOT EXISTS ce_pipeline_links (
       id TEXT PRIMARY KEY,
       taskId TEXT NOT NULL,

--- a/plugins/fusion-plugin-compound-engineering/src/session/orchestrator.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/session/orchestrator.ts
@@ -465,29 +465,20 @@ export class CeOrchestrator {
 
     /*
      * FNXC:CompoundEngineeringPlanning 2026-07-10-22:52:
-     * Brainstorm creates the requirements-only unified plan. A same-project Plan session must carry the selected completed predecessor's safe docs/plans artifact path, accept it only while it remains requirements-only, and atomically replace it with valid implementation-ready output; absent a compatible handoff, legacy new-file behavior remains available.
+     * Brainstorm creates the requirements-only unified plan. A same-project Plan session must carry the selected completed predecessor's safe docs/plans artifact path, accept it only while it remains requirements-only, and atomically claim it with row creation so concurrent starts cannot enrich the same file; absent a compatible handoff, legacy new-file behavior remains available.
      */
     const handoffArtifactPath = stageId === PLAN_STAGE_ID
       ? this.findBrainstormHandoffArtifact(opts.projectId ?? null, opts.sourceSessionId)
       : null;
-    if (handoffArtifactPath) {
-      const competingPlan = this.store.list({ stage: PLAN_STAGE_ID }).find((candidate) => (
-        candidate.projectId === (opts.projectId ?? null)
-        && candidate.artifactPath === handoffArtifactPath
-        && candidate.status !== "completed"
-        && candidate.status !== "error"
-        && candidate.status !== "interrupted"
-      ));
-      if (competingPlan) {
-        throw new Error(`Plan session ${competingPlan.id} is already enriching ${handoffArtifactPath}`);
-      }
-    }
-    const session = this.store.create({
+    const sessionInput = {
       stage: stageId,
       projectId: opts.projectId ?? null,
       artifactPath: handoffArtifactPath,
       turnIntervalMs: this.turnTimeoutMs,
-    });
+    };
+    const session = handoffArtifactPath
+      ? this.store.createWithPlanHandoffClaim(sessionInput, handoffArtifactPath)
+      : this.store.create(sessionInput);
     this.store.appendHistory(session.id, { role: "user", text: opts.openingMessage, at: new Date().toISOString() });
 
     const turn = this.runOpeningTurn(session.id, stage, opts.openingMessage);

--- a/plugins/fusion-plugin-compound-engineering/src/session/orchestrator.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/session/orchestrator.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, isAbsolute, join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type {
   CreateInteractiveAiSessionFactory,
   CreateInteractiveAiSessionOptions,
@@ -22,6 +22,8 @@ import { getStage, type CeStageDefinition } from "./stage-registry.js";
  * the board (U7). Its skill is `ce-work` (see the stage registry).
  */
 export const WORK_STAGE_ID = "work";
+const BRAINSTORM_STAGE_ID = "brainstorm";
+const PLAN_STAGE_ID = "plan";
 
 /**
  * CE provenance identity constants. Defined in `../sync/ce-task.ts` (so the
@@ -223,6 +225,8 @@ export interface StartStageOptions {
   /** Opening user message (the stage prompt / topic). */
   openingMessage: string;
   projectId?: string | null;
+  /** Completed predecessor session whose artifact should be handed to the next stage. */
+  sourceSessionId?: string;
   /**
    * Return as soon as the session row exists, with the turn running in the
    * background (the route posture — lets clients watch live working output
@@ -305,7 +309,7 @@ export class CeOrchestrator {
     warnIfStageSkillMissing(this.ctx.logger, stage, additionalSkillPaths);
     return {
       cwd: this.projectRoot,
-      systemPrompt: buildStageSystemPrompt(stage),
+      systemPrompt: this.buildSystemPrompt(stage, sessionId),
       tools: "coding",
       requestedSkillNames: [stage.skillId],
       additionalSkillPaths,
@@ -318,6 +322,13 @@ export class CeOrchestrator {
       ...(defaultProvider ? { defaultProvider } : {}),
       ...(defaultModelId ? { defaultModelId } : {}),
     };
+  }
+
+  private buildSystemPrompt(stage: CeStageDefinition, sessionId: string): string {
+    const base = buildStageSystemPrompt(stage);
+    const artifactPath = this.store.get(sessionId)?.artifactPath;
+    if (stage.stageId !== PLAN_STAGE_ID || !artifactPath) return base;
+    return `${base}\n\nThe requirements-only unified plan is at ${artifactPath}. Read it and enrich that exact artifact in place to artifact_readiness: implementation-ready; do not create a sibling plan.`;
   }
 
   /**
@@ -452,9 +463,29 @@ export class CeOrchestrator {
       );
     }
 
+    /*
+     * FNXC:CompoundEngineeringPlanning 2026-07-10-22:52:
+     * Brainstorm creates the requirements-only unified plan. A same-project Plan session must carry the selected completed predecessor's safe docs/plans artifact path, accept it only while it remains requirements-only, and atomically replace it with valid implementation-ready output; absent a compatible handoff, legacy new-file behavior remains available.
+     */
+    const handoffArtifactPath = stageId === PLAN_STAGE_ID
+      ? this.findBrainstormHandoffArtifact(opts.projectId ?? null, opts.sourceSessionId)
+      : null;
+    if (handoffArtifactPath) {
+      const competingPlan = this.store.list({ stage: PLAN_STAGE_ID }).find((candidate) => (
+        candidate.projectId === (opts.projectId ?? null)
+        && candidate.artifactPath === handoffArtifactPath
+        && candidate.status !== "completed"
+        && candidate.status !== "error"
+        && candidate.status !== "interrupted"
+      ));
+      if (competingPlan) {
+        throw new Error(`Plan session ${competingPlan.id} is already enriching ${handoffArtifactPath}`);
+      }
+    }
     const session = this.store.create({
       stage: stageId,
       projectId: opts.projectId ?? null,
+      artifactPath: handoffArtifactPath,
       turnIntervalMs: this.turnTimeoutMs,
     });
     this.store.appendHistory(session.id, { role: "user", text: opts.openingMessage, at: new Date().toISOString() });
@@ -466,6 +497,46 @@ export class CeOrchestrator {
       return { session: this.requireSession(session.id) };
     }
     return turn;
+  }
+
+  /** Resolve the newest durable same-project Brainstorm handoff accepted for in-place Plan enrichment. */
+  private findBrainstormHandoffArtifact(projectId: string | null, sourceSessionId?: string): string | null {
+    const candidates = sourceSessionId
+      ? [this.store.get(sourceSessionId)].filter((session): session is CeSession => Boolean(session))
+      : this.store.list({ stage: BRAINSTORM_STAGE_ID });
+    const candidate = candidates.find((session) => (
+      session.stage === BRAINSTORM_STAGE_ID
+      && session.status === "completed"
+      && session.projectId === projectId
+      && session.artifactPath
+      && this.isSafePlanArtifactPath(session.artifactPath)
+      && this.isRequirementsOnlyPlanArtifact(session.artifactPath)
+    ));
+    return candidate?.artifactPath ?? null;
+  }
+
+  private isRequirementsOnlyPlanArtifact(artifactPath: string): boolean {
+    try {
+      const prefix = readFileSync(artifactPath, "utf8").slice(0, 8 * 1024);
+      return /(?:^|\n)artifact_contract:\s*ce-unified-plan\/v1\s*(?:\n|$)/.test(prefix)
+        && /(?:^|\n)artifact_readiness:\s*requirements-only\s*(?:\n|$)/.test(prefix);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Handoffs may be absolute (current sessions) or root-relative (legacy rows), but must resolve inside docs/plans. */
+  private isSafePlanArtifactPath(artifactPath: string): boolean {
+    const planRoot = resolve(this.projectRoot, getStage(PLAN_STAGE_ID)?.artifactLocation ?? "docs/plans/");
+    const candidate = isAbsolute(artifactPath) ? resolve(artifactPath) : resolve(this.projectRoot, artifactPath);
+    const rel = relative(planRoot, candidate);
+    if (rel.startsWith("..") || isAbsolute(rel) || rel === "") return false;
+    try {
+      const realRel = relative(realpathSync(planRoot), realpathSync(candidate));
+      return realRel !== "" && !realRel.startsWith("..") && !isAbsolute(realRel);
+    } catch {
+      return false;
+    }
   }
 
   /** Create the live handle and run the opening turn. Never rejects. */
@@ -773,7 +844,17 @@ export class CeOrchestrator {
     }
     watchdog.cancel();
 
-    const session = this.applyEvent(sessionId, event);
+    let session: CeSession;
+    try {
+      session = this.applyEvent(sessionId, event);
+    } catch (error) {
+      session = this.failSession(sessionId, error);
+      this.disposeLive(sessionId);
+      return {
+        session,
+        event: { type: "error", data: { message: session.error ?? "artifact persistence failed", cause: error } },
+      };
+    }
     if (event.type === "complete" || event.type === "error") {
       this.disposeLive(sessionId);
     }
@@ -930,12 +1011,30 @@ export class CeOrchestrator {
     const location = stage?.artifactLocation ?? `docs/ce/${session.stage}/`;
     const content = this.extractArtifactContent(data);
 
-    const target = location.endsWith("/")
-      ? join(location, `${session.stage}-${session.id}.md`)
-      : location;
+    const target = session.stage === PLAN_STAGE_ID
+      && session.artifactPath
+      && this.isSafePlanArtifactPath(session.artifactPath)
+      ? session.artifactPath
+      : location.endsWith("/")
+        ? join(location, `${session.stage}-${session.id}.md`)
+        : location;
     const abs = isAbsolute(target) ? target : join(this.projectRoot, target);
     mkdirSync(dirname(abs), { recursive: true });
-    writeFileSync(abs, content, "utf-8");
+    if (session.stage === PLAN_STAGE_ID && session.artifactPath === target) {
+      if (!/(?:^|\n)artifact_contract:\s*ce-unified-plan\/v1\s*(?:\n|$)/.test(content)
+        || !/(?:^|\n)artifact_readiness:\s*implementation-ready\s*(?:\n|$)/.test(content)) {
+        throw new Error("Plan completion must produce an implementation-ready ce-unified-plan/v1 artifact");
+      }
+      const temporary = `${abs}.tmp-${session.id}`;
+      try {
+        writeFileSync(temporary, content, "utf-8");
+        renameSync(temporary, abs);
+      } finally {
+        if (existsSync(temporary)) unlinkSync(temporary);
+      }
+    } else {
+      writeFileSync(abs, content, "utf-8");
+    }
     return abs;
   }
 

--- a/plugins/fusion-plugin-compound-engineering/src/session/session-store.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/session/session-store.ts
@@ -93,6 +93,16 @@ export interface CreateCeSessionInput {
   id?: string;
 }
 
+export class PlanHandoffClaimError extends Error {
+  constructor(
+    readonly artifactPath: string,
+    readonly sessionId: string,
+  ) {
+    super(`Plan session ${sessionId} is already enriching ${artifactPath}`);
+    this.name = "PlanHandoffClaimError";
+  }
+}
+
 /**
  * Default multiple of the turn interval beyond which a non-terminal session is
  * considered stale. Mirrors the FN-4172 rubric (`> 3× interval`), interval-
@@ -172,8 +182,34 @@ export class CeSessionStore {
   }
 
   create(input: CreateCeSessionInput): CeSession {
+    const session = this.newSession(input);
+    this.insert(session);
+    return session;
+  }
+
+  /*
+   * FNXC:CompoundEngineeringPlanning 2026-07-11-00:18:
+   * A requirements artifact can have exactly one Plan owner until that session is discarded. Claim it in the same immediate transaction as the Plan row so concurrent dashboard/API requests cannot both enrich the same document; discarding that session intentionally releases the claim for a retry.
+   */
+  createWithPlanHandoffClaim(input: CreateCeSessionInput, artifactPath: string): CeSession {
+    const session = this.newSession({ ...input, artifactPath });
+    return this.db.transactionImmediate(() => {
+      const existing = this.db
+        .prepare("SELECT sessionId FROM ce_plan_handoff_claims WHERE artifactPath = ?")
+        .get(artifactPath) as { sessionId: string } | undefined;
+      if (existing) throw new PlanHandoffClaimError(artifactPath, existing.sessionId);
+
+      this.insert(session);
+      this.db
+        .prepare("INSERT INTO ce_plan_handoff_claims (artifactPath, sessionId, projectId, createdAt) VALUES (?, ?, ?, ?)")
+        .run(artifactPath, session.id, session.projectId, session.createdAt);
+      return session;
+    });
+  }
+
+  private newSession(input: CreateCeSessionInput): CeSession {
     const now = new Date().toISOString();
-    const session: CeSession = {
+    return {
       id: input.id ?? randomUUID(),
       stage: input.stage,
       status: "launching",
@@ -187,6 +223,9 @@ export class CeSessionStore {
       createdAt: now,
       updatedAt: now,
     };
+  }
+
+  private insert(session: CeSession): void {
     this.db
       .prepare(
         `INSERT INTO ce_sessions
@@ -207,7 +246,6 @@ export class CeSessionStore {
         session.createdAt,
         session.updatedAt,
       );
-    return session;
   }
 
   get(id: string): CeSession | undefined {
@@ -281,8 +319,14 @@ export class CeSessionStore {
 
   /** Delete a session row. Returns true when a row was removed. */
   delete(id: string): boolean {
-    const result = this.db.prepare(`DELETE FROM ce_sessions WHERE id = ?`).run(id);
-    return Number(result.changes ?? 0) > 0;
+    return this.db.transactionImmediate(() => {
+      const result = this.db.prepare(`DELETE FROM ce_sessions WHERE id = ?`).run(id);
+      if (Number(result.changes ?? 0) > 0) {
+        this.db.prepare("DELETE FROM ce_plan_handoff_claims WHERE sessionId = ?").run(id);
+        return true;
+      }
+      return false;
+    });
   }
 
   /** Append a turn to the conversation history (no other field touched). */

--- a/plugins/fusion-plugin-compound-engineering/src/session/session-store.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/session/session-store.ts
@@ -215,7 +215,7 @@ export class CeSessionStore {
     return row ? rowToSession(row) : undefined;
   }
 
-  list(filter: { status?: CeSessionStatus; stage?: string } = {}): CeSession[] {
+  list(filter: { status?: CeSessionStatus; stage?: string; projectId?: string } = {}): CeSession[] {
     const clauses: string[] = [];
     const params: unknown[] = [];
     if (filter.status) {
@@ -225,6 +225,10 @@ export class CeSessionStore {
     if (filter.stage) {
       clauses.push("stage = ?");
       params.push(filter.stage);
+    }
+    if (filter.projectId) {
+      clauses.push("projectId = ?");
+      params.push(filter.projectId);
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
     const rows = this.db

--- a/plugins/fusion-plugin-compound-engineering/src/session/stage-registry.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/session/stage-registry.ts
@@ -20,6 +20,8 @@ export interface CeStageDefinition {
    * earlier; values need not be contiguous (gaps leave room to insert between).
    */
   order: number;
+  /** Whether this launchable stage participates in automatic progression. Defaults to true. */
+  participatesInPipeline?: boolean;
   /** Bundled skill the orchestrator loads for this stage. */
   skillId: string;
   /**
@@ -105,11 +107,12 @@ const STAGE_DEFINITIONS: CeStageDefinition[] = [
   },
   {
     /*
-     * FNXC:CompoundEngineering 2026-06-16-19:40:
-     * debug is an operator-launchable investigation session appended after work so the existing strategy→ideate→brainstorm→plan→work auto-advance chain remains unchanged.
+     * FNXC:CompoundEngineeringPipeline 2026-07-10-22:52:
+     * Debug is manually launchable but does not participate in automatic Strategy -> Ideate -> Brainstorm -> Plan -> Work progression. Work remains the terminal automatic stage.
      */
     stageId: "debug",
     order: 600,
+    participatesInPipeline: false,
     skillId: "ce-debug",
     artifactLocation: "docs/debug/",
     icon: "Bug",
@@ -130,6 +133,11 @@ export function getStage(stageId: string): CeStageDefinition | undefined {
  */
 export function listStages(): CeStageDefinition[] {
   return [...REGISTRY.values()].sort((a, b) => a.order - b.order || a.stageId.localeCompare(b.stageId));
+}
+
+/** Automatic stages only; manual utility stages remain available through listStages/getStage. */
+export function listPipelineStages(): CeStageDefinition[] {
+  return listStages().filter((stage) => stage.participatesInPipeline !== false);
 }
 
 /**

--- a/plugins/fusion-plugin-compound-engineering/src/session/stage-registry.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/session/stage-registry.ts
@@ -55,6 +55,7 @@ const STAGE_DEFINITIONS: CeStageDefinition[] = [
   {
     stageId: "strategy",
     order: 100,
+    participatesInPipeline: false,
     skillId: "ce-strategy",
     artifactLocation: "STRATEGY.md",
     icon: "Compass",
@@ -64,6 +65,7 @@ const STAGE_DEFINITIONS: CeStageDefinition[] = [
   {
     stageId: "ideate",
     order: 200,
+    participatesInPipeline: false,
     skillId: "ce-ideate",
     artifactLocation: "docs/ideation/",
     icon: "Lightbulb",
@@ -107,11 +109,24 @@ const STAGE_DEFINITIONS: CeStageDefinition[] = [
   },
   {
     /*
+     * FNXC:CompoundEngineeringPipeline 2026-07-11-00:02:
+     * The upstream ce-work skill already owns implementation, phase-boundary simplification, and code review. Compound is the next distinct durable stage, saving reusable learnings after delivery instead of ending the user journey at Work.
+     */
+    stageId: "compound",
+    order: 600,
+    skillId: "ce-compound",
+    artifactLocation: "docs/solutions/",
+    icon: "BookOpenCheck",
+    label: "Compound",
+    artifactGlob: "docs/solutions/**/*.md",
+  },
+  {
+    /*
      * FNXC:CompoundEngineeringPipeline 2026-07-10-22:52:
-     * Debug is manually launchable but does not participate in automatic Strategy -> Ideate -> Brainstorm -> Plan -> Work progression. Work remains the terminal automatic stage.
+     * Debug is manually launchable but does not participate in automatic Strategy -> Ideate -> Brainstorm -> Plan -> Work -> Compound progression. Compound is the terminal automatic stage.
      */
     stageId: "debug",
-    order: 600,
+    order: 700,
     participatesInPipeline: false,
     skillId: "ce-debug",
     artifactLocation: "docs/debug/",

--- a/plugins/fusion-plugin-compound-engineering/src/sync/reconciler.ts
+++ b/plugins/fusion-plugin-compound-engineering/src/sync/reconciler.ts
@@ -1,5 +1,5 @@
 import type { PluginContext, Task } from "@fusion/core";
-import { listStages } from "../session/stage-registry.js";
+import { listPipelineStages } from "../session/stage-registry.js";
 import { createCeTaskWithLink } from "./ce-task.js";
 import {
   getCePipelineStore,
@@ -57,12 +57,11 @@ export interface ReconcileResult {
 
 /**
  * The linear CE stage order. The pipeline advances along this sequence.
- * `listStages()` is sorted by each stage's explicit `order` ordinal (NOT Map
- * insertion order), so a stage registered out of order — or inserted mid-
- * pipeline later — slots into the correct position here.
+ * Manual utility stages are excluded; remaining stages are sorted by explicit
+ * `order`, so runtime stages inserted mid-pipeline slot into the right place.
  */
 function stageOrder(): string[] {
-  return listStages().map((s) => s.stageId);
+  return listPipelineStages().map((s) => s.stageId);
 }
 
 /** The stage AFTER `stageId` in the pipeline, or `undefined` if it's terminal. */


### PR DESCRIPTION
## Summary

Compound Engineering now matches the upstream operating model: optional Strategy and Ideate foundation work feeds a repeatable Brainstorm → Plan → Work → Compound delivery loop, while Debug remains a separate path for broken behavior. Work explicitly includes its built-in simplification and code-review tail, so operators are not asked to repeat quality stages.

Brainstorm and Plan support many runs and artifacts instead of one permanent stage result. The overview distinguishes current strategy, historical artifacts, active work, input-needed sessions, and completed runs; long histories keep the four newest items visible with full collections available on demand.

The Brainstorm-to-Plan transition carries the exact source session and validates artifact readiness before reuse. Project-scoped session listing, atomic persistence, competing-session guards, runtime stage discovery, and recoverable error state prevent cross-project or malformed handoffs from silently breaking later stages.

## Flow decisions

| Area | Behavior |
| --- | --- |
| Foundation | Strategy and Ideate are optional grounding, not automatic delivery gates |
| Delivery loop | Brainstorm → Plan → Work → Compound repeats for each meaningful change |
| Quality | Work owns implementation, phase-boundary simplification, and code review |
| Investigation | Debug remains accessible without entering automatic progression |
| Artifacts | Brainstorms, plans, and learnings are collections with latest-first progressive disclosure |
| Continuity | Session selection survives URL restoration and all session consumers are project-scoped |

## Screenshots

### Desktop

![Compound Engineering workflow on desktop](https://github.com/Runfusion/Fusion/blob/6b67e0af9703905f62746afb0b57622deef5f95c/docs/screenshots/compound-engineering/pipeline-desktop.png?raw=1)

### Mobile

<img src="https://github.com/Runfusion/Fusion/blob/6b67e0af9703905f62746afb0b57622deef5f95c/docs/screenshots/compound-engineering/pipeline-mobile.png?raw=1" alt="Compound Engineering workflow on mobile" width="390" />

## Validation

- Compared the flow and bundled skill responsibilities against the [official Compound Engineering repository](https://github.com/EveryInc/compound-engineering-plugin).
- Full Compound Engineering plugin suite: 33 files and 324 tests passed.
- Plugin build, strict changeset validation, and diff checks passed.
- Exercised desktop and 390px mobile journeys in a real browser: stage launch, Foundation and Delivery-loop navigation, multi-artifact history, artifact open, session resume states, Debug separation, responsive stacking, and Work → Compound progression.
- Browser console remained clean; the dashboard also tolerates legacy `solution` API groups during upgrade.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stage-aware Compound Engineering dashboard with pipeline overview, readiness badges, and “Open artifact” / “Start next stage” actions.
  * Plan now supports in-place enrichment from compatible Brainstorm results, with exclusive handoffs to prevent conflicting plan creation.
  * Enhanced session navigation with URL-based deep links and optional project-scoped session listing.
  * Debug is available via a dedicated **Investigate** action (not automatic pipeline progression).

* **Improvements**
  * Single-select and guidance flows now require an explicit “Confirm choice”; empty multi-select submissions are blocked.
  * Terminal session discard now uses a two-step delete confirmation; improved responsive layout and artifact/history display.

* **Tests**
  * Expanded coverage for pipeline progression, artifact discovery, browser-safety, and UI interaction gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->