### PR TITLE
fix: resolve remaining full-suite CI failures — chat engine mock + TaskDetail tabs + changeset (round 6)

### DIFF
--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.definition-actions.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.definition-actions.test.tsx
@@ -289,11 +289,13 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // In-progress tasks show exactly 11 tabs:
-      // Activity, Chat, Plan, Changes, Review, Comments, Artifacts, Model, Workflow, Stats, Routing
+      // FNXC:CostAndTerminalTabs FN-7820 (commit 937650472) added the "Cost" tab between Chat and Plan;
+      // FN-7826 (commit 17d7bd19e) made the interactive "Terminal" tab always available at the end.
+      // In-progress tasks show exactly 13 tabs:
+      // Activity, Chat, Cost, Plan, Changes, Review, Comments, Artifacts, Model, Workflow, Stats, Routing, Terminal
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing",
+        "Activity", "Chat", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
       ]);
       // Commits tab should NOT be present for non-done tasks
       expect(screen.queryByText("Commits")).toBeNull();
@@ -313,10 +315,11 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // In-progress task with workflow steps: 11 tabs (Review after Changes, Workflow after Model)
+      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above: "Cost" after Chat, "Terminal" at end.
+      // In-progress task with workflow steps: 13 tabs (Review after Changes, Workflow after Model)
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing",
+        "Activity", "Chat", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
       ]);
     });
 
@@ -337,10 +340,11 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // Done task with commit SHA: Activity, Chat, Summary, Plan, Changes, Review, Comments, Artifacts, Model, Workflow, Stats, Routing (12 tabs, no Commits)
+      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above. Done task: "Cost" after Summary (before Plan), "Terminal" at end.
+      // Done task with commit SHA: Activity, Chat, Summary, Cost, Plan, Changes, Review, Comments, Artifacts, Model, Workflow, Stats, Routing, Terminal (14 tabs, no Commits)
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Summary", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing",
+        "Activity", "Chat", "Summary", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
       ]);
       // Commits tab should NOT be present
       expect(screen.queryByText("Commits")).toBeNull();
@@ -364,10 +368,11 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // Done task with workflow steps and commit SHA: 12 tabs including Summary and Review (no Commits)
+      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above.
+      // Done task with workflow steps and commit SHA: 14 tabs including Summary, Cost and Review (no Commits)
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Summary", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing",
+        "Activity", "Chat", "Summary", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
       ]);
       // Commits tab should NOT be present
       expect(screen.queryByText("Commits")).toBeNull();
@@ -388,8 +393,9 @@ describe("TaskDetailModal", () => {
       );
 
       const triageTabs = triageContainer.querySelectorAll(".detail-tab");
+      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above. Triage has no Changes tab; "Cost" after Chat, "Terminal" at end.
       expect(Array.from(triageTabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Plan", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing",
+        "Activity", "Chat", "Cost", "Plan", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
       ]);
 
       const { container: todoContainer } = render(
@@ -406,8 +412,9 @@ describe("TaskDetailModal", () => {
       );
 
       const todoTabs = todoContainer.querySelectorAll(".detail-tab");
+      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above (todo, same as triage).
       expect(Array.from(todoTabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Plan", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing",
+        "Activity", "Chat", "Cost", "Plan", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
       ]);
     });
 

--- a/packages/dashboard/app/components/settings/sections/__tests__/settings-default-descriptions.test.tsx
+++ b/packages/dashboard/app/components/settings/sections/__tests__/settings-default-descriptions.test.tsx
@@ -338,6 +338,19 @@ const NOT_SURFACED_ALLOWLIST: Record<string, string> = {
   validatorGlobalModelId: "configured via the model-lane picker, not a plain description field",
   defaultProviderOverride: "configured via the model-lane picker, not a plain description field",
   defaultModelIdOverride: "configured via the model-lane picker, not a plain description field",
+  // FNXC:Settings-ThinkingLevel 2026-07-10: FN-7770 (commit 5f14a58d3) / FN-7772 (commit df8ad460a) /
+  // FN-7795 (commit 3d5cc0ada) added inline thinking-level companion selectors rendered inside the
+  // model-lane pickers (GlobalModelsSection / ProjectModelsSection). They are NOT standalone
+  // description fields — they ride alongside their provider/model lane pair, exactly like
+  // executionGlobalProvider / titleSummarizerProvider etc. above.
+  executionGlobalThinkingLevel: "inline thinking companion for the global execution lane, configured via the model-lane picker, not a plain description field",
+  planningGlobalThinkingLevel: "inline thinking companion for the global planning lane, configured via the model-lane picker, not a plain description field",
+  validatorGlobalThinkingLevel: "inline thinking companion for the global validator lane, configured via the model-lane picker, not a plain description field",
+  titleSummarizerGlobalThinkingLevel: "inline thinking companion for the global title-summarizer lane, configured via the model-lane picker, not a plain description field",
+  defaultThinkingLevelOverride: "project-scoped Default-lane inline thinking companion, configured via the model-lane picker, not a plain description field",
+  titleSummarizerThinkingLevel: "project title-summarizer inline thinking companion, configured via the model-lane picker, not a plain description field",
+  titleSummarizerFallbackThinkingLevel: "project title-summarizer fallback inline thinking companion, configured via the model-lane picker, not a plain description field",
+  fallbackThinkingLevel: "global fallback model inline thinking companion, configured via the model-lane picker, not a plain description field",
   agentPrompts2: "not a real key (placeholder guard)",
   promptOverrides2: "not a real key (placeholder guard)",
   taskTokenBudget: "not yet exposed as a distinct Settings field",
@@ -446,6 +459,11 @@ const NOT_SURFACED_ALLOWLIST: Record<string, string> = {
   useLlamaCpp: "configured via CliBinaryPanel, not a plain description field",
   useCursorCli: "configured via CliBinaryPanel, not a plain description field",
   cursorCliBinaryPath: "configured via CliBinaryPanel, not a plain description field",
+  // FNXC:GrokCli 2026-07-09: FN-7705 (commit 081dae0e0) / FN-7790 (commit db9b9d22c) added the Grok
+  // CLI runtime adapter. Its enable toggle + binary path are managed by GrokCliProviderCard in the
+  // Authentication section (POSTs /auth/grok-cli), not rendered as a plain description field.
+  useGrokCli: "managed via GrokCliProviderCard in the Authentication section, not a plain description field",
+  grokCliBinaryPath: "managed via GrokCliProviderCard in the Authentication section, not a plain description field",
   vitestAutoKillEnabled: "dashboard TUI memory guard, no Settings UI field",
   vitestKillThresholdPct: "dashboard TUI memory guard, no Settings UI field",
   agentMemoryInclusionMode: "not yet exposed as a distinct Settings field",

--- a/packages/dashboard/src/__tests__/chat.test.ts
+++ b/packages/dashboard/src/__tests__/chat.test.ts
@@ -26,11 +26,35 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 // Mock @fusion/core to prevent cascade loading of real fs modules
 vi.mock("@fusion/core", () => ({
   summarizeTitle: vi.fn(),
-  // FNXC:DashboardChatTests 2026-07-08-12:00: FN-7675 added FUSION_RUNTIME_SELF_AWARENESS to chat.ts's @fusion/core imports (CHAT_SYSTEM_PROMPT embeds it). The hand-written core mock must stub it so chat.js loads; importOriginal is intentionally avoided to prevent the real fs cascade this mock exists to block.
+  // FNXC:DashboardChatTests 2026-07-08-12:00: FN-7675 added FUSION_RUNTIME_SELF_AWARENESS to chat.ts's direct @fusion/core imports (CHAT_SYSTEM_PROMPT embeds it).
   FUSION_RUNTIME_SELF_AWARENESS: "",
   AgentStore: vi.fn(),
   ChatStore: vi.fn(),
   registerTraitHookImpl: vi.fn(),
+}));
+/*
+FNXC:DashboardChatTests 2026-07-12-08:15:
+chat.ts has 14 named runtime imports + `import * as engineModule` from @fusion/engine (lines 43-59).
+The engine module transitively imports many @fusion/core exports (AWAITING_APPROVAL_PAUSE_REASON,
+THINKING_LEVELS, etc.), so loading the real engine against a partial @fusion/core mock throws.
+Since this test only exercises resolveFileReferences (no real AI calls), stub every engine export
+chat.ts references so the real engine module never loads.
+*/
+vi.mock("@fusion/engine", () => ({
+  createFnAgent: vi.fn(),
+  createResolvedAgentSession: vi.fn(),
+  promptWithFallback: vi.fn(),
+  extractRuntimeHint: vi.fn(() => undefined),
+  extractRuntimeModel: vi.fn(() => undefined),
+  buildSessionSkillContextSync: vi.fn(() => ({ skillSelectionContext: undefined, resolvedSkillNames: [], skillSource: "none" as const })),
+  createSendMessageTool: vi.fn(() => ({})),
+  createReadMessagesTool: vi.fn(() => ({})),
+  createAskQuestionTool: vi.fn(() => ({})),
+  createChatArtifactTools: vi.fn(() => []),
+  createChatTaskDocumentTools: vi.fn(() => []),
+  createWorkflowAuthoringTools: vi.fn(() => []),
+  resolveMcpServersForStore: vi.fn(async () => ({ servers: [], errors: [] })),
+  resolveExecutorThinkingLevel: vi.fn(() => undefined),
 }));
 
 describe("resolveFileReferences", () => {


### PR DESCRIPTION
## Summary

Fixes all remaining full-suite CI failures on `main` (run 29176917063). **4 test files + 1 changeset fixed**.

## Fixes

### Engine (shards 1+2) — verified clean
Engine full suite: **9014 passed, 0 real failures** (only 2 local-only `pi-ai/compat` staleness suites). No shard-specific failures — both engine shards pass.

### Dashboard (shard 3)
- **chat.test.ts** — the hand-written `@fusion/core` mock kept breaking as new engine exports (AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS) were transitively loaded via `import * as engineModule from "@fusion/engine"`. Root-cause fix: mock `@fusion/engine` with proper stubs for all 14 named imports + wildcard so the real engine never loads against the partial core mock. This breaks the recurring cascade permanently.

### Dashboard app (shard 4) — 2 files
- **TaskDetailModal.definition-actions.test.tsx** — two new tabs since last green run: "Cost" (FN-7820, between Chat and Plan) and "Terminal" (FN-7826, always-on at end after Routing). Updated all 6 stale expected tab arrays across 5 failing tests. FNXC comments cite both commits.
- **settings-default-descriptions.test.tsx** — 10 new DEFAULT_SETTINGS keys (FN-7770/7772/7795 thinking-level companions + FN-7705/7790 Grok CLI settings) had no description mapping. Added to NOT_SURFACED_ALLOWLIST with FNXC reasons (none are plain description fields).

### Changeset fix
- **artifacts-doc-editing-and-comment-fix.md** — pre-existing on main: summary was 175 chars (>120 limit). Shortened to 80 chars.

## Verification
- **Merge gate**: exit 0 (engine-core 335 + ci-shape 63 + changeset format).
- **Engine full suite**: 9014 passed / 0 failures.
- **chat.test.ts**: 14/14 ✅. **TaskDetailModal**: 65/65 ✅. **settings-default-descriptions**: 4/4 ✅. Combined scoped: 69/69 ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for task detail tabs, including Cost and Terminal across task states.
  * Updated settings coverage for inline thinking-level controls and authentication options.
  * Improved chat test isolation and reliability when resolving file references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->