### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,3 +318,15 @@ Note: the embedded main-content views Workflows (`_WorkflowEditorView`), Import 
    The modal should be 20% wider than the first section-sidebar layout and use a taller viewport so more settings remain visible without scrolling.
    */
    ```
+
+## Cursor Cloud specific instructions
+
+Runtime prerequisites (already present on the base image): Node.js >= 22.5, `pnpm` 10.33 (pinned via `packageManager`), and `git`. Dependencies are refreshed on startup by the update script (`pnpm install --frozen-lockfile`); no other one-off setup is required.
+
+Standard lint/test/build/run commands live in `package.json` scripts, `README.md` → Development, and `docs/testing.md` — use those. Non-obvious caveats for this environment:
+
+- **Run the dev node with `pnpm local`** (starts dashboard + AI engine on the first free port at/above 4050). Port 4040 is reserved (never bind or kill it) and `pnpm local` auto-skips it. Prefer an explicit non-4040 port, e.g. `pnpm local --port 4050`. On localhost, auth is disabled automatically, so the board is reachable at `http://localhost:<port>` with no token. Health check: `GET /api/health` returns 200.
+- **`pnpm smoke:boot` requires a prior `pnpm build`** — the boot smoke runs against the built CLI/dashboard (`packages/cli/bin.mjs`, `dist/client`), not source. Run `pnpm build` first or the smoke will fail on a clean tree.
+- **No AI provider is connected by default.** The dashboard, board, CLI, task CRUD, and REST API all work without one, but planning/execution lanes cannot run real AI work until a provider is configured in Settings → Authentication (or `testMode`/mock provider is enabled to force scripted lanes). A "No AI provider connected" banner is expected, not a failure.
+- `pnpm local` auto-runs `fn init` and registers the repo as a project (creates `.fusion/fusion.db`, which is gitignored). This is expected on first run.
+- `qmd` is not installed; memory search silently falls back to local file search. This warning is benign.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Fusion development environment for Cloud Agents and documents durable, non-obvious run caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section.

The only code/repo change is the `AGENTS.md` documentation addition. No application code was modified — the repo already builds, lints, tests, and runs.

## Environment setup

- **Update script** (runs on VM startup): `pnpm install --frozen-lockfile`
- Runtime prerequisites already on the base image: Node.js 22.14 (repo requires >= 22.5), pnpm 10.33 (pinned via `packageManager`), git.

## Verification

All commands run from a clean install:

- `pnpm lint` — passed
- `pnpm build` — passed (default workspace packages)
- `pnpm smoke:boot` — passed (`fn --help` OK, `GET /api/health` 200, clean shutdown)
- `pnpm test:gate` — passed (engine core 337 tests, CLI ci-shape 63 tests, plus static checks)
- `pnpm local --port 4050` — dashboard + AI engine boot; `GET /api/health` returns 200

## Hello-world demo

Created a task through the dashboard UI ("Demo task created via Fusion dashboard UI"), which appears on the Planning column of the kanban board. Task creation also verified via the REST API (`POST /api/tasks`).

[fusion_dashboard_create_task_demo.mp4](https://cursor.com/agents/bc-023eec06-1881-44e8-a112-4e04dc25c35c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffusion_dashboard_create_task_demo.mp4)

[New task card created on the Fusion board](https://cursor.com/agents/bc-023eec06-1881-44e8-a112-4e04dc25c35c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffusion_task_created_board.webp)

Note: no AI provider is connected by default, so planning/execution lanes require provider credentials (or mock/test mode). The dashboard, board, CLI, task CRUD, and REST API all work without one.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-023eec06-1881-44e8-a112-4e04dc25c35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-023eec06-1881-44e8-a112-4e04dc25c35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

