### PR TITLE
fix: wait for GitHub import re-translate after body edit

### DIFF
--- a/packages/dashboard/app/components/__tests__/GitHubImportAutoTranslate.test.tsx
+++ b/packages/dashboard/app/components/__tests__/GitHubImportAutoTranslate.test.tsx
@@ -176,7 +176,12 @@ describe("useGitHubImportAutoTranslate — background streaming", () => {
     // Same issue number, edited body -> must re-request.
     rerender({ items: [{ number: 1, title: "t1", body: "EDITED", state: "open" as const }] });
     await waitFor(() => expect(autoTranslateImportIssues).toHaveBeenCalledTimes(2));
-    expect(result.current.translations.get(1)?.title).toBe("T1");
+    /*
+    FNXC:GitHubImportTranslate 2026-07-18-10:10:
+    Full-suite can observe the second request before the streamed map is committed.
+    Wait for the translated title, not only the mock call count.
+    */
+    await waitFor(() => expect(result.current.translations.get(1)?.title).toBe("T1"));
   });
 
   it("does NOT re-request when the same issue set re-renders unchanged", async () => {


### PR DESCRIPTION
## Summary
Full Suite shard 3 failed `GitHubImportAutoTranslate` re-request after body edit: mock call count hit 2 before `translations.get(1).title` committed. Wait for the map entry.

## Test plan
- [x] Local re-request test green
- [ ] PR gate + Full Suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated translation test timing to reliably account for asynchronous translation results when issue content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->