### PR TITLE
fix(engine): reclaim leaked semaphore slots when the system is busy, not only at total idle

### DIFF
--- a/packages/engine/src/__tests__/concurrency.test.ts
+++ b/packages/engine/src/__tests__/concurrency.test.ts
@@ -567,6 +567,101 @@ describe("AgentSemaphore", () => {
     sem.release();
   });
 
+  /*
+  FNXC:GlobalConcurrencyControls 2026-07-16-00:00:
+  The idle-only valve never fired when a few zombie in-progress rows kept
+  persistedActive nonzero, so slots leaked by abnormal teardown accumulated
+  until activeCount pinned the limit and the engine sat idle until restart.
+  The generalized valve clamps to the persisted+in-flight bound after the
+  (long) stale-excess window while leaving legitimate nested overshoot alone.
+  */
+  it("recovers stale excess above the persisted bound after the stale-excess window", async () => {
+    const sem = new AgentSemaphore(8);
+    for (let i = 0; i < 6; i++) await sem.acquire();
+    // Two genuinely running tasks persist; four held slots are leaked.
+    const tasks = [
+      { column: "in-progress" },
+      { column: "in-progress" },
+    ] as Task[];
+
+    const first = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: null,
+      nowMs: 1_000,
+    });
+    expect(first).toEqual({ candidateSinceMs: 1_000 });
+    expect(sem.activeCount).toBe(6);
+
+    // Idle 5s window elapsed — but bound > 0, so the long window governs.
+    const early = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: first.candidateSinceMs,
+      nowMs: 6_001,
+    });
+    expect(early).toEqual({ candidateSinceMs: 1_000 });
+    expect(sem.activeCount).toBe(6);
+
+    const repaired = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: early.candidateSinceMs,
+      nowMs: 1_000 + 600_001,
+    });
+    expect(repaired).toEqual({
+      candidateSinceMs: null,
+      reconciliation: { before: 6, after: 2, changed: true },
+    });
+    expect(sem.activeCount).toBe(2);
+  });
+
+  it("resets the stale-excess candidate when the excess clears (nested overshoot ends)", async () => {
+    const sem = new AgentSemaphore(4);
+    await sem.acquire();
+    sem.acquireNestedSlot(); // legitimate nested overshoot: active=2, persisted=1
+    const tasks = [{ column: "in-progress" }] as Task[];
+
+    const candidate = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: null,
+      nowMs: 1_000,
+    });
+    expect(candidate).toEqual({ candidateSinceMs: 1_000 });
+
+    sem.releaseNestedSlot(); // nested run finishes; excess is gone
+
+    const reset = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: candidate.candidateSinceMs,
+      nowMs: 1_000 + 600_001,
+    });
+    expect(reset).toEqual({ candidateSinceMs: null });
+    expect(sem.activeCount).toBe(1);
+    sem.release();
+  });
+
+  it("counts caller in-flight sessions into the stale-excess bound", async () => {
+    const sem = new AgentSemaphore(4);
+    await sem.acquire();
+    await sem.acquire();
+    // One persisted running task + one triage in-flight session account for
+    // both held slots — no excess, no candidate.
+    const result = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks: [{ column: "in-progress" }] as Task[],
+      candidateSinceMs: 999,
+      inFlightCount: 1,
+      nowMs: 700_000,
+    });
+    expect(result).toEqual({ candidateSinceMs: null });
+    expect(sem.activeCount).toBe(2);
+    sem.release();
+    sem.release();
+  });
+
   it("run() gates concurrent calls", async () => {
     const sem = new AgentSemaphore(2);
     let concurrent = 0;

--- a/packages/engine/src/__tests__/concurrency.test.ts
+++ b/packages/engine/src/__tests__/concurrency.test.ts
@@ -616,7 +616,14 @@ describe("AgentSemaphore", () => {
     expect(sem.activeCount).toBe(2);
   });
 
-  it("resets the stale-excess candidate when the excess clears (nested overshoot ends)", async () => {
+  /*
+  FNXC:GlobalConcurrencyControls 2026-07-17-00:00:
+  Greptile PR #2265 ("Candidate Outlives Slot Ownership"): a pure nested
+  overshoot is legitimate work above the persisted bound and must never become a
+  stale-excess candidate. Recovery excludes `nestedActiveCount` from the excess,
+  so a nested run — however long it runs — never arms the repair timer.
+  */
+  it("never treats a pure nested overshoot as a stale-excess candidate", async () => {
     const sem = new AgentSemaphore(4);
     await sem.acquire();
     sem.acquireNestedSlot(); // legitimate nested overshoot: active=2, persisted=1
@@ -628,19 +635,65 @@ describe("AgentSemaphore", () => {
       candidateSinceMs: null,
       nowMs: 1_000,
     });
-    expect(candidate).toEqual({ candidateSinceMs: 1_000 });
+    // active(2) == bound(1) + nested(1) → no reclaimable excess, no candidate.
+    expect(candidate).toEqual({ candidateSinceMs: null });
 
-    sem.releaseNestedSlot(); // nested run finishes; excess is gone
-
-    const reset = recoverIdleSemaphoreLeakCandidate({
+    // Even well past the long stale window the nested slot is untouched.
+    const stillClean = recoverIdleSemaphoreLeakCandidate({
       semaphore: sem,
       tasks,
-      candidateSinceMs: candidate.candidateSinceMs,
+      candidateSinceMs: null,
       nowMs: 1_000 + 600_001,
     });
-    expect(reset).toEqual({ candidateSinceMs: null });
+    expect(stillClean).toEqual({ candidateSinceMs: null });
+    expect(sem.activeCount).toBe(2);
+
+    sem.releaseNestedSlot();
     expect(sem.activeCount).toBe(1);
     sem.release();
+  });
+
+  /*
+  FNXC:GlobalConcurrencyControls 2026-07-17-00:00:
+  Greptile PR #2265 ("Candidate Outlives Slot Ownership"): when a leaked slot
+  keeps the excess continuously positive, a live nested run that starts mid-window
+  must NOT be reclaimed with the leaked slot. Recovery clamps only to
+  `bound + nestedActiveCount`, so exactly the leaked slot is removed and the live
+  nested run survives.
+  */
+  it("reclaims only the leaked slot, never a coexisting live nested run", async () => {
+    const sem = new AgentSemaphore(8);
+    for (let i = 0; i < 5; i++) await sem.acquire(); // 5 persisted running tasks
+    await sem.acquire(); // 1 leaked slot (no persisted task backs it)
+    sem.acquireNestedSlot(); // live nested run starts: active=7, nested=1
+    const tasks = Array.from({ length: 5 }, () => ({ column: "in-progress" })) as Task[];
+
+    const first = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: null,
+      nowMs: 1_000,
+    });
+    // active(7) - (bound 5 + nested 1) = 1 leaked → candidate armed.
+    expect(first).toEqual({ candidateSinceMs: 1_000 });
+
+    const repaired = recoverIdleSemaphoreLeakCandidate({
+      semaphore: sem,
+      tasks,
+      candidateSinceMs: first.candidateSinceMs,
+      nowMs: 1_000 + 600_001,
+    });
+    // Clamp to bound + nested = 6: the leaked slot is dropped, the nested run kept.
+    expect(repaired).toEqual({
+      candidateSinceMs: null,
+      reconciliation: { before: 7, after: 6, changed: true },
+    });
+    expect(sem.activeCount).toBe(6);
+    expect(sem.nestedActiveCount).toBe(1);
+
+    sem.releaseNestedSlot(); // nested run finishes cleanly → back to the 5 persisted
+    expect(sem.activeCount).toBe(5);
+    for (let i = 0; i < 5; i++) sem.release();
   });
 
   it("counts caller in-flight sessions into the stale-excess bound", async () => {

--- a/packages/engine/src/concurrency.ts
+++ b/packages/engine/src/concurrency.ts
@@ -20,6 +20,21 @@ interface PriorityWaiter {
 
 export const IDLE_SEMAPHORE_LEAK_REPAIR_MS = 5_000;
 
+/**
+ * FNXC:GlobalConcurrencyControls 2026-07-16-00:00:
+ * Repair window for the NON-idle stale-excess case (semaphore holds more slots
+ * than persisted running tasks + caller in-flight sessions while some agent
+ * work is still persisted-running). Deliberately much longer than the idle
+ * window: nested helper agents ({@link AgentSemaphore.runNested}) legitimately
+ * push `activeCount` above the persisted top-level count for the duration of a
+ * nested run, so an excess must persist far longer than any plausible nested
+ * session before it is treated as leaked. A real leak (observed in production:
+ * slots pinned at the limit for days with planning=0/processing=0 while a few
+ * zombie in-progress rows kept the idle valve from ever firing) survives this
+ * window trivially; a live nested reviewer does not.
+ */
+export const STALE_SEMAPHORE_EXCESS_REPAIR_MS = 600_000;
+
 function createAbortError(): Error {
   if (typeof DOMException === "function") {
     try {
@@ -103,6 +118,22 @@ export interface IdleSemaphoreLeakRecoveryResult {
   reconciliation?: { before: number; after: number; changed: boolean };
 }
 
+/*
+FNXC:GlobalConcurrencyControls 2026-07-16-00:00:
+Generalized from the idle-only valve. The previous guard (`persistedActive !== 0
+|| inFlightCount > 0` → reset) meant leaked slots were only ever reclaimed when
+the WHOLE system quiesced. In production a handful of zombie in-progress rows
+kept `persistedActive` nonzero indefinitely, so slots leaked by abnormal agent
+teardown accumulated until `activeCount` pinned the limit — the engine then sat
+fully idle ("Hold release … no reservable slot" on every sweep, planning=0,
+processing=0, merge queue growing) until a process restart. The valve now
+clamps `activeCount` down to the persisted+in-flight bound whenever the
+semaphore over-holds CONTINUOUSLY for the repair window: the strict idle case
+keeps its fast 5s window (same behavior as before), while the non-idle case
+uses the conservative {@link STALE_SEMAPHORE_EXCESS_REPAIR_MS} so legitimate
+nested-agent overshoot is never touched. `reconcileActiveCount` only lowers
+the count, and the candidate timestamp resets the moment the excess clears.
+*/
 export function recoverIdleSemaphoreLeakCandidate(params: {
   semaphore: AgentSemaphore | undefined;
   tasks: Task[];
@@ -110,6 +141,8 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
   inFlightCount?: number;
   nowMs?: number;
   repairAfterMs?: number;
+  /** Override for the non-idle stale-excess window (tests). */
+  staleExcessRepairAfterMs?: number;
 }): IdleSemaphoreLeakRecoveryResult {
   const {
     semaphore,
@@ -118,12 +151,15 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
     inFlightCount = 0,
     nowMs = Date.now(),
     repairAfterMs = IDLE_SEMAPHORE_LEAK_REPAIR_MS,
+    staleExcessRepairAfterMs = STALE_SEMAPHORE_EXCESS_REPAIR_MS,
   } = params;
 
   if (!semaphore) return { candidateSinceMs: null };
 
   const persistedActive = persistedTopLevelAgentSlots(tasks);
-  if (persistedActive !== 0 || semaphore.activeCount <= 0 || inFlightCount > 0) {
+  const bound = persistedActive + Math.max(0, Math.floor(inFlightCount));
+  const excess = semaphore.activeCount - bound;
+  if (excess <= 0) {
     return { candidateSinceMs: null };
   }
 
@@ -131,13 +167,14 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
     return { candidateSinceMs: nowMs };
   }
 
-  if (nowMs - candidateSinceMs < repairAfterMs) {
+  const windowMs = bound === 0 ? repairAfterMs : staleExcessRepairAfterMs;
+  if (nowMs - candidateSinceMs < windowMs) {
     return { candidateSinceMs };
   }
 
   return {
     candidateSinceMs: null,
-    reconciliation: semaphore.reconcileActiveCount(0),
+    reconciliation: semaphore.reconcileActiveCount(bound),
   };
 }
 

--- a/packages/engine/src/concurrency.ts
+++ b/packages/engine/src/concurrency.ts
@@ -158,7 +158,20 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
 
   const persistedActive = persistedTopLevelAgentSlots(tasks);
   const bound = persistedActive + Math.max(0, Math.floor(inFlightCount));
-  const excess = semaphore.activeCount - bound;
+  /*
+  FNXC:GlobalConcurrencyControls 2026-07-17-00:00:
+  Exclude live nested helper-agent slots from the reclaimable excess (and from
+  the reconcile target). Nested runs legitimately hold slots above `bound`, so
+  counting them as excess would let a leaked slot's continuous-excess timer
+  reclaim a nested slot that only just started — reconciling away live work and
+  admitting an extra session (Greptile PR #2265, "Candidate Outlives Slot
+  Ownership"). With nested excluded, `excess` reflects only slots the semaphore
+  holds beyond persisted top-level work + caller in-flight + live nested runs —
+  i.e. genuinely leaked slots — and the reclaim floor keeps nested runs intact.
+  */
+  const nestedActive = Math.max(0, semaphore.nestedActiveCount);
+  const reclaimFloor = bound + nestedActive;
+  const excess = semaphore.activeCount - reclaimFloor;
   if (excess <= 0) {
     return { candidateSinceMs: null };
   }
@@ -167,6 +180,8 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
     return { candidateSinceMs: nowMs };
   }
 
+  // The strict-idle case (no persisted + no in-flight top-level work) keeps the
+  // fast idle window; any live top-level work uses the conservative stale window.
   const windowMs = bound === 0 ? repairAfterMs : staleExcessRepairAfterMs;
   if (nowMs - candidateSinceMs < windowMs) {
     return { candidateSinceMs };
@@ -174,7 +189,7 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
 
   return {
     candidateSinceMs: null,
-    reconciliation: semaphore.reconcileActiveCount(bound),
+    reconciliation: semaphore.reconcileActiveCount(reclaimFloor),
   };
 }
 
@@ -216,6 +231,17 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
  */
 export class AgentSemaphore {
   private _active = 0;
+  /**
+   * FNXC:GlobalConcurrencyControls 2026-07-17-00:00:
+   * Count of slots currently held by nested helper agents ({@link runNested}).
+   * Nested runs legitimately push `_active` above the persisted top-level bound,
+   * so stale-semaphore recovery must exclude them from the reclaimable excess —
+   * otherwise a leaked slot's repair-window timer (continuous positive excess)
+   * could reclaim a live nested slot that only just started (Greptile PR #2265,
+   * "Candidate Outlives Slot Ownership"). Tracked separately from `_active` so
+   * recovery can compute `active - (bound + nested)` = truly-leaked excess only.
+   */
+  private _nestedActive = 0;
   private _waiters: PriorityWaiter[] = [];
   private _getLimit: () => number;
   private _excessReleaseWarned = false;
@@ -232,6 +258,15 @@ export class AgentSemaphore {
   /** Number of slots currently held by running agents. */
   get activeCount(): number {
     return Math.max(0, this._active);
+  }
+
+  /**
+   * Number of slots currently held by nested helper agents ({@link runNested}).
+   * Clamped into `[0, activeCount]` so it can never over-report the legitimate
+   * overshoot that stale-semaphore recovery excludes from reclaimable excess.
+   */
+  get nestedActiveCount(): number {
+    return Math.max(0, Math.min(this._nestedActive, this._active));
   }
 
   /** Number of callers currently queued for a semaphore slot. */
@@ -407,10 +442,12 @@ export class AgentSemaphore {
   /** Reserve a nested helper-agent slot without queueing. */
   acquireNestedSlot(): void {
     this._active++;
+    this._nestedActive++;
   }
 
   /** Return a nested helper-agent slot. */
   releaseNestedSlot(): void {
+    if (this._nestedActive > 0) this._nestedActive--;
     this.returnSlot("runNested");
   }
 
@@ -487,6 +524,16 @@ export class ScopedAgentSemaphore extends AgentSemaphore {
   /** Shared-pool active count, preserving scheduler/metrics semantics. */
   override get activeCount(): number {
     return this.delegate.activeCount;
+  }
+
+  /**
+   * Shared-pool nested count, kept in the same frame of reference as
+   * {@link activeCount} (both read the delegate). Nested slots reserved through
+   * this scope's {@link runNested} bump the delegate, so recovery reading the
+   * delegate's nested total never treats a live nested slot as leaked excess.
+   */
+  override get nestedActiveCount(): number {
+    return this.delegate.nestedActiveCount;
   }
 
   override get waitingCount(): number {

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -587,6 +587,13 @@ export class InProcessRuntime
         maxConcurrent: this.config.maxConcurrent,
         maxWorktrees: this.config.maxWorktrees,
         semaphore: this.projectSemaphore,
+        // FNXC:GlobalConcurrencyControls 2026-07-17-00:00: Feed the triage service's
+        // live pre-planning in-flight count into the scheduler's stale-semaphore
+        // recovery so a triage session holding a slot before it writes
+        // status:"planning" is never mistaken for a leaked slot. Read lazily —
+        // triageProcessor is constructed after the scheduler but exists by the
+        // time the first scheduling pass runs.
+        getInFlightTopLevelCount: () => this.triageProcessor?.getProcessingTaskIds().size ?? 0,
         agentStore: this.agentStore,
         hasActiveAgentExecution: (agentId: string) => this.heartbeatMonitor?.getTrackedAgents().includes(agentId) ?? false,
         missionStore,

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -401,7 +401,7 @@ function recoverIdleSemaphoreLeak(
   if (result.reconciliation?.changed) {
     schedulerLog.warn(
       `${source}: recovered stale semaphore active count ${result.reconciliation.before} -> ${result.reconciliation.after} ` +
-      "(no persisted in-progress/planning/review agent work)",
+      "(semaphore over-held vs persisted+in-flight top-level agent work)",
     );
   }
   return result.candidateSinceMs;

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -392,11 +392,13 @@ function recoverIdleSemaphoreLeak(
   tasks: Task[],
   source: string,
   candidateSinceMs: number | null,
+  inFlightCount: number = 0,
 ): number | null {
   const result = recoverIdleSemaphoreLeakCandidate({
     semaphore,
     tasks,
     candidateSinceMs,
+    inFlightCount,
   });
   if (result.reconciliation?.changed) {
     schedulerLog.warn(
@@ -560,6 +562,18 @@ export interface SchedulerOptions {
   localNodeId?: string;
   /** Optional shared auto-claim snapshot manager for invalidation on task mutations. */
   snapshotManager?: AutoClaimSnapshotManager;
+  /**
+   * FNXC:GlobalConcurrencyControls 2026-07-17-00:00:
+   * Live count of top-level triage sessions that already hold a semaphore slot
+   * but have not yet persisted `status:"planning"` (pre-planning `processing`
+   * entries). Read lazily on each scheduling pass and fed into stale-semaphore
+   * recovery as `inFlightCount` so the scheduler's reclaim bound never undercounts
+   * a live triage acquire — otherwise a pre-planning triage slot would look like
+   * leaked excess (bound=0 → fast idle window) and get released, admitting an
+   * agent above the configured limit (Greptile PR #2265, "Scheduler Omits Live
+   * Triage Slots"). Matches the triage service's own `inFlightCount` semantics.
+   */
+  getInFlightTopLevelCount?: () => number;
 }
 
 /**
@@ -1305,6 +1319,7 @@ export class Scheduler {
         tasks,
         "scheduler",
         this.idleSemaphoreLeakCandidateSince,
+        this.options.getInFlightTopLevelCount?.() ?? 0,
       );
 
       // Refresh the poll interval if the persisted setting has changed

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -819,7 +819,7 @@ export class TriageProcessor {
         if (result.reconciliation?.changed) {
           planLog.warn(
             `triage: recovered stale semaphore active count ${result.reconciliation.before} -> ${result.reconciliation.after} ` +
-            "(no persisted in-progress/planning/review agent work)",
+            "(semaphore over-held vs persisted+in-flight top-level agent work)",
           );
         }
         this.idleSemaphoreLeakCandidateSince = result.candidateSinceMs;


### PR DESCRIPTION
## fix(engine): reclaim leaked semaphore slots when the system is busy, not only at total idle

### The bug

`recoverIdleSemaphoreLeakCandidate` only reclaims stale `AgentSemaphore` slots when the system is **completely** idle (`persistedActive === 0 && inFlightCount === 0` → reconcile to 0). If even one in-progress row persists — e.g. a zombie task whose agent session died without its `finally` release — the valve never opens, and slots leaked by abnormal teardown accumulate monotonically until `activeCount` pins the limit.

At that point the engine deadlocks in a distinctive way:
- every hold/release sweep logs `Hold release for <task> deferred — no reservable slot for in-progress`
- triage/plan report `planning=0 … processing=0, semaphore active=<limit>/<limit>, available=0`
- the merge queue grows unboundedly (merges also need a slot)
- only a process restart recovers

`reapLeakedConcurrencySlots` (FN-6782) doesn't help — it reconciles **worktree** slots, not the shared semaphore.

### Production evidence

Observed twice on a 6-project embedded-PG deployment driving a local model:

- After ~5 days of continuous operation: `semaphore active=24/24`, `planning=0/24, processing=0`, 5 persisted in-progress rows (dead sessions), merge queue at 88, **zero merges for >24h**. Restart immediately restored merging.
- Same signature earlier at `active=40/40` with both LLM backends idle (`kvcache≈0`).

The handful of zombie in-progress rows kept `persistedActive` nonzero indefinitely, so the idle-only valve could never fire.

### The fix

Generalize the valve: clamp `activeCount` down to the **persisted + in-flight bound** whenever the semaphore over-holds **continuously** for a repair window.

- The strict-idle case (`bound === 0`) keeps its existing fast 5s window — behavior unchanged, existing tests pass as-is.
- The non-idle case uses a deliberately conservative new window (`STALE_SEMAPHORE_EXCESS_REPAIR_MS = 600_000`, 10 min): nested helper agents (`runNested`) legitimately push `activeCount` above the persisted top-level count for the duration of a nested run, so the excess must outlive any plausible nested session before it is treated as leaked. The candidate timestamp resets the moment the excess clears.
- `reconcileActiveCount` only ever lowers the count, so the clamp cannot inflate capacity; a late release from a genuinely live agent after a (worst-case, mis-timed) clamp is absorbed by the existing excess-release guard (FN-6423).

Call-site changes are limited to the two log messages (the old parenthetical claimed "no persisted … agent work", which is no longer the only repair case).

### Tests

- existing idle-valve tests pass unchanged (same window, same reconcile-to-0)
- new: stale excess above a nonzero persisted bound is repaired only after the long window, and clamps exactly to the bound
- new: candidate resets when the excess clears (nested overshoot ending)
- new: caller in-flight sessions count into the bound (no false candidate)

### Files

- `packages/engine/src/concurrency.ts` — generalized valve + `STALE_SEMAPHORE_EXCESS_REPAIR_MS`
- `packages/engine/src/scheduler.ts`, `packages/engine/src/triage.ts` — log message accuracy
- `packages/engine/src/__tests__/concurrency.test.ts` — 3 new tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale “semaphore excess” recovery by using a configurable repair window when excess persists.
  * Prevented premature capacity corrections by accounting for in-flight top-level work during reconciliation.
  * Correctly handles nested helper activity so only leaked excess is reclaimed, preserving legitimate nested runs.
  * Updated reconciliation to clamp excess to the appropriate reclaim floor instead of waiting indefinitely.
* **Improvements**
  * Refreshed diagnostic warning text to clarify the over-held vs persisted+in-flight work comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->