### PR TITLE
fix(ci): restore Full Suite bookkeeping after concurrent main landings

### DIFF
--- a/packages/dashboard/app/components/settings/sections/GeneralSection.tsx
+++ b/packages/dashboard/app/components/settings/sections/GeneralSection.tsx
@@ -280,14 +280,20 @@ export function GeneralSection({ form, setForm, projectId, addToast, prefixError
         the four guided report actions can explicitly opt into direct filing.
         Persist overrides as one map so the pipeline resolves them consistently.
         */}
-        <label htmlFor="reportMode">In-app report mode</label>
+        {/*
+        FNXC:ReportPipeline 2026-07-18-12:40:
+        FN-8277 report mode is a plain Settings control; bind help to i18n paths that state the
+        draft-review default and the unset per-action override so settings-default-descriptions stays green.
+        */}
+        <label htmlFor="reportMode">{t("settings.general.reportMode", "In-app report mode")}</label>
         <select id="reportMode" value={form.reportMode ?? "draft-review"} onChange={(e) => setForm((f) => ({ ...f, reportMode: e.target.value as "draft-review" | "auto-file" }))}>
-          <option value="draft-review">Review draft before filing</option>
-          <option value="auto-file">File automatically</option>
+          <option value="draft-review">{t("settings.general.reportModeDraftReview", "Review draft before filing")}</option>
+          <option value="auto-file">{t("settings.general.reportModeAutoFile", "File automatically")}</option>
         </select>
+        <p className="form-help">{t("settings.general.reportModeHelp", "How in-app bug/feedback/idea/help reports are filed. Default: draft-review (operator reviews a draft before filing).")}</p>
         {(["bug", "feedback", "idea", "help"] as const).map((action) => (
           <label key={action} htmlFor={`reportMode-${action}`}>
-            {`${action[0].toUpperCase()}${action.slice(1)} report override`}
+            {t(`settings.general.reportModeOverride.${action}`, `${action[0].toUpperCase()}${action.slice(1)} report override`)}
             <select id={`reportMode-${action}`} value={form.reportModeByAction?.[action] ?? ""} onChange={(e) => setForm((current) => {
               const reportModeByAction = { ...current.reportModeByAction };
               const selected = e.target.value as "" | "draft-review" | "auto-file";
@@ -295,12 +301,13 @@ export function GeneralSection({ form, setForm, projectId, addToast, prefixError
               else delete reportModeByAction[action as ReportActionType];
               return { ...current, reportModeByAction: Object.keys(reportModeByAction).length ? reportModeByAction : undefined };
             })}>
-              <option value="">Use project default</option>
-              <option value="draft-review">Review draft before filing</option>
-              <option value="auto-file">File automatically</option>
+              <option value="">{t("settings.general.reportModeUseProjectDefault", "Use project default")}</option>
+              <option value="draft-review">{t("settings.general.reportModeDraftReview", "Review draft before filing")}</option>
+              <option value="auto-file">{t("settings.general.reportModeAutoFile", "File automatically")}</option>
             </select>
           </label>
         ))}
+        <p className="form-help">{t("settings.general.reportModeByActionHelp", "Optional per-action override of the project report mode for bug, feedback, idea, or help. No default — unset actions inherit reportMode.")}</p>
       </div>
       {/*
         FNXC:SettingsGeneral 2026-07-15-17:35:

--- a/packages/dashboard/app/components/settings/sections/__tests__/settings-default-descriptions.test.tsx
+++ b/packages/dashboard/app/components/settings/sections/__tests__/settings-default-descriptions.test.tsx
@@ -163,6 +163,12 @@ const SETTING_DESCRIPTION_KEYS: Record<string, string> = {
   memoryBackupRetention: "backups.numberOfMemoryBackupsToKeepOldestAre",
   memoryBackupDir: "backups.directoryForMemoryBackupsRelativeToProjectRoot",
   memoryBackupScope: "backups.memoryBackupScopeHint",
+  /*
+  FNXC:EmbeddedPostgres 2026-07-18-12:40:
+  feat(postgres) surfaces embeddedPostgresMaxConnections in DatabaseBackupsSection advanced
+  disclosure; map the existing help string so the DEFAULT_SETTINGS inventory stays complete.
+  */
+  embeddedPostgresMaxConnections: "database.embeddedConnectionCapHelp",
   // MemorySection
   memoryEnabled: "memory.agentsGetMemorySearchMemoryGetAndMemory",
   memoryAutoSummarizeEnabled: "memory.automaticallyCompactMemoryWhenItExceedsTheThreshold",
@@ -255,6 +261,14 @@ const SETTING_DESCRIPTION_KEYS: Record<string, string> = {
   // GeneralSection beside the other import-scoped GitHub settings.
   githubImportAutoTranslate: "general.autoTranslateImportedIssuesHelp",
   importTranslateTargetLocale: "general.translationTargetLanguageHelp",
+  /*
+  FNXC:ReportPipeline 2026-07-18-12:40:
+  FN-8277 surfaces reportMode + per-action overrides in GeneralSection; map them here so
+  DEFAULT_SETTINGS bookkeeping requires a default-stating description (draft-review project default;
+  reportModeByAction is unset until an action opts in).
+  */
+  reportMode: "general.reportModeHelp",
+  reportModeByAction: "general.reportModeByActionHelp",
   githubTrackingDedupEnabled: "general.whenEnabledFusionChecksOpenAndClosedIssues",
   githubTrackingEnabledByDefault: "general.offDefault",
   sessionAdvisorEnabledByDefault: "general.offDefault",

--- a/packages/engine/src/__tests__/executor-prompt.test.ts
+++ b/packages/engine/src/__tests__/executor-prompt.test.ts
@@ -2647,7 +2647,14 @@ describe("fn_task_update bare-call guard (P1 api-contract)", () => {
     expect(text).not.toContain("fn_task_update requires at least one of");
   });
 
-  it("narrates a store-accepted skipped transition exactly once", async () => {
+  it("accepts a store-accepted skipped transition without tool-side agent-log narration", async () => {
+    /*
+    FNXC:ProactiveChatStatus 2026-07-18-12:40:
+    FN-8064 moved step start/success/skip narration into TaskStore.updateStep (merge-queue-ops)
+    so workflow projection, review auto-approval, and self-healing share the same chat rows.
+    fn_task_update only reports progress text; appendAgentLog is store-owned when
+    proactiveTaskChatEnabled is true. Covered by packages/core proactive-step-status.pg.test.ts.
+    */
     const { store, tool } = makeTool();
     store.updateStep.mockResolvedValue(createMockTaskDetail({
       steps: [{ name: "No code change needed", status: "skipped", dependsOn: [] }],
@@ -2656,14 +2663,10 @@ describe("fn_task_update bare-call guard (P1 api-contract)", () => {
     const result = await tool.execute("call-1", { step: 0, status: "skipped" });
 
     expect(result.isError).not.toBe(true);
-    expect(store.appendAgentLog).toHaveBeenCalledTimes(1);
-    expect(store.appendAgentLog).toHaveBeenCalledWith(
-      "FN-001",
-      "Step 0 was skipped — No code change needed.",
-      "status",
-      undefined,
-      "executor",
-    );
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("Step 0");
+    expect(text).toContain("skipped");
+    expect(store.appendAgentLog).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/engine/src/__tests__/gating-classifications.test.ts
+++ b/packages/engine/src/__tests__/gating-classifications.test.ts
@@ -144,6 +144,8 @@ describe("gating-classifications parity", () => {
         "fn_memory_append",
         "fn_memory_get",
         "fn_memory_search",
+        "fn_mission_list",
+        "fn_mission_show",
         "fn_post_room_message",
         "fn_read_evaluations",
         "fn_read_messages",

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -3272,10 +3272,13 @@ describe("executeHeartbeat", () => {
       /*
       FNXC:TaskAgentLog 2026-07-16-08:05:
       Heartbeat customTools include FN-8058 fn_task_logs_read after fn_task_log so durable agents can read agent-log.jsonl. Count stays exact so new tools fail loudly.
+
+      FNXC:MissionToolParity 2026-07-18-12:40:
+      FN-8294 adds the full Mission hierarchy surface (15 tools) to task-scoped heartbeat sessions via createMissionTools, after agent provisioning and before goal retrieval. Count rose 43→58; keep exact so new tools fail loudly.
       */
-      // fn_artifact_register/list/view, agent config/provisioning, goals/evaluations/identity,
+      // fn_artifact_register/list/view, agent config/provisioning, mission hierarchy, goals/evaluations/identity,
       // task read discovery (incl. logs_read), workflow discovery/authoring, task promotion, bounded research, clarification, web fetch, memory, and fn_heartbeat_done.
-      expect(callArgs.customTools).toHaveLength(43);
+      expect(callArgs.customTools).toHaveLength(58);
       expect(callArgs.customTools!.map((tool) => tool.name)).toEqual([
         "fn_task_create",
         "fn_task_log",
@@ -3292,6 +3295,21 @@ describe("executeHeartbeat", () => {
         "fn_update_agent_config",
         "fn_agent_create",
         "fn_agent_delete",
+        "fn_mission_list",
+        "fn_mission_show",
+        "fn_mission_create",
+        "fn_mission_update",
+        "fn_mission_delete",
+        "fn_milestone_add",
+        "fn_milestone_update",
+        "fn_milestone_delete",
+        "fn_slice_add",
+        "fn_slice_activate",
+        "fn_slice_delete",
+        "fn_feature_add",
+        "fn_feature_update",
+        "fn_feature_delete",
+        "fn_feature_link_task",
         "fn_goal_list",
         "fn_goal_show",
         "fn_read_evaluations",

--- a/packages/i18n/locales/en/app.json
+++ b/packages/i18n/locales/en/app.json
@@ -5963,7 +5963,9 @@
       "disabledFusionWorkflowsAreHiddenFromWorkflow": "Disabled Fusion workflows are hidden from workflow pickers. Existing tasks that already use one continue to resolve. Default: all built-in workflows enabled (unset).",
       "aiUndoTaskWorkflow": "AI-undo task workflow",
       "aiUndoTaskWorkflowInherit": "Inherit project default workflow",
-      "aiUndoTaskWorkflowHelp": "Workflow assigned to AI-undo (revert) tasks, which reverse already-shipped code and warrant stricter review. Choose \"Inherit project default workflow\" to leave them on the project default. Default: review-heavy."
+      "aiUndoTaskWorkflowHelp": "Workflow assigned to AI-undo (revert) tasks, which reverse already-shipped code and warrant stricter review. Choose \"Inherit project default workflow\" to leave them on the project default. Default: review-heavy.",
+      "reportModeHelp": "How in-app bug/feedback/idea/help reports are filed. Default: draft-review (operator reviews a draft before filing).",
+      "reportModeByActionHelp": "Optional per-action override of the project report mode for bug, feedback, idea, or help. No default — unset actions inherit reportMode."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": " and shows update notices in the CLI and dashboard. Cadence is governed by the frequency below. Default: enabled. ",
@@ -6815,6 +6817,12 @@
       "resetAllProjectAction": "Reset all project settings",
       "menuResetSuccess": "{{section}} settings reset to defaults",
       "allProjectResetSuccess": "All project settings reset to defaults"
+    },
+    "database": {
+      "embeddedConnectionCapHelp": "Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Default: 500. External PostgreSQL uses its provider's connection limit.",
+      "embeddedConnectionCap": "Embedded PostgreSQL connection cap",
+      "embeddedConnectionCapError": "Enter a value between 32 and 2,000.",
+      "advanced": "Advanced database settings"
     }
   },
   "setup": {

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -1580,6 +1580,43 @@
       },
       "title": ""
     },
+    "portability": {
+      "title": "Exportación / importación de organización",
+      "description": "Descarga o previsualiza un paquete de organización sin secretos.",
+      "export": {
+        "action": "Exportar paquete de organización",
+        "working": "Exportando…",
+        "success": "Exportación lista",
+        "error": "Error al exportar"
+      },
+      "import": {
+        "label": "JSON del paquete de organización",
+        "placeholder": "Pega un paquete de organización sin secretos",
+        "preview": "Vista previa de importación",
+        "previewing": "Generando vista previa…",
+        "previewReady": "Vista previa lista. Confirma para aplicar este paquete.",
+        "apply": "Aplicar importación",
+        "importing": "Importando…",
+        "invalid": "Pega un documento JSON de paquete de organización válido",
+        "error": "No se pudo previsualizar o importar el paquete",
+        "confirmTitle": "¿Importar paquete de organización?",
+        "confirmMessage": "Esto aplica la configuración previsualizada a este proyecto.",
+        "confirmApply": "Importar paquete"
+      },
+      "versions": {
+        "title": "Versiones de configuración",
+        "description": "Restaura cualquier versión de configuración del proyecto registrada.",
+        "loading": "Cargando versiones…",
+        "empty": "Aún no hay versiones de configuración.",
+        "loadError": "No se pudieron cargar las versiones de configuración",
+        "rollback": "Revertir",
+        "rollingBack": "Revirtiendo…",
+        "rollbackError": "No se pudo revertir la configuración",
+        "confirmTitle": "¿Revertir la configuración?",
+        "confirmMessage": "¿Restaurar esta versión? La reversión se registra como una nueva versión.",
+        "confirmRollback": "Revertir"
+      }
+    },
     "ecosystem": {
       "breadthTitle": "",
       "empty": "",
@@ -5902,7 +5939,9 @@
       "ephemeralAgentTaskCreationPolicyHint": "Sin valor predeterminado — si no se define, se usa Permitir. «Tras validación» envía una propuesta a tu buzón para aprobar con un clic; Denegar rechaza la creación de tareas de seguimiento.",
       "ephemeralAgentTaskCreationPolicyAllow": "Permitir",
       "ephemeralAgentTaskCreationPolicyUponValidation": "Tras validación",
-      "ephemeralAgentTaskCreationPolicyDeny": "Denegar"
+      "ephemeralAgentTaskCreationPolicyDeny": "Denegar",
+      "reportModeHelp": "Cómo se archivan los informes in-app (error, feedback, idea, ayuda). Predeterminado: draft-review (el operador revisa un borrador antes de archivar).",
+      "reportModeByActionHelp": "Anulación opcional por acción del modo de informe del proyecto (error, feedback, idea o ayuda). Sin valor predeterminado: las acciones no definidas heredan reportMode."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6768,6 +6807,12 @@
       "resetAllProjectAction": "",
       "menuResetSuccess": "",
       "allProjectResetSuccess": ""
+    },
+    "database": {
+      "embeddedConnectionCapHelp": "Máximo de conexiones de servidor para el PostgreSQL integrado de Fusion. Se aplica al reiniciar Fusion. Rango: 32–2.000. Predeterminado: 500. PostgreSQL externo usa el límite de su proveedor.",
+      "embeddedConnectionCap": "Límite de conexiones de PostgreSQL integrado",
+      "embeddedConnectionCapError": "Introduce un valor entre 32 y 2.000.",
+      "advanced": "Ajustes avanzados de base de datos"
     }
   },
   "setup": {

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -1580,6 +1580,43 @@
       },
       "title": ""
     },
+    "portability": {
+      "title": "Export / import d'organisation",
+      "description": "Téléchargez ou prévisualisez un bundle d'organisation expurgé des secrets.",
+      "export": {
+        "action": "Exporter le bundle d'organisation",
+        "working": "Export en cours…",
+        "success": "Export prêt",
+        "error": "Échec de l'export"
+      },
+      "import": {
+        "label": "JSON du bundle d'organisation",
+        "placeholder": "Collez un bundle d'organisation expurgé des secrets",
+        "preview": "Prévisualiser l'import",
+        "previewing": "Prévisualisation…",
+        "previewReady": "Aperçu prêt. Confirmez pour appliquer ce bundle.",
+        "apply": "Appliquer l'import",
+        "importing": "Import en cours…",
+        "invalid": "Collez un document JSON de bundle d'organisation valide",
+        "error": "Impossible de prévisualiser ou d'importer le bundle",
+        "confirmTitle": "Importer le bundle d'organisation ?",
+        "confirmMessage": "Cela applique la configuration prévisualisée à ce projet.",
+        "confirmApply": "Importer le bundle"
+      },
+      "versions": {
+        "title": "Versions de configuration",
+        "description": "Restaurez n'importe quelle version de configuration de projet enregistrée.",
+        "loading": "Chargement des versions…",
+        "empty": "Aucune version de configuration pour l'instant.",
+        "loadError": "Impossible de charger les versions de configuration",
+        "rollback": "Revenir en arrière",
+        "rollingBack": "Retour en cours…",
+        "rollbackError": "Impossible de revenir en arrière sur la configuration",
+        "confirmTitle": "Revenir à une configuration antérieure ?",
+        "confirmMessage": "Restaurer cette version ? Le retour est enregistré comme une nouvelle version.",
+        "confirmRollback": "Revenir en arrière"
+      }
+    },
     "ecosystem": {
       "breadthTitle": "",
       "empty": "",
@@ -5902,7 +5939,9 @@
       "ephemeralAgentTaskCreationPolicyHint": "Pas de valeur par défaut — non défini revient à Autoriser. « Sur validation » envoie une proposition à votre boîte pour une approbation en un clic ; Refuser bloque la création de tâches de suivi.",
       "ephemeralAgentTaskCreationPolicyAllow": "Autoriser",
       "ephemeralAgentTaskCreationPolicyUponValidation": "Sur validation",
-      "ephemeralAgentTaskCreationPolicyDeny": "Refuser"
+      "ephemeralAgentTaskCreationPolicyDeny": "Refuser",
+      "reportModeHelp": "Comment les rapports in-app (bug, feedback, idée, aide) sont déposés. Par défaut : draft-review (l'opérateur revoit un brouillon avant dépôt).",
+      "reportModeByActionHelp": "Surcharge optionnelle par action du mode de rapport du projet (bug, feedback, idée ou aide). Aucune valeur par défaut — les actions non définies héritent de reportMode."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6768,6 +6807,12 @@
       "resetAllProjectAction": "",
       "menuResetSuccess": "",
       "allProjectResetSuccess": ""
+    },
+    "database": {
+      "embeddedConnectionCapHelp": "Nombre maximal de connexions serveur pour le PostgreSQL embarqué de Fusion. Appliqué après redémarrage de Fusion. Plage : 32–2 000. Par défaut : 500. PostgreSQL externe utilise la limite de son fournisseur.",
+      "embeddedConnectionCap": "Plafond de connexions PostgreSQL embarqué",
+      "embeddedConnectionCapError": "Saisissez une valeur entre 32 et 2 000.",
+      "advanced": "Paramètres de base de données avancés"
     }
   },
   "setup": {

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -1580,6 +1580,43 @@
       },
       "title": ""
     },
+    "portability": {
+      "title": "조직 내보내기 / 가져오기",
+      "description": "비밀이 제거된 조직 번들을 다운로드하거나 미리 봅니다.",
+      "export": {
+        "action": "조직 번들 내보내기",
+        "working": "내보내는 중…",
+        "success": "내보내기 준비됨",
+        "error": "내보내기 실패"
+      },
+      "import": {
+        "label": "조직 번들 JSON",
+        "placeholder": "비밀이 제거된 조직 번들을 붙여넣으세요",
+        "preview": "가져오기 미리보기",
+        "previewing": "미리보는 중…",
+        "previewReady": "미리보기가 준비되었습니다. 이 번들을 적용하려면 확인하세요.",
+        "apply": "가져오기 적용",
+        "importing": "가져오는 중…",
+        "invalid": "유효한 조직 번들 JSON 문서를 붙여넣으세요",
+        "error": "번들을 미리보거나 가져올 수 없습니다",
+        "confirmTitle": "조직 번들을 가져올까요?",
+        "confirmMessage": "미리본 구성을 이 프로젝트에 적용합니다.",
+        "confirmApply": "번들 가져오기"
+      },
+      "versions": {
+        "title": "구성 버전",
+        "description": "기록된 프로젝트 구성 버전을 복원합니다.",
+        "loading": "버전 불러오는 중…",
+        "empty": "아직 구성 버전이 없습니다.",
+        "loadError": "구성 버전을 불러올 수 없습니다",
+        "rollback": "롤백",
+        "rollingBack": "롤백 중…",
+        "rollbackError": "구성을 롤백할 수 없습니다",
+        "confirmTitle": "구성을 롤백할까요?",
+        "confirmMessage": "이 버전을 복원할까요? 롤백은 새 버전으로 기록됩니다.",
+        "confirmRollback": "롤백"
+      }
+    },
     "ecosystem": {
       "breadthTitle": "",
       "empty": "",
@@ -5902,7 +5939,9 @@
       "ephemeralAgentTaskCreationPolicyHint": "기본값 없음 — 미설정 시 허용으로 폴백합니다. 검증 후는 받은편지함으로 제안을 보내 원클릭 승인합니다. 거부는 후속 작업 생성을 거부합니다.",
       "ephemeralAgentTaskCreationPolicyAllow": "허용",
       "ephemeralAgentTaskCreationPolicyUponValidation": "검증 후",
-      "ephemeralAgentTaskCreationPolicyDeny": "거부"
+      "ephemeralAgentTaskCreationPolicyDeny": "거부",
+      "reportModeHelp": "인앱 버그/피드백/아이디어/도움말 리포트 제출 방식. 기본값: draft-review(제출 전 운영자가 초안 검토).",
+      "reportModeByActionHelp": "버그·피드백·아이디어·도움말 등 작업별 프로젝트 리포트 모드 선택 재정의. 기본값 없음 — 미설정 작업은 reportMode를 상속합니다."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6768,6 +6807,12 @@
       "resetAllProjectAction": "",
       "menuResetSuccess": "",
       "allProjectResetSuccess": ""
+    },
+    "database": {
+      "embeddedConnectionCapHelp": "Fusion 내장 PostgreSQL의 최대 서버 연결 수. Fusion 재시작 후 적용. 범위: 32–2,000. 기본값: 500. 외부 PostgreSQL은 제공자 연결 한도를 사용합니다.",
+      "embeddedConnectionCap": "내장 PostgreSQL 연결 상한",
+      "embeddedConnectionCapError": "32에서 2,000 사이의 값을 입력하세요.",
+      "advanced": "고급 데이터베이스 설정"
     }
   },
   "setup": {

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -1580,6 +1580,43 @@
       },
       "title": ""
     },
+    "portability": {
+      "title": "组织导出 / 导入",
+      "description": "下载或预览已清除机密的组织配置包。",
+      "export": {
+        "action": "导出组织包",
+        "working": "正在导出…",
+        "success": "导出就绪",
+        "error": "导出失败"
+      },
+      "import": {
+        "label": "组织包 JSON",
+        "placeholder": "粘贴已清除机密的组织包",
+        "preview": "预览导入",
+        "previewing": "正在预览…",
+        "previewReady": "预览就绪。确认后应用此包。",
+        "apply": "应用导入",
+        "importing": "正在导入…",
+        "invalid": "请粘贴有效的组织包 JSON 文档",
+        "error": "无法预览或导入包",
+        "confirmTitle": "导入组织包？",
+        "confirmMessage": "这会将预览的配置应用到此项目。",
+        "confirmApply": "导入包"
+      },
+      "versions": {
+        "title": "配置版本",
+        "description": "恢复任意已记录的项目配置版本。",
+        "loading": "正在加载版本…",
+        "empty": "尚无配置版本。",
+        "loadError": "无法加载配置版本",
+        "rollback": "回滚",
+        "rollingBack": "正在回滚…",
+        "rollbackError": "无法回滚配置",
+        "confirmTitle": "回滚配置？",
+        "confirmMessage": "恢复此版本？回滚会记录为新版本。",
+        "confirmRollback": "回滚"
+      }
+    },
     "ecosystem": {
       "breadthTitle": "",
       "empty": "",
@@ -5902,7 +5939,9 @@
       "ephemeralAgentTaskCreationPolicyHint": "无默认值 — 未设置时回退为允许。需验证会将提案发送到邮箱供一键批准；拒绝则禁止创建后续任务。",
       "ephemeralAgentTaskCreationPolicyAllow": "允许",
       "ephemeralAgentTaskCreationPolicyUponValidation": "需验证",
-      "ephemeralAgentTaskCreationPolicyDeny": "拒绝"
+      "ephemeralAgentTaskCreationPolicyDeny": "拒绝",
+      "reportModeHelp": "应用内缺陷/反馈/想法/帮助报告的提交方式。默认：draft-review（提交前由操作者审阅草稿）。",
+      "reportModeByActionHelp": "可选的按操作覆盖项目报告模式（缺陷、反馈、想法或帮助）。无默认值 — 未设置的操作继承 reportMode。"
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6768,6 +6807,12 @@
     },
     "modelPricing": {
       "description": ""
+    },
+    "database": {
+      "embeddedConnectionCapHelp": "Fusion 嵌入式 PostgreSQL 的最大服务器连接数。重启 Fusion 后生效。范围：32–2,000。默认：500。外部 PostgreSQL 使用其提供方的连接限制。",
+      "embeddedConnectionCap": "嵌入式 PostgreSQL 连接上限",
+      "embeddedConnectionCapError": "请输入 32 到 2,000 之间的值。",
+      "advanced": "高级数据库设置"
     }
   },
   "setup": {

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -1580,6 +1580,43 @@
       },
       "title": ""
     },
+    "portability": {
+      "title": "組織匯出 / 匯入",
+      "description": "下載或預覽已清除機密的組織設定包。",
+      "export": {
+        "action": "匯出組織包",
+        "working": "正在匯出…",
+        "success": "匯出就緒",
+        "error": "匯出失敗"
+      },
+      "import": {
+        "label": "組織包 JSON",
+        "placeholder": "貼上已清除機密的組織包",
+        "preview": "預覽匯入",
+        "previewing": "正在預覽…",
+        "previewReady": "預覽就緒。確認後套用此包。",
+        "apply": "套用匯入",
+        "importing": "正在匯入…",
+        "invalid": "請貼上有效的組織包 JSON 文件",
+        "error": "無法預覽或匯入包",
+        "confirmTitle": "匯入組織包？",
+        "confirmMessage": "這會將預覽的設定套用到此專案。",
+        "confirmApply": "匯入包"
+      },
+      "versions": {
+        "title": "設定版本",
+        "description": "還原任意已記錄的專案設定版本。",
+        "loading": "正在載入版本…",
+        "empty": "尚無設定版本。",
+        "loadError": "無法載入設定版本",
+        "rollback": "回滾",
+        "rollingBack": "正在回滾…",
+        "rollbackError": "無法回滾設定",
+        "confirmTitle": "回滾設定？",
+        "confirmMessage": "還原此版本？回滾會記錄為新版本。",
+        "confirmRollback": "回滾"
+      }
+    },
     "ecosystem": {
       "breadthTitle": "",
       "empty": "",
@@ -5902,7 +5939,9 @@
       "ephemeralAgentTaskCreationPolicyHint": "無預設值 — 未設定時回退為允許。需驗證會將提案傳送到信箱供一鍵核准；拒絕則禁止建立後續任務。",
       "ephemeralAgentTaskCreationPolicyAllow": "允許",
       "ephemeralAgentTaskCreationPolicyUponValidation": "需驗證",
-      "ephemeralAgentTaskCreationPolicyDeny": "拒絕"
+      "ephemeralAgentTaskCreationPolicyDeny": "拒絕",
+      "reportModeHelp": "應用內缺陷/回饋/想法/說明報告的提交方式。預設：draft-review（提交前由操作者審閱草稿）。",
+      "reportModeByActionHelp": "可選的依操作覆寫專案報告模式（缺陷、回饋、想法或說明）。無預設值 — 未設定的操作繼承 reportMode。"
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6768,6 +6807,12 @@
       "resetAllProjectAction": "",
       "menuResetSuccess": "",
       "allProjectResetSuccess": ""
+    },
+    "database": {
+      "embeddedConnectionCapHelp": "Fusion 內嵌 PostgreSQL 的最大伺服器連線數。重新啟動 Fusion 後生效。範圍：32–2,000。預設：500。外部 PostgreSQL 使用其提供者的連線限制。",
+      "embeddedConnectionCap": "內嵌 PostgreSQL 連線上限",
+      "embeddedConnectionCapError": "請輸入 32 到 2,000 之間的值。",
+      "advanced": "進階資料庫設定"
     }
   },
   "setup": {

--- a/plugins/fusion-plugin-quality/vitest.config.ts
+++ b/plugins/fusion-plugin-quality/vitest.config.ts
@@ -31,7 +31,8 @@ export default defineConfig({
   },
   test: {
     include: ["src/**/*.test.{ts,tsx}"],
-    exclude: ["**/node_modules/**", "**/dist/**"],
+    // Quarantine ledger: scripts/lib/test-quarantine.json — async-quality-store.pg.test.ts (2026-07-18).
+    exclude: ["**/node_modules/**", "**/dist/**", "src/__tests__/async-quality-store.pg.test.ts"],
     environment: "node",
     setupFiles: [fileURLToPath(new URL("../../packages/core/src/__test-utils__/vitest-setup.ts", import.meta.url))],
     globalSetup: [fileURLToPath(new URL("../../packages/core/src/__test-utils__/vitest-teardown.ts", import.meta.url))],

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -10,6 +10,11 @@
       "file": "packages/cli/src/commands/__tests__/task-lock-retry.test.ts",
       "reason": "Full-suite shard 4 after FN-8271 restore (runs 29648812375 / 29648952207): 5s timeouts / store.getTask not a function under package-lane shard load without product-bug evidence; fake-timer board-write mock recovery remains load-sensitive. Quarantine on sight per AGENTS.md. Mirrored in packages/cli/vitest.config.ts.",
       "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "plugins/fusion-plugin-quality/src/__tests__/async-quality-store.pg.test.ts",
+      "reason": "Full-suite shard 3 (run 29657633544): 5s timeout + leftover psql child under package-lane load without product-bug evidence; embedded-PG lifecycle remains load-sensitive. Quarantine on sight per AGENTS.md. Mirrored in plugins/fusion-plugin-quality/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Align heartbeat `customTools` expectations with FN-8294 mission hierarchy tools (43→58).
- Refresh `COORDINATION_EXEMPT_TOOLS` snapshot for `fn_mission_list` / `fn_mission_show`.
- Backfill `commandCenter.portability.*` for non-en locales and map `reportMode` / `reportModeByAction` / `embeddedPostgresMaxConnections` into settings default-description inventory with i18n help text.
- Realign FN-8064 skip-narration unit test with store-owned proactive chat (no tool-side `appendAgentLog`).
- Quarantine load-sensitive `async-quality-store.pg.test.ts` (5s timeout + leftover psql under full-suite shard load; run 29657633544).

## Test plan
- [x] `pnpm --filter @fusion/engine exec vitest run` gating-classifications + executor-prompt + heartbeat expected-tools case
- [x] `pnpm --filter @fusion/i18n exec vitest run` i18n-gate-coverage + parity
- [x] `pnpm --filter @fusion/dashboard exec vitest run` settings-default-descriptions
- [ ] Full Suite all 4 shards green on main after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Settings**
  * Added clearer, localized help text for report modes and per-action overrides, including inheritance behavior.
  * Added advanced embedded database connection-limit settings and validation guidance.

* **Localization**
  * Expanded translations for report settings, database tuning, and organization configuration import/export workflows across supported languages.

* **Tests & Maintenance**
  * Updated test coverage and expectations for expanded tools and reporting behavior.
  * Quarantined a flaky database-related test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->