### PR TITLE
fix(ci): index embedded Postgres cap and mock portability API in CC controls

### DIFF
--- a/packages/dashboard/app/components/command-center/__tests__/CommandCenterControls.test.tsx
+++ b/packages/dashboard/app/components/command-center/__tests__/CommandCenterControls.test.tsx
@@ -16,6 +16,15 @@ const legacyMocks = vi.hoisted(() => ({
   updateSettings: vi.fn(),
   fetchGlobalConcurrency: vi.fn(),
   updateGlobalConcurrency: vi.fn(),
+  /*
+  FNXC:OrgPortability 2026-07-18-13:05:
+  FN-8284 mounts OrgPortabilityControls inside CommandCenterControls; that card imports
+  withProjectId + api from legacy. Partial mocks must re-export both or every controls
+  suite fails with "No withProjectId export".
+  */
+  api: vi.fn().mockResolvedValue({ revisions: [] }),
+  withProjectId: (path: string, projectId?: string) =>
+    projectId ? `${path}?projectId=${projectId}` : path,
 }));
 
 vi.mock("../../../api/legacy", () => legacyMocks);

--- a/packages/dashboard/app/components/settings/sections/DatabaseBackupsSection.search.ts
+++ b/packages/dashboard/app/components/settings/sections/DatabaseBackupsSection.search.ts
@@ -48,4 +48,19 @@ export const databaseBackupsSearchEntries: SettingsSearchEntry[] = [
       "Directory for backup files, relative to project root. Default: .fusion/backups.",
     keywords: ["location", "folder", "destination"],
   },
+  /*
+  FNXC:EmbeddedPostgres 2026-07-18-13:05:
+  feat(postgres) adds embeddedPostgresMaxConnections under Advanced database settings.
+  Index it so Settings search can find the connection cap beside the other backup controls.
+  */
+  {
+    sectionId: "backups-global",
+    key: "embeddedPostgresMaxConnections",
+    labelKey: "settings.database.embeddedConnectionCap",
+    labelFallback: "Embedded PostgreSQL connection cap",
+    helpKey: "settings.database.embeddedConnectionCapHelp",
+    helpFallback:
+      "Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Default: 500. External PostgreSQL uses its provider's connection limit.",
+    keywords: ["postgres", "postgresql", "connections", "embedded", "cap", "database"],
+  },
 ];


### PR DESCRIPTION
## Summary
- Index `embeddedPostgresMaxConnections` in Settings search (backups-global).
- Export `withProjectId` + `api` from `CommandCenterControls` legacy mock so FN-8284 portability card can mount under the controls suite.

## Test plan
- [x] CommandCenterControls + settings-search-index tests green locally
- [ ] Full Suite all 4 shards green on main after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the embedded PostgreSQL maximum connections setting to Settings search, with relevant labels, help text, and keywords.

* **Tests**
  * Improved test coverage setup for controls that use project-specific API paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->