### PR TITLE
fix: repair embedded postgres macOS dylib links

### DIFF
--- a/.changeset/embedded-postgres-macos-dylib-links.md
+++ b/.changeset/embedded-postgres-macos-dylib-links.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Repair macOS embedded PostgreSQL dylib compatibility links before startup.
+category: fix
+dev: Adds an idempotent embedded-postgres macOS preflight that creates missing ABI-name symlinks such as `libpq.5.dylib` and `libzstd.1.dylib` from bundled versioned dylibs before `initdb`/`postgres` spawn, fixing zero-config startup when package symlink hydration is absent or incomplete.

--- a/packages/core/src/__tests__/postgres/embedded-lifecycle.test.ts
+++ b/packages/core/src/__tests__/postgres/embedded-lifecycle.test.ts
@@ -15,7 +15,15 @@
  */
 
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, existsSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  existsSync,
+  rmSync,
+  writeFileSync,
+  readlinkSync,
+  mkdirSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import postgres from "postgres";
@@ -24,6 +32,7 @@ import {
   EmbeddedStartTimeoutError,
   DEFAULT_START_TIMEOUT_MS,
   isDataDirInitialized,
+  normalizeMacosEmbeddedPostgresDylibSymlinks,
   readPortFromPostmasterPid,
   type EmbeddedLifecycleOptions,
 } from "../../postgres/embedded-lifecycle.js";
@@ -135,6 +144,57 @@ describe("embedded-lifecycle: constructor + URL helpers (no process)", () => {
       password: "password",
     });
     expect(lifecycle.getPort()).toBe(55433);
+  });
+});
+
+describe("embedded-lifecycle: macOS dylib compatibility links", () => {
+  it("repairs missing compatibility-name symlinks from versioned dylibs", () => {
+    const nativeRoot = mkdtempSync(join(tmpdir(), "fusion-embedded-native-"));
+    try {
+      const libDir = join(nativeRoot, "lib");
+      mkdirSync(libDir, { recursive: true });
+      writeFileSync(join(libDir, "libpq.5.15.dylib"), "");
+      writeFileSync(join(libDir, "libzstd.1.5.7.dylib"), "");
+      writeFileSync(join(libDir, "liblz4.1.10.0.dylib"), "");
+      writeFileSync(join(libDir, "libz.1.3.2.dylib"), "");
+      writeFileSync(join(libDir, "libicui18n.68.2.dylib"), "");
+
+      const created = normalizeMacosEmbeddedPostgresDylibSymlinks(nativeRoot);
+
+      expect(created.map((link) => link.expected).sort()).toEqual([
+        "libicui18n.dylib",
+        "liblz4.1.dylib",
+        "libpq.5.dylib",
+        "libz.1.dylib",
+        "libzstd.1.dylib",
+      ]);
+      expect(readlinkSync(join(libDir, "libpq.5.dylib"))).toBe("libpq.5.15.dylib");
+      expect(readlinkSync(join(libDir, "libzstd.1.dylib"))).toBe("libzstd.1.5.7.dylib");
+
+      // Idempotent: the second pass sees the compatibility names and creates nothing.
+      expect(normalizeMacosEmbeddedPostgresDylibSymlinks(nativeRoot)).toEqual([]);
+    } finally {
+      rmSync(nativeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces stale broken compatibility-name symlinks", () => {
+    const nativeRoot = mkdtempSync(join(tmpdir(), "fusion-embedded-native-"));
+    try {
+      const libDir = join(nativeRoot, "lib");
+      mkdirSync(libDir, { recursive: true });
+      writeFileSync(join(libDir, "libpq.5.16.dylib"), "");
+      symlinkSync("libpq.5.15.dylib", join(libDir, "libpq.5.dylib"));
+
+      const created = normalizeMacosEmbeddedPostgresDylibSymlinks(nativeRoot);
+
+      expect(created).toEqual([
+        { expected: "libpq.5.dylib", target: "libpq.5.16.dylib", created: true },
+      ]);
+      expect(readlinkSync(join(libDir, "libpq.5.dylib"))).toBe("libpq.5.16.dylib");
+    } finally {
+      rmSync(nativeRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/postgres/embedded-lifecycle.ts
+++ b/packages/core/src/postgres/embedded-lifecycle.ts
@@ -44,9 +44,16 @@
 // (DATABASE_URL unset AND FUSION_NO_EMBEDDED_PG not set — the default since
 // the flip-embedded-pg-default change; the runtime startup factory is the
 // sole caller and it dynamically imports this module only in that case).
-import { existsSync, readFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  unlinkSync,
+} from "node:fs";
 import { createServer, type Server } from "node:net";
-import { join } from "node:path";
+import { dirname, join, basename } from "node:path";
 import { createRequire } from "node:module";
 import { createLogger } from "../logger.js";
 import { redactConnectionString } from "./credential-redact.js";
@@ -158,6 +165,130 @@ const PG_VERSION_FILENAME = "PG_VERSION";
  */
 export function isDataDirInitialized(dataDir: string): boolean {
   return existsSync(join(dataDir, PG_VERSION_FILENAME));
+}
+
+interface EmbeddedDylibSymlinkSpec {
+  readonly expected: string;
+  readonly candidate: RegExp;
+}
+
+export interface EmbeddedDylibNormalization {
+  readonly expected: string;
+  readonly target: string;
+  readonly created: boolean;
+}
+
+const MACOS_EMBEDDED_DYLIB_SYMLINKS: readonly EmbeddedDylibSymlinkSpec[] = [
+  { expected: "libpq.5.dylib", candidate: /^libpq\.5\..+\.dylib$/ },
+  { expected: "libzstd.1.dylib", candidate: /^libzstd\.1\..+\.dylib$/ },
+  { expected: "liblz4.1.dylib", candidate: /^liblz4\.1\..+\.dylib$/ },
+  { expected: "libz.1.dylib", candidate: /^libz\.1\..+\.dylib$/ },
+  { expected: "libicui18n.dylib", candidate: /^libicui18n\..+\.dylib$/ },
+];
+
+function sortDylibCandidates(files: readonly string[], candidate: RegExp): string[] {
+  return files
+    .filter((file) => candidate.test(file))
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+}
+
+/**
+ * Normalize macOS embedded-postgres library names before initdb/postgres spawn.
+ *
+ * The @embedded-postgres/darwin-* packages can contain fully-versioned dylibs
+ * (for example libpq.5.15.dylib, libzstd.1.5.7.dylib) while the bundled
+ * binaries link against ABI compatibility names such as libpq.5.dylib and
+ * libzstd.1.dylib via @loader_path/../lib/.... When the package postinstall
+ * symlink hydration is skipped or incomplete, dyld fails before initdb can run.
+ *
+ * This is intentionally local to the embedded binary package and idempotent:
+ * existing compatibility names are left alone; missing compatibility names are
+ * repaired with relative symlinks to the matching versioned dylib.
+ */
+export function normalizeMacosEmbeddedPostgresDylibSymlinks(
+  nativeRoot: string,
+): EmbeddedDylibNormalization[] {
+  const libDir = join(nativeRoot, "lib");
+  if (!existsSync(libDir)) return [];
+
+  const files = readdirSync(libDir);
+  const results: EmbeddedDylibNormalization[] = [];
+  for (const spec of MACOS_EMBEDDED_DYLIB_SYMLINKS) {
+    const expectedPath = join(libDir, spec.expected);
+    if (existsSync(expectedPath)) continue;
+    const target = sortDylibCandidates(files, spec.candidate)[0];
+    if (!target) continue;
+    try {
+      // existsSync() returns false for dangling symlinks. If a previous install
+      // left libpq.5.dylib -> libpq.5.15.dylib behind and the versioned target
+      // was later removed, symlinkSync() would otherwise throw EEXIST and abort
+      // startup. Remove only that broken symlink case; leave real files alone.
+      const existing = lstatSync(expectedPath, { throwIfNoEntry: false });
+      if (existing?.isSymbolicLink()) {
+        unlinkSync(expectedPath);
+      }
+      symlinkSync(target, expectedPath);
+    } catch {
+      // Best-effort repair: read-only package stores or filesystem quirks should
+      // not crash startup before dyld gets a chance to use already-valid links.
+      continue;
+    }
+    files.push(spec.expected);
+    results.push({ expected: spec.expected, target, created: true });
+  }
+  return results;
+}
+
+function findPnpmVirtualStore(start: string): string | null {
+  let current = start;
+  for (let depth = 0; depth < 12; depth += 1) {
+    if (basename(current) === ".pnpm") return current;
+    const next = dirname(current);
+    if (next === current) return null;
+    current = next;
+  }
+  return null;
+}
+
+function resolvePnpmPlatformPackageNativeRoot(packageName: string): string | null {
+  try {
+    const embeddedEntrypoint = require.resolve("embedded-postgres");
+    const virtualStore = findPnpmVirtualStore(dirname(embeddedEntrypoint));
+    if (!virtualStore) return null;
+    const encodedName = packageName.replace("/", "+");
+    const entry = readdirSync(virtualStore).find((name) => name.startsWith(`${encodedName}@`));
+    if (!entry) return null;
+    const packageRoot = join(virtualStore, entry, "node_modules", ...packageName.split("/"));
+    return existsSync(packageRoot) ? join(packageRoot, "native") : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveMacosEmbeddedPostgresNativeRoot(): string | null {
+  if (process.platform !== "darwin") return null;
+  const packageName = process.arch === "arm64"
+    ? "@embedded-postgres/darwin-arm64"
+    : process.arch === "x64"
+      ? "@embedded-postgres/darwin-x64"
+      : null;
+  if (!packageName) return null;
+
+  try {
+    const entrypoint = require.resolve(packageName);
+    return join(dirname(entrypoint), "..", "native");
+  } catch {
+    return resolvePnpmPlatformPackageNativeRoot(packageName);
+  }
+}
+
+function normalizeBundledMacosDylibs(onLog: (message: string) => void): void {
+  const nativeRoot = resolveMacosEmbeddedPostgresNativeRoot();
+  if (!nativeRoot) return;
+  const created = normalizeMacosEmbeddedPostgresDylibSymlinks(nativeRoot);
+  for (const link of created) {
+    onLog(`embedded postgres: repaired macOS dylib link ${link.expected} -> ${link.target}`);
+  }
 }
 
 /**
@@ -452,6 +583,8 @@ export class EmbeddedPostgresLifecycle {
     this.resolvedPort = port;
 
     const alreadyInitialized = isDataDirInitialized(this.options.dataDir);
+
+    normalizeBundledMacosDylibs(this.options.onLog);
 
     this.pg = new (getEmbeddedPostgresCtor())({
       databaseDir: this.options.dataDir,


### PR DESCRIPTION
## Summary

- Repairs macOS embedded PostgreSQL startup when the bundled `@embedded-postgres/darwin-*` package is missing ABI compatibility-name dylibs such as `libpq.5.dylib` and `libzstd.1.dylib`.
- Adds an idempotent preflight before `initdb`/`postgres` spawn that creates relative compatibility symlinks from the versioned dylibs already shipped in `native/lib`.
- Covers the repair with a no-process unit test and adds a patch changeset.

## Why

On macOS arm64, `pnpm smoke:boot` failed before the app could boot embedded PG:

```text
dyld: Library not loaded: @loader_path/../lib/libpq.5.dylib
Referenced from: .../native/bin/initdb
Reason: tried: .../native/lib/libpq.5.dylib (no such file)
```

After manually adding `libpq.5.dylib`, startup hit the same class again:

```text
dyld: Library not loaded: @loader_path/../lib/libzstd.1.dylib
Referenced from: .../native/bin/postgres
Reason: tried: .../native/lib/libzstd.1.dylib (no such file)
```

The package did contain the versioned dylibs (`libpq.5.15.dylib`, `libzstd.1.5.7.dylib`, etc.); only the compatibility names were missing/incomplete.

## Verification

- [x] `FUSION_EMBEDDED_TEST_SKIP=1 pnpm --filter @fusion/core exec vitest run src/__tests__/postgres/embedded-lifecycle.test.ts --silent=passed-only --reporter=dot`
  - 15 passed, 5 skipped
- [x] `pnpm --filter @fusion/core typecheck`
- [x] `pnpm build`
- [x] Removed the compatibility dylibs from local `node_modules/.pnpm/@embedded-postgres+darwin-arm64.../native/lib`, then ran `pnpm smoke:boot`
  - `GET /api/health 200`
  - clean shutdown
  - PASS
- [x] Docker external PG + serialized PG gate:
  - `CI=true VITEST_MAX_WORKERS=1 FUSION_PG_TEST_URL_BASE=postgresql://postgres@127.0.0.1:55432 pnpm --filter @fusion/core test:pg-gate`
  - 23 files / 96 tests passed

## Notes

Full root `pnpm lint` still reports pre-existing unrelated no-unused-vars errors in current `feature/postgres` files (`backup.ts`, `memory-backup.ts`, `mission.ts`, `chat-store.ts`, `remaining-ops-4.ts`). The changed source file passes targeted ESLint; the test file is ignored by the current ESLint config.
