### PR TITLE
test(core): align settings parity + schema 0020 bookkeeping

### DIFF
--- a/packages/core/src/__tests__/postgres/schema-applier.test.ts
+++ b/packages/core/src/__tests__/postgres/schema-applier.test.ts
@@ -45,6 +45,7 @@ import {
   IMPORT_TRANSLATION_CACHE_VERSION,
   IMPORT_TRANSLATION_CACHE_SCOPE_FIX_VERSION,
   IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
+  TASK_PROPOSAL_CLAIM_VERSION,
   OWNER_PROJECT_ID_SPLIT_VERSION,
   /*
   FNXC:PostgresSchema 2026-07-16-08:00:
@@ -161,6 +162,12 @@ describe("schema-applier: immutable migration identities", () => {
     expect(BULK_COMPLETION_REFUSAL_AT_VERSION).toBe("0018");
     expect(Number(SCHEMA_BASELINE_VERSION)).toBeGreaterThanOrEqual(Number(BULK_COMPLETION_REFUSAL_AT_VERSION));
   });
+
+  it("keeps the task proposal claim marker assigned to version 0020", () => {
+    expect(TASK_PROPOSAL_CLAIM_VERSION).toBe("0020");
+    expect(Number(SCHEMA_BASELINE_VERSION)).toBeGreaterThanOrEqual(Number(TASK_PROPOSAL_CLAIM_VERSION));
+  });
+
 });
 
 /*
@@ -1143,6 +1150,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_MERGER_MODEL_LANE_VERSION,
       BULK_COMPLETION_REFUSAL_AT_VERSION,
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
+      TASK_PROPOSAL_CLAIM_VERSION,
     ]);
     expect((await applySchemaBaseline(ctx.db, { pluginHooks: [] })).applied).toBe(false);
   });
@@ -1188,6 +1196,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_MERGER_MODEL_LANE_VERSION,
       BULK_COMPLETION_REFUSAL_AT_VERSION,
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
+      TASK_PROPOSAL_CLAIM_VERSION,
     ]);
   });
 
@@ -1322,6 +1331,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_MERGER_MODEL_LANE_VERSION,
       BULK_COMPLETION_REFUSAL_AT_VERSION,
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
+      TASK_PROPOSAL_CLAIM_VERSION,
     ]);
   });
 
@@ -1381,6 +1391,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_MERGER_MODEL_LANE_VERSION,
       BULK_COMPLETION_REFUSAL_AT_VERSION,
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
+      TASK_PROPOSAL_CLAIM_VERSION,
     ]);
   });
 
@@ -1440,6 +1451,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_MERGER_MODEL_LANE_VERSION,
       BULK_COMPLETION_REFUSAL_AT_VERSION,
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
+      TASK_PROPOSAL_CLAIM_VERSION,
     ]);
   });
 });

--- a/packages/core/src/__tests__/settings-parity.test.ts
+++ b/packages/core/src/__tests__/settings-parity.test.ts
@@ -9,6 +9,7 @@ import {
   isGlobalSettingsKey,
   isProjectSettingsKey,
 } from "../types.js";
+import { NON_DEFAULT_PROJECT_SETTINGS_KEYS } from "../settings-schema.js";
 import { BUILTIN_WORKFLOW_SETTINGS } from "../builtin-workflow-settings.js";
 
 function assertExactKeyCoverage(scopeName: string, actual: readonly string[], expected: readonly string[]): void {
@@ -40,11 +41,17 @@ describe("settings key parity", () => {
     );
   });
 
+  /*
+  FNXC:SettingsParity 2026-07-18-11:15:
+  PROJECT_SETTINGS_KEYS = defaults keys + NON_DEFAULT_PROJECT_SETTINGS_KEYS
+  (e.g. ephemeralAgentTaskCreationPolicy has no default; resolver owns fallback).
+  Full-suite failed when the parity test still expected defaults-only coverage.
+  */
   it("PROJECT_SETTINGS_KEYS is derived from the project settings defaults", () => {
     assertExactKeyCoverage(
       "PROJECT_SETTINGS_KEYS",
       PROJECT_SETTINGS_KEYS as readonly string[],
-      Object.keys(DEFAULT_PROJECT_SETTINGS),
+      [...Object.keys(DEFAULT_PROJECT_SETTINGS), ...NON_DEFAULT_PROJECT_SETTINGS_KEYS],
     );
   });
 


### PR DESCRIPTION
## Summary
- Full Suite run [29641723814](https://github.com/Runfusion/Fusion/actions/runs/29641723814) left shards 1–3 green; shard 4 (`@fusion/core`) failed after FN-8265 landed.
- `settings-parity`: `PROJECT_SETTINGS_KEYS` now includes `NON_DEFAULT_PROJECT_SETTINGS_KEYS` (`ephemeralAgentTaskCreationPolicy` has no default; resolver owns fallback).
- `schema-applier`: expected applied-migration lists and identity suite include `TASK_PROPOSAL_CLAIM_VERSION` (`0020`).

## Test plan
- [x] `pnpm --filter @fusion/core exec vitest run src/__tests__/settings-parity.test.ts src/__tests__/postgres/schema-applier.test.ts` — 136 passed
- [ ] Full Suite all 4 shards green on main after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated migration validation tests to include the latest task proposal claim migration.
  * Expanded settings parity checks to cover non-default project settings.
  * Added coverage confirming migration ordering and immutable migration identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->