### PR TITLE
fix: gate customTools for non-pi runtimes (Grok ACP follow-up)

### DIFF
--- a/packages/engine/src/__tests__/agent-session-helpers.test.ts
+++ b/packages/engine/src/__tests__/agent-session-helpers.test.ts
@@ -622,6 +622,127 @@ describe("createResolvedAgentSession", () => {
 
     warnSpy.mockRestore();
   });
+
+  /*
+  FNXC:GrokAcp 2026-07-12-06:30:
+  PR #2011 Greptile P1: non-pi runtimes must receive action-gated customTools so
+  Grok ACP loopback execute cannot bypass AgentPermissionPolicy.
+  */
+  it("wraps customTools with action gate for non-pi runtimes before createSession", async () => {
+    const mockSession = { prompt: vi.fn() } as any;
+    const createSessionMock = vi.fn().mockResolvedValue({ session: mockSession });
+    resolveRuntimeMock.mockResolvedValue({
+      runtime: {
+        id: "grok",
+        name: "Grok Runtime",
+        createSession: createSessionMock,
+        promptWithFallback: vi.fn(),
+        describeModel: vi.fn(() => "grok/default"),
+      },
+      runtimeId: "grok",
+      wasConfigured: true,
+    });
+
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const rawTool = {
+      name: "fn_workflow_delete",
+      label: "Delete Workflow",
+      description: "",
+      parameters: {},
+      execute,
+    };
+    const lockedDownPolicy = {
+      presetId: "locked-down",
+      rules: {
+        git_write: "block",
+        file_write_delete: "block",
+        command_execution: "block",
+        network_api: "block",
+        task_agent_mutation: "block",
+        review_gate_bypass: "block",
+        file_scope: "block",
+      },
+    };
+
+    const { createResolvedAgentSession } = await import("../agent-session-helpers.js");
+    await createResolvedAgentSession({
+      sessionPurpose: "executor",
+      cwd: "/tmp/project",
+      systemPrompt: "system",
+      customTools: [rawTool as any],
+      actionGateContext: {
+        agentId: "agent-1",
+        agentName: "Agent",
+        isEphemeral: false,
+        taskId: "FN-1",
+        permissionPolicy: lockedDownPolicy as any,
+        createApprovalRequest: vi.fn(),
+        findApprovalByDedupeKey: vi.fn().mockResolvedValue(null),
+      } as any,
+    });
+
+    expect(createSessionMock).toHaveBeenCalledTimes(1);
+    const passedTools = createSessionMock.mock.calls[0][0].customTools as Array<{
+      name: string;
+      execute: (...args: unknown[]) => Promise<unknown>;
+    }>;
+    expect(passedTools).toHaveLength(1);
+    expect(passedTools[0].name).toBe("fn_workflow_delete");
+    expect(passedTools[0].execute).not.toBe(execute);
+    // Gated execute must not call the raw tool when policy blocks.
+    const blocked = await passedTools[0].execute("call-1", { workflow_id: "WF-1" });
+    expect(blocked).toEqual(
+      expect.objectContaining({
+        isError: true,
+      }),
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("does not pre-wrap customTools for the pi runtime (createFnAgent owns the chain)", async () => {
+    const mockSession = { prompt: vi.fn() } as any;
+    const createSessionMock = vi.fn().mockResolvedValue({ session: mockSession });
+    resolveRuntimeMock.mockResolvedValue({
+      runtime: {
+        id: "pi",
+        name: "Default PI Runtime",
+        createSession: createSessionMock,
+        promptWithFallback: vi.fn(),
+        describeModel: vi.fn(() => "mock/model"),
+      },
+      runtimeId: "pi",
+      wasConfigured: false,
+    });
+
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const rawTool = {
+      name: "fn_workflow_delete",
+      label: "Delete",
+      description: "",
+      parameters: {},
+      execute,
+    };
+
+    const { createResolvedAgentSession } = await import("../agent-session-helpers.js");
+    await createResolvedAgentSession({
+      sessionPurpose: "executor",
+      cwd: "/tmp/project",
+      systemPrompt: "system",
+      customTools: [rawTool as any],
+      actionGateContext: {
+        agentId: "agent-1",
+        agentName: "Agent",
+        isEphemeral: false,
+        taskId: "FN-1",
+        permissionPolicy: { defaultDisposition: "block", rules: {} } as any,
+        createApprovalRequest: vi.fn(),
+        findApprovalByDedupeKey: vi.fn(),
+      } as any,
+    });
+
+    const passedTools = createSessionMock.mock.calls[0][0].customTools;
+    expect(passedTools[0]).toBe(rawTool);
+  });
 });
 
 describe("resolveMergerSessionModel", () => {

--- a/packages/engine/src/agent-session-helpers.ts
+++ b/packages/engine/src/agent-session-helpers.ts
@@ -38,6 +38,10 @@ import {
 import type { RunAuditor } from "./run-audit.js";
 import { MockAgentRuntime } from "./providers/mock-provider.js";
 
+/** Logger for agent session helpers */
+const sessionLog = createLogger("agent-session");
+const mockRuntimeSingleton = new MockAgentRuntime();
+
 /*
 FNXC:GrokAcp 2026-07-12-06:30:
 Non-pi plugin runtimes (Grok ACP, Hermes, OpenClaw, …) receive `customTools` as
@@ -58,13 +62,31 @@ const RUNTIMES_WITH_INTERNAL_TOOL_GATING = new Set(["pi"]);
 /**
  * Apply Fusion tool policy wrappers for plugin runtimes that do not wrap tools
  * themselves. Mirrors the customTools portion of the pi createFnAgent chain.
+ *
+ * FNXC:GrokAcp 2026-07-12-06:35:
+ * Missing `actionGateContext` / `permanentAgentGating` is intentionally fail-open
+ * and matches `wrapToolsWithActionGate` / pi `createFnAgent`: when the caller
+ * omits gate context (dashboard chat, room responders, triage), tools stay
+ * ungated coordination primitives. Executor/heartbeat permanent-agent lanes
+ * pass gate context and get full policy. Do not invent a deny-all default here —
+ * that would break chat workflow tools on Grok while pi still allows them.
+ * Emit a content-free warn (tool count + which layers were applied) so missing
+ * context on a non-pi path is visible without logging tool names/args.
  */
 export function wrapCustomToolsForPluginRuntime(
   tools: ToolDefinition[] | undefined,
   options: Pick<AgentRuntimeOptions, "actionGateContext" | "permanentAgentGating">,
+  logContext?: { runtimeId: string; sessionPurpose: string },
 ): ToolDefinition[] | undefined {
   if (!tools || tools.length === 0) {
     return tools;
+  }
+  const hasActionGate = Boolean(options.actionGateContext) && options.actionGateContext?.isEphemeral !== true;
+  const hasPermanentGate = Boolean(options.permanentAgentGating);
+  if (!hasActionGate && !hasPermanentGate && logContext) {
+    sessionLog.warn(
+      `[${logContext.sessionPurpose}] non-pi runtime "${logContext.runtimeId}" received ${tools.length} customTool(s) without actionGateContext/permanentAgentGating; wrappers apply RTK rewrite only (matches pi fail-open when gate context is omitted)`,
+    );
   }
   const withRtk = wrapToolsWithRtkRewrite(tools);
   const withPermanent = wrapToolsWithPermanentAgentGating(withRtk, options.permanentAgentGating);
@@ -74,10 +96,6 @@ export function wrapCustomToolsForPluginRuntime(
 function shouldWrapCustomToolsForRuntime(runtimeId: string): boolean {
   return !RUNTIMES_WITH_INTERNAL_TOOL_GATING.has(runtimeId);
 }
-
-/** Logger for agent session helpers */
-const sessionLog = createLogger("agent-session");
-const mockRuntimeSingleton = new MockAgentRuntime();
 
 function extractSkillNamesFromSelection(skillSelection: SkillSelectionContext | undefined): string[] {
   if (!skillSelection || !Array.isArray(skillSelection.requestedSkillNames)) {
@@ -638,6 +656,7 @@ export async function createResolvedAgentSession(
           customTools: wrapCustomToolsForPluginRuntime(
             effectiveRuntimeOptionsWithModel.customTools,
             effectiveRuntimeOptionsWithModel,
+            { runtimeId: resolved.runtimeId, sessionPurpose },
           ),
         }
       : effectiveRuntimeOptionsWithModel;

--- a/packages/engine/src/agent-session-helpers.ts
+++ b/packages/engine/src/agent-session-helpers.ts
@@ -10,7 +10,7 @@
 import type { AgentRuntimeOptions } from "./agent-runtime.js";
 import type { SkillSelectionContext } from "./skill-resolver.js";
 import type { PluginRunner } from "./plugin-runner.js";
-import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import type { AgentSession, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import {
   GROK_CLI_PROVIDER_ID,
   isGrokApiKeyFusionVisible,
@@ -28,9 +28,52 @@ import {
 } from "@fusion/core";
 import { resolveRuntime, buildRuntimeResolutionContext, isMockProviderId, type SessionPurpose } from "./runtime-resolution.js";
 import { createLogger } from "./logger.js";
-import { promptWithFallback, describeModel } from "./pi.js";
+import {
+  promptWithFallback,
+  describeModel,
+  wrapToolsWithActionGate,
+  wrapToolsWithPermanentAgentGating,
+  wrapToolsWithRtkRewrite,
+} from "./pi.js";
 import type { RunAuditor } from "./run-audit.js";
 import { MockAgentRuntime } from "./providers/mock-provider.js";
+
+/*
+FNXC:GrokAcp 2026-07-12-06:30:
+Non-pi plugin runtimes (Grok ACP, Hermes, OpenClaw, …) receive `customTools` as
+engine-injected `fn_*` ToolDefinitions and dispatch them via in-process execute
+(or a loopback MCP bridge). Pi applies RTK rewrite → permanent-agent gating →
+action gate inside `createFnAgent` before tools reach a session; plugin runtimes
+previously skipped that chain and executed raw `execute` closures (Greptile P1
+on PR #2011). Apply the same policy wrappers once here for every non-pi runtime
+before `runtime.createSession`, so Grok/other CLI bridges cannot bypass gate
+policy. Do not wrap for `pi` — `createFnAgent` still owns that chain and must
+not double-wrap. Boundary jailing stays pi-local (needs worktree paths derived
+inside createFnAgent).
+*/
+
+/** Runtime ids that already wrap customTools inside their own createSession path. */
+const RUNTIMES_WITH_INTERNAL_TOOL_GATING = new Set(["pi"]);
+
+/**
+ * Apply Fusion tool policy wrappers for plugin runtimes that do not wrap tools
+ * themselves. Mirrors the customTools portion of the pi createFnAgent chain.
+ */
+export function wrapCustomToolsForPluginRuntime(
+  tools: ToolDefinition[] | undefined,
+  options: Pick<AgentRuntimeOptions, "actionGateContext" | "permanentAgentGating">,
+): ToolDefinition[] | undefined {
+  if (!tools || tools.length === 0) {
+    return tools;
+  }
+  const withRtk = wrapToolsWithRtkRewrite(tools);
+  const withPermanent = wrapToolsWithPermanentAgentGating(withRtk, options.permanentAgentGating);
+  return wrapToolsWithActionGate(withPermanent, options.actionGateContext);
+}
+
+function shouldWrapCustomToolsForRuntime(runtimeId: string): boolean {
+  return !RUNTIMES_WITH_INTERNAL_TOOL_GATING.has(runtimeId);
+}
 
 /** Logger for agent session helpers */
 const sessionLog = createLogger("agent-session");
@@ -584,7 +627,21 @@ export async function createResolvedAgentSession(
   // latest sync point (just before LLM session instantiation) rather than
   // here, before the runtime's own awaited setup work runs. See
   // AgentRuntimeOptions.beforeSpawnSession for the contract.
-  const result = await resolved.runtime.createSession(effectiveRuntimeOptionsWithModel);
+  //
+  // FNXC:GrokAcp 2026-07-12-06:30:
+  // Gate customTools for non-pi runtimes before createSession so ACP/CLI
+  // bridges (e.g. Grok loopback MCP) execute already-gated closures.
+  const sessionCreateOptions: AgentRuntimeOptions =
+    shouldWrapCustomToolsForRuntime(resolved.runtimeId)
+      ? {
+          ...effectiveRuntimeOptionsWithModel,
+          customTools: wrapCustomToolsForPluginRuntime(
+            effectiveRuntimeOptionsWithModel.customTools,
+            effectiveRuntimeOptionsWithModel,
+          ),
+        }
+      : effectiveRuntimeOptionsWithModel;
+  const result = await resolved.runtime.createSession(sessionCreateOptions);
 
   const testModeActive = settings ? isTestModeActive(settings) : false;
   const mockProviderActive = isMockProviderId(runtimeOptions.defaultProvider);


### PR DESCRIPTION
## Summary

Follow-up to #2011 Greptile **P1 Raw Tool Execution Bypasses Gate**.

Non-pi plugin runtimes (Grok ACP, Hermes, OpenClaw, …) were receiving engine-injected `fn_*` `customTools` and dispatching their raw `execute` closures (e.g. via Grok’s loopback MCP bridge). Pi applies RTK rewrite → permanent-agent gating → action gate inside `createFnAgent`; plugin runtimes skipped that chain.

This PR applies the same policy wrappers **once** in `createResolvedAgentSession` for every non-pi runtime **before** `runtime.createSession`:

`wrapToolsWithRtkRewrite` → `wrapToolsWithPermanentAgentGating` → `wrapToolsWithActionGate`

- **Pi excluded** so `createFnAgent` still owns its wrap chain (no double-wrap).
- Worktree boundary jailing remains pi-local (needs worktree paths derived inside `createFnAgent`).
- Grok ACP loopback bridge continues to only dispatch already-gated closures over `127.0.0.1`.

## Test plan

- [x] `pnpm --filter @fusion/engine exec vitest run src/__tests__/agent-session-helpers.test.ts`
- [x] Grok runtime path: locked-down policy blocks `fn_workflow_delete` without calling raw execute
- [x] Pi path: raw tool reference still passed through (createFnAgent wraps)

Related: https://github.com/Runfusion/Fusion/pull/2011#discussion_r3565778861