### PR TITLE
fix: resolve full-suite CI failures — pi.js wrap mocks + heartbeat FN-7835 transitions + executor moveTask + i18n storageMigrationNotice (round 8)

### DIFF
--- a/packages/engine/src/__tests__/executor-prompt.test.ts
+++ b/packages/engine/src/__tests__/executor-prompt.test.ts
@@ -776,7 +776,8 @@ describe("TaskExecutor pause behavior", () => {
     // Should move to todo, NOT mark as failed. This path (agent threw mid-
     // execution while paused) explicitly nukes worktree+branch — work is
     // discarded — so it must NOT flag preserveResumeState.
-    expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", undefined);
+    // FNXC:ExecutorMoveTaskOptions 2026-07-12: executor.ts:11622-11625 now always passes a moveTask options object built from conditional spreads; with no resumable progress and no preserved pause it collapses to {} (previously undefined). The intent (no preserveResumeState) is unchanged.
+    expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", {});
     expect(store.updateTask).not.toHaveBeenCalledWith("FN-001", { status: "failed" });
   });
 
@@ -2117,7 +2118,8 @@ describe("TaskExecutor global pause behavior", () => {
       createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
     });
 
-    expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", undefined);
+    // FNXC:ExecutorMoveTaskOptions 2026-07-12: executor.ts:11622-11625 now always passes a moveTask options object (conditional spreads collapse to {} when nothing to preserve); previously undefined. Intent (not marked failed) unchanged.
+    expect(store.moveTask).toHaveBeenCalledWith("FN-001", "todo", {});
     expect(store.updateTask).not.toHaveBeenCalledWith("FN-001", { status: "failed" });
   });
 

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -884,8 +884,8 @@ describe("executeHeartbeat", () => {
 
       expect(result).toBeDefined();
       expect(result.status).toBe("completed");
-      // FNXC:HeartbeatTests 2026-07-12-09:30: FN-7835 adds recoveryEligible to the invalid_state resultJson so the UI/recovery logic knows whether auto-recovery applies.
-      expect(result.resultJson).toEqual({ reason: "invalid_state", recoveryEligible: false, state: "error" });
+      // FNXC:HeartbeatTests 2026-07-12-FN7835: FN-7835 reclassified the error-state-not-recovery-eligible resultJson reason from "invalid_state" to "error-unrecoverable" (HEARTBEAT_ERROR_UNRECOVERABLE_PAUSE_REASON) so parked-unrecoverable agents are distinguishable from other invalid states. The paused-state case above still uses "invalid_state".
+      expect(result.resultJson).toEqual({ reason: "error-unrecoverable", recoveryEligible: false, state: "error" });
       expect(mockedCreateFnAgent).not.toHaveBeenCalled();
       expect(store.updateAgentState).not.toHaveBeenCalledWith("agent-001", "active");
     });
@@ -920,8 +920,10 @@ describe("executeHeartbeat", () => {
         status: "completed",
       });
 
-      expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "error");
-      expect(store.updateAgent).toHaveBeenCalledWith("agent-001", { lastError: "Prompt failed" });
+      // FNXC:HeartbeatTests 2026-07-12-FN7835: FN-7835/FN-7859 park non-recoverable heartbeat failures as "paused" (pauseReason: error-unrecoverable) instead of bare "error". The subsequent successful run still clears the stale lastError and returns to active.
+      expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "paused");
+      expect(store.updateAgentState).not.toHaveBeenCalledWith("agent-001", "error");
+      expect(store.updateAgent).toHaveBeenCalledWith("agent-001", expect.objectContaining({ lastError: "Prompt failed" }));
       expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "active");
       // FNXC:HeartbeatTests 2026-07-12-10:10: FN-7835's success path also resets error-recovery metadata alongside lastError, so use objectContaining to tolerate the extra metadata key.
       expect(store.updateAgent).toHaveBeenCalledWith("agent-001", expect.objectContaining({ lastError: undefined }));
@@ -3693,8 +3695,8 @@ describe("executeHeartbeat", () => {
       expect(result).toBeDefined();
       expect(result.status).toBe("failed");
       expect(result.stderrExcerpt).toContain("Model unavailable");
-      // Agent state should be set to error
-      expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "error");
+      // FNXC:HeartbeatTests 2026-07-12-FN7835: FN-7835/FN-7859 park non-recoverable failures (e.g. "Model unavailable") as "paused" with pauseReason error-unrecoverable instead of bare "error".
+      expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "paused");
     });
 
     it("fails soft on timer heartbeat when model provider credentials are unavailable", async () => {

--- a/packages/engine/src/__tests__/heartbeat-session-prompt.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-session-prompt.test.ts
@@ -740,7 +740,8 @@ describe("Budget Governance", () => {
     });
 
     expect(store.getBudgetStatus).not.toHaveBeenCalled();
-    expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "error");
+    // FNXC:HeartbeatTests 2026-07-12-FN7835: FN-7835/FN-7859 park non-recoverable run failures as "paused" (pauseReason: error-unrecoverable) instead of bare "error". Budget governance still does not engage on failure (assertion below: never paused with budget-exhausted reason).
+    expect(store.updateAgentState).toHaveBeenCalledWith("agent-001", "paused");
     expect(store.updateAgent).not.toHaveBeenCalledWith("agent-001", { pauseReason: "budget-exhausted" });
   });
 

--- a/packages/engine/src/__tests__/openclaw-runtime-e2e.test.ts
+++ b/packages/engine/src/__tests__/openclaw-runtime-e2e.test.ts
@@ -39,6 +39,10 @@ vi.mock("../pi.js", () => ({
   createFnAgent: mockCreateFnAgent,
   promptWithFallback: mockPromptWithFallback,
   describeModel: mockDescribeModel,
+  // FNXC: pi.js tool-policy wrappers (wrapToolsWithRtkRewrite, wrapToolsWithPermanentAgentGating, wrapToolsWithActionGate) are now imported by agent-session-helpers.ts (wrapCustomToolsForPluginRuntime, called from createResolvedAgentSession). Mocks pass tools through unchanged.
+  wrapToolsWithRtkRewrite: vi.fn((tools) => tools),
+  wrapToolsWithPermanentAgentGating: vi.fn((tools) => tools),
+  wrapToolsWithActionGate: vi.fn((tools) => tools),
 }));
 
 vi.mock("node:child_process", () => ({

--- a/packages/engine/src/__tests__/openclaw-runtime-integration.test.ts
+++ b/packages/engine/src/__tests__/openclaw-runtime-integration.test.ts
@@ -19,6 +19,10 @@ vi.mock("../pi.js", () => ({
   createFnAgent: mockCreateFnAgent,
   promptWithFallback: vi.fn().mockResolvedValue(undefined),
   describeModel: vi.fn().mockReturnValue("pi/default"),
+  // FNXC: pi.js tool-policy wrappers (wrapToolsWithRtkRewrite, wrapToolsWithPermanentAgentGating, wrapToolsWithActionGate) are now imported by agent-session-helpers.ts (wrapCustomToolsForPluginRuntime, called from createResolvedAgentSession). Mocks pass tools through unchanged.
+  wrapToolsWithRtkRewrite: vi.fn((tools) => tools),
+  wrapToolsWithPermanentAgentGating: vi.fn((tools) => tools),
+  wrapToolsWithActionGate: vi.fn((tools) => tools),
 }));
 
 function isAgentRuntime(value: unknown): value is AgentRuntime {

--- a/packages/engine/src/__tests__/reviewer.test.ts
+++ b/packages/engine/src/__tests__/reviewer.test.ts
@@ -18,6 +18,10 @@ vi.mock("../pi.js", () => ({
       await session.promptWithFallback(prompt, options);
     }
   }),
+  // FNXC: pi.js tool-policy wrappers (wrapToolsWithRtkRewrite, wrapToolsWithPermanentAgentGating, wrapToolsWithActionGate) are now imported by agent-session-helpers.ts (wrapCustomToolsForPluginRuntime, called from createResolvedAgentSession). Mocks pass tools through unchanged.
+  wrapToolsWithRtkRewrite: vi.fn((tools) => tools),
+  wrapToolsWithPermanentAgentGating: vi.fn((tools) => tools),
+  wrapToolsWithActionGate: vi.fn((tools) => tools),
 }));
 
 import { resolveAgentPrompt } from "@fusion/core";

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -1410,6 +1410,11 @@
     "versionMismatchPrefix": "Tu",
     "versionMismatchSuffix": "Actualiza para mantenerte sincronizado."
   },
+  "storageMigrationNotice": {
+    "body": "",
+    "dismissLabel": "",
+    "title": ""
+  },
   "cliBinary": {
     "binaryLabel": "",
     "checking": "Verificando…",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -1410,6 +1410,11 @@
     "versionMismatchPrefix": "Votre",
     "versionMismatchSuffix": "Mettez à jour pour rester synchronisé."
   },
+  "storageMigrationNotice": {
+    "body": "",
+    "dismissLabel": "",
+    "title": ""
+  },
   "cliBinary": {
     "binaryLabel": "",
     "checking": "Vérification…",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -1410,6 +1410,11 @@
     "versionMismatchPrefix": "설치된",
     "versionMismatchSuffix": "최신 버전으로 업데이트하여 동기화를 유지하세요."
   },
+  "storageMigrationNotice": {
+    "body": "",
+    "dismissLabel": "",
+    "title": ""
+  },
   "cliBinary": {
     "binaryLabel": "",
     "checking": "확인 중…",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -1410,6 +1410,11 @@
     "versionMismatchPrefix": "你安装的",
     "versionMismatchSuffix": "更新以保持同步。"
   },
+  "storageMigrationNotice": {
+    "body": "",
+    "dismissLabel": "",
+    "title": ""
+  },
   "cliBinary": {
     "binaryLabel": "",
     "checking": "检查中…",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -1410,6 +1410,11 @@
     "versionMismatchPrefix": "你安裝的",
     "versionMismatchSuffix": "更新以保持同步。"
   },
+  "storageMigrationNotice": {
+    "body": "",
+    "dismissLabel": "",
+    "title": ""
+  },
   "cliBinary": {
     "binaryLabel": "",
     "checking": "檢查中…",


### PR DESCRIPTION
## Summary

Fixes all remaining full-suite CI failures (run 29204312067). **4 commits, 7 files, 14 real failures fixed** (10 engine + i18n parity).

## Fixes

### Engine (10 failures across 6 files)
- **openclaw-runtime-e2e/integration + reviewer** (4 tests) — `wrapToolsWithRtkRewrite`, `wrapToolsWithPermanentAgentGating`, `wrapToolsWithActionGate` missing from `../pi.js` mock. These 3 wrap exports are chained in `agent-session-helpers.ts:91-93`. Added pass-through mocks to all 3 files.
- **heartbeat-executor** (3 tests) — FN-7835/FN-7859 changed error-state transitions: (a) `resultJson.reason` is now `"error-unrecoverable"` not `"invalid_state"` for non-recovery-eligible error agents; (b) `completeRun(failed)` now parks non-recoverable failures as `paused` (not `error`). Updated all assertions with FNXC comments.
- **heartbeat-session-prompt** (1 test) — same `completeRun(failed)` parked-paused transition.
- **executor-prompt** (2 tests) — `moveTask("FN-001", "todo", undefined)` now gets `{}` (empty options object) because the pause-abort path always builds an options object from conditional spreads. Updated both assertions.
- **grok-runtime-routing** (10 tests) — SKIPPED: local-only `@agentclientprotocol/sdk` not installed; CI's lockfile resolves it.

### i18n (shard 4)
- **storageMigrationNotice** — 3 keys (`body`, `dismissLabel`, `title`) missing from all 5 non-en locales. Added empty-string entries.

### Dashboard (shard 3)
- **process-lifecycle** — local-only `@agentclientprotocol/sdk` import failure (same as grok-runtime; CI resolves it).

## Verification
- Gate: exit 0.
- Engine 6-file consolidated: 402 passed, 0 failures.
- i18n parity + gate-coverage: 7/7 ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Non-recoverable agent failures are now parked in a paused state with a clear reason instead of remaining in an error state.
  - Successful follow-up heartbeats clear stale error information.
  - Task moves consistently preserve an empty options set when no special handling applies.

- **Localization**
  - Added translation placeholders for storage migration notices in Spanish, French, Korean, Simplified Chinese, and Traditional Chinese.

- **Tests**
  - Updated heartbeat, task execution, runtime, and reviewer coverage to reflect the revised failure handling and tool-policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->