### PR TITLE
fix(dashboard): mock store.getTask for tracking done comments

### DIFF
--- a/packages/dashboard/src/__tests__/github-issue-comment.test.ts
+++ b/packages/dashboard/src/__tests__/github-issue-comment.test.ts
@@ -26,11 +26,20 @@ vi.mock("../github-auth.js", () => ({
 class MockStore extends EventEmitter {
   private settings: Record<string, unknown>;
   logEntry: Mock;
+  /*
+  FNXC:DashboardTests 2026-07-18-12:55:
+  GitHubTrackingCommentService re-reads the authoritative task via store.getTask on done moves
+  so Done comments can include a landing commit that was not yet on the task:moved snapshot.
+  MockStore must implement getTask; returning null keeps the product's snapshot fallback so
+  comment-posting assertions stay deterministic.
+  */
+  getTask: Mock;
 
   constructor(settings: Record<string, unknown>) {
     super();
     this.settings = settings;
     this.logEntry = vi.fn().mockResolvedValue(undefined);
+    this.getTask = vi.fn().mockResolvedValue(null);
   }
 
   async getSettings(): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- Full Suite [29644469846](https://github.com/Runfusion/Fusion/actions/runs/29644469846): shards 1–3 green; shard 4 failed `github-issue-comment` (`this.store.getTask is not a function`).
- Tracking Done comments re-read the task for landing-commit metadata; MockStore now implements `getTask` (null → product snapshot fallback).

## Test plan
- [x] `github-issue-comment.test.ts` — 33 passed
- [ ] Full Suite all 4 shards green on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GitHub issue comment test scaffolding to support task lookups during completion handling.
  * Kept comment-posting assertions deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->