### PR TITLE
fix: backup automation mock + Claude probes dashboard alias

### DIFF
--- a/packages/dashboard/src/__tests__/routes-automation.test.ts
+++ b/packages/dashboard/src/__tests__/routes-automation.test.ts
@@ -230,6 +230,13 @@ function createMockStore(overrides: Partial<TaskStore> = {}): TaskStore {
     updatePrInfo: vi.fn().mockResolvedValue(undefined),
     updateIssueInfo: vi.fn().mockResolvedValue(undefined),
     getRootDir: vi.fn().mockReturnValue("/fake/root"),
+    /*
+    FNXC:DashboardTests 2026-07-18-09:45:
+    Backup automation path calls resolveGlobalBackupRoot(store) which requires
+    getGlobalSettingsDir. Full-suite shard 4 failed FN-7537 manual backup parity
+    with "store.getGlobalSettingsDir is not a function" after product drift.
+    */
+    getGlobalSettingsDir: vi.fn().mockReturnValue("/fake/global/.fusion"),
     listWorkflowSteps: vi.fn().mockResolvedValue([]),
     createWorkflowStep: vi.fn(),
     getWorkflowStep: vi.fn(),
@@ -1402,7 +1409,15 @@ describe("Automation routes", () => {
             ...FAKE_SCHEDULE,
             command: "fn backup --create",
           });
-          const store = createMockStore({ getFusionDir: vi.fn().mockReturnValue(fusionDir) } as any);
+          /*
+          FNXC:DashboardTests 2026-07-18-09:45:
+          resolveGlobalBackupRoot reads getGlobalSettingsDir (not getFusionDir). Point both
+          at the temp fixture so FN-7537 still asserts the in-process backup intercept.
+          */
+          const store = createMockStore({
+            getFusionDir: vi.fn().mockReturnValue(fusionDir),
+            getGlobalSettingsDir: vi.fn().mockReturnValue(fusionDir),
+          } as any);
           const app = express();
           app.use(express.json());
           app.use("/api", createApiRoutes(store, { automationStore: mockStore as any }));
@@ -1445,7 +1460,10 @@ describe("Automation routes", () => {
               },
             ],
           });
-          const store = createMockStore({ getFusionDir: vi.fn().mockReturnValue(fusionDir) } as any);
+          const store = createMockStore({
+            getFusionDir: vi.fn().mockReturnValue(fusionDir),
+            getGlobalSettingsDir: vi.fn().mockReturnValue(fusionDir),
+          } as any);
           const app = express();
           app.use(express.json());
           app.use("/api", createApiRoutes(store, { automationStore: mockStore as any }));
@@ -1472,7 +1490,10 @@ describe("Automation routes", () => {
             ...FAKE_SCHEDULE,
             command: "fn backup --create",
           });
-          const store = createMockStore({ getFusionDir: vi.fn().mockReturnValue(fusionDir) } as any);
+          const store = createMockStore({
+            getFusionDir: vi.fn().mockReturnValue(fusionDir),
+            getGlobalSettingsDir: vi.fn().mockReturnValue(fusionDir),
+          } as any);
           const app = express();
           app.use(express.json());
           app.use("/api", createApiRoutes(store, { automationStore: mockStore as any }));

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -583,9 +583,19 @@ export default defineConfig({
         __dirname,
         "../../plugins/fusion-plugin-grok-runtime/src/index.ts",
       ),
+      /*
+      FNXC:DashboardTests 2026-07-18-09:45:
+      Alias Claude runtime to probes-entry (probe + model discovery only), not the full
+      ACP index — same class as CLI #2292. Importing index pulls @agentclientprotocol/sdk
+      and breaks dashboard-api-quality under source-checkout full-suite resolution.
+      */
       "@fusion-plugin-examples/claude-runtime": resolve(
         __dirname,
-        "../../plugins/fusion-plugin-claude-runtime/src/index.ts",
+        "../../plugins/fusion-plugin-claude-runtime/src/probes-entry.ts",
+      ),
+      "@fusion-plugin-examples/claude-runtime/probe": resolve(
+        __dirname,
+        "../../plugins/fusion-plugin-claude-runtime/src/probe.ts",
       ),
       /*
       FNXC:OmpAcp 2026-07-11-23:35:


### PR DESCRIPTION
## Summary
Full Suite after #2292: shards 1–3 green; shard 4 failed FN-7537 backup automation tests with `store.getGlobalSettingsDir is not a function`.

- Add `getGlobalSettingsDir` to routes-automation mock store
- Point backup-parity fixtures’ global dir at the temp fusion dir
- Dashboard Vitest: alias `@fusion-plugin-examples/claude-runtime` → `probes-entry` (same class as CLI #2292)

## Test plan
- [x] Local manual backup run parity (4 tests)
- [ ] PR gate
- [ ] Post-merge Full Suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation backup test coverage for global backup directory handling.
  * Preserved reliable manual backup behavior and event ordering across supported automation steps.
  * Fixed dashboard API test configuration for Claude runtime probe resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->