### PR TITLE
fix: resolve claude-runtime probe source for CLI full-suite

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -191,6 +191,21 @@ export default defineConfig({
         replacement: resolve(__dirname, "../../plugins/fusion-plugin-omp-runtime/src/index.ts"),
       },
       /*
+      FNXC:CliTests 2026-07-18-09:15:
+      runtime-provider-probes imports @fusion-plugin-examples/claude-runtime for probe/model
+      discovery only. Alias the package root to probes-entry (not full index) so CLI tests do
+      not load ACP/runtime-adapter or require @agentclientprotocol/sdk on the CLI resolver path.
+      Full-suite shard 4 failed with dist/ entry resolution + missing ACP deps under package lane.
+      */
+      {
+        find: /^@fusion-plugin-examples\/claude-runtime\/probe$/,
+        replacement: resolve(__dirname, "../../plugins/fusion-plugin-claude-runtime/src/probe.ts"),
+      },
+      {
+        find: /^@fusion-plugin-examples\/claude-runtime$/,
+        replacement: resolve(__dirname, "../../plugins/fusion-plugin-claude-runtime/src/probes-entry.ts"),
+      },
+      /*
       FNXC:PluginTests 2026-07-04-09:30:
       The roadmap plugin (@fusion-plugin-examples/roadmap) is imported by the CLI extension. Without source aliases, Vite resolves to the dist/ exports which don't exist in a source checkout.
       */

--- a/plugins/fusion-plugin-claude-runtime/src/probes-entry.ts
+++ b/plugins/fusion-plugin-claude-runtime/src/probes-entry.ts
@@ -5,5 +5,6 @@ Importing the full plugin index pulls ACP/runtime-adapter (and @agentclientproto
 which is not required for binary probe / model discovery and fails full-suite CLI
 resolution when dist/ is absent or ACP deps are not on the CLI resolver path.
 */
-export { probeClaudeBinary, type ClaudeBinaryStatus } from "./probe.js";
+export { probeClaudeBinary } from "./probe.js";
+export type { ClaudeBinaryStatus } from "./types.js";
 export { discoverClaudeProviderModels } from "./provider.js";

--- a/plugins/fusion-plugin-claude-runtime/src/probes-entry.ts
+++ b/plugins/fusion-plugin-claude-runtime/src/probes-entry.ts
@@ -1,0 +1,9 @@
+/*
+FNXC:CliTests 2026-07-18-09:15:
+Thin entry for dashboard runtime-provider-probes and CLI vitest source aliases.
+Importing the full plugin index pulls ACP/runtime-adapter (and @agentclientprotocol/sdk)
+which is not required for binary probe / model discovery and fails full-suite CLI
+resolution when dist/ is absent or ACP deps are not on the CLI resolver path.
+*/
+export { probeClaudeBinary, type ClaudeBinaryStatus } from "./probe.js";
+export { discoverClaudeProviderModels } from "./provider.js";


### PR DESCRIPTION
## Summary
Full Suite after #2291: shards 1–3 green; shard 4 failed CLI suites with:

`Failed to resolve entry for package "@fusion-plugin-examples/claude-runtime"`

from `dashboard/src/runtime-provider-probes.ts` under the CLI vitest package lane.

- Add `plugins/fusion-plugin-claude-runtime/src/probes-entry.ts` (probe + model discovery only)
- Alias `@fusion-plugin-examples/claude-runtime` to that entry in CLI vitest config (same class as Cursor/Grok/OMP source aliases, but avoids ACP index load)

## Test plan
- [x] Local: vitest-workspace-resolution, task-steer, extension-task-tools
- [ ] PR gate
- [ ] Post-merge Full Suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI resolution for Claude runtime diagnostics and provider model discovery.
  * Prevented unnecessary runtime dependencies from affecting CLI test execution.
* **Refactor**
  * Added a lightweight entry point for accessing Claude binary checks and provider model discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->