### PR TITLE
fix: isolate mDNS node broadcasts

### DIFF
--- a/packages/core/src/__tests__/node-discovery.test.ts
+++ b/packages/core/src/__tests__/node-discovery.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { DiscoveryConfig, DiscoveredNode } from "../types.js";
 
@@ -73,14 +74,14 @@ function createService(overrides: Record<string, unknown> = {}): Record<string, 
 
 describe("NodeDiscovery", () => {
   let browser: MockBrowser;
-  let publishService: { stop: ReturnType<typeof vi.fn> };
+  let publishService: EventEmitter & { stop: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
 
     browser = createMockBrowser();
-    publishService = { stop: vi.fn() };
+    publishService = Object.assign(new EventEmitter(), { stop: vi.fn() });
 
     publishMock.mockReturnValue(publishService);
     findMock.mockReturnValue(browser);
@@ -104,7 +105,7 @@ describe("NodeDiscovery", () => {
 
     expect(publishMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: "Local Node",
+        name: "Local Node-_local_1",
         type: "fusion",
         protocol: "tcp",
         port: 4040,
@@ -127,7 +128,7 @@ describe("NodeDiscovery", () => {
 
     expect(publishMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: expect.any(String),
+      name: expect.stringMatching(/-_local_1$/),
       }),
     );
   });
@@ -279,6 +280,14 @@ describe("NodeDiscovery", () => {
 
     expect(() => discovery.start("node_local_1", "Local")).not.toThrow();
     expect(errorHandler).toHaveBeenCalledWith(error);
+  });
+
+  it("contains asynchronous broadcast collisions without an error listener", () => {
+    const discovery = new NodeDiscovery(defaultConfig({ broadcast: true }));
+
+    discovery.start("node_local_1", "Local");
+
+    expect(() => publishService.emit("error", new Error("Service name is already in use on the network"))).not.toThrow();
   });
 
   it("continues when listener startup throws and emits error", () => {

--- a/packages/core/src/node-discovery.ts
+++ b/packages/core/src/node-discovery.ts
@@ -114,7 +114,14 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
 
     try {
       this.broadcastService = bonjour.publish({
-        name: nodeName.trim() || os.hostname(),
+        /*
+         * FNXC:NodeDiscovery 2026-07-15-18:05:
+         * Multiple local Fusion dashboards may share a friendly node name.
+         * DNS-SD requires each advertised service name to be unique, so retain
+         * the readable name while suffixing stable node identity to prevent an
+         * optional mDNS collision from disrupting the dashboard process.
+         */
+        name: `${nodeName.trim() || os.hostname()}-${nodeId.slice(-8)}`,
         type: serviceType.type,
         protocol: serviceType.protocol,
         port: this.config.port,
@@ -124,9 +131,9 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
           version: FUSION_VERSION,
         },
       });
+      this.broadcastService.on("error", this.onBroadcastError);
     } catch (error) {
-      this.warn("Failed to start mDNS broadcast", error);
-      this.emit("error", this.asError(error));
+      this.reportError("Failed to start mDNS broadcast", error);
     }
   }
 
@@ -136,10 +143,10 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
     }
 
     try {
+      this.broadcastService.off("error", this.onBroadcastError);
       this.broadcastService.stop?.();
     } catch (error) {
-      this.warn("Failed to stop mDNS broadcast", error);
-      this.emit("error", this.asError(error));
+      this.reportError("Failed to stop mDNS broadcast", error);
     } finally {
       this.broadcastService = null;
     }
@@ -161,8 +168,7 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
       this.browser.on("up", this.onServiceUp);
       this.browser.on("down", this.onServiceDown);
     } catch (error) {
-      this.warn("Failed to start mDNS listening", error);
-      this.emit("error", this.asError(error));
+      this.reportError("Failed to start mDNS listening", error);
     }
   }
 
@@ -178,8 +184,7 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
       browser.off("down", this.onServiceDown);
       browser.stop();
     } catch (error) {
-      this.warn("Failed to stop mDNS listening", error);
-      this.emit("error", this.asError(error));
+      this.reportError("Failed to stop mDNS listening", error);
     } finally {
       this.browser = null;
     }
@@ -250,6 +255,10 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
 
     this.discoveredNodes.delete(service.name);
     this.emit("node:lost", service.name);
+  };
+
+  private onBroadcastError = (error: unknown): void => {
+    this.reportError("mDNS broadcast failed", error);
   };
 
   private getBonjour(): Bonjour {
@@ -327,6 +336,16 @@ export class NodeDiscovery extends EventEmitter<NodeDiscoveryEvents> {
     }
 
     console.warn(`[node-discovery] ${message}`);
+  }
+
+  private reportError(message: string, error: unknown): void {
+    this.warn(message, error);
+    // EventEmitter reserves "error" for fatal exceptions when nobody is
+    // listening. Discovery is optional, so preserve observability for callers
+    // that subscribe without allowing a network collision to crash the host.
+    if (this.listenerCount("error") > 0) {
+      this.emit("error", this.asError(error));
+    }
   }
 
   private asError(error: unknown): Error {


### PR DESCRIPTION
## Summary

- Make Fusion mDNS broadcast names node-unique to avoid same-name DNS-SD collisions.
- Treat asynchronous Bonjour broadcast errors as non-fatal diagnostics when no listener is registered.
- Add regression coverage for a service-name collision.

## Validation

- `pnpm --filter @fusion/core exec vitest run src/__tests__/node-discovery.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/core typecheck`
