### PR TITLE
fix(dashboard): Settings Memory nav + Loading ready wait

### DIFF
--- a/packages/dashboard/app/components/__tests__/SettingsModal.general.test.tsx
+++ b/packages/dashboard/app/components/__tests__/SettingsModal.general.test.tsx
@@ -838,7 +838,12 @@ describe("SettingsModal", () => {
       );
       expect(initialCallHasDisabled).toBe(true);
 
-      await settingsModalUser.click(screen.getByRole("button", { name: /Memory/ }));
+      /*
+      FNXC:DashboardTests 2026-07-18-13:35:
+      Settings nav also exposes "Memory Backups"; /Memory/ matches both. Use the exact
+      Memory section label so the deferred memory-backend status hook test stays scoped.
+      */
+      await settingsModalUser.click(screen.getByRole("button", { name: "Memory" }));
 
       await waitFor(() => {
         const enabledCallSeen = mockUseMemoryBackendStatus.mock.calls.some(

--- a/packages/dashboard/app/components/__tests__/SettingsModal.test-harness.tsx
+++ b/packages/dashboard/app/components/__tests__/SettingsModal.test-harness.tsx
@@ -142,8 +142,16 @@ export function renderModal(props: Partial<ComponentProps<typeof SettingsModal>>
 }
 
 export async function waitForSettingsModalReady() {
+  /*
+  FNXC:DashboardTests 2026-07-18-13:35:
+  Full Suite shard 4 failed when mockFetchSettings was called but the modal still showed
+  Loading… on the next paint (OAuth incomplete-toast test). Wait for Loading to clear so
+  Authentication/section clicks do not race the initial settings fetch.
+  */
   await waitFor(() => expect(mockFetchSettings).toHaveBeenCalled());
-  expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
 }
 
 export async function renderModalSection(


### PR DESCRIPTION
## Summary
- Full Suite [29645564540](https://github.com/Runfusion/Fusion/actions/runs/29645564540): shards 1–3 green; shard 4 settings suite failed.
- Exact `Memory` nav name (vs `/Memory/` matching **Memory Backups**).
- `waitForSettingsModalReady` waits for Loading… to clear after fetchSettings.

## Test plan
- [x] memory backend status hook test
- [x] Anthropic Subscription OAuth incomplete toast
- [ ] Full Suite all 4 shards green on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved settings modal test synchronization to reliably wait for loading to finish.
  * Refined memory settings navigation checks to target the correct section and avoid ambiguous matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->