### PR TITLE
fix(missions): reconcile lifecycle invariants

### DIFF
--- a/.changeset/mission-lifecycle-invariants.md
+++ b/.changeset/mission-lifecycle-invariants.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Reconcile completed and stale generated-fix mission invariants.
+category: fix
+dev: Completed missions now normalize autopilot/auto-advance to inactive during autopilot completion, polling, and restart recovery. Mission reconciliation also supersedes generated fix features whose own validator state is already passed, and the scheduler startup sweep runs stale generated-fix reconciliation before trying to relink or retriage active slice features. This prevents complete missions from remaining watched and prevents stale generated fix rows from keeping otherwise-drained missions administratively active.

--- a/packages/core/src/__tests__/mission-store.test.ts
+++ b/packages/core/src/__tests__/mission-store.test.ts
@@ -1762,14 +1762,17 @@ describe("MissionStore", () => {
         const staleFix = store.createGeneratedFixFeature(source.id, failedRun.id, ["CA-source"]);
         createTaskInDb(db, "FN-own-passed-fix", "Own passed stale fix task", undefined, { column: "todo" });
         store.updateFeature(staleFix.id, {
-          status: "blocked",
+          status: "done",
           loopState: "passed",
           lastValidatorStatus: "passed",
           taskId: "FN-own-passed-fix",
         });
         db.prepare("UPDATE tasks SET missionId = ?, sliceId = ? WHERE id = ?").run(mission.id, slice.id, "FN-own-passed-fix");
 
-        expect(store.computeSliceStatus(slice.id)).not.toBe("complete");
+        expect(db.prepare("SELECT missionId, sliceId FROM tasks WHERE id = ?").get("FN-own-passed-fix")).toEqual({
+          missionId: mission.id,
+          sliceId: slice.id,
+        });
 
         const report = store.reconcileSupersededGeneratedFixFeatures(slice.id);
 

--- a/packages/core/src/__tests__/mission-store.test.ts
+++ b/packages/core/src/__tests__/mission-store.test.ts
@@ -1748,6 +1748,36 @@ describe("MissionStore", () => {
         expect(store.getFeature(staleFix.id)).toMatchObject({ status: "done", loopState: "passed", lastValidatorStatus: "passed" });
         expect(store.computeSliceStatus(slice.id)).toBe("complete");
       });
+
+      it("reconciles generated fix features whose own validator already passed", () => {
+        const mission = store.createMission({ title: "Mission" });
+        const milestone = store.addMilestone(mission.id, { title: "Milestone" });
+        const slice = store.addSlice(milestone.id, { title: "Slice" });
+        const source = store.addFeature(slice.id, { title: "Source" });
+
+        store.updateFeature(source.id, { status: "done" });
+        const failedRun = store.startValidatorRun(source.id, "task_completion");
+        store.completeValidatorRun(failedRun.id, "failed", "missing evidence");
+        const staleFix = store.createGeneratedFixFeature(source.id, failedRun.id, ["CA-source"]);
+        store.updateFeature(staleFix.id, {
+          status: "blocked",
+          loopState: "passed",
+          lastValidatorStatus: "passed",
+          taskId: undefined,
+        });
+
+        expect(store.computeSliceStatus(slice.id)).toBe("pending");
+
+        const report = store.reconcileSupersededGeneratedFixFeatures(slice.id);
+
+        expect(report).toEqual({ supersededCount: 1, featureIds: [staleFix.id] });
+        expect(store.getFeature(staleFix.id)).toMatchObject({
+          status: "done",
+          taskId: undefined,
+          loopState: "passed",
+          lastValidatorStatus: "passed",
+        });
+      });
     });
 
     describe("computeMilestoneStatus", () => {

--- a/packages/core/src/__tests__/mission-store.test.ts
+++ b/packages/core/src/__tests__/mission-store.test.ts
@@ -1719,6 +1719,7 @@ describe("MissionStore", () => {
           sliceId: null,
         });
         expect(store.computeSliceStatus(slice.id)).toBe("complete");
+        expect(store.getSlice(slice.id)).toMatchObject({ status: "complete" });
       });
 
       it("reconciles stale generated fix features when a source validator run passes", () => {
@@ -1759,14 +1760,16 @@ describe("MissionStore", () => {
         const failedRun = store.startValidatorRun(source.id, "task_completion");
         store.completeValidatorRun(failedRun.id, "failed", "missing evidence");
         const staleFix = store.createGeneratedFixFeature(source.id, failedRun.id, ["CA-source"]);
+        createTaskInDb(db, "FN-own-passed-fix", "Own passed stale fix task", undefined, { column: "todo" });
         store.updateFeature(staleFix.id, {
           status: "blocked",
           loopState: "passed",
           lastValidatorStatus: "passed",
-          taskId: undefined,
+          taskId: "FN-own-passed-fix",
         });
+        db.prepare("UPDATE tasks SET missionId = ?, sliceId = ? WHERE id = ?").run(mission.id, slice.id, "FN-own-passed-fix");
 
-        expect(store.computeSliceStatus(slice.id)).toBe("pending");
+        expect(store.computeSliceStatus(slice.id)).not.toBe("complete");
 
         const report = store.reconcileSupersededGeneratedFixFeatures(slice.id);
 
@@ -1776,6 +1779,10 @@ describe("MissionStore", () => {
           taskId: undefined,
           loopState: "passed",
           lastValidatorStatus: "passed",
+        });
+        expect(db.prepare("SELECT missionId, sliceId FROM tasks WHERE id = ?").get("FN-own-passed-fix")).toEqual({
+          missionId: null,
+          sliceId: null,
         });
       });
     });

--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -3215,7 +3215,7 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
 
     const supersededFeatureIds = features
       .filter((feature) => feature.generatedFromFeatureId && (featureHasPassed(feature) || hasPassedAncestor(feature)))
-      .filter((feature) => feature.status !== "done" || feature.loopState !== "passed" || feature.lastValidatorStatus !== "passed")
+      .filter((feature) => feature.status !== "done" || feature.loopState !== "passed" || feature.lastValidatorStatus !== "passed" || feature.taskId)
       .map((feature) => feature.id);
 
     if (supersededFeatureIds.length > 0) {

--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -3170,8 +3170,8 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
   }
 
   /**
-   * Mark generated Fix Features obsolete once an ancestor feature has already
-   * passed validation.
+   * Mark generated Fix Features obsolete once an ancestor feature, or the fix's
+   * own validation evidence, has already passed.
    *
    * Validator failures can create a chain of generated features. If the original
    * feature is later validated successfully, older descendants are no longer
@@ -3181,6 +3181,10 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
    * FNXC:Missions 2026-07-05-22:09:
    * Superseded generated Fix Features must become terminal and lose live board-task ownership.
    * Otherwise mission recovery can keep resuming stale remediation tasks after the source feature is already validated.
+   *
+   * FNXC:Missions 2026-07-11-12:35:
+   * A generated fix can also supersede itself once its own validator/loop evidence has passed.
+   * Reconciliation treats that as terminal evidence so a completed fix does not stay active only because its ancestor previously failed.
    */
   reconcileSupersededGeneratedFixFeatures(sliceId: string): { supersededCount: number; featureIds: string[] } {
     const features = this.listFeatures(sliceId);

--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -3210,7 +3210,7 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
     };
 
     const supersededFeatureIds = features
-      .filter((feature) => feature.generatedFromFeatureId && hasPassedAncestor(feature))
+      .filter((feature) => feature.generatedFromFeatureId && (featureHasPassed(feature) || hasPassedAncestor(feature)))
       .filter((feature) => feature.status !== "done" || feature.loopState !== "passed" || feature.lastValidatorStatus !== "passed")
       .map((feature) => feature.id);
 

--- a/packages/engine/src/__tests__/mission-autopilot.test.ts
+++ b/packages/engine/src/__tests__/mission-autopilot.test.ts
@@ -616,6 +616,49 @@ describe("MissionAutopilot", () => {
       expect(autopilot.isWatching("M-TEST1")).toBe(false);
     });
 
+    it("normalizes already-complete autopilot state when completion is checked", async () => {
+      const mission = createMockMission({
+        id: "M-COMPLETE-CHECK",
+        status: "complete",
+        autoAdvance: true,
+        autopilotEnabled: true,
+        autopilotState: "watching",
+      });
+      const store = createMockMissionStore([mission]);
+      const ap = new MissionAutopilot(taskStore as any, store as any, { scheduler });
+      store.listMilestones.mockReturnValue([createMockMilestone({ missionId: mission.id, status: "complete" })]);
+      store.getMissionWithHierarchy.mockReturnValue({
+        ...mission,
+        milestones: [{
+          ...createMockMilestone({ missionId: mission.id, status: "complete" }),
+          slices: [{
+            ...createMockSlice({ id: "SL-COMPLETE-CHECK", status: "complete" }),
+            features: [createMockFeature({ id: "F-COMPLETE-CHECK", status: "done" })],
+          }],
+        }],
+      });
+
+      ap.watchMission(mission.id);
+      const result = await ap.checkMissionCompletion(mission.id);
+
+      expect(result).toBe(true);
+      expect(store.updateMission).toHaveBeenCalledWith(
+        mission.id,
+        expect.objectContaining({
+          autoAdvance: false,
+          autopilotEnabled: false,
+          autopilotState: "inactive",
+        }),
+      );
+      expect(store.logMissionEvent).toHaveBeenCalledWith(
+        mission.id,
+        "autopilot_disabled",
+        expect.stringContaining("Autopilot disabled for already-complete mission"),
+        expect.objectContaining({ source: "checkMissionCompletion" }),
+      );
+      expect(ap.isWatching(mission.id)).toBe(false);
+    });
+
     it("should return false when milestones are not all complete", async () => {
       const m1 = createMockMilestone({ status: "active" });
       missionStore.listMilestones.mockReturnValue([m1]);
@@ -688,6 +731,34 @@ describe("MissionAutopilot", () => {
         "M-TEST1",
         expect.objectContaining({ status: "complete" }),
       );
+    });
+
+    it("normalizes autopilot flags when checkMissionCompletion completes the mission", async () => {
+      missionStore.listMilestones.mockReturnValue([createMockMilestone({ status: "complete" })]);
+      missionStore.getMissionWithHierarchy.mockReturnValue({
+        ...createMockMission(),
+        milestones: [{
+          ...createMockMilestone({ id: "MS-001", status: "complete" }),
+          slices: [{
+            ...createMockSlice({ id: "SL-001", status: "complete" }),
+            features: [createMockFeature({ id: "F-001", status: "done" })],
+          }],
+        }],
+      });
+
+      autopilot.watchMission("M-TEST1");
+      missionStore.updateMission.mockClear();
+      missionStore.logMissionEvent.mockClear();
+      const result = await autopilot.checkMissionCompletion("M-TEST1");
+
+      expect(result).toBe(true);
+      expect(missionStore.updateMission).toHaveBeenCalledWith("M-TEST1", expect.objectContaining({ status: "complete" }));
+      expect(missionStore.updateMission).toHaveBeenCalledWith("M-TEST1", expect.objectContaining({
+        autoAdvance: false,
+        autopilotEnabled: false,
+        autopilotState: "inactive",
+      }));
+      expect(autopilot.isWatching("M-TEST1")).toBe(false);
     });
   });
 
@@ -933,6 +1004,32 @@ describe("MissionAutopilot", () => {
   // ── Poll / stale detection ──────────────────────────────────────
 
   describe("poll stale detection", () => {
+    it("normalizes complete missions during poll", async () => {
+      const completeMission = createMockMission({
+        status: "complete",
+        autoAdvance: true,
+        autopilotEnabled: true,
+        autopilotState: "watching",
+      });
+      const store = createMockMissionStore([completeMission]);
+      const ap = new MissionAutopilot(taskStore as any, store as any, { scheduler });
+
+      ap.watchMission("M-TEST1");
+      store.updateMission.mockClear();
+      store.logMissionEvent.mockClear();
+      ap.start();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(store.updateMission).toHaveBeenCalledWith("M-TEST1", expect.objectContaining({
+        autoAdvance: false,
+        autopilotEnabled: false,
+        autopilotState: "inactive",
+      }));
+      expect(ap.isWatching("M-TEST1")).toBe(false);
+
+      ap.stop();
+    });
+
     it("recovers stale activating missions back to watching and advances slices", async () => {
       const staleMission = createMockMission({
         autopilotState: "activating",
@@ -1092,6 +1189,59 @@ describe("MissionAutopilot", () => {
         expect.objectContaining({ source: "recoverMissions" }),
       );
       expect(ap.isWatching("M-COMPLETE")).toBe(false);
+    });
+
+    it("normalizes complete missions that still have autopilot watching during poll", async () => {
+      const mission = createMockMission({
+        id: "M-COMPLETE-POLL",
+        status: "complete",
+        autoAdvance: true,
+        autopilotEnabled: true,
+        autopilotState: "watching",
+      });
+      const store = createMockMissionStore([mission]);
+      const ap = new MissionAutopilot(taskStore as any, store as any, { scheduler });
+
+      ap.watchMission(mission.id);
+      (ap as any).running = true;
+      await (ap as any).poll();
+
+      expect(store.updateMission).toHaveBeenCalledWith(
+        mission.id,
+        expect.objectContaining({
+          autoAdvance: false,
+          autopilotEnabled: false,
+          autopilotState: "inactive",
+        }),
+      );
+      expect(store.logMissionEvent).toHaveBeenCalledWith(
+        mission.id,
+        "autopilot_disabled",
+        expect.stringContaining("Autopilot disabled for already-complete mission"),
+        expect.objectContaining({ source: "poll" }),
+      );
+      expect(ap.isWatching(mission.id)).toBe(false);
+    });
+
+    it("does not clear watched state when normalization is accidentally called for an active mission", () => {
+      const mission = createMockMission({
+        id: "M-ACTIVE",
+        status: "active",
+        autoAdvance: true,
+        autopilotEnabled: true,
+        autopilotState: "watching",
+      });
+      const store = createMockMissionStore([mission]);
+      const ap = new MissionAutopilot(taskStore as any, store as any, { scheduler });
+
+      ap.watchMission("M-ACTIVE");
+      store.updateMission.mockClear();
+      store.logMissionEvent.mockClear();
+      (ap as any).normalizeCompleteMissionAutopilotState("M-ACTIVE", "test");
+
+      expect(ap.isWatching("M-ACTIVE")).toBe(true);
+      expect(store.updateMission).not.toHaveBeenCalled();
+      expect(store.logMissionEvent).not.toHaveBeenCalled();
     });
 
     it("recovers missions stuck in activating state", async () => {

--- a/packages/engine/src/__tests__/mission-autopilot.test.ts
+++ b/packages/engine/src/__tests__/mission-autopilot.test.ts
@@ -1064,6 +1064,36 @@ describe("MissionAutopilot", () => {
       expect(ap.isWatching("M-FOUR")).toBe(false);
     });
 
+    it("normalizes complete missions that still have autopilot watching", async () => {
+      const mission = createMockMission({
+        id: "M-COMPLETE",
+        status: "complete",
+        autoAdvance: true,
+        autopilotEnabled: true,
+        autopilotState: "watching",
+      });
+      const store = createMockMissionStore([mission]);
+      const ap = new MissionAutopilot(taskStore as any, store as any, { scheduler });
+
+      await ap.recoverMissions(store as any);
+
+      expect(store.updateMission).toHaveBeenCalledWith(
+        "M-COMPLETE",
+        expect.objectContaining({
+          autoAdvance: false,
+          autopilotEnabled: false,
+          autopilotState: "inactive",
+        }),
+      );
+      expect(store.logMissionEvent).toHaveBeenCalledWith(
+        "M-COMPLETE",
+        "autopilot_disabled",
+        expect.stringContaining("Autopilot disabled for already-complete mission"),
+        expect.objectContaining({ source: "recoverMissions" }),
+      );
+      expect(ap.isWatching("M-COMPLETE")).toBe(false);
+    });
+
     it("recovers missions stuck in activating state", async () => {
       const mission = createMockMission({ autopilotState: "activating" });
       const store = createMockMissionStore([mission]);

--- a/packages/engine/src/__tests__/reliability-interactions/mission-stranded-feature-retriage.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/mission-stranded-feature-retriage.test.ts
@@ -287,6 +287,104 @@ describe("FN-5754 reliability: mission stranded feature retriage", () => {
     expect(missionStore.updateFeature).not.toHaveBeenCalled();
   });
 
+  it("keeps ordinary done linked features in startup task-drift reconciliation", async () => {
+    const tasks = [{ id: "FN-DONE", title: "Completed feature", missionId: "M-001", sliceId: "SL-001", column: "done", status: "queued" }];
+    const features = [feature({ id: "F-DONE", title: "Completed feature", status: "done", taskId: "FN-DONE" })];
+    const missionStore = {
+      listMissions: vi.fn(() => [{ id: "M-001", status: "active", autopilotEnabled: true }]),
+      getMissionWithHierarchy: vi.fn(() => ({
+        id: "M-001",
+        status: "active",
+        milestones: [{ id: "MS-001", slices: [{ id: "SL-001", status: "active", features }] }],
+      })),
+      updateFeatureStatus: vi.fn(),
+      listAssertionsForFeature: vi.fn(() => []),
+    };
+    const store = createTaskStore(tasks);
+
+    const scheduler = new Scheduler(store, { missionStore: missionStore as any });
+    await scheduler.reconcileAllMissionFeatures();
+
+    expect(store.getTask).toHaveBeenCalledWith("FN-DONE");
+  });
+
+  it("keeps done generated fixes with live task ownership in startup task-drift reconciliation", async () => {
+    const tasks = [{ id: "FN-GENERATED-DONE", title: "Fix: completed generated remediation", missionId: "M-001", sliceId: "SL-001", column: "done", status: "queued" }];
+    const features = [feature({
+      id: "F-GENERATED-DONE",
+      title: "Fix: completed generated remediation",
+      status: "done",
+      generatedFromFeatureId: "F-SOURCE",
+      taskId: "FN-GENERATED-DONE",
+    })];
+    const missionStore = {
+      listMissions: vi.fn(() => [{ id: "M-001", status: "active", autopilotEnabled: true }]),
+      getMissionWithHierarchy: vi.fn(() => ({
+        id: "M-001",
+        status: "active",
+        milestones: [{ id: "MS-001", slices: [{ id: "SL-001", status: "active", features }] }],
+      })),
+      updateFeatureStatus: vi.fn(),
+      listAssertionsForFeature: vi.fn(() => []),
+    };
+    const store = createTaskStore(tasks);
+
+    const scheduler = new Scheduler(store, { missionStore: missionStore as any });
+    await scheduler.reconcileAllMissionFeatures();
+
+    expect(store.getTask).toHaveBeenCalledWith("FN-GENERATED-DONE");
+  });
+
+  it("does not block superseded done generated fixes during refreshed startup reconciliation", async () => {
+    const supersededFix = feature({
+      id: "F-SUPERSEDED-FIX",
+      title: "Fix: already validated remediation",
+      status: "done",
+      loopState: "passed",
+      lastValidatorStatus: "passed",
+      generatedFromFeatureId: "F-SOURCE",
+      taskId: undefined,
+    });
+    const remainingFeature = feature({ id: "F-REMAINING", title: "Remaining feature", status: "defined", taskId: undefined });
+    let features = [supersededFix, remainingFeature];
+    const tasks: any[] = [{
+      id: "FN-STALE-FIX",
+      title: "Fix: already validated remediation",
+      missionId: "M-001",
+      sliceId: "SL-001",
+      column: "todo",
+      status: "queued",
+    }];
+    const missionStore = {
+      listMissions: vi.fn(() => [{ id: "M-001", status: "active", autopilotEnabled: true }]),
+      getMissionWithHierarchy: vi.fn(() => ({
+        id: "M-001",
+        status: "active",
+        milestones: [{ id: "MS-001", slices: [{ id: "SL-001", status: "active", features }] }],
+      })),
+      reconcileSupersededGeneratedFixFeatures: vi.fn(() => ({ supersededCount: 1, featureIds: ["F-SUPERSEDED-FIX"] })),
+      listFeatures: vi.fn(() => features),
+      getSlice: vi.fn(() => ({ id: "SL-001", milestoneId: "MS-001", status: "active", features })),
+      triageFeature: vi.fn(async (featureId: string) => {
+        const taskId = `FN-${featureId}`;
+        tasks.push({ id: taskId, title: "Remaining feature", missionId: "M-001", sliceId: "SL-001", column: "todo", status: "queued" });
+        features = features.map((candidate) => candidate.id === featureId ? { ...candidate, taskId, status: "triaged" } : candidate);
+        return features.find((candidate) => candidate.id === featureId);
+      }),
+      linkFeatureToTask: vi.fn(),
+      updateFeature: vi.fn(),
+      updateFeatureStatus: vi.fn(),
+      listAssertionsForFeature: vi.fn(() => []),
+    };
+
+    const scheduler = new Scheduler(createTaskStore(tasks), { missionStore: missionStore as any });
+    await scheduler.reconcileAllMissionFeatures();
+
+    expect(missionStore.updateFeature).not.toHaveBeenCalledWith("F-SUPERSEDED-FIX", expect.objectContaining({ status: "blocked" }));
+    expect(missionStore.linkFeatureToTask).not.toHaveBeenCalledWith("F-SUPERSEDED-FIX", "FN-STALE-FIX");
+    expect(missionStore.triageFeature).toHaveBeenCalledWith("F-REMAINING");
+  });
+
   it("leaves non-autopilot and blocked features untouched", async () => {
     const autopilotOffFeature = feature({ id: "F-001", status: "defined", taskId: undefined });
     const blockedFeature = feature({ id: "F-002", status: "blocked", taskId: undefined, title: "Blocked feature" });

--- a/packages/engine/src/mission-autopilot.ts
+++ b/packages/engine/src/mission-autopilot.ts
@@ -834,6 +834,15 @@ export class MissionAutopilot {
       return;
     }
 
+    if (mission.status !== "complete") {
+      /*
+      FNXC:Missions 2026-07-11-12:35:
+      Autopilot cleanup is only safe for missions that are already complete.
+      Active missions may still need watched-state and retry memory even if a future caller reaches this helper by mistake.
+      */
+      return;
+    }
+
     this.watchedMissions.delete(missionId);
     this.perMissionTaskRetries.delete(missionId);
 

--- a/packages/engine/src/mission-autopilot.ts
+++ b/packages/engine/src/mission-autopilot.ts
@@ -528,9 +528,7 @@ export class MissionAutopilot {
         { milestoneCount: milestones.length },
       );
       this.updateActivity(missionId);
-      this.setAutopilotState(missionId, "inactive");
-      this.watchedMissions.delete(missionId);
-      this.perMissionTaskRetries.delete(missionId);
+      this.normalizeCompleteMissionAutopilotState(missionId, "checkMissionCompletion");
       return true;
     }
 
@@ -580,8 +578,13 @@ export class MissionAutopilot {
       const missions = this.missionStore.listMissions();
 
       for (const mission of missions) {
+        if (mission.status === "complete") {
+          this.normalizeCompleteMissionAutopilotState(mission.id, "poll");
+          continue;
+        }
+
         // Auto-watch missions with autopilot enabled that aren't being watched
-        if (mission.autopilotEnabled && !this.isWatching(mission.id) && mission.status !== "complete" && mission.status !== "archived") {
+        if (mission.autopilotEnabled && !this.isWatching(mission.id) && mission.status !== "archived") {
           autopilotLog.log(`Poll: auto-watching mission ${mission.id}`);
           this.watchMission(mission.id);
         }
@@ -776,7 +779,12 @@ export class MissionAutopilot {
       let inconsistencyFixes = 0;
 
       for (const mission of missions) {
-        if (!mission.autopilotEnabled || mission.status === "complete" || mission.status === "archived") {
+        if (mission.status === "complete") {
+          this.normalizeCompleteMissionAutopilotState(mission.id, "recoverMissions");
+          continue;
+        }
+
+        if (!mission.autopilotEnabled || mission.status === "archived") {
           continue;
         }
 
@@ -818,6 +826,37 @@ export class MissionAutopilot {
     } catch (err) {
       autopilotLog.error("Mission recovery failed:", err);
     }
+  }
+
+  private normalizeCompleteMissionAutopilotState(missionId: string, source: string): void {
+    const mission = this.missionStore.getMission(missionId);
+    if (!mission) {
+      return;
+    }
+
+    this.watchedMissions.delete(missionId);
+    this.perMissionTaskRetries.delete(missionId);
+
+    if (!mission.autopilotEnabled && !mission.autoAdvance && mission.autopilotState === "inactive") {
+      return;
+    }
+
+    this.missionStore.updateMission(missionId, {
+      autoAdvance: false,
+      autopilotEnabled: false,
+      autopilotState: "inactive",
+    });
+    this.logMissionEventSafe(
+      missionId,
+      "autopilot_disabled",
+      `Autopilot disabled for already-complete mission ${mission.title}`,
+      {
+        source,
+        previousAutoAdvance: mission.autoAdvance,
+        previousAutopilotEnabled: mission.autopilotEnabled,
+        previousAutopilotState: mission.autopilotState ?? "inactive",
+      },
+    );
   }
 
   private async reconcileMissionConsistency(

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -3073,8 +3073,18 @@ export class Scheduler {
 
         for (const slice of activeSlices) {
           const missionAutoTriageEnabled = mission.autopilotEnabled === true || mission.autoAdvance === true;
+          const supersededFixes = missionStore.reconcileSupersededGeneratedFixFeatures(slice.id);
+          if (supersededFixes.supersededCount > 0) {
+            totalFixed += supersededFixes.supersededCount;
+            schedulerLog.warn(
+              `Superseded ${supersededFixes.supersededCount} stale generated fix feature(s) during mission reconciliation for slice ${slice.id}`,
+            );
+          }
+          const features = supersededFixes.supersededCount > 0
+            ? missionStore.listFeatures(slice.id)
+            : slice.features;
 
-          for (const feature of slice.features) {
+          for (const feature of features) {
             let featureForReconciliation = feature;
             let task: Task | undefined;
             if (feature.taskId) {

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -3073,7 +3073,8 @@ export class Scheduler {
 
         for (const slice of activeSlices) {
           const missionAutoTriageEnabled = mission.autopilotEnabled === true || mission.autoAdvance === true;
-          const supersededFixes = missionStore.reconcileSupersededGeneratedFixFeatures(slice.id);
+          const supersededFixes = missionStore.reconcileSupersededGeneratedFixFeatures?.(slice.id)
+            ?? { supersededCount: 0, featureIds: [] };
           if (supersededFixes.supersededCount > 0) {
             totalFixed += supersededFixes.supersededCount;
             schedulerLog.warn(
@@ -3083,10 +3084,40 @@ export class Scheduler {
           const features = supersededFixes.supersededCount > 0
             ? missionStore.listFeatures(slice.id)
             : slice.features;
+          const supersededFeatureIds = new Set(supersededFixes.featureIds);
+
+          if (supersededFixes.supersededCount > 0) {
+            const refreshedSlice = missionStore.getSlice?.(slice.id);
+            if (refreshedSlice?.status === "complete") {
+              /*
+              FNXC:Missions 2026-07-11-12:35:
+              Startup reconciliation can terminalize every stale generated-fix feature in an active slice before the scheduler loop runs no-task recovery.
+              Treat the recomputed complete slice as complete immediately so stale fixes do not keep an active slice from advancing after restart.
+              */
+              await this.onSliceComplete(refreshedSlice);
+              continue;
+            }
+          }
 
           for (const feature of features) {
             let featureForReconciliation = feature;
             let task: Task | undefined;
+            if (supersededFeatureIds.has(feature.id)) {
+              /*
+              FNXC:Missions 2026-07-11-12:35:
+              The title-to-task map is built before generated-fix supersedence detaches stale task ownership.
+              Skip freshly superseded features so pre-reconciliation task links cannot be restored in the same startup sweep.
+              */
+              continue;
+            }
+            if (feature.status === "done" && this.isGeneratedFixFeature(feature) && !feature.taskId) {
+              /*
+              FNXC:Missions 2026-07-11-12:35:
+              Done generated-fix features with no task ownership are terminal after supersedence clears their board links.
+              Keep any done feature that still has task ownership in startup self-healing so linked task drift can still be repaired.
+              */
+              continue;
+            }
             if (feature.taskId) {
               task = await this.store.getTask(feature.taskId);
             } else {


### PR DESCRIPTION
## Summary
- normalize completed missions so autopilot/auto-advance are disabled during completion, polling, and restart recovery
- treat generated fix features whose own validator state has already passed as superseded terminal work
- run generated-fix reconciliation during scheduler startup mission-feature sweeps before relinking/retriaging stranded active-slice features

## Why
Atlas Notes hit a mission lifecycle invariant failure where the board was empty from an operator perspective, but Fusion kept missions administratively active or watched:
- complete missions could remain `autopilotEnabled=true` / `autopilotState=watching`
- stale generated fix rows with passed validator state could keep slices/missions non-terminal
- the scheduler startup reconciliation path did not apply stale generated-fix reconciliation before deciding whether stranded features needed more work

That forced manual DB repair. This PR turns that scar into product behavior.

## Test Plan
- `pnpm --dir packages/core exec vitest run --silent=passed-only --reporter=dot src/__tests__/mission-store.test.ts`
- `pnpm --dir packages/engine exec vitest run --silent=passed-only --reporter=dot --project=engine-default src/__tests__/mission-autopilot.test.ts`
- `pnpm --dir packages/core exec tsc --noEmit -p tsconfig.json`
- `pnpm --dir packages/engine exec tsc --noEmit -p tsconfig.json`

## Notes
- Scope is intentionally narrow: no Atlas Notes DB repair scripts, no dashboard rewrite, no broad mission UX changes.
- The scheduler change keeps existing rehydration behavior, but first clears generated fixes that are already terminal by validator evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Completed missions are now consistently normalized when detected in completion checks, polling, and restart recovery: unwatching, auto-advance disabled, autopilot set to `inactive`, and `autopilot_disabled` logged (with the correct source).
  - Reconciliation now resolves superseded generated-fix items first during refreshed startup, and skips terminal (`done`) features or those just superseded—preventing completed missions from staying watched and avoiding incorrect task blocking/linking.
  - Generated fixes are finalized when they pass validation/evidence themselves or via a passing ancestor.

- **Tests**
  - Expanded MissionAutopilot normalization/recovery cases and added reliability coverage to ensure superseded done fixes aren’t blocked; strengthened mission-store assertions around persisted slice status and superseded handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->