### PR TITLE
fix: fetchGlobalSettings mock for PlanningMode autosize/initial

### DIFF
--- a/packages/dashboard/app/components/__tests__/PlanningModeModal.autosize.test.tsx
+++ b/packages/dashboard/app/components/__tests__/PlanningModeModal.autosize.test.tsx
@@ -62,6 +62,28 @@ vi.mock("../../api", () => ({
   fetchAiSession: (...args: any[]) => mockFetchAiSession(...args),
   parseConversationHistory: (...args: any[]) => mockParseConversationHistory(...args),
   fetchSettings: vi.fn().mockResolvedValue({ modelPresets: [], autoSelectModelPreset: false, defaultPresetBySize: {} }),
+  /*
+  FNXC:PlanningModeSettings 2026-07-18-10:50:
+  Product mounts fetchGlobalSettings for clarification gating. Without this export
+  the suite fails at render (full-suite shard 4). Sync-settle like planning-flow
+  so Start Planning is not blocked by a microtask.
+  */
+  fetchGlobalSettings: vi.fn(() => {
+    const settled = {
+      then(onFulfilled: (settings: Record<string, never>) => unknown) {
+        onFulfilled({});
+        return settled;
+      },
+      catch() {
+        return settled;
+      },
+      finally(onFinally: () => unknown) {
+        onFinally();
+        return settled;
+      },
+    };
+    return settled;
+  }),
   fetchModels: (...args: any[]) => mockFetchModels(...args),
   fetchWorkflowSteps: vi.fn().mockResolvedValue([]),
   updateGlobalSettings: vi.fn().mockResolvedValue({}),

--- a/packages/dashboard/app/components/__tests__/PlanningModeModal.initial.test.tsx
+++ b/packages/dashboard/app/components/__tests__/PlanningModeModal.initial.test.tsx
@@ -95,7 +95,26 @@ vi.mock("../../api", () => ({
   rejectPlan: (...args: any[]) => mockRejectPlan(...args),
   refineTask: (...args: any[]) => mockRefineTask(...args),
   fetchSettings: vi.fn().mockResolvedValue({ modelPresets: [], autoSelectModelPreset: false, defaultPresetBySize: {} }),
-  fetchGlobalSettings: vi.fn().mockResolvedValue({ agentClarificationEnabled: false }),
+  /*
+  FNXC:PlanningModeSettings 2026-07-18-10:50:
+  Sync-settle clarification settings so Start Planning is not racey under full-suite load.
+  */
+  fetchGlobalSettings: vi.fn(() => {
+    const settled = {
+      then(onFulfilled: (settings: { agentClarificationEnabled: boolean }) => unknown) {
+        onFulfilled({ agentClarificationEnabled: false });
+        return settled;
+      },
+      catch() {
+        return settled;
+      },
+      finally(onFinally: () => unknown) {
+        onFinally();
+        return settled;
+      },
+    };
+    return settled;
+  }),
   fetchModels: (...args: any[]) => mockFetchModels(...args),
   fetchWorkflowSteps: vi.fn().mockResolvedValue([]),
   refineText: vi.fn(),


### PR DESCRIPTION
## Summary
Full Suite shard 4 failed `PlanningModeModal.autosize` with missing `fetchGlobalSettings` on the `../../api` mock (product clarification gating).

- Autosize: add sync-settled `fetchGlobalSettings` (FN-8245 pattern)
- Initial: replace async `mockResolvedValue` with the same sync settle

## Test plan
- [x] Local autosize + initial (29 tests) green
- [ ] PR gate + Full Suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Planning Mode modal test reliability by making global settings responses consistently complete.
  * Reduced timing and race-condition sensitivity across initialization and autosizing test scenarios.
  * Added coverage for handling completed settings-loading flows without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->