### PR TITLE
fix: stabilize project MCP bootstrap and approval resume

### DIFF
--- a/.changeset/main-008-project-mcp-resume.md
+++ b/.changeset/main-008-project-mcp-resume.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep project MCP tools available across fresh executors and approval resumes.
+category: fix
+dev: Executor MCP bootstrap now fails with sanitized diagnostics and resumes approved calls exactly once.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -266,7 +266,21 @@ When an AI lane or readonly dashboard helper starts a session, Fusion resolves t
 
 Runtime support is guarded. Claude/pi/ACP-compatible runtimes receive MCP servers; mock or unsupported runtimes skip forwarding and emit only structured count/provider/runtime metadata. Skipped forwarding is not a settings error: it means the selected runtime does not accept MCP server declarations.
 
-The default pi runtime connects resolved MCP servers inside the engine because pi does not consume raw `mcpServers` declarations itself. For each reachable server, Fusion performs the MCP handshake, lists tools, and registers each tool as a pi custom tool named `mcp__<server>__<tool>` with sanitized, deterministic suffixes for collisions. Unreachable or disabled servers fail soft with content-free logs, and all MCP clients/transports are closed when the agent session is disposed so stdio subprocesses are reaped.
+The default pi runtime connects resolved MCP servers inside the engine because pi does not consume raw `mcpServers` declarations itself. For each reachable server, Fusion performs the MCP handshake, lists tools, and registers each tool as a pi custom tool named `mcp__<server>__<tool>` with sanitized, deterministic suffixes for collisions. A genuine empty or disabled effective configuration creates no MCP tools. By contrast, secret materialization, connection, or tool-listing failure aborts configured session bootstrap with only the server name and a coarse failure category; Fusion never silently turns that failure into an apparently empty catalog and never includes raw exception text or server contents. Every client is tracked before connection and closed exactly once on success, failure, abort, model fallback, approval suspension, or normal session disposal.
+
+Executor, retry, workflow-node, self-fix, child, and unpause-resume sessions resolve the effective project/global MCP set immediately before each new runtime session. Resolution is not cached in task state, and materialized secret values remain in memory only for that session bootstrap.
+
+Namespaced MCP tools remain governed external network actions. When policy requires approval, the first call creates or reuses one pending request, pauses the task/agent, and disposes the active session. Approval and denial use the shared `POST /api/approvals/:id/decision` route on desktop and mobile. If the decision arrives while the old executor is still unwinding, Fusion records one deferred resume and starts it only after the old execution lock and session surfaces are released. The resumed session re-resolves and reconnects MCP before prompting: an approved request permits the matching logical call once and is then marked completed; a denied request makes no MCP call. User-paused tasks remain paused.
+
+### Verifying executor MCP lifecycle
+
+After installing a build with an MCP lifecycle change, use a non-mutating configured tool to verify the runtime rather than relying on settings presence alone:
+
+1. Start three genuinely fresh executor runs and record sanitized run ids/start times.
+2. Confirm each actual tool catalog contains the same expected `mcp__<server>__<tool>` name.
+3. Invoke one explicitly read-only operation, approve that request through the normal dashboard approval route, and confirm the resumed call returns once and the approval reaches `completed`.
+4. Confirm audit evidence contains no other external tool invocation and that no client/session remains active.
+5. If any configured server reports `secret-materialization`, `connect`, `list`, `aborted`, or another coarse error category, treat the run as a bootstrap failure. Do not inspect or log the server definition, URL, command arguments, headers, environment, secret values, or raw exception text.
 
 Read-only sessions do not receive MCP tools automatically. Interactive planning and mission interview lanes (planning, streaming planning, mission interview, milestone interview, and slice interview) explicitly opt in because their job is to gather context and create plans, so configured MCP documentation/context tools are available there while still passing through the same custom-tool read-only filter, allowlists, permanent-agent gating, action-gate wrapping, worktree-boundary wrapping, schema preservation, redacted logging, and teardown path. Other read-only validator/helper lanes must make their own reviewed opt-in before external MCP tools appear.
 

--- a/packages/dashboard/src/__tests__/routes-approval.test.ts
+++ b/packages/dashboard/src/__tests__/routes-approval.test.ts
@@ -319,6 +319,9 @@ describe("approval routes", async () => {
     );
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("denied");
+    expect(state.task.paused).toBe(false);
+    expect(state.pauseTaskCalls).toEqual([{ id: "FN-1", paused: false }]);
+    expect(updateAgent).toHaveBeenCalledWith("agent-1", { pauseReason: undefined });
   });
 
   it("approves provisioning create and records audit", async () => {

--- a/packages/engine/src/__tests__/agent-action-gate.test.ts
+++ b/packages/engine/src/__tests__/agent-action-gate.test.ts
@@ -122,6 +122,75 @@ describe("agent-action-gate", () => {
     expect(result.resourceType).toBe("command");
   });
 
+  it("classifies namespaced MCP tools as governed network API actions", () => {
+    const decision = evaluateAgentActionGate({
+      agentId: "agent-1",
+      taskId: "MAIN-008",
+      toolName: "mcp__postiz__integrationlist",
+      args: {},
+      permissionPolicy: approvalPolicy,
+    });
+
+    expect(decision).toMatchObject({
+      category: "network_api",
+      disposition: "require-approval",
+      operation: "mcp__postiz__integrationlist",
+      resourceType: "research",
+    });
+  });
+
+  it("executes an approved namespaced MCP operation once and never executes a denied one", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "real-shape-result" }] });
+    const tool = { name: "mcp__postiz__integrationlist", label: "List integrations", description: "", parameters: {}, execute };
+    const { wrapToolsWithActionGate } = await import("../pi.js");
+    const requests = new Map<string, { id: string; status: "pending" | "approved" | "denied" | "completed" }>();
+    const createApprovalRequest = vi.fn(async (decision: { approvalDedupeKey: string }) => {
+      const request = { id: "apr-main-008", status: "pending" as const };
+      requests.set(decision.approvalDedupeKey, request);
+      return request;
+    });
+    const findApprovalByDedupeKey = vi.fn(async (key: string) => requests.get(key) ?? null);
+    const markApprovalCompleted = vi.fn(async (id: string) => {
+      for (const [key, request] of requests) {
+        if (request.id === id) requests.set(key, { ...request, status: "completed" });
+      }
+    });
+    const context = {
+      agentId: "agent-main-008",
+      agentName: "MAIN-008 agent",
+      isEphemeral: false,
+      taskId: "MAIN-008",
+      permissionPolicy: approvalPolicy,
+      createApprovalRequest,
+      findApprovalByDedupeKey,
+      pauseForApproval: vi.fn(),
+      markApprovalCompleted,
+    };
+
+    const initial = wrapToolsWithActionGate([tool as any], context);
+    const pending = await (initial[0] as any).execute("pending", {});
+    expect(pending.isError).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+    expect(createApprovalRequest).toHaveBeenCalledTimes(1);
+
+    const [dedupeKey, request] = [...requests.entries()][0]!;
+    requests.set(dedupeKey, { ...request, status: "approved" });
+    const resumed = wrapToolsWithActionGate([tool as any], context);
+    await expect((resumed[0] as any).execute("approved", {})).resolves.toEqual({
+      content: [{ type: "text", text: "real-shape-result" }],
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(markApprovalCompleted).toHaveBeenCalledWith("apr-main-008");
+    expect(requests.get(dedupeKey)?.status).toBe("completed");
+
+    execute.mockClear();
+    requests.set(dedupeKey, { id: "apr-denied", status: "denied" });
+    const denied = wrapToolsWithActionGate([tool as any], context);
+    const rejection = await (denied[0] as any).execute("denied", {});
+    expect(rejection.error).toMatch(/denied/i);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("classifies explicit network and management tools", () => {
     expect(evaluateAgentActionGate({ agentId: "a1", toolName: "fn_research_run", args: {}, permissionPolicy: unrestrictedPolicy }).category).toBe("network_api");
     expect(evaluateAgentActionGate({ agentId: "a1", toolName: "fn_task_create", args: {}, permissionPolicy: unrestrictedPolicy }).category).toBe("task_agent_mutation");

--- a/packages/engine/src/__tests__/executor-project-mcp-resume.test.ts
+++ b/packages/engine/src/__tests__/executor-project-mcp-resume.test.ts
@@ -1,0 +1,92 @@
+import "./executor-test-helpers.js";
+import { describe, expect, it, vi } from "vitest";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { TaskExecutor } from "../executor.js";
+import { connectMcpSessionTools, type McpSessionClient } from "../mcp-session-tools.js";
+
+function createStore(options: { secretFailure?: boolean } = {}) {
+  const revealSecret = vi.fn(async () => {
+    if (options.secretFailure) throw new Error("credential-bearing detail must not escape");
+    return { key: "postiz-token", plaintextValue: "in-memory-only" };
+  });
+  return {
+    on: vi.fn(),
+    off: vi.fn(),
+    getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false })),
+    listTasks: vi.fn(async () => []),
+    getSettingsByScope: vi.fn(async () => ({
+      global: { mcpServers: { enabled: true, servers: [] } },
+      project: {
+        mcpServers: {
+          enabled: true,
+          servers: [{
+            name: "postiz",
+            transport: "streamable-http",
+            url: "https://redacted.invalid/mcp",
+            headers: { Authorization: { secretRef: "postiz-token", scope: "project" } },
+          }],
+        },
+      },
+    })),
+    getSecretsStore: vi.fn(async () => ({ revealSecret })),
+  } as any;
+}
+
+function fakeClient(close: ReturnType<typeof vi.fn>): McpSessionClient {
+  return {
+    connect: vi.fn(async () => undefined),
+    listTools: vi.fn(async () => ({ tools: [{ name: "integrationlist", inputSchema: { type: "object" } }] })),
+    callTool: vi.fn(async () => ({ content: [{ type: "text", text: "[]" }] })),
+    close,
+  };
+}
+
+const transportFactory = () => ({}) as Transport;
+
+describe("executor project MCP bootstrap and approval resume invariant", () => {
+  it("re-resolves one effective project server for every independent executor identity and fresh toolset", async () => {
+    const store = createStore();
+    const executor = new TaskExecutor(store, "/tmp/project");
+    const identities = [undefined, "agent-main-004", "agent-main-005"];
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+
+    for (const agentId of identities) {
+      const servers = await (executor as any).resolveMcpServers(agentId);
+      const close = vi.fn(async () => undefined);
+      closes.push(close);
+      const toolset = await connectMcpSessionTools(servers, {
+        clientFactory: () => fakeClient(close),
+        transportFactory,
+      });
+      expect(toolset.tools.map((tool) => tool.name)).toEqual(["mcp__postiz__integrationlist"]);
+      await toolset.dispose();
+    }
+
+    expect(store.getSettingsByScope).toHaveBeenCalledTimes(3);
+    expect(closes.every((close) => close.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("fails executor bootstrap with a sanitized outcome when secret materialization fails", async () => {
+    const executor = new TaskExecutor(createStore({ secretFailure: true }), "/tmp/project");
+
+    await expect((executor as any).resolveMcpServers("agent-main-007")).rejects.toThrow(
+      /^MCP resolution failed: server=postiz reason=secret-materialization$/,
+    );
+  });
+
+  it("closes a client whose connection fails before registration", async () => {
+    const close = vi.fn(async () => undefined);
+    const client = fakeClient(close);
+    client.connect = vi.fn(async () => {
+      throw new TypeError("credential-bearing detail must not escape");
+    });
+
+    const toolset = await connectMcpSessionTools(
+      [{ name: "postiz", transport: "stdio", command: "fake" }],
+      { clientFactory: () => client, transportFactory },
+    );
+
+    expect(toolset.skipped).toEqual([{ name: "postiz", reason: "TypeError" }]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/engine/src/__tests__/executor-project-mcp-resume.test.ts
+++ b/packages/engine/src/__tests__/executor-project-mcp-resume.test.ts
@@ -74,6 +74,36 @@ describe("executor project MCP bootstrap and approval resume invariant", () => {
     );
   });
 
+  it("defers an approval decision received during unwind and dispatches exactly one resume", async () => {
+    const listeners = new Map<string, (...args: any[]) => unknown>();
+    const task = { id: "MAIN-008", title: "test", description: "test", column: "in-progress", paused: false, userPaused: false, steps: [], currentStep: 0 };
+    const store = {
+      on: vi.fn((event: string, listener: (...args: any[]) => unknown) => listeners.set(event, listener)),
+      off: vi.fn(),
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false })),
+      listTasks: vi.fn(async () => []),
+      getTask: vi.fn(async () => task),
+      updateTask: vi.fn(async () => task),
+      logEntry: vi.fn(async () => undefined),
+    } as any;
+    const executor = new TaskExecutor(store, "/tmp/project");
+    const execute = vi.spyOn(executor, "execute").mockResolvedValue(undefined);
+    (executor as any).approvalSuspended.add(task.id);
+    (executor as any).executing.add(task.id);
+
+    await listeners.get("task:updated")?.(task);
+    await listeners.get("task:updated")?.(task);
+    expect(execute).not.toHaveBeenCalled();
+    expect((executor as any).approvalResumeAfterUnwind.size).toBe(1);
+
+    (executor as any).executing.delete(task.id);
+    await (executor as any).resumeApprovalAfterUnwindIfNeeded(task.id);
+    await (executor as any).resumeApprovalAfterUnwindIfNeeded(task.id);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect((executor as any).approvalSuspended.has(task.id)).toBe(false);
+  });
+
   it("closes a client whose connection fails before registration", async () => {
     const close = vi.fn(async () => undefined);
     const client = fakeClient(close);

--- a/packages/engine/src/__tests__/mcp-resolution.test.ts
+++ b/packages/engine/src/__tests__/mcp-resolution.test.ts
@@ -83,6 +83,27 @@ describe("resolveMcpServersForRuntime", () => {
     });
   });
 
+  it("treats a missing settings seam as a genuine empty configuration", async () => {
+    const { resolveMcpServersForStore } = await import("../mcp-resolution.js");
+    await expect(resolveMcpServersForStore({})).resolves.toEqual({ servers: [], errors: [] });
+  });
+
+  it("honors an explicitly disabled project scope and disabled project shadow", async () => {
+    const disabledScope = await resolveMcpServersForRuntime({
+      globalSettings: { mcpServers: { enabled: true, servers: [{ name: "global", transport: "stdio", command: "node" }] } },
+      projectSettings: { mcpServers: { enabled: false, servers: [] } },
+      secrets: secrets({}),
+    });
+    const disabledShadow = await resolveMcpServersForRuntime({
+      globalSettings: { mcpServers: { enabled: true, servers: [{ name: "global", transport: "stdio", command: "node" }] } },
+      projectSettings: { mcpServers: { enabled: true, servers: [{ name: "global", enabled: false, transport: "stdio", command: "noop" }] } },
+      secrets: secrets({}),
+    });
+
+    expect(disabledScope).toEqual({ servers: [], errors: [] });
+    expect(disabledShadow).toEqual({ servers: [], errors: [] });
+  });
+
   it("returns materialization errors without leaking through logs", async () => {
     const result = await resolveMcpServersForRuntime({
       globalSettings: {

--- a/packages/engine/src/__tests__/mcp-surface-coverage.test.ts
+++ b/packages/engine/src/__tests__/mcp-surface-coverage.test.ts
@@ -93,6 +93,17 @@ describe("MCP surface coverage", () => {
     await expect(resolveHeartbeatMcpForAgent(undefined, "agent-heartbeat-1")).resolves.toEqual({ servers: [], errors: [] });
   });
 
+  it("keeps every executor-owned fresh-session seam on immediate MCP re-resolution", () => {
+    const source = readFileSync(join(process.cwd(), "src/executor.ts"), "utf8");
+    const immediateResolutions = source.match(/mcpServers: await this\.resolveMcpServers\(/g) ?? [];
+
+    // Main executor, fresh retry, workflow/manual model seams, self-fix/review,
+    // and spawned-child paths all resolve at their own create-session call.
+    expect(immediateResolutions.length).toBeGreaterThanOrEqual(6);
+    expect(source).toContain("resumeApprovalAfterUnwindIfNeeded");
+    expect(source).toContain("approvalResumeAfterUnwind");
+  });
+
   it("keeps the heartbeat createResolvedAgentSession seam wired to the resolved MCP result", () => {
     expectResolvedMcpForwarded(
       "src/agent-heartbeat.ts",

--- a/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
+++ b/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
@@ -2289,6 +2289,38 @@ describe("createFnAgent", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["connect", "TypeError"],
+    ["list", "RangeError"],
+  ] as const)("fails configured MCP session bootstrap explicitly on %s failure and closes once", async (phase, reason) => {
+    const close = vi.fn(async () => undefined);
+    const mcpClient = {
+      connect: vi.fn(async () => {
+        if (phase === "connect") throw new TypeError("sensitive connection detail");
+      }),
+      listTools: vi.fn(async () => {
+        if (phase === "list") throw new RangeError("sensitive listing detail");
+        return { tools: [] };
+      }),
+      callTool: vi.fn(),
+      close,
+    };
+    const { createFnAgent } = await import("../pi.js");
+
+    await expect(createFnAgent({
+      cwd: "/test/project",
+      systemPrompt: "test",
+      tools: "coding",
+      defaultProvider: "anthropic",
+      defaultModelId: "claude-sonnet-4-5",
+      mcpServers: [{ name: "postiz", transport: "stdio", command: "redacted", enabled: true }],
+      mcpClientFactory: () => mcpClient as any,
+    })).rejects.toThrow(`MCP session bootstrap failed: server=postiz reason=${reason}`);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("keeps MCP tools out of readonly sessions without the explicit opt-in", async () => {
     const { createFnAgent } = await import("../pi.js");
     const mcpClient = {

--- a/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
+++ b/packages/engine/src/__tests__/pi-create-fn-agent.test.ts
@@ -957,20 +957,22 @@ describe("wrapToolsWithActionGate", () => {
     expect(tool.execute).not.toHaveBeenCalled();
   });
 
-  it("skips gating wrapper for ephemeral contexts", async () => {
+  it("applies the status-aware action gate to ephemeral and fallback task workers", async () => {
     const tool = { name: "write", label: "Write", description: "", parameters: {}, execute: vi.fn().mockResolvedValue({ ok: true }) };
     const { wrapToolsWithActionGate } = await import("../pi.js");
     const wrapped = wrapToolsWithActionGate([tool as any], {
-      agentId: "agent-1",
-      agentName: "Agent",
+      agentId: "executor-MAIN-008",
+      agentName: "Fallback task worker",
       isEphemeral: true,
+      taskId: "MAIN-008",
       permissionPolicy: { presetId: "locked-down", rules: lockedDownRules },
       createApprovalRequest: vi.fn(),
-      findApprovalByDedupeKey: vi.fn(),
+      findApprovalByDedupeKey: vi.fn().mockResolvedValue(null),
     });
 
-    await (wrapped[0] as any).execute("t1", { path: "a.ts" });
-    expect(tool.execute).toHaveBeenCalled();
+    const result = await (wrapped[0] as any).execute("t1", { path: "a.ts" });
+    expect(result.isError).toBe(true);
+    expect(tool.execute).not.toHaveBeenCalled();
   });
 
   it("governs newly exposed heartbeat network tools by policy instead of withholding them", async () => {
@@ -2244,6 +2246,50 @@ describe("createFnAgent", () => {
 
     const createSessionArgs = createAgentSessionMock.mock.calls[0]?.[0] as { customTools: Array<{ name: string }> };
     expect(createSessionArgs.customTools.map((tool) => tool.name)).toContain("fn_heartbeat_done");
+  });
+
+  it("uses the status-aware action gate as the single approval authority when both gate contexts are present", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const permanentCreateApproval = vi.fn();
+    const markApprovalCompleted = vi.fn();
+    const { createFnAgent } = await import("../pi.js");
+
+    await createFnAgent({
+      cwd: "/tmp",
+      systemPrompt: "test",
+      tools: "coding",
+      customTools: [{ name: "mcp__postiz__integrationlist", label: "List", description: "", parameters: {}, execute } as any],
+      actionGateContext: {
+        agentId: "executor-MAIN-008",
+        agentName: "Fallback worker",
+        isEphemeral: true,
+        taskId: "MAIN-008",
+        permissionPolicy: {
+          presetId: "approval",
+          rules: { git_write: "allow", file_write_delete: "allow", command_execution: "allow", network_api: "require-approval", task_agent_mutation: "allow" },
+        },
+        createApprovalRequest: vi.fn(),
+        findApprovalByDedupeKey: vi.fn().mockResolvedValue({ id: "apr-main-008", status: "approved" }),
+        markApprovalCompleted,
+      },
+      permanentAgentGating: {
+        permissionPolicy: {
+          presetId: "approval",
+          rules: { git_write: "allow", file_write_delete: "allow", command_execution: "allow", network_api: "require-approval", task_agent_mutation: "allow" },
+        },
+        requester: { actorId: "executor-MAIN-008", actorType: "agent", actorName: "Fallback worker" },
+        taskId: "MAIN-008",
+        createApprovalRequest: permanentCreateApproval,
+        findPendingApprovalRequest: vi.fn(),
+      } as any,
+    });
+
+    const createSessionArgs = createAgentSessionMock.mock.calls[0]?.[0] as { customTools: Array<{ name: string; execute: (...args: any[]) => Promise<unknown> }> };
+    const mcpTool = createSessionArgs.customTools.find((tool) => tool.name === "mcp__postiz__integrationlist")!;
+    await expect(mcpTool.execute("call", {})).resolves.toEqual({ content: [{ type: "text", text: "ok" }] });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(markApprovalCompleted).toHaveBeenCalledWith("apr-main-008");
+    expect(permanentCreateApproval).not.toHaveBeenCalled();
   });
 
   it("exposes connected MCP tools in readonly sessions only with the explicit opt-in", async () => {

--- a/packages/engine/src/agent-action-gate.ts
+++ b/packages/engine/src/agent-action-gate.ts
@@ -179,7 +179,14 @@ export function evaluateAgentActionGate(params: {
     category = "command_execution";
     operation = params.toolName;
     resourceType = "command";
-  } else if (NETWORK_API_TOOLS.has(params.toolName)) {
+  } else if (NETWORK_API_TOOLS.has(params.toolName) || params.toolName.startsWith("mcp__")) {
+    /*
+    FNXC:AgentGating 2026-07-12-17:18:
+    MAIN-008 requires every namespaced project MCP operation to remain inside
+    the external-action approval boundary. MCP tools are dynamically named and
+    therefore cannot live in the static tool registry; classify the namespace
+    as network_api instead of falling through to the exempt default.
+    */
     category = "network_api";
     operation = params.toolName;
     resourceType = "research";

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -94,7 +94,7 @@ import {
 } from "./agent-session-helpers.js";
 import { buildSessionSkillContext } from "./session-skill-context.js";
 import type { SkillSelectionContext } from "./skill-resolver.js";
-import { resolveMcpServersForStore } from "./mcp-resolution.js";
+import { assertMcpResolutionSucceeded, resolveMcpServersForStore } from "./mcp-resolution.js";
 import { reviewStep, proseSignalsClearApproval, extractJsonObjectCandidates, type ReviewVerdict, type ReviewResult } from "./reviewer.js";
 import { buildUserCommentsPromptSection, selectUserCommentsForAgentContext } from "./agent-user-comments.js";
 import { resolveSandboxBackend } from "./sandbox/index.js";
@@ -2797,9 +2797,23 @@ export class TaskExecutor {
    * Paused tasks are moved back to `todo` rather than marked as `failed`.
    */
   private async resolveMcpServers(agentId?: string | null) {
-    // FNXC:McpConfig 2026-06-25-22:20:
-    // Executor-owned lanes (main execution, retry, workflow model nodes, self-fix, and spawned child sessions) resolve the same trusted MCP server set from the task store immediately before session creation so secret material is never persisted in task state.
-    return (await resolveMcpServersForStore(this.store, { agentId: agentId ?? undefined })).servers;
+    /*
+     * FNXC:McpConfig 2026-06-25-22:20:
+     * Executor-owned lanes (main execution, retry, workflow model nodes, self-fix, and spawned child sessions) resolve the same trusted MCP server set from the task store immediately before session creation so secret material is never persisted in task state.
+     *
+     * FNXC:McpConfig 2026-07-12-17:02:
+     * MAIN-008 forbids executor paths from silently consuming a partially
+     * materialized server set. Convert secret-resolution errors into a
+     * content-free bootstrap failure before any runtime can connect with
+     * missing credentials; only server names/counts and a coarse category may
+     * cross this seam.
+     */
+    const resolved = await resolveMcpServersForStore(this.store, { agentId: agentId ?? undefined });
+    if (resolved.errors.length > 0) {
+      const serverNames = [...new Set(resolved.errors.map((error) => error.serverName))].sort();
+      executorLog.warn(`MCP executor resolution failed: servers=${serverNames.join(",")} count=${serverNames.length} reason=secret-materialization`);
+    }
+    return assertMcpResolutionSucceeded(resolved);
   }
 
   constructor(

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1707,6 +1707,10 @@ export class TaskExecutor {
   private executing = new Set<string>();
   /** Tasks currently being prepared for unpause resume, before execute() has registered them. */
   private resumingUnpaused = new Set<string>();
+  /** Tasks whose active session was intentionally suspended by an action gate. */
+  private approvalSuspended = new Set<string>();
+  /** Approval decisions received while the old execute() lifecycle is still unwinding. */
+  private approvalResumeAfterUnwind = new Set<string>();
   /** Completed orphan recovery tasks currently running during startup. */
   private recoveringCompleted = new Set<string>();
   /**
@@ -2319,8 +2323,20 @@ export class TaskExecutor {
           `paused: true` was set with no reason, which self-healing's
           autoReboundPausedScopeDecay could rebound before the operator ever
           decided.
+
+          FNXC:ApprovalResume 2026-07-12-17:02:
+          MAIN-008: record the approval-specific suspension before pauseTask emits its
+          task:updated event so every abort branch can preserve the in-progress row
+          for a deterministic fresh resume. Clear the mark if pauseTask fails so a
+          failed pause does not leave a sticky suspended marker.
           */
-          await this.store.pauseTask(taskId, true, this.getRunContextFor(taskId), { pausedByAgentId: actorId, pausedReason: AWAITING_APPROVAL_PAUSE_REASON });
+          this.approvalSuspended.add(taskId);
+          try {
+            await this.store.pauseTask(taskId, true, this.getRunContextFor(taskId), { pausedByAgentId: actorId, pausedReason: AWAITING_APPROVAL_PAUSE_REASON });
+          } catch (error) {
+            this.approvalSuspended.delete(taskId);
+            throw error;
+          }
           await this.store.logEntry(
             taskId,
             `Approval required for ${decision.toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`,
@@ -2465,6 +2481,8 @@ export class TaskExecutor {
     this.executing.delete(taskId);
     this.recoveringCompleted.delete(taskId);
     this.resumingUnpaused.delete(taskId);
+    this.approvalSuspended.delete(taskId);
+    this.approvalResumeAfterUnwind.delete(taskId);
     TaskExecutor.processWideGraphRouting.delete(taskId);
     executingTaskLock.release(taskId);
     this.effectiveColumnAgentByTask.delete(taskId);
@@ -2796,6 +2814,74 @@ export class TaskExecutor {
    * prevents new work dispatch — running sessions continue to completion.
    * Paused tasks are moved back to `todo` rather than marked as `failed`.
    */
+  private async parkApprovalSuspension(taskId: string, surface: string): Promise<boolean> {
+    if (!this.approvalSuspended.has(taskId)) return false;
+    this.clearPausedAborted(taskId);
+    await this.store.logEntry(
+      taskId,
+      `Execution suspended for approval — ${surface} disposed; task remains in progress for decision resume`,
+      undefined,
+      this.getRunContextFor(taskId),
+    );
+    executorLog.log(`${taskId}: approval suspension parked after ${surface} disposal`);
+    return true;
+  }
+
+  private async dispatchUnpauseResume(task: Task): Promise<boolean> {
+    if (
+      this.executing.has(task.id)
+      || this.resumingUnpaused.has(task.id)
+      || this.recoveringCompleted.has(task.id)
+      || this.activeSessions.has(task.id)
+      || this.activeStepExecutors.has(task.id)
+      || this.activeWorkflowStepSessions.has(task.id)
+    ) {
+      return false;
+    }
+
+    const pauseLabel = await this.getExecutionPauseLabel();
+    if (pauseLabel) {
+      executorLog.log(`Skipping unpause resume for ${task.id} — ${pauseLabel} active`);
+      return false;
+    }
+
+    this.approvalSuspended.delete(task.id);
+    if (this.isTaskWorkComplete(task) && !task.mergeDetails) {
+      this.recoveringCompleted.add(task.id);
+      executorLog.log(`${task.id} unpaused with completed work and no session — recovering directly to in-review`);
+      void this.recoverCompletedTask(task)
+        .catch((err) => executorLog.error(`Failed to recover completed unpaused task ${task.id}:`, err))
+        .finally(() => this.recoveringCompleted.delete(task.id));
+      return true;
+    }
+
+    this.resumingUnpaused.add(task.id);
+    executorLog.log(`Unpaused ${task.id} in-progress with no session — resuming execution`);
+    try {
+      await this.clearResumeFailureState(task);
+      await this.store.updateTask(task.id, {
+        resumeLimboCount: 0,
+        resumeLimboTipSha: null,
+        resumeLimboStepSignature: null,
+      });
+      await this.store.logEntry(task.id, "Resuming execution after unpause", undefined, this.getRunContextFor(task.id));
+      await this.recoverApprovedStepsOnResume(task.id);
+    } catch (clearErr) {
+      executorLog.warn(`${task.id} clearResumeFailureState failed during unpause: ${clearErr instanceof Error ? clearErr.message : String(clearErr)}`);
+    }
+    this.execute(task)
+      .catch((err) => executorLog.error(`Failed to resume unpaused ${task.id}:`, err))
+      .finally(() => this.resumingUnpaused.delete(task.id));
+    return true;
+  }
+
+  private async resumeApprovalAfterUnwindIfNeeded(taskId: string): Promise<boolean> {
+    if (!this.approvalResumeAfterUnwind.delete(taskId)) return false;
+    const latestTask = await this.store.getTask(taskId);
+    if (latestTask.paused || latestTask.userPaused || latestTask.column !== "in-progress") return false;
+    return this.dispatchUnpauseResume(latestTask);
+  }
+
   private async resolveMcpServers(agentId?: string | null) {
     /*
      * FNXC:McpConfig 2026-06-25-22:20:
@@ -2895,6 +2981,8 @@ export class TaskExecutor {
     });
 
     store.on("task:deleted", (task) => {
+      this.approvalSuspended.delete(task.id);
+      this.approvalResumeAfterUnwind.delete(task.id);
       this.trackTaskDisposal(
         task.id,
         this.awaitAbortInFlightTaskWork(task.id, "task soft-deleted", { userCanceled: true }),
@@ -2931,9 +3019,23 @@ export class TaskExecutor {
         }
 
         // Handle unpause of an in-progress task with no active session.
-        // This covers orphaned states (e.g., engine restarted while task was
-        // paused in-progress) where the task needs to resume execution.
-        // The executing/resuming guards prevent duplicate runs.
+        // Approval can be decided while the old session is still unwinding;
+        // remember that edge instead of losing the only task:updated event.
+        if (!task.paused && task.column === "in-progress" && this.approvalSuspended.has(task.id)) {
+          if (
+            this.executing.has(task.id)
+            || this.activeSessions.has(task.id)
+            || this.activeStepExecutors.has(task.id)
+            || this.activeWorkflowStepSessions.has(task.id)
+          ) {
+            this.approvalResumeAfterUnwind.add(task.id);
+            executorLog.log(`${task.id}: approval decision received during session unwind — deferred one resume`);
+            return;
+          }
+        }
+
+        // This also covers orphaned states (for example, engine restart while
+        // paused in-progress). dispatchUnpauseResume owns all duplicate guards.
         if (
           !task.paused
           && task.column === "in-progress"
@@ -2941,52 +3043,7 @@ export class TaskExecutor {
           && !this.activeStepExecutors.has(task.id)
           && !this.activeWorkflowStepSessions.has(task.id)
         ) {
-          if (
-            !this.executing.has(task.id)
-            && !this.resumingUnpaused.has(task.id)
-            && !this.recoveringCompleted.has(task.id)
-          ) {
-            const pauseLabel = await this.getExecutionPauseLabel();
-            if (pauseLabel) {
-              executorLog.log(`Skipping unpause resume for ${task.id} — ${pauseLabel} active`);
-              return;
-            }
-
-            if (this.isTaskWorkComplete(task) && !task.mergeDetails) {
-              this.recoveringCompleted.add(task.id);
-              executorLog.log(`${task.id} unpaused with completed work and no session — recovering directly to in-review`);
-              void this.recoverCompletedTask(task)
-                .catch((err) =>
-                  executorLog.error(`Failed to recover completed unpaused task ${task.id}:`, err),
-                )
-                .finally(() => {
-                  this.recoveringCompleted.delete(task.id);
-                });
-              return;
-            }
-
-            this.resumingUnpaused.add(task.id);
-            executorLog.log(`Unpaused ${task.id} in-progress with no session — resuming execution`);
-            try {
-              await this.clearResumeFailureState(task);
-              await this.store.updateTask(task.id, {
-                resumeLimboCount: 0,
-                resumeLimboTipSha: null,
-                resumeLimboStepSignature: null,
-              });
-              await this.store.logEntry(task.id, "Resuming execution after unpause", undefined, this.getRunContextFor(task.id));
-              await this.recoverApprovedStepsOnResume(task.id);
-            } catch (clearErr) {
-              executorLog.warn(`${task.id} clearResumeFailureState failed during unpause: ${clearErr instanceof Error ? clearErr.message : String(clearErr)}`);
-            }
-            this.execute(task)
-              .catch((err) =>
-                executorLog.error(`Failed to resume unpaused ${task.id}:`, err),
-              )
-              .finally(() => {
-                this.resumingUnpaused.delete(task.id);
-              });
-          }
+          await this.dispatchUnpauseResume(task);
           return;
         }
 
@@ -10035,6 +10092,7 @@ export class TaskExecutor {
               await this.store.logEntry(task.id, "Execution canceled by user — leaving task in todo");
               return;
             }
+            if (await this.parkApprovalSuspension(task.id, "step sessions")) return;
             this.clearPausedAborted(task.id);
             await this.store.logEntry(task.id, "Execution paused — step sessions terminated, moved to todo", undefined, this.getRunContextFor(task.id));
             this.markGraphExecuteSelfRequeued(task.id);
@@ -10318,6 +10376,7 @@ export class TaskExecutor {
               await this.store.logEntry(task.id, "Execution canceled by user — leaving task in todo");
               return;
             }
+            if (await this.parkApprovalSuspension(task.id, "step session")) return;
             this.clearPausedAborted(task.id);
             await this.store.logEntry(task.id, "Execution paused during step-session", undefined, this.getRunContextFor(task.id));
             this.markGraphExecuteSelfRequeued(task.id);
@@ -10994,6 +11053,10 @@ export class TaskExecutor {
               await this.store.logEntry(task.id, "Execution canceled by user — leaving task in todo");
               return;
             }
+            if (await this.parkApprovalSuspension(task.id, "agent session")) {
+              wasPaused = true;
+              return;
+            }
             this.clearPausedAborted(task.id);
             wasPaused = true;
             if (await this.shouldFinalizeCompletedTask(task.id, taskDone)) {
@@ -11531,6 +11594,7 @@ export class TaskExecutor {
           await this.store.logEntry(task.id, "Execution canceled by user — leaving task in todo");
           return;
         }
+        if (await this.parkApprovalSuspension(task.id, "executor session")) return;
         this.clearPausedAborted(task.id);
         const latestTask = await this.store.getTask(task.id);
         if (
@@ -12273,6 +12337,16 @@ export class TaskExecutor {
           }
         }
       }
+
+      /*
+       * FNXC:AgentGating 2026-07-12-17:12:
+       * MAIN-008 closes the approval-decision/unwind race. The dashboard can
+       * unpause while the original executor still owns its process-wide lock;
+       * consume that single deferred edge only after every old-session cleanup
+       * path above has run, then bootstrap one new executor session. A Set plus
+       * resumingUnpaused makes duplicate task updates idempotent.
+       */
+      await this.resumeApprovalAfterUnwindIfNeeded(task.id);
     }
   }
 

--- a/packages/engine/src/mcp-resolution.ts
+++ b/packages/engine/src/mcp-resolution.ts
@@ -22,6 +22,32 @@ export interface ResolvedMcpServersForRuntime {
 }
 
 /**
+ * A content-free executor bootstrap failure. The message deliberately contains
+ * only server names and a coarse category; raw secret-store errors can contain
+ * credential-bearing configuration details.
+ */
+export class McpResolutionBootstrapError extends Error {
+  readonly serverNames: string[];
+  readonly reason = "secret-materialization" as const;
+
+  constructor(errors: McpSecretResolutionError[]) {
+    const serverNames = [...new Set(errors.map((error) => error.serverName))].sort();
+    super(`MCP resolution failed: server=${serverNames.join(",")} reason=secret-materialization`);
+    this.name = "McpResolutionBootstrapError";
+    this.serverNames = serverNames;
+  }
+}
+
+export function assertMcpResolutionSucceeded(
+  result: ResolvedMcpServersForRuntime,
+): ResolvedMcpServerDefinition[] {
+  if (result.errors.length > 0) {
+    throw new McpResolutionBootstrapError(result.errors);
+  }
+  return result.servers;
+}
+
+/**
  * FNXC:McpConfig 2026-06-25-21:43:
  * Runtime MCP forwarding uses Fusion's trusted-once-enabled model: enabled effective servers are materialized once at session/probe creation and then forwarded without per-call prompts. Plaintext env/header values exist only in this in-memory return value and callers must log only counts/errors, never server contents.
  */

--- a/packages/engine/src/mcp-session-tools.ts
+++ b/packages/engine/src/mcp-session-tools.ts
@@ -15,6 +15,19 @@ export interface McpSessionToolset {
   skipped: Array<{ name: string; reason: string }>;
 }
 
+export class McpSessionBootstrapError extends Error {
+  readonly failures: Array<{ name: string; reason: string }>;
+
+  constructor(failures: Array<{ name: string; reason: string }>) {
+    const sanitized = failures
+      .map(({ name, reason }) => ({ name, reason }))
+      .sort((a, b) => a.name.localeCompare(b.name) || a.reason.localeCompare(b.reason));
+    super(`MCP session bootstrap failed: ${sanitized.map(({ name, reason }) => `server=${name} reason=${reason}`).join("; ")}`);
+    this.name = "McpSessionBootstrapError";
+    this.failures = sanitized;
+  }
+}
+
 export interface McpSessionClient {
   connect(transport: Transport): Promise<void>;
   listTools(): Promise<{ tools?: McpToolMetadata[] }>;
@@ -68,13 +81,20 @@ export async function connectMcpSessionTools(
   const connected: string[] = [];
   const skipped: Array<{ name: string; reason: string }> = [];
   const clients: McpSessionClient[] = [];
+  const closedClients = new WeakSet<McpSessionClient>();
   const usedToolNames = new Set<string>();
   let disposed = false;
+
+  const closeOnce = async (client: McpSessionClient): Promise<void> => {
+    if (closedClients.has(client)) return;
+    closedClients.add(client);
+    await closeClient(client, opts.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS);
+  };
 
   const closeAll = async (): Promise<void> => {
     if (disposed) return;
     disposed = true;
-    await Promise.allSettled(clients.map((client) => closeClient(client, opts.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS)));
+    await Promise.allSettled(clients.map(closeOnce));
   };
 
   const onAbort = (): void => {
@@ -93,13 +113,19 @@ export async function connectMcpSessionTools(
         break;
       }
       const client = (opts.clientFactory ?? defaultClientFactory)(server);
-      let didConnect = false;
+      // Track the client before transport creation/connect so abort and every
+      // partial-bootstrap failure can close it exactly once.
+      clients.push(client);
       try {
         const transport = (opts.transportFactory ?? defaultTransportFactory)(server, { cwd: opts.cwd });
         await client.connect(transport);
-        didConnect = true;
-        clients.push(client);
+        if (opts.signal?.aborted || disposed) {
+          throw new DOMException("MCP bootstrap aborted", "AbortError");
+        }
         const listed = await client.listTools();
+        if (opts.signal?.aborted || disposed) {
+          throw new DOMException("MCP bootstrap aborted", "AbortError");
+        }
         connected.push(server.name);
         const listedTools = listed.tools ?? [];
         opts.logger?.log?.(`MCP server connected for pi session: name=${server.name} transport=${server.transport} tools=${listedTools.length}`);
@@ -107,12 +133,10 @@ export async function connectMcpSessionTools(
           tools.push(wrapMcpTool(server.name, tool, client, usedToolNames));
         }
       } catch (error) {
-        const reason = safeErrorReason(error);
+        const reason = opts.signal?.aborted ? "aborted" : safeErrorReason(error);
         skipped.push({ name: server.name, reason });
         opts.logger?.warn?.(`Skipping MCP server for pi session: name=${server.name} transport=${server.transport} reason=${reason}`);
-        if (didConnect) {
-          await closeClient(client, opts.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS);
-        }
+        await closeOnce(client);
       }
     }
   } finally {

--- a/packages/engine/src/pi.ts
+++ b/packages/engine/src/pi.ts
@@ -79,7 +79,7 @@ import { READONLY_ALLOWLIST, filterCustomToolsForReadonly, isReadonlyAllowed } f
 import { createStreamingDeltaNormalizer } from "./streaming-delta.js";
 import { isModelAuthTierIncompatibilityError, isProviderModelNotFoundError, isUnsupportedMessageRoleError } from "./transient-error-detector.js";
 import { logMcpForwardingSkipped, runtimeSupportsMcp } from "./mcp-runtime-support.js";
-import { connectMcpSessionTools, type McpClientFactory, type McpSessionToolset } from "./mcp-session-tools.js";
+import { connectMcpSessionTools, McpSessionBootstrapError, type McpClientFactory, type McpSessionToolset } from "./mcp-session-tools.js";
 export { isModelAuthTierIncompatibilityError } from "./transient-error-detector.js";
 
 const RTK_ACCEPTED_REWRITE_EXIT_CODES = new Set([0, 3]);
@@ -2327,6 +2327,18 @@ export async function createFnAgent(options: AgentOptions): Promise<AgentResult>
         clientFactory: options.mcpClientFactory,
         logger: piLog,
       });
+      /*
+       * FNXC:McpConfig 2026-07-12-17:02:
+       * MAIN-008 requires a configured MCP bootstrap failure to be observably
+       * different from a genuine zero-server/tool catalog. Fail session creation
+       * using names plus coarse categories only, and dispose every partially
+       * connected client before the error crosses the runtime boundary.
+       */
+      const bootstrapFailures = mcpToolset.skipped.filter(({ reason }) => reason !== "disabled");
+      if (bootstrapFailures.length > 0) {
+        await mcpToolset.dispose();
+        throw new McpSessionBootstrapError(bootstrapFailures);
+      }
     } else if (forwardedMcpServers.length > 0 && isReadonly) {
       piLog.log(`readonly session — MCP servers (${forwardedMcpServers.length}) skipped`);
     }

--- a/packages/engine/src/pi.ts
+++ b/packages/engine/src/pi.ts
@@ -1904,7 +1904,7 @@ export function wrapToolsWithActionGate(
   tools: ToolDefinition[],
   gateContext: AgentActionGateContext | undefined,
 ): ToolDefinition[] {
-  if (!gateContext || gateContext.isEphemeral) {
+  if (!gateContext) {
     return tools;
   }
 
@@ -2369,10 +2369,18 @@ export async function createFnAgent(options: AgentOptions): Promise<AgentResult>
       ...allowlistFilteredCustomTools.allowed,
     ];
     const toolsWithRtkRewrite = wrapToolsWithRtkRewrite(toolChainStart);
-    const toolsWithPermanentGating = wrapToolsWithPermanentAgentGating(
-      toolsWithRtkRewrite,
-      options.permanentAgentGating,
-    );
+    /*
+     * FNXC:AgentGating 2026-07-12-17:22:
+     * MAIN-008 requires one approval authority per tool call. Executor sessions
+     * provide the status-aware action gate for permanent, ephemeral, and
+     * fallback task-worker identities; applying the legacy permanent gate
+     * inside it would reject the call again after the outer gate consumed an
+     * approved request. Standalone lanes without actionGateContext retain the
+     * permanent gate unchanged.
+     */
+    const toolsWithPermanentGating = options.actionGateContext
+      ? toolsWithRtkRewrite
+      : wrapToolsWithPermanentAgentGating(toolsWithRtkRewrite, options.permanentAgentGating);
     const toolsWithActionGate = wrapToolsWithActionGate(
       toolsWithPermanentGating,
       options.actionGateContext,


### PR DESCRIPTION
## Summary

Rebased replacement for #2020 (fork push was denied with 403, so conflicts could not be resolved on the original head).

Automated Tchorizo engineering agent implementation for MAIN-008, rebased onto current `main`.

- fail configured executor MCP bootstrap explicitly with sanitized server/category diagnostics
- track and dispose partial MCP clients exactly once
- govern dynamic MCP tools through one status-aware action gate for all executor identities
- preserve approval suspension and defer one resume until the old executor releases its guards
- cover approved execute-once/completed and denied zero-call outcomes

## Conflict resolution

While rebasing onto `main`, resolved a content conflict in `packages/engine/src/executor.ts` `pauseForApproval`:

- **Kept from `main` (FN-7736):** stamp `pausedReason: AWAITING_APPROVAL_PAUSE_REASON` so recovery/oversight can recognize approval holds.
- **Kept from MAIN-008:** mark `approvalSuspended` before `pauseTask` (and clear it if pause fails) so abort paths preserve the in-progress row for a deterministic fresh resume.

## Verification

Inherited from #2020 author verification; conflict resolution was a pure merge of both intents in one pause path. Targeted follow-up recommended after CI:

- engine approval/MCP resume tests
- gate suite if CI is green on the rest

## Relation to #2020

Supersedes https://github.com/Runfusion/Fusion/pull/2020 — same commits, rebased + conflict fixed. Prefer merging this PR and closing #2020.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tools now remain available when starting new executor sessions or resuming approved actions.
  * Namespaced MCP operations are correctly handled by approval policies.
  * Approved actions resume exactly once, including decisions received during executor shutdown.

* **Bug Fixes**
  * MCP connection and configuration failures now provide safe, actionable diagnostics without exposing sensitive details.
  * MCP resources are cleaned up reliably after connection failures.
  * Denied approvals consistently unpause affected tasks.

* **Documentation**
  * Clarified MCP connection, approval, failure, and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->