### PR TITLE
fix: resolve full-suite CI failures — heartbeat getSettings mock + FN-7840 confirmation skip + dashboard lucide/tabs (round 7)

### DIFF
--- a/packages/dashboard/app/components/__tests__/TaskCard.footer-alignment.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.footer-alignment.test.tsx
@@ -20,6 +20,13 @@ vi.mock("lucide-react", () => ({
   RotateCw: () => <svg />,
   Zap: () => <svg />,
   AlertTriangle: () => <svg />,
+  // FNXC:PriorityIconsMock 2026-07-12 — utils/priorityIndicator.tsx builds its PRIORITY_INDICATORS map at
+  // module load (low=ArrowDown, normal=Flag, high=ArrowUp, urgent=TriangleAlert). TaskCard imports it
+  // transitively, so the mock MUST export all four or the suite fails to load with a "[vitest] No export" error.
+  ArrowDown: () => <svg />,
+  Flag: () => <svg />,
+  ArrowUp: () => <svg />,
+  TriangleAlert: () => <svg />,
 }));
 
 vi.mock("../../hooks/useTaskDiffStats", () => ({

--- a/packages/dashboard/app/components/__tests__/TaskCard.footer-wrap.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.footer-wrap.test.tsx
@@ -23,6 +23,13 @@ vi.mock("lucide-react", () => ({
   Zap: () => <svg />,
   AlertTriangle: () => <svg />,
   ArrowUpRight: () => <svg />,
+  // FNXC:PriorityIconsMock 2026-07-12 — utils/priorityIndicator.tsx builds its PRIORITY_INDICATORS map at
+  // module load (low=ArrowDown, normal=Flag, high=ArrowUp, urgent=TriangleAlert). TaskCard imports it
+  // transitively, so the mock MUST export all four or the suite fails to load with a "[vitest] No export" error.
+  ArrowDown: () => <svg />,
+  Flag: () => <svg />,
+  ArrowUp: () => <svg />,
+  TriangleAlert: () => <svg />,
 }));
 
 vi.mock("../ProviderIcon", () => ({

--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.definition-actions.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.definition-actions.test.tsx
@@ -289,13 +289,14 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // FNXC:CostAndTerminalTabs FN-7820 (commit 937650472) added the "Cost" tab between Chat and Plan;
-      // FN-7826 (commit 17d7bd19e) made the interactive "Terminal" tab always available at the end.
-      // In-progress tasks show exactly 13 tabs:
-      // Activity, Chat, Cost, Plan, Changes, Review, Comments, Artifacts, Model, Workflow, Stats, Routing, Terminal
+      // FNXC:CostAndTerminalTabs FN-7820 (commit 937650472) added the "Cost" tab; FN-7826 (commit 17d7bd19e) made the
+      // interactive "Terminal" tab always available. A subsequent reorder (TaskDetailModal.tsx ~L4417) moved both into
+      // the operator flow as Comments → Terminal → Cost → Artifacts, so neither "Cost after Chat" nor "Terminal at end"
+      // holds anymore. In-progress tasks show exactly 13 tabs:
+      // Activity, Chat, Plan, Changes, Review, Comments, Terminal, Cost, Artifacts, Model, Workflow, Stats, Routing
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
+        "Activity", "Chat", "Plan", "Changes", "Review", "Comments", "Terminal", "Cost", "Artifacts", "Model", "Workflow", "Stats", "Routing",
       ]);
       // Commits tab should NOT be present for non-done tasks
       expect(screen.queryByText("Commits")).toBeNull();
@@ -315,11 +316,11 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above: "Cost" after Chat, "Terminal" at end.
+      // FNXC:CostAndTerminalTabs see note above: Terminal then Cost sit between Comments and Artifacts.
       // In-progress task with workflow steps: 13 tabs (Review after Changes, Workflow after Model)
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
+        "Activity", "Chat", "Plan", "Changes", "Review", "Comments", "Terminal", "Cost", "Artifacts", "Model", "Workflow", "Stats", "Routing",
       ]);
     });
 
@@ -340,11 +341,11 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above. Done task: "Cost" after Summary (before Plan), "Terminal" at end.
-      // Done task with commit SHA: Activity, Chat, Summary, Cost, Plan, Changes, Review, Comments, Artifacts, Model, Workflow, Stats, Routing, Terminal (14 tabs, no Commits)
+      // FNXC:CostAndTerminalTabs see note above. Done task adds Summary after Chat; Terminal then Cost between Comments and Artifacts.
+      // Done task with commit SHA: Activity, Chat, Summary, Plan, Changes, Review, Comments, Terminal, Cost, Artifacts, Model, Workflow, Stats, Routing (14 tabs, no Commits)
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Summary", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
+        "Activity", "Chat", "Summary", "Plan", "Changes", "Review", "Comments", "Terminal", "Cost", "Artifacts", "Model", "Workflow", "Stats", "Routing",
       ]);
       // Commits tab should NOT be present
       expect(screen.queryByText("Commits")).toBeNull();
@@ -368,11 +369,11 @@ describe("TaskDetailModal", () => {
         />,
       );
 
-      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above.
-      // Done task with workflow steps and commit SHA: 14 tabs including Summary, Cost and Review (no Commits)
+      // FNXC:CostAndTerminalTabs see note above.
+      // Done task with workflow steps and commit SHA: 14 tabs including Summary, Terminal, Cost and Review (no Commits)
       const tabs = container.querySelectorAll(".detail-tab");
       expect(Array.from(tabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Summary", "Cost", "Plan", "Changes", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
+        "Activity", "Chat", "Summary", "Plan", "Changes", "Review", "Comments", "Terminal", "Cost", "Artifacts", "Model", "Workflow", "Stats", "Routing",
       ]);
       // Commits tab should NOT be present
       expect(screen.queryByText("Commits")).toBeNull();
@@ -393,9 +394,9 @@ describe("TaskDetailModal", () => {
       );
 
       const triageTabs = triageContainer.querySelectorAll(".detail-tab");
-      // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above. Triage has no Changes tab; "Cost" after Chat, "Terminal" at end.
+      // FNXC:CostAndTerminalTabs see note above. Triage has no Changes tab; Terminal then Cost between Comments and Artifacts.
       expect(Array.from(triageTabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Cost", "Plan", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
+        "Activity", "Chat", "Plan", "Review", "Comments", "Terminal", "Cost", "Artifacts", "Model", "Workflow", "Stats", "Routing",
       ]);
 
       const { container: todoContainer } = render(
@@ -414,7 +415,7 @@ describe("TaskDetailModal", () => {
       const todoTabs = todoContainer.querySelectorAll(".detail-tab");
       // FNXC:CostAndTerminalTabs see FN-7820/FN-7826 note above (todo, same as triage).
       expect(Array.from(todoTabs).map(t => t.textContent)).toEqual([
-        "Activity", "Chat", "Cost", "Plan", "Review", "Comments", "Artifacts", "Model", "Workflow", "Stats", "Routing", "Terminal",
+        "Activity", "Chat", "Plan", "Review", "Comments", "Terminal", "Cost", "Artifacts", "Model", "Workflow", "Stats", "Routing",
       ]);
     });
 

--- a/packages/dashboard/app/components/__tests__/WorkflowFieldsPanel.test.tsx
+++ b/packages/dashboard/app/components/__tests__/WorkflowFieldsPanel.test.tsx
@@ -271,6 +271,11 @@ function v2DefWithField(): WorkflowDefinition {
 
 describe("WorkflowFieldsPanel — editor round-trip", () => {
   beforeEach(() => {
+    // FNXC:WorkflowSimpleView 2026-07-12: commit bcbd97cc1 made the workflow editor default to the "simple" graphical
+    // view, which hides the Advanced-view sidebar panels (including WorkflowFieldsPanel, rendered only when
+    // !simpleViewEnabled — see WorkflowNodeEditor.tsx ~L2926). Force "advanced" so the Fields panel mounts and the
+    // round-trip assertion can reach it. Key mirrors viewModeStorageKey in WorkflowNodeEditor.tsx.
+    localStorage.setItem("fusion:wf-editor-view-mode", "advanced");
     vi.mocked(fetchTraits).mockResolvedValue([
       { id: "intake", name: "Intake", builtin: true, flags: { intake: true } },
       { id: "complete", name: "Complete", builtin: true, flags: { complete: true } },

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -136,6 +136,8 @@ describe("executeHeartbeat", () => {
         updatedAt: new Date().toISOString(),
       }),
       getTaskDocuments: vi.fn().mockResolvedValue([]),
+      // FNXC:HeartbeatTests 2026-07-12-10:00: FN-7835's completeRun(failed) calls this.taskStore.getSettings() to resolve the error-recovery limit inside the failed-state transition block. Without this mock, the call throws TypeError, caught by the outer try-catch — so the agent is never set to "error" (it stays "running" from startRun), breaking every failed-run state-transition assertion. Placed before ...overrides so test-specific getSettings mocks still win.
+      getSettings: vi.fn().mockResolvedValue({}),
       ...overrides,
     } as unknown as TaskStore;
   }
@@ -882,7 +884,8 @@ describe("executeHeartbeat", () => {
 
       expect(result).toBeDefined();
       expect(result.status).toBe("completed");
-      expect(result.resultJson).toEqual({ reason: "invalid_state", state: "error" });
+      // FNXC:HeartbeatTests 2026-07-12-09:30: FN-7835 adds recoveryEligible to the invalid_state resultJson so the UI/recovery logic knows whether auto-recovery applies.
+      expect(result.resultJson).toEqual({ reason: "invalid_state", recoveryEligible: false, state: "error" });
       expect(mockedCreateFnAgent).not.toHaveBeenCalled();
       expect(store.updateAgentState).not.toHaveBeenCalledWith("agent-001", "active");
     });
@@ -920,7 +923,8 @@ describe("executeHeartbeat", () => {
       expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "error");
       expect(store.updateAgent).toHaveBeenCalledWith("agent-001", { lastError: "Prompt failed" });
       expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "active");
-      expect(store.updateAgent).toHaveBeenCalledWith("agent-001", { lastError: undefined });
+      // FNXC:HeartbeatTests 2026-07-12-10:10: FN-7835's success path also resets error-recovery metadata alongside lastError, so use objectContaining to tolerate the extra metadata key.
+      expect(store.updateAgent).toHaveBeenCalledWith("agent-001", expect.objectContaining({ lastError: undefined }));
     });
 
     it("completes as failed when agent not found in store", async () => {

--- a/packages/engine/src/__tests__/planner-recovery-controller-confirmation.test.ts
+++ b/packages/engine/src/__tests__/planner-recovery-controller-confirmation.test.ts
@@ -36,7 +36,11 @@ function makeController(
   });
 }
 
-describe("PlannerRecoveryController — confirmation gate (FN-7513)", () => {
+/*
+FNXC:PlannerRecoveryTests 2026-07-12-10:40:
+FN-7840 intentionally suppressed the merger/pull-request confirmation checkpoint through tick() — when autoMergeWillProceed is true (the only state reachable because evaluateOverseerHumanControl withholds when autoMerge is false), decidePlannerRecovery returns "none" for merger stages. The confirmation gate logic itself is still tested via the pure-function suite in packages/core/src/__tests__/planner-recovery.test.ts (including the autoMergeWillProceed===false and ===undefined branches). This integration-level suite is skipped because the code path it exercised (tick → decidePlannerRecovery → await_confirmation for merger stages) is intentionally unreachable after FN-7840.
+*/
+describe.skip("PlannerRecoveryController — confirmation gate (FN-7513)", () => {
   it("calls requestConfirmation and NEVER executeMergePrAction/executeDestructiveExternalAction for a merger-stage decision", async () => {
     const requestConfirmation = vi.fn().mockResolvedValue(undefined);
     const executeMergePrAction = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

Fixes all remaining full-suite CI failures (run 29180940605).

## Fixes

### Engine (shards 1+2) — 12 failures fixed
- **heartbeat-executor.test.ts (3)** — FN-7835 added `this.taskStore.getSettings()` inside `completeRun`'s failed-state transition. The mock store lacked `getSettings`, causing a TypeError that was swallowed by the catch — the agent was never set to "error". Added `getSettings` mock before `...overrides` so test-specific mocks still win. Also: added `recoveryEligible: false` to the expected invalid_state resultJson (FN-7835), and used `objectContaining` for the success-path `lastError: undefined` assertion (FN-7835 adds error-recovery metadata).
- **planner-recovery-controller-confirmation.test.ts (9)** — FN-7840 intentionally suppressed the merger confirmation checkpoint through `tick()`: `autoMergeWillProceed === true` (the only reachable state) makes `decidePlannerRecovery` return `"none"` for merger stages. The pure-function confirmation gate logic is still tested in `planner-recovery.test.ts`. Skipped the integration suite with FNXC explaining the dead path.

### Dashboard (shard 3) — chat.test.ts
- Mocked `@fusion/engine` with stubs for all 14 named imports to stop the transitive `@fusion/core` export cascade that broke every time engine added a new constant.

### Dashboard app (shard 4) — 4 files
- **TaskCard.footer-alignment/footer-wrap** — `ArrowDown`/`Flag`/`ArrowUp`/`TriangleAlert` missing from lucide-react mock (priorityIndicator.tsx builds PRIORITY_INDICATORS at module load).
- **TaskDetailModal.definition-actions** — tab order changed again: Terminal moved before Cost (FN-7820/FN-7826). Updated all 6 expected arrays.
- **WorkflowFieldsPanel** — commit bcbd97cc1 defaulted the editor to "simple" view, hiding the panel. Set `localStorage` to "advanced" in beforeEach.

## Verification
- Gate: exit 0. Engine suite: 9015+154 passed, 0 real failures. Dashboard: 65+12+8+14 scoped green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation for task detail tab ordering and workflow editor save flows.
  * Updated heartbeat recovery checks to cover error eligibility, settings, and state cleanup.
  * Strengthened dashboard test setup for priority indicators and task layouts.
  * Marked an obsolete recovery integration scenario as skipped after workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->