### PR TITLE
fix(ci): sync TaskDetail lucide mock and ideation schema bookkeeping

### DIFF
--- a/packages/core/src/__tests__/postgres/schema-applier.test.ts
+++ b/packages/core/src/__tests__/postgres/schema-applier.test.ts
@@ -47,6 +47,7 @@ import {
   IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
   TASK_PROPOSAL_CLAIM_VERSION,
   CONFIGURATION_REVISIONS_VERSION,
+  IDEATION_SCHEMA_VERSION,
   OWNER_PROJECT_ID_SPLIT_VERSION,
   /*
   FNXC:PostgresSchema 2026-07-16-08:00:
@@ -519,7 +520,7 @@ pgDescribe("schema-applier: VAL-SCHEMA-001 final-schema parity (table counts)", 
     ctx = null;
   });
 
-  it("creates all 91 project tables, 18 central tables, 1 archive table", async () => {
+  it("creates all 93 project tables, 18 central tables, 1 archive table", async () => {
     ctx = await setupFreshDb();
     // FNXC:PostgresCutover 2026-07-05-15:55: apply the BASELINE only.
     // applySchemaBaseline now runs the plugin schema-init hooks by default,
@@ -536,9 +537,10 @@ pgDescribe("schema-applier: VAL-SCHEMA-001 final-schema parity (table counts)", 
     const bySchema = Object.fromEntries(rows.map((r) => [r.table_schema, r.n]));
     // Project: 87 typed core tables + 2 lossless legacy preservation tables
     // + 1 import_translation_cache (FNXC:GitHubImportTranslate 2026-07-15-09:30)
-    // + 1 configuration_revisions (FNXC:ConfigVersioning 2026-07-18-14:00).
+    // + 1 configuration_revisions (FNXC:ConfigVersioning 2026-07-18-14:00)
+    // + 2 ideation_sessions/ideation_candidates (FNXC:Ideation 2026-07-18-13:25 / FN-8295).
     // Plugin tables are added separately by the hook.
-    expect(bySchema.project).toBe(91);
+    expect(bySchema.project).toBe(93);
     expect(bySchema.central).toBe(18);
     expect(bySchema.archive).toBe(1);
   });
@@ -1073,6 +1075,15 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       );
       /* FNXC:GitHubImportTranslate 2026-07-16-23:30: Later durable-task migrations run after this historical 0000 fixture, so retain their required task table surface. */
       CREATE TABLE project.tasks (id text PRIMARY KEY);
+      /*
+      FNXC:Ideation 2026-07-18-13:25:
+      FN-8295 migration 0022 FKs ideation rows to missions/mission_features on (project_id, id).
+      A historical 0000 fixture must retain those parent tables so 0006 can rewrite their PKs to
+      composite ownership before 0022 attaches FKs; otherwise upgrade-from-0000 tests fail with
+      missing relation project.missions.
+      */
+      CREATE TABLE project.missions (id text PRIMARY KEY);
+      CREATE TABLE project.mission_features (id text PRIMARY KEY);
       CREATE TABLE project.automations (
         id text PRIMARY KEY,
         name text NOT NULL,
@@ -1154,6 +1165,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
+      IDEATION_SCHEMA_VERSION,
     ]);
     expect((await applySchemaBaseline(ctx.db, { pluginHooks: [] })).applied).toBe(false);
   });
@@ -1201,6 +1213,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
+      IDEATION_SCHEMA_VERSION,
     ]);
   });
 
@@ -1337,6 +1350,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
+      IDEATION_SCHEMA_VERSION,
     ]);
   });
 
@@ -1398,6 +1412,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
+      IDEATION_SCHEMA_VERSION,
     ]);
   });
 
@@ -1459,6 +1474,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       IMPORT_TRANSLATION_CACHE_LEGACY_PARTITION_BACKFILL_VERSION,
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
+      IDEATION_SCHEMA_VERSION,
     ]);
   });
 });

--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.mock-coverage.test.ts
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.mock-coverage.test.ts
@@ -18,5 +18,9 @@ describe("TaskDetailModal lucide mock coverage", () => {
     expect(lucideMock.Pencil).toBeDefined();
     expect(lucideMock.Workflow).toBeDefined();
     expect(lucideMock.X).toBeDefined();
+    // FN-8286 ArtifactsGallery / TaskReviewTab icons
+    expect(lucideMock.Image).toBeDefined();
+    expect(lucideMock.FileText).toBeDefined();
+    expect(lucideMock.User).toBeDefined();
   });
 });

--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.test-helpers.ts
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.test-helpers.ts
@@ -148,6 +148,20 @@ vi.mock("lucide-react", () => ({
   // FN-7582's copy change) — keep this list in sync with the node-editor icon set.
   HelpCircle: () => null,
   DoorOpen: () => null,
+  /*
+  FNXC:ReviewArtifacts 2026-07-18-13:25:
+  FN-8286 mounts ArtifactsGallery + TaskReviewTab from TaskDetailModal. Their lucide imports
+  (Image/FileText/FileType/Video/AudioLines/Package/Download/User) must stay on this shared mock
+  or every focused TaskDetailModal suite fails at import with missing lucide exports.
+  */
+  Image: (props: any) => React.createElement("svg", { "data-testid": "image-icon", ...props }),
+  FileText: (props: any) => React.createElement("svg", { "data-testid": "file-text-icon", ...props }),
+  FileType: (props: any) => React.createElement("svg", { "data-testid": "file-type-icon", ...props }),
+  Video: (props: any) => React.createElement("svg", { "data-testid": "video-icon", ...props }),
+  AudioLines: (props: any) => React.createElement("svg", { "data-testid": "audio-lines-icon", ...props }),
+  Package: (props: any) => React.createElement("svg", { "data-testid": "package-icon", ...props }),
+  Download: (props: any) => React.createElement("svg", { "data-testid": "download-icon", ...props }),
+  User: (props: any) => React.createElement("svg", { "data-testid": "user-icon", ...props }),
 }));
 
 vi.mock("../../hooks/useAgentLogs", () => ({


### PR DESCRIPTION
## Summary
- Extend shared TaskDetailModal lucide mock for FN-8286 ArtifactsGallery/TaskReviewTab icons.
- Update schema-applier bookkeeping for FN-8295 ideation (93 project tables, version 0022).
- Seed historical 0000 upgrade fixtures with missions/mission_features stubs so ideation FKs apply after ownership rewrite.

## Test plan
- [x] TaskDetail modal suites + mock-coverage green locally
- [x] Full schema-applier suite (59 tests) green locally
- [ ] Full Suite all 4 shards green on main after merge