### PR TITLE
fix: settle multi-select Speed checkbox before Other in planning tests

### DIFF
--- a/packages/dashboard/app/components/__tests__/PlanningModeModal.planning-flow.test.tsx
+++ b/packages/dashboard/app/components/__tests__/PlanningModeModal.planning-flow.test.tsx
@@ -766,9 +766,20 @@ describe("PlanningModeModal", () => {
       });
 
       const continueButton = screen.getByRole("button", { name: "Continue" });
-      fireEvent.click(screen.getByText("Speed"));
+      /*
+      FNXC:PlanningModeOptions 2026-07-18-10:35:
+      Full-suite shard load observed getByText("Speed") not committing the multi-select
+      checkbox state before Other was toggled (payload lost q-priorities and only sent
+      _other). Click the option checkbox by accessible name and wait for checked before
+      combining Other — same FN-8245 settle discipline as Other-only.
+      */
+      const speedCheckbox = screen.getByRole("checkbox", { name: /Speed/i });
+      fireEvent.click(speedCheckbox);
+      await waitFor(() => {
+        expect(speedCheckbox).toBeChecked();
+      });
       fireEvent.click(within(screen.getByTestId("planning-option-other")).getByRole("checkbox"));
-      const otherInput = screen.getByTestId("planning-other-input");
+      const otherInput = await screen.findByTestId("planning-other-input");
       fireEvent.change(otherInput, { target: { value: "  Preserve operator control  " } });
       expect(continueButton).toBeEnabled();
       fireEvent.click(continueButton);


### PR DESCRIPTION
## Summary
Full Suite shard 3 (run 29640624429) failed mobile multi-select + Other: submit payload only had `_other` and dropped `q-priorities: [\"speed\"]` under load.

Hardens the test to click the Speed **checkbox by accessible name**, wait for checked, then combine Other (FN-8245 settle discipline).

## Test plan
- [x] Local multi-select planning tests green
- [ ] PR gate
- [ ] Post-merge Full Suite all shards green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved mobile planning-flow test reliability by ensuring multi-select choices are committed before entering additional “Other” text.
  * Reduced the risk of intermittent CI failures when combining predefined options with custom responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->