### PR TITLE
fix(ci): parent-task uniqueness mocks, roadmap search index, flake quarantine

### DIFF
--- a/packages/dashboard/app/components/settings/sections/GeneralSection.search.ts
+++ b/packages/dashboard/app/components/settings/sections/GeneralSection.search.ts
@@ -203,4 +203,18 @@ export const generalSearchEntries: SettingsSearchEntry[] = [
       "Language imported issues are translated into when auto-translation is enabled. No default — unset inherits the dashboard language.",
     keywords: ["locale", "localization"],
   },
+  /*
+  FNXC:ReportPipeline 2026-07-18-14:45:
+  FN-8326 surfaces reportRoadmapDedup as a SettingsToggleRow in GeneralSection; index it so operators can find roadmap-dedup before filing.
+  */
+  {
+    sectionId: "general",
+    key: "reportRoadmapDedup",
+    labelKey: "settings.general.reportRoadmapDedup",
+    labelFallback: "Check roadmap before filing reports",
+    helpKey: "settings.general.reportRoadmapDedupHelp",
+    helpFallback:
+      "When enabled, matching roadmap features are shown inline instead of filing another GitHub Issue or Discussion. Default: off.",
+    keywords: ["roadmap", "dedup", "report", "duplicate"],
+  },
 ];

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -353,6 +353,14 @@ const quarantinedDashboardTests: string[] = [
   Quarantine on sight — mirrored in scripts/lib/test-quarantine.json.
   */
   "app/components/__tests__/TaskDetailModal.tab-persistence.test.tsx",
+  /*
+  FNXC:DashboardTestQuarantine 2026-07-18-14:40:
+  Full-suite shard 4 (run 29661202279): re-flaked stdout/fallback-probe race in
+  clears fallback probe timer when URL is detected from logs under the loaded
+  API backfill lane (prior FN-6722 quarantine / FN-6860 rescue). Quarantine on
+  sight — mirrored in scripts/lib/test-quarantine.json.
+  */
+  "src/__tests__/dev-server-process.test.ts",
 ];
 
 const qualityApiTests = [

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -123,6 +123,12 @@ describe("executeHeartbeat", () => {
         dependencies: [],
         column: "triage",
       }),
+      /*
+      FNXC:TaskCreateDedup 2026-07-18-14:45:
+      FN-8277 parent-scoped uniqueness pre-check calls findRecentTasksBySourceParentTaskId before createTask.
+      Default empty candidates so heartbeat fn_task_create tool tests reach the store write.
+      */
+      findRecentTasksBySourceParentTaskId: vi.fn().mockResolvedValue([]),
       logEntry: vi.fn().mockResolvedValue({}),
       addComment: vi.fn().mockResolvedValue({}),
       appendAgentLog: vi.fn().mockResolvedValue(undefined),
@@ -3896,6 +3902,7 @@ describe("executeHeartbeat", () => {
       await monitor.executeHeartbeat({ agentId: "agent-001", source: "on_demand" });
 
       // FN-7536+: createTask input no longer carries `column` (defaulted server-side to triage) and now forwards `githubTracking`; objectContaining tolerates the extra key.
+      // FNXC:TaskCreateDedup 2026-07-18-14:45: second arg also carries onProposalClaimConflict after FN-8277; match loosely.
       expect(mockTaskStore.createTask).toHaveBeenCalledWith(expect.objectContaining({
         description: "Follow-up task",
         dependencies: undefined,
@@ -3910,7 +3917,7 @@ describe("executeHeartbeat", () => {
             contentFingerprint: expect.any(String),
           }),
         }),
-      }), { settings: {} });
+      }), expect.objectContaining({ settings: {} }));
     });
 
     it("forwards explicit priority when fn_task_create tool is called", async () => {

--- a/packages/engine/src/__tests__/triage-split-into-subtasks-delete.test.ts
+++ b/packages/engine/src/__tests__/triage-split-into-subtasks-delete.test.ts
@@ -69,6 +69,11 @@ function createStore(overrides: Partial<TaskStore> = {}): TaskStore {
     // FNXC:EngineTests 2026-07-17-11:45: flagTriageDuplicate records task:auto-archived-duplicate activity.
     recordActivity: vi.fn().mockResolvedValue(undefined),
     appendAgentLog: vi.fn().mockResolvedValue(undefined),
+    /*
+    FNXC:TaskCreateDedup 2026-07-18-14:45:
+    FN-8277 parent-scoped uniqueness pre-check requires this on TaskStore; empty siblings let split create children.
+    */
+    findRecentTasksBySourceParentTaskId: vi.fn().mockResolvedValue([]),
     parseDependenciesFromPrompt: vi.fn().mockResolvedValue([]),
     parseStepsFromPrompt: vi.fn().mockResolvedValue([]),
     on: vi.fn(),

--- a/packages/engine/src/__tests__/triage.test.ts
+++ b/packages/engine/src/__tests__/triage.test.ts
@@ -136,6 +136,12 @@ function createMockStore(overrides: Partial<TaskStore> = {}): TaskStore {
     updateSettings: vi.fn(),
     logEntry: vi.fn().mockResolvedValue(undefined),
     /*
+    FNXC:TaskCreateDedup 2026-07-18-14:45:
+    FN-8277 aborts parent-scoped createTask when findRecentTasksBySourceParentTaskId throws.
+    Shared triage mocks return no recent siblings so proactive subtask tool tests can create children.
+    */
+    findRecentTasksBySourceParentTaskId: vi.fn().mockResolvedValue([]),
+    /*
     FNXC:TriageTestMock 2026-07-16-14:15:
     Duplicate finalization records activity for near-duplicates and explicit DUPLICATE markers, so shared TaskStore mocks must provide an awaited no-op. The reviewer-outage retry test explicitly selects the delete resolution because the runtime default is prompt and only delete reaches deleteTask.
     */

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -20,6 +20,11 @@
       "file": "packages/dashboard/app/components/__tests__/TaskDetailModal.tab-persistence.test.tsx",
       "reason": "Full-suite shard 2 (run 29660321240): Terminal-guard tab settle race under dashboard-app-quality-backfill load without product-bug evidence; passes focused/local thrice. Quarantine on sight per AGENTS.md. Mirrored in packages/dashboard/vitest.config.ts.",
       "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "packages/dashboard/src/__tests__/dev-server-process.test.ts",
+      "reason": "Full-suite shard 4 (run 29661202279): clears fallback probe timer when URL is detected from logs — detectedEvents length 0 under dashboard-api-quality-backfill load; known timer/stdout race (prior FN-6722 quarantine, FN-6860 rescue). Re-flaked without product-bug evidence. Quarantine on sight per AGENTS.md. Mirrored in packages/dashboard/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- FN-8277 parent-scoped uniqueness: mock `findRecentTasksBySourceParentTaskId` in heartbeat/triage/split suites.
- FN-8326: index `reportRoadmapDedup` in Settings search.
- Quarantine re-flaked `dev-server-process` under full-suite API load (run 29661202279).

## Test plan
- [x] Targeted createTask / search-index tests green locally
- [ ] Full Suite all 4 shards green on main after merge