### PR TITLE
test: preserve default getTask mock for DUPLICATE recovery

### DIFF
--- a/packages/engine/src/__tests__/triage-finalize-duplicate-lineage.test.ts
+++ b/packages/engine/src/__tests__/triage-finalize-duplicate-lineage.test.ts
@@ -113,11 +113,17 @@ describe("triage finalize duplicate lineage", () => {
     */
     const store = createMockStore({
       getSettings: vi.fn().mockResolvedValue({ requirePlanApproval: false, triageDuplicateResolution: "delete" } as Settings),
-      getTask: vi.fn().mockImplementation(async (id: string) => (
-        id === "FN-4894"
-          ? createTask({ id: "FN-4894", title: "Canonical", column: "todo", status: null })
-          : undefined
-      )),
+      /*
+      FNXC:EngineTests 2026-07-17-18:10:
+      PR #2275 review: preserve a default current-task mock for non-canonical IDs.
+      Returning undefined for FN-001 risks NPEs if recovery re-fetches the subject task.
+      */
+      getTask: vi.fn().mockImplementation(async (id: string) => {
+        if (id === "FN-4894") {
+          return createTask({ id: "FN-4894", title: "Canonical", column: "todo", status: null });
+        }
+        return createTask({ id: "FN-001" });
+      }),
     });
     await runRecovery(createTask(), "DUPLICATE: FN-4894\n", store);
 
@@ -132,11 +138,12 @@ describe("triage finalize duplicate lineage", () => {
 
   it("flags and parks DUPLICATE markers under default prompt resolution", async () => {
     const store = createMockStore({
-      getTask: vi.fn().mockImplementation(async (id: string) => (
-        id === "FN-4894"
-          ? createTask({ id: "FN-4894", title: "Canonical", column: "todo", status: null })
-          : undefined
-      )),
+      getTask: vi.fn().mockImplementation(async (id: string) => {
+        if (id === "FN-4894") {
+          return createTask({ id: "FN-4894", title: "Canonical", column: "todo", status: null });
+        }
+        return createTask({ id: "FN-001" });
+      }),
     });
     await runRecovery(createTask(), "DUPLICATE: FN-4894\n", store);
 

--- a/packages/engine/src/__tests__/triage-split-into-subtasks-delete.test.ts
+++ b/packages/engine/src/__tests__/triage-split-into-subtasks-delete.test.ts
@@ -165,11 +165,17 @@ describe("triage split/delete lineage forwarding", () => {
         autoMerge: true,
         triageDuplicateResolution: "delete",
       } as Settings),
-      getTask: vi.fn().mockImplementation(async (id: string) => (
-        id === "FN-4894"
-          ? createTask({ id: "FN-4894", title: "Canonical", column: "todo", status: null })
-          : undefined
-      )),
+      /*
+      FNXC:EngineTests 2026-07-17-18:10:
+      PR #2275 review: keep the createStore default current-task mock for non-canonical
+      IDs. Returning undefined risks NPEs if recovery re-fetches FN-001 mid-path.
+      */
+      getTask: vi.fn().mockImplementation(async (id: string) => {
+        if (id === "FN-4894") {
+          return createTask({ id: "FN-4894", title: "Canonical", column: "todo", status: null });
+        }
+        return createTask({ attachments: [], comments: [] } as any);
+      }),
       deleteTask: vi.fn().mockResolvedValue(undefined),
     });
 


### PR DESCRIPTION
## Summary
Follow-up to #2275 review feedback: `getTask` mocks for DUPLICATE recovery tests now return a default current-task fixture for non-canonical IDs instead of `undefined`.

## Context
CodeRabbit on #2275 noted that returning `undefined` for every id except the canonical task could break recovery if the subject task is re-fetched mid-path.

## Test plan
- [x] `triage-split-into-subtasks-delete.test.ts`
- [x] `triage-finalize-duplicate-lineage.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved duplicate-resolution test coverage by preserving task data during recovery and re-fetch scenarios.
  * Added validation for non-canonical task handling to prevent errors when duplicate tasks are resolved or split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->