### PR TITLE
fix(ci): quarantine CLI bundle-output and dist-barrel load flakes

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -104,9 +104,14 @@ const quarantinedCliTests: string[] = [
 
   FNXC:CliTests 2026-07-18-15:20:
   Full-suite shard 4 after FN-8271 (runs 29648812375 / 29648952207) re-observed mcp-lock-retry and task-lock-retry 5s timeouts under package-lane shard load without product-bug evidence. Quarantine on sight in lockstep with scripts/lib/test-quarantine.json — do not raise testTimeout or fake-timer budgets.
+
+  FNXC:CliTests 2026-07-18-15:20:
+  Full-suite shard 4 on tip after #2322 (run 29662476909): bundle-output failed building desktop assets (ENOENT vendor-reactflow CSS) and extension-dist-barrel beforeAll timed out at 10s under package-lane load without product-bug evidence. Quarantine on sight — do not raise hookTimeout or soften build assertions.
   */
   "src/commands/__tests__/mcp-lock-retry.test.ts",
   "src/commands/__tests__/task-lock-retry.test.ts",
+  "src/__tests__/bundle-output.test.ts",
+  "src/__tests__/extension-dist-barrel.test.ts",
 ];
 
 /*

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -25,6 +25,16 @@
       "file": "packages/dashboard/src/__tests__/dev-server-process.test.ts",
       "reason": "Full-suite shard 4 (run 29661202279): clears fallback probe timer when URL is detected from logs — detectedEvents length 0 under dashboard-api-quality-backfill load; known timer/stdout race (prior FN-6722 quarantine, FN-6860 rescue). Re-flaked without product-bug evidence. Quarantine on sight per AGENTS.md. Mirrored in packages/dashboard/vitest.config.ts.",
       "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "packages/cli/src/__tests__/bundle-output.test.ts",
+      "reason": "Full-suite shard 4 (run 29662476909): pnpm build:package / desktop vite build ENOENT on vendor-reactflow CSS under concurrent package-lane load without product-bug evidence. Quarantine on sight per AGENTS.md. Mirrored in packages/cli/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "packages/cli/src/__tests__/extension-dist-barrel.test.ts",
+      "reason": "Full-suite shard 4 (run 29662476909): beforeAll hook timed out at 10s under package-lane load without product-bug evidence (prior FN-8093/FN-8271 rescue). Quarantine on sight per AGENTS.md. Mirrored in packages/cli/vitest.config.ts.",
+      "quarantinedAt": "2026-07-18"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Quarantine `bundle-output.test.ts` and `extension-dist-barrel.test.ts` after tip Full Suite shard 4 (run 29662476909) hit package-lane-only desktop build ENOENT + 10s beforeAll timeout. Prior green Full Suite: run 29662309385 on #2323.

## Test plan
- [ ] Full Suite all 4 shards green on main after merge