### PR TITLE
fix: clean up OMP tool-bridge temp schema files on dispose

### DIFF
--- a/plugins/fusion-plugin-omp-runtime/src/__tests__/tool-bridge.test.ts
+++ b/plugins/fusion-plugin-omp-runtime/src/__tests__/tool-bridge.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   FUSION_OMP_TOOL_BRIDGE_URL,
@@ -83,7 +84,12 @@ describe("tool-bridge", () => {
     expect(showBody.isError).toBe(false);
     expect(showBody.content?.[0]?.text).toContain("FN-2");
 
+    const schemaPath = "args" in bridge!.mcpServer ? bridge!.mcpServer.args[1] : undefined;
+    expect(schemaPath).toBeTruthy();
+    expect(existsSync(schemaPath!)).toBe(true);
+
     await bridge!.dispose();
+    expect(existsSync(schemaPath!)).toBe(false);
   });
 
   it("returns null when there are no custom tools", async () => {

--- a/plugins/fusion-plugin-omp-runtime/src/tool-bridge.ts
+++ b/plugins/fusion-plugin-omp-runtime/src/tool-bridge.ts
@@ -8,7 +8,7 @@ after the session ends. Ported from fusion-plugin-grok-runtime for full fn_* par
 */
 
 import { createServer, type Server } from "node:http";
-import { writeFileSync } from "node:fs";
+import { unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -195,6 +195,16 @@ export async function startFusionToolBridge(
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
+      /*
+      FNXC:OmpAcp 2026-07-14-00:30:
+      Remove the temp schema JSON on session end so repeated sessions do not accumulate
+      fusion-omp-mcp-schemas-* files under tmpdir().
+      */
+      try {
+        unlinkSync(schemaPath);
+      } catch {
+        // best-effort cleanup
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary

- Follow-up to #2083: remove the temp `fusion-omp-mcp-schemas-*.json` file when the OMP Fusion `fn_*` MCP tool bridge is disposed.
- Prevents schema JSON from accumulating under `tmpdir()` after every OMP ACP session.

## Context

PR #2083 was merged before this cleanup commit landed on `feature/omp-acp`. This cherry-picks that fix onto main.

## Test plan

- [x] `pnpm --filter @fusion-plugin-examples/omp-runtime test` (includes dispose removes schema path assertion)