### PR TITLE
fix(ci): quarantine CLI lock-retry flakes + settle planning tab-lock

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -101,7 +101,12 @@ const quarantinedCliTests: string[] = [
   /*
   FNXC:CliTests 2026-07-18-07:30:
   FN-8271 rescued the shard-4 cascade after removing unrelated PostgreSQL template-copy and persistent-seeding work from extension-dist-barrel's built-dist hook. All fourteen affected CLI files return to the default lane with their matching quarantine-ledger rows removed; retain normal worker budgets and timeout defaults rather than reintroducing appeasement.
+
+  FNXC:CliTests 2026-07-18-15:20:
+  Full-suite shard 4 after FN-8271 (runs 29648812375 / 29648952207) re-observed mcp-lock-retry and task-lock-retry 5s timeouts under package-lane shard load without product-bug evidence. Quarantine on sight in lockstep with scripts/lib/test-quarantine.json — do not raise testTimeout or fake-timer budgets.
   */
+  "src/commands/__tests__/mcp-lock-retry.test.ts",
+  "src/commands/__tests__/task-lock-retry.test.ts",
 ];
 
 /*

--- a/packages/dashboard/app/components/__tests__/PlanningModeModal.planning-flow.test.tsx
+++ b/packages/dashboard/app/components/__tests__/PlanningModeModal.planning-flow.test.tsx
@@ -524,16 +524,27 @@ describe("PlanningModeModal", () => {
       expect(mockAcquireSessionLock).not.toHaveBeenCalled();
       expect(mockForceAcquireSessionLock).not.toHaveBeenCalled();
 
-      fireEvent.click(screen.getByText("Small"));
-      fireEvent.click(screen.getByText("Continue"));
+      /*
+      FNXC:DashboardTests 2026-07-18-15:20:
+      Full Suite shard 3 (29648952207) observed Small+Continue not reaching respondToPlanning
+      under load (0 calls). Click the option radio by role and wait for checked + respond
+      with the same settle bound as "allows normal question interaction".
+      */
+      const smallOption = screen.getByRole("radio", { name: /Small/i });
+      fireEvent.click(smallOption);
+      await waitFor(() => expect(smallOption).toBeChecked());
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
-      await waitFor(() => {
-        expect(mockRespondToPlanning).toHaveBeenCalledWith(
-          "session-123",
-          { "q-scope": "small" },
-          undefined,
-        );
-      });
+      await waitFor(
+        () => {
+          expect(mockRespondToPlanning).toHaveBeenCalledWith(
+            "session-123",
+            { "q-scope": "small" },
+            undefined,
+          );
+        },
+        { timeout: 3000 },
+      );
     });
 
     it("allows normal question interaction", async () => {

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -1,4 +1,15 @@
 {
-  "$comment": "Flaky-test quarantine ledger (deletion ratchet — see AGENTS.md 'Flaky tests: quarantine on sight' and docs/testing.md 'Quarantine ledger and the deletion ratchet'). A test observed failing without a corresponding real bug is quarantined ON SIGHT: add an entry here AND a matching one-line `exclude` entry in that package's vitest config, in the same commit. Every entry needs a non-empty `reason` (link the failing run) and a `quarantinedAt` date — the entry expires 14 days later, at which point the test file is DELETED unless someone rescues it with evidence it catches real regressions plus a root-cause fix (never appeasement). There is deliberately no loader module and no automation around this file: it is a dated record, the vitest config is the enforcement.",
-  "entries": []
+  "$comment": "Flaky-test quarantine ledger (deletion ratchet \u2014 see AGENTS.md 'Flaky tests: quarantine on sight' and docs/testing.md 'Quarantine ledger and the deletion ratchet'). A test observed failing without a corresponding real bug is quarantined ON SIGHT: add an entry here AND a matching one-line `exclude` entry in that package's vitest config, in the same commit. Every entry needs a non-empty `reason` (link the failing run) and a `quarantinedAt` date \u2014 the entry expires 14 days later, at which point the test file is DELETED unless someone rescues it with evidence it catches real regressions plus a root-cause fix (never appeasement). There is deliberately no loader module and no automation around this file: it is a dated record, the vitest config is the enforcement.",
+  "entries": [
+    {
+      "file": "packages/cli/src/commands/__tests__/mcp-lock-retry.test.ts",
+      "reason": "Full-suite shard 4 after FN-8271 restore (runs 29648812375 / 29648952207): 5s timeouts under package-lane shard load without product-bug evidence; getSettings/close races and timer recovery still load-sensitive. Quarantine on sight per AGENTS.md. Mirrored in packages/cli/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "packages/cli/src/commands/__tests__/task-lock-retry.test.ts",
+      "reason": "Full-suite shard 4 after FN-8271 restore (runs 29648812375 / 29648952207): 5s timeouts / store.getTask not a function under package-lane shard load without product-bug evidence; fake-timer board-write mock recovery remains load-sensitive. Quarantine on sight per AGENTS.md. Mirrored in packages/cli/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Full Suite after FN-8271 restore turned red again ([29648952207](https://github.com/Runfusion/Fusion/actions/runs/29648952207)):
  - **shard 4**: `mcp-lock-retry` / `task-lock-retry` 5s timeouts under package-lane load
  - **shard 3**: planning “never acquires a tab lock…” — `respondToPlanning` never called after Small/Continue
- Re-quarantine the two CLI lock-retry files in ledger + `packages/cli/vitest.config.ts` (no timeout appeasement).
- Planning tab-lock test: select Small via radio role, wait for checked, longer `waitFor` on respond.

## Test plan
- [x] lockstep-cli-quarantine
- [x] planning tab-lock interaction test
- [ ] Full Suite all 4 shards green on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the dashboard planning flow by using more precise controls and bounded waits during automated interactions.

* **Tests**
  * Quarantined two intermittently timing-out CLI integration tests to reduce full-suite instability.
  * Documented the quarantine reasons and tracking details for the affected tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->