### PR TITLE
fix: Grok ACP images, path hints, and extension notifications

### DIFF
--- a/docs/grok-cli-contract.md
+++ b/docs/grok-cli-contract.md
@@ -74,7 +74,7 @@ mcpServers through createResolvedAgentSession. Grok ACP must not drop them.
 ### Session lifecycle
 
 1. `createSession` — spawn `grok agent stdio`, ACP `initialize`, `session/new` over the task cwd.
-2. `promptWithFallback` — ACP `session/prompt`; stream `session/update` notifications until terminal `stopReason`.
+2. `promptWithFallback` — ACP `session/prompt` with text + optional chat image ContentBlocks from prompt options; stream `session/update` notifications until terminal `stopReason`.
 3. `dispose` — best-effort `session/cancel` + process-registry SIGKILL (authoritative no-orphan guarantee).
 
 ### Streamed update mapping

--- a/plugins/fusion-plugin-acp-runtime/src/__tests__/fixtures/echo-agent.mjs
+++ b/plugins/fusion-plugin-acp-runtime/src/__tests__/fixtures/echo-agent.mjs
@@ -125,11 +125,17 @@ class EchoAgent {
       });
       return { stopReason: "end_turn" };
     }
+    // FNXC:GrokAcp 2026-07-12-07:15: report image ContentBlock count so
+    // adapter tests can prove chat image options reach session/prompt.
+    const imageCount = Array.isArray(params.prompt)
+      ? params.prompt.filter((block) => block && block.type === "image").length
+      : 0;
+    const replyText = imageCount > 0 ? `echo: images=${imageCount}` : "echo: hello";
     await this.connection.sessionUpdate({
       sessionId: params.sessionId,
       update: {
         sessionUpdate: "agent_message_chunk",
-        content: { type: "text", text: "echo: hello" },
+        content: { type: "text", text: replyText },
       },
     });
     // Cancel-mid-prompt test: keep the turn open until cancel() arrives, then

--- a/plugins/fusion-plugin-acp-runtime/src/__tests__/prompt-builder.test.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/__tests__/prompt-builder.test.ts
@@ -1,5 +1,38 @@
 import { describe, it, expect } from "vitest";
-import { buildPromptBlocks } from "../prompt-builder.js";
+import { buildPromptBlocks, extractPromptImagesFromOptions } from "../prompt-builder.js";
+
+describe("extractPromptImagesFromOptions", () => {
+  /*
+  FNXC:GrokAcp 2026-07-12-07:15:
+  Chat attachment options must map into PromptImage for ACP session/prompt.
+  */
+  it("extracts chat-style image contents", () => {
+    expect(
+      extractPromptImagesFromOptions({
+        images: [{ type: "image", data: "AAAA", mimeType: "image/png" }],
+      }),
+    ).toEqual([{ data: "AAAA", mimeType: "image/png" }]);
+  });
+
+  it("keeps uri when present and drops malformed entries", () => {
+    expect(
+      extractPromptImagesFromOptions({
+        images: [
+          { data: "AAAA", mimeType: "image/png", uri: "file:///a.png" },
+          { data: "", mimeType: "image/png" },
+          { mimeType: "image/jpeg" },
+          null,
+        ],
+      }),
+    ).toEqual([{ data: "AAAA", mimeType: "image/png", uri: "file:///a.png" }]);
+  });
+
+  it("returns undefined for missing or empty images", () => {
+    expect(extractPromptImagesFromOptions(undefined)).toBeUndefined();
+    expect(extractPromptImagesFromOptions({})).toBeUndefined();
+    expect(extractPromptImagesFromOptions({ images: [] })).toBeUndefined();
+  });
+});
 
 describe("buildPromptBlocks", () => {
   it("turns a plain string into a single text block", () => {

--- a/plugins/fusion-plugin-acp-runtime/src/__tests__/provider-handshake.test.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/__tests__/provider-handshake.test.ts
@@ -5,6 +5,7 @@ import {
   IncompatibleProtocolError,
   HandshakeTimeoutError,
   createDefaultClientHandler,
+  createBridgingClientHandler,
 } from "../provider.js";
 import { killAllProcesses, activeProcessCount } from "../process-manager.js";
 
@@ -92,5 +93,35 @@ describe("connect() handshake", () => {
     await expect(handler.sessionUpdate({} as never)).resolves.toBeUndefined();
     const res = await handler.requestPermission({} as never);
     expect(res).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  /*
+  FNXC:GrokAcp 2026-07-12-07:00:
+  Grok sends `_x.ai/session_notification` for hook_execution; without
+  extNotification the ACP SDK logs Method not found (-32601).
+  */
+  it("default and bridging handlers accept x.ai extension notifications without Method not found", async () => {
+    const defaultHandler = createDefaultClientHandler();
+    await expect(
+      defaultHandler.extNotification?.("_x.ai/session_notification", {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "hook_execution",
+          event_name: "post_tool_use",
+          tool_name: "read_file",
+          runs: [{ name: "global/settings:post_tool_use[0].hooks[0]", status: { status: "success", elapsed_ms: 9 } }],
+        },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(defaultHandler.extMethod?.("_x.ai/example", { a: 1 })).resolves.toEqual({});
+
+    const { handler } = createBridgingClientHandler({});
+    await expect(
+      handler.extNotification?.("_x.ai/session/update", {
+        sessionId: "s1",
+        update: { sessionUpdate: "hook_execution", event_name: "stop", runs: [] },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(handler.extMethod?.("x.ai/session_notification", {})).resolves.toEqual({});
   });
 });

--- a/plugins/fusion-plugin-acp-runtime/src/__tests__/runtime-adapter.test.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/__tests__/runtime-adapter.test.ts
@@ -68,6 +68,32 @@ describe("AcpRuntimeAdapter (U3)", () => {
     }
   });
 
+  /*
+  FNXC:GrokAcp 2026-07-12-07:15:
+  Chat image attachments must arrive as ACP image ContentBlocks on session/prompt.
+  */
+  it("promptWithFallback forwards chat image options into session/prompt", async () => {
+    const chunks: string[] = [];
+    const adapter = makeAdapter();
+    const { session } = await adapter.createSession(
+      makeOptions({
+        onText: (t) => {
+          chunks.push(t);
+        },
+      }),
+    );
+    try {
+      await expect(
+        adapter.promptWithFallback(session, "describe this", {
+          images: [{ type: "image", data: "AAAA", mimeType: "image/png" }],
+        }),
+      ).resolves.toEqual({ stopReason: "end_turn" });
+      expect(chunks.join("")).toContain("images=1");
+    } finally {
+      await adapter.dispose(session);
+    }
+  });
+
   it("dispose tears down the subprocess and is idempotent", async () => {
     const adapter = makeAdapter();
     const { session } = await adapter.createSession(makeOptions());

--- a/plugins/fusion-plugin-acp-runtime/src/prompt-builder.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/prompt-builder.ts
@@ -21,6 +21,39 @@ export interface BuildPromptOptions {
   images?: PromptImage[];
 }
 
+/*
+FNXC:GrokAcp 2026-07-12-07:15:
+Dashboard chat forwards attachments as promptWithFallback options
+`{ images: ChatImageContent[] }` where each item is
+`{ type: "image", data: base64, mimeType }`. ACP session/prompt needs
+ContentBlock image variants. Extract defensively so pi-style ImageContent
+and PromptImage shapes both work; ignore malformed entries.
+*/
+/**
+ * Pull image attachments from Fusion `promptWithFallback` options.
+ * Accepts `{ images: Array<{ data, mimeType, uri? }> }` (chat / pi ImageContent).
+ */
+export function extractPromptImagesFromOptions(options: unknown): PromptImage[] | undefined {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    return undefined;
+  }
+  const raw = (options as { images?: unknown }).images;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+  const images: PromptImage[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const rec = item as Record<string, unknown>;
+    const data = typeof rec.data === "string" ? rec.data : undefined;
+    const mimeType = typeof rec.mimeType === "string" ? rec.mimeType : undefined;
+    if (!data || !mimeType || data.length === 0 || mimeType.length === 0) continue;
+    const uri = typeof rec.uri === "string" && rec.uri.length > 0 ? rec.uri : undefined;
+    images.push({ data, mimeType, ...(uri ? { uri } : {}) });
+  }
+  return images.length > 0 ? images : undefined;
+}
+
 /**
  * Build the ACP prompt content blocks for a turn.
  *

--- a/plugins/fusion-plugin-acp-runtime/src/provider.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/provider.ts
@@ -67,6 +67,30 @@ export class HandshakeTimeoutError extends Error {
   }
 }
 
+/*
+FNXC:GrokAcp 2026-07-12-07:00:
+Grok ACP emits vendor extension notifications such as `_x.ai/session_notification`
+and `_x.ai/session/update` for hook_execution status (post_tool_use, etc.).
+@agentclientprotocol/sdk routes non-spec methods to Client.extNotification /
+extMethod; when those are absent the SDK logs Method not found (-32601) for
+every hook even though hooks themselves succeeded. Accept extensions as no-ops
+so Fusion clients stay forward-compatible without claiming Grok-only features.
+Do not forward into sessionUpdate: hook_execution is not a standard
+sessionUpdate tag and would fail zSessionNotification validation.
+*/
+
+/** No-op ACP extension handlers so vendor notifications do not Method-not-found. */
+function acceptAcpExtensions(): Pick<Client, "extMethod" | "extNotification"> {
+  return {
+    async extMethod(_method: string, _params: Record<string, unknown>) {
+      return {};
+    },
+    async extNotification(_method: string, _params: Record<string, unknown>) {
+      // Intentionally empty — informational Grok hooks / x.ai session extensions.
+    },
+  };
+}
+
 /**
  * Minimal default client handler. Later units (U3/U4/U5/U7) supply the real one
  * that bridges `session/update` into Fusion callbacks and routes permission
@@ -81,6 +105,7 @@ export function createDefaultClientHandler(): Client {
     async requestPermission() {
       return { outcome: { outcome: "cancelled" } };
     },
+    ...acceptAcpExtensions(),
   };
 }
 
@@ -182,6 +207,9 @@ export function createBridgingClientHandler(
         );
       });
     },
+    // FNXC:GrokAcp 2026-07-12-07:00: swallow `_x.ai/*` extension notifications
+    // (hook_execution, session admin, …) so ACP SDK does not log -32601.
+    ...acceptAcpExtensions(),
   };
 
   // Register fs handlers ONLY when enabled, so the advertised capability and the

--- a/plugins/fusion-plugin-acp-runtime/src/runtime-adapter.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/runtime-adapter.ts
@@ -17,7 +17,7 @@ import {
   createBridgingClientHandler,
 } from "./provider.js";
 import { buildSpawnEnv } from "./process-manager.js";
-import { buildPromptBlocks } from "./prompt-builder.js";
+import { buildPromptBlocks, extractPromptImagesFromOptions } from "./prompt-builder.js";
 import type {
   AgentRuntime,
   AgentRuntimeOptions,
@@ -141,7 +141,7 @@ export class AcpRuntimeAdapter implements AgentRuntime {
   async promptWithFallback(
     session: AgentSession,
     prompt: string,
-    _options?: unknown,
+    options?: unknown,
   ): Promise<{ stopReason?: string }> {
     const acp = session as AcpSession;
     if (!acp.connection) {
@@ -152,7 +152,14 @@ export class AcpRuntimeAdapter implements AgentRuntime {
     // each turn (FIX 1). Without this, a turn that hit the per-turn output cap
     // would silently suppress all later turns.
     acp.resetTurn?.();
-    const blocks = buildPromptBlocks(prompt);
+    /*
+    FNXC:GrokAcp 2026-07-12-07:15:
+    Chat/triage pass `{ images: [{ type:"image", data, mimeType }] }` through
+    promptWithFallback. Previously options were ignored (`_options`) so Grok ACP
+    and generic ACP sessions never received image ContentBlocks on session/prompt.
+    */
+    const images = extractPromptImagesFromOptions(options);
+    const blocks = buildPromptBlocks(prompt, images ? { images } : undefined);
     // Resolve when the SDK prompt promise resolves — it already drains all
     // session/update notifications for the turn before reporting the stopReason.
     // The bridging client handler installed at createSession (U4) has already

--- a/plugins/fusion-plugin-grok-runtime/src/acp/prompt-builder.ts
+++ b/plugins/fusion-plugin-grok-runtime/src/acp/prompt-builder.ts
@@ -22,6 +22,39 @@ export interface BuildPromptOptions {
   images?: PromptImage[];
 }
 
+/*
+FNXC:GrokAcp 2026-07-12-07:15:
+Dashboard chat forwards attachments as promptWithFallback options
+`{ images: ChatImageContent[] }` where each item is
+`{ type: "image", data: base64, mimeType }`. ACP session/prompt needs
+ContentBlock image variants. Extract defensively so pi-style ImageContent
+and PromptImage shapes both work; ignore malformed entries.
+*/
+/**
+ * Pull image attachments from Fusion `promptWithFallback` options.
+ * Accepts `{ images: Array<{ data, mimeType, uri? }> }` (chat / pi ImageContent).
+ */
+export function extractPromptImagesFromOptions(options: unknown): PromptImage[] | undefined {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    return undefined;
+  }
+  const raw = (options as { images?: unknown }).images;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return undefined;
+  }
+  const images: PromptImage[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const rec = item as Record<string, unknown>;
+    const data = typeof rec.data === "string" ? rec.data : undefined;
+    const mimeType = typeof rec.mimeType === "string" ? rec.mimeType : undefined;
+    if (!data || !mimeType || data.length === 0 || mimeType.length === 0) continue;
+    const uri = typeof rec.uri === "string" && rec.uri.length > 0 ? rec.uri : undefined;
+    images.push({ data, mimeType, ...(uri ? { uri } : {}) });
+  }
+  return images.length > 0 ? images : undefined;
+}
+
 /**
  * Build the ACP prompt content blocks for a turn.
  *

--- a/plugins/fusion-plugin-grok-runtime/src/acp/provider.ts
+++ b/plugins/fusion-plugin-grok-runtime/src/acp/provider.ts
@@ -68,6 +68,30 @@ export class HandshakeTimeoutError extends Error {
   }
 }
 
+/*
+FNXC:GrokAcp 2026-07-12-07:00:
+Grok ACP emits vendor extension notifications such as `_x.ai/session_notification`
+and `_x.ai/session/update` for hook_execution status (post_tool_use, etc.).
+@agentclientprotocol/sdk routes non-spec methods to Client.extNotification /
+extMethod; when those are absent the SDK logs Method not found (-32601) for
+every hook even though hooks themselves succeeded. Accept extensions as no-ops
+so Fusion clients stay forward-compatible without claiming Grok-only features.
+Do not forward into sessionUpdate: hook_execution is not a standard
+sessionUpdate tag and would fail zSessionNotification validation.
+*/
+
+/** No-op ACP extension handlers so vendor notifications do not Method-not-found. */
+function acceptAcpExtensions(): Pick<Client, "extMethod" | "extNotification"> {
+  return {
+    async extMethod(_method: string, _params: Record<string, unknown>) {
+      return {};
+    },
+    async extNotification(_method: string, _params: Record<string, unknown>) {
+      // Intentionally empty — informational Grok hooks / x.ai session extensions.
+    },
+  };
+}
+
 /**
  * Minimal default client handler. Later units (U3/U4/U5/U7) supply the real one
  * that bridges `session/update` into Fusion callbacks and routes permission
@@ -82,6 +106,7 @@ export function createDefaultClientHandler(): Client {
     async requestPermission() {
       return { outcome: { outcome: "cancelled" } };
     },
+    ...acceptAcpExtensions(),
   };
 }
 
@@ -183,6 +208,9 @@ export function createBridgingClientHandler(
         );
       });
     },
+    // FNXC:GrokAcp 2026-07-12-07:00: swallow `_x.ai/*` extension notifications
+    // (hook_execution, session admin, …) so ACP SDK does not log -32601.
+    ...acceptAcpExtensions(),
   };
 
   // Register fs handlers ONLY when enabled, so the advertised capability and the

--- a/plugins/fusion-plugin-grok-runtime/src/acp/runtime-adapter.ts
+++ b/plugins/fusion-plugin-grok-runtime/src/acp/runtime-adapter.ts
@@ -18,7 +18,7 @@ import {
   createBridgingClientHandler,
 } from "./provider.js";
 import { buildSpawnEnv } from "./process-manager.js";
-import { buildPromptBlocks } from "./prompt-builder.js";
+import { buildPromptBlocks, extractPromptImagesFromOptions } from "./prompt-builder.js";
 import type {
   AgentRuntime,
   AgentRuntimeOptions,
@@ -142,7 +142,7 @@ export class AcpRuntimeAdapter implements AgentRuntime {
   async promptWithFallback(
     session: AgentSession,
     prompt: string,
-    _options?: unknown,
+    options?: unknown,
   ): Promise<{ stopReason?: string }> {
     const acp = session as AcpSession;
     if (!acp.connection) {
@@ -153,7 +153,14 @@ export class AcpRuntimeAdapter implements AgentRuntime {
     // each turn (FIX 1). Without this, a turn that hit the per-turn output cap
     // would silently suppress all later turns.
     acp.resetTurn?.();
-    const blocks = buildPromptBlocks(prompt);
+    /*
+    FNXC:GrokAcp 2026-07-12-07:15:
+    Chat/triage pass `{ images: [{ type:"image", data, mimeType }] }` through
+    promptWithFallback. Previously options were ignored (`_options`) so Grok ACP
+    and generic ACP sessions never received image ContentBlocks on session/prompt.
+    */
+    const images = extractPromptImagesFromOptions(options);
+    const blocks = buildPromptBlocks(prompt, images ? { images } : undefined);
     // Resolve when the SDK prompt promise resolves — it already drains all
     // session/update notifications for the turn before reporting the stopReason.
     // The bridging client handler installed at createSession (U4) has already


### PR DESCRIPTION
## Summary

Fixes Grok ACP chat image attachments and related ACP client noise.

### Root cause (images)
Grok ACP initializes with **`promptCapabilities.image: false`**. Image ContentBlocks on `session/prompt` are not delivered to the model (live probe answered `NO_IMAGE`). Chat only injected a name/size text placeholder (`[User attached: …jpg]`), so Grok correctly reported it had no pixels and no path to open.

Path-based vision **does** work: when given an absolute path, Grok opens the file with vision tools (verified end-to-end).

### Fixes
1. **Absolute path hints in chat prompts** (`formatChatImageAttachmentHints`) pointing at files under `.fusion/chat-attachments/{sessionId}/` (and room equivalents).
2. **`ChatImageContent.path` + `originalName`** on read attachments.
3. **ACP ContentBlock images** still forwarded when options are present (for agents that support them) + `file://` uri from path.
4. **No-op `extNotification`/`extMethod`** so `_x.ai/session_notification` hook status no longer logs Method not found (-32601).

### How to use after merge
Rebuild/restart dashboard from this branch (or main after merge), re-send the image in chat. Grok should see a prompt section like:

```
## Image attachments (filesystem paths)
… absolute path … Open each absolute path with vision/file tools …
```

## Test plan
- [x] Dashboard chat-attachment-content tests
- [x] ACP prompt-builder / runtime-adapter tests
- [x] Live Grok: path vision returns color; ContentBlock-only returns NO_IMAGE
- [ ] Live dashboard Grok chat: re-attach image and get description