### PR TITLE
fix(ci): ideation heartbeat tools, review-artifact i18n, tab-persist quarantine

### DIFF
--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -346,6 +346,13 @@ const quarantinedDashboardTests: string[] = [
   async-store or applicable mock/non-store contracts. Remove their ledger/exclude
   pairs so dashboard-api-quality-backfill collects the restored coverage.
   */
+  /*
+  FNXC:DashboardTestQuarantine 2026-07-18-14:05:
+  Full-suite shard 2 (run 29660321240): Terminal-guard tab settle race under
+  dashboard-app-quality-backfill load; passes focused thrice with no product bug.
+  Quarantine on sight — mirrored in scripts/lib/test-quarantine.json.
+  */
+  "app/components/__tests__/TaskDetailModal.tab-persistence.test.tsx",
 ];
 
 const qualityApiTests = [

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -3275,10 +3275,13 @@ describe("executeHeartbeat", () => {
 
       FNXC:MissionToolParity 2026-07-18-12:40:
       FN-8294 adds the full Mission hierarchy surface (15 tools) to task-scoped heartbeat sessions via createMissionTools, after agent provisioning and before goal retrieval. Count rose 43→58; keep exact so new tools fail loudly.
+
+      FNXC:Ideation 2026-07-18-14:05:
+      FN-8295 mounts createIdeationTools (5 tools) immediately after missions on task-scoped and no-task heartbeats. Count rose 58→63.
       */
-      // fn_artifact_register/list/view, agent config/provisioning, mission hierarchy, goals/evaluations/identity,
+      // fn_artifact_register/list/view, agent config/provisioning, mission hierarchy, ideation, goals/evaluations/identity,
       // task read discovery (incl. logs_read), workflow discovery/authoring, task promotion, bounded research, clarification, web fetch, memory, and fn_heartbeat_done.
-      expect(callArgs.customTools).toHaveLength(58);
+      expect(callArgs.customTools).toHaveLength(63);
       expect(callArgs.customTools!.map((tool) => tool.name)).toEqual([
         "fn_task_create",
         "fn_task_log",
@@ -3310,6 +3313,11 @@ describe("executeHeartbeat", () => {
         "fn_feature_update",
         "fn_feature_delete",
         "fn_feature_link_task",
+        "fn_ideation_list",
+        "fn_ideation_show",
+        "fn_ideation_start",
+        "fn_ideation_diverge",
+        "fn_ideation_converge",
         "fn_goal_list",
         "fn_goal_show",
         "fn_read_evaluations",

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -1807,7 +1807,8 @@
       "team": "",
       "workflows": "Workflows",
       "tokens": "",
-      "tools": ""
+      "tools": "",
+      "reviewArtifacts": "Artefactos de revisión"
     },
     "team": {
       "agent": "",
@@ -1885,6 +1886,10 @@
       "sessions": "",
       "summaryTitle": "",
       "toolCalls": ""
+    },
+    "reviewArtifacts": {
+      "title": "Artefactos de revisión",
+      "empty": "Aún no hay artefactos de revisión disponibles."
     }
   },
   "comments": {
@@ -5941,7 +5946,9 @@
       "ephemeralAgentTaskCreationPolicyUponValidation": "Tras validación",
       "ephemeralAgentTaskCreationPolicyDeny": "Denegar",
       "reportModeHelp": "Cómo se archivan los informes in-app (error, feedback, idea, ayuda). Predeterminado: draft-review (el operador revisa un borrador antes de archivar).",
-      "reportModeByActionHelp": "Anulación opcional por acción del modo de informe del proyecto (error, feedback, idea o ayuda). Sin valor predeterminado: las acciones no definidas heredan reportMode."
+      "reportModeByActionHelp": "Anulación opcional por acción del modo de informe del proyecto (error, feedback, idea o ayuda). Sin valor predeterminado: las acciones no definidas heredan reportMode.",
+      "reviewArtifacts": "Artefactos de revisión",
+      "reviewArtifactsHint": "Controla si las tareas futuras elegibles generan entregables de revisión. Los informes de usuario y la captura de actividad se mantienen independientes. Predeterminado: desactivado."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -1807,7 +1807,8 @@
       "team": "",
       "workflows": "Workflows",
       "tokens": "",
-      "tools": ""
+      "tools": "",
+      "reviewArtifacts": "Artefacts de revue"
     },
     "team": {
       "agent": "",
@@ -1885,6 +1886,10 @@
       "sessions": "",
       "summaryTitle": "",
       "toolCalls": ""
+    },
+    "reviewArtifacts": {
+      "title": "Artefacts de revue",
+      "empty": "Aucun artefact de revue n'est encore disponible."
     }
   },
   "comments": {
@@ -5941,7 +5946,9 @@
       "ephemeralAgentTaskCreationPolicyUponValidation": "Sur validation",
       "ephemeralAgentTaskCreationPolicyDeny": "Refuser",
       "reportModeHelp": "Comment les rapports in-app (bug, feedback, idée, aide) sont déposés. Par défaut : draft-review (l'opérateur revoit un brouillon avant dépôt).",
-      "reportModeByActionHelp": "Surcharge optionnelle par action du mode de rapport du projet (bug, feedback, idée ou aide). Aucune valeur par défaut — les actions non définies héritent de reportMode."
+      "reportModeByActionHelp": "Surcharge optionnelle par action du mode de rapport du projet (bug, feedback, idée ou aide). Aucune valeur par défaut — les actions non définies héritent de reportMode.",
+      "reviewArtifacts": "Artefacts de revue",
+      "reviewArtifactsHint": "Contrôle si les futures tâches éligibles génèrent des livrables de revue. Les rapports utilisateur et la capture d'activité restent séparés. Par défaut : désactivé."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -1807,7 +1807,8 @@
       "team": "",
       "workflows": "Workflows",
       "tokens": "",
-      "tools": ""
+      "tools": "",
+      "reviewArtifacts": "리뷰 산출물"
     },
     "team": {
       "agent": "",
@@ -1885,6 +1886,10 @@
       "sessions": "",
       "summaryTitle": "",
       "toolCalls": ""
+    },
+    "reviewArtifacts": {
+      "title": "리뷰 산출물",
+      "empty": "아직 사용 가능한 리뷰 산출물이 없습니다."
     }
   },
   "comments": {
@@ -5941,7 +5946,9 @@
       "ephemeralAgentTaskCreationPolicyUponValidation": "검증 후",
       "ephemeralAgentTaskCreationPolicyDeny": "거부",
       "reportModeHelp": "인앱 버그/피드백/아이디어/도움말 리포트 제출 방식. 기본값: draft-review(제출 전 운영자가 초안 검토).",
-      "reportModeByActionHelp": "버그·피드백·아이디어·도움말 등 작업별 프로젝트 리포트 모드 선택 재정의. 기본값 없음 — 미설정 작업은 reportMode를 상속합니다."
+      "reportModeByActionHelp": "버그·피드백·아이디어·도움말 등 작업별 프로젝트 리포트 모드 선택 재정의. 기본값 없음 — 미설정 작업은 reportMode를 상속합니다.",
+      "reviewArtifacts": "리뷰 산출물",
+      "reviewArtifactsHint": "적격한 향후 작업이 리뷰 산출물을 생성할지 제어합니다. 사용자 보고와 활동 캡처는 별도로 유지됩니다. 기본값: 꺼짐."
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -1807,7 +1807,8 @@
       "team": "",
       "workflows": "Workflows",
       "tokens": "",
-      "tools": ""
+      "tools": "",
+      "reviewArtifacts": "评审产物"
     },
     "team": {
       "agent": "",
@@ -1885,6 +1886,10 @@
       "sessions": "",
       "summaryTitle": "",
       "toolCalls": ""
+    },
+    "reviewArtifacts": {
+      "title": "评审产物",
+      "empty": "尚无评审产物。"
     }
   },
   "comments": {
@@ -5941,7 +5946,9 @@
       "ephemeralAgentTaskCreationPolicyUponValidation": "需验证",
       "ephemeralAgentTaskCreationPolicyDeny": "拒绝",
       "reportModeHelp": "应用内缺陷/反馈/想法/帮助报告的提交方式。默认：draft-review（提交前由操作者审阅草稿）。",
-      "reportModeByActionHelp": "可选的按操作覆盖项目报告模式（缺陷、反馈、想法或帮助）。无默认值 — 未设置的操作继承 reportMode。"
+      "reportModeByActionHelp": "可选的按操作覆盖项目报告模式（缺陷、反馈、想法或帮助）。无默认值 — 未设置的操作继承 reportMode。",
+      "reviewArtifacts": "评审产物",
+      "reviewArtifactsHint": "控制符合条件的未来任务是否生成评审交付物。面向用户的报告与活动捕获保持独立。默认：关闭。"
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -1807,7 +1807,8 @@
       "team": "",
       "workflows": "Workflows",
       "tokens": "",
-      "tools": ""
+      "tools": "",
+      "reviewArtifacts": "審查產物"
     },
     "team": {
       "agent": "",
@@ -1885,6 +1886,10 @@
       "sessions": "",
       "summaryTitle": "",
       "toolCalls": ""
+    },
+    "reviewArtifacts": {
+      "title": "審查產物",
+      "empty": "尚無審查產物。"
     }
   },
   "comments": {
@@ -5941,7 +5946,9 @@
       "ephemeralAgentTaskCreationPolicyUponValidation": "需驗證",
       "ephemeralAgentTaskCreationPolicyDeny": "拒絕",
       "reportModeHelp": "應用內缺陷/回饋/想法/說明報告的提交方式。預設：draft-review（提交前由操作者審閱草稿）。",
-      "reportModeByActionHelp": "可選的依操作覆寫專案報告模式（缺陷、回饋、想法或說明）。無預設值 — 未設定的操作繼承 reportMode。"
+      "reportModeByActionHelp": "可選的依操作覆寫專案報告模式（缺陷、回饋、想法或說明）。無預設值 — 未設定的操作繼承 reportMode。",
+      "reviewArtifacts": "審查產物",
+      "reviewArtifactsHint": "控制符合條件的未來任務是否產生審查交付物。面向使用者的報告與活動擷取保持獨立。預設：關閉。"
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -15,6 +15,11 @@
       "file": "plugins/fusion-plugin-quality/src/__tests__/async-quality-store.pg.test.ts",
       "reason": "Full-suite shard 3 (run 29657633544): 5s timeout + leftover psql child under package-lane load without product-bug evidence; embedded-PG lifecycle remains load-sensitive. Quarantine on sight per AGENTS.md. Mirrored in plugins/fusion-plugin-quality/vitest.config.ts.",
       "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "packages/dashboard/app/components/__tests__/TaskDetailModal.tab-persistence.test.tsx",
+      "reason": "Full-suite shard 2 (run 29660321240): Terminal-guard tab settle race under dashboard-app-quality-backfill load without product-bug evidence; passes focused/local thrice. Quarantine on sight per AGENTS.md. Mirrored in packages/dashboard/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Heartbeat customTools inventory includes FN-8295 ideation tools (63 total).
- Non-en i18n parity for FN-8286 `reviewArtifacts` Command Center + settings keys.
- Quarantine `TaskDetailModal.tab-persistence.test.tsx` (CI load flake; green focused thrice).

## Test plan
- [x] heartbeat expected-tools case green
- [x] i18n-gate-coverage + parity green
- [ ] Full Suite all 4 shards green on main after merge