### PR TITLE
fix(ci): mock createAgentTask for route tests; quarantine merge-reuse slow flake

### DIFF
--- a/packages/dashboard/src/__tests__/routes-github.test.ts
+++ b/packages/dashboard/src/__tests__/routes-github.test.ts
@@ -211,6 +211,12 @@ function createMockStore(overrides: Partial<TaskStore> = {}): TaskStore {
     getSettingsByScopeFast: vi.fn().mockResolvedValue({ global: {}, project: {} }),
     getGlobalSettingsStore: vi.fn().mockReturnValue(createMockGlobalSettingsStore()),
     logEntry: vi.fn().mockResolvedValue(undefined),
+    /*
+    FNXC:TaskCreateDedup 2026-07-18-15:55:
+    FN-8277 parent-scoped uniqueness pre-check requires findRecentTasksBySourceParentTaskId;
+    default empty so subtask create-tasks routes return 201 under mock stores.
+    */
+    findRecentTasksBySourceParentTaskId: vi.fn().mockResolvedValue([]),
     // FNXC:GitHubImportAttachments 2026-07-15-11:20: import downloads issue screenshots into task attachments.
     addAttachment: vi.fn().mockResolvedValue(undefined),
     getAgentLogs: vi.fn().mockResolvedValue([]),

--- a/packages/dashboard/src/__tests__/routes-planning.test.ts
+++ b/packages/dashboard/src/__tests__/routes-planning.test.ts
@@ -219,6 +219,12 @@ function createMockStore(overrides: Partial<TaskStore> = {}): TaskStore {
     getSettingsByScopeFast: vi.fn().mockResolvedValue({ global: {}, project: {} }),
     getGlobalSettingsStore: vi.fn().mockReturnValue(createMockGlobalSettingsStore()),
     logEntry: vi.fn().mockResolvedValue(undefined),
+    /*
+    FNXC:TaskCreateDedup 2026-07-18-15:55:
+    FN-8277 parent-scoped uniqueness pre-check requires findRecentTasksBySourceParentTaskId;
+    default empty so planning create-task / subtask routes return 201 under mock stores.
+    */
+    findRecentTasksBySourceParentTaskId: vi.fn().mockResolvedValue([]),
     getAgentLogs: vi.fn().mockResolvedValue([]),
     getAgentLogCount: vi.fn().mockResolvedValue(0),
     getAgentLogsByTimeRange: vi.fn().mockResolvedValue([]),

--- a/packages/dashboard/src/test/mockCoreEngine.ts
+++ b/packages/dashboard/src/test/mockCoreEngine.ts
@@ -79,6 +79,24 @@ export function createEngineMock(overrides: AnyModule = {}): AnyModule {
     )),
     // FNXC:McpConfig 2026-07-02-13:45: Planning/mission route tests share this engine mock; MCP resolution must return the full shaped empty result so readonly session creation can proceed without importing real engine stores.
     resolveMcpServersForStore: vi.fn(async () => ({ servers: [], errors: [] })),
+    /*
+    FNXC:TaskCreateDedup 2026-07-18-15:55:
+    FN-8277 routes planning/subtask creation through createAgentTask. The wholesale
+    @fusion/engine mock previously fell back to vi.fn() → undefined, so
+    `const { task } = await createAgentTask(...)` threw. Default to a thin wrapper
+    that uses the real store.createTask and reports wasDuplicate:false.
+    */
+    createAgentTask: vi.fn(async (
+      store: { createTask?: (input: unknown, options?: unknown) => Promise<unknown> },
+      input: unknown,
+      _options?: unknown,
+    ) => {
+      if (typeof store?.createTask !== "function") {
+        throw new Error("createAgentTask mock requires store.createTask");
+      }
+      const task = await store.createTask(input, { settings: {} });
+      return { task, wasDuplicate: false };
+    }),
     ...overrides,
   });
 }

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -404,6 +404,13 @@ export default defineConfig({
             "src/__tests__/reliability-interactions/branch-group-single-pr-e2e.slow.test.ts",
             "src/__tests__/reliability-interactions/shared-branch-group-lifecycle.slow.test.ts",
             // SQLite-path (delete-sqlite-runtime-final PHASE A): uses inMemoryDb via _helpers.ts.
+            /*
+            FNXC:EngineTests 2026-07-18-15:55:
+            Full-suite engine-slow (run 29663725381): FN-5363 queue-head pollution handoff left a
+            leased merge-queue row after successful merge under load without product-bug evidence.
+            Quarantine on sight — mirrored in scripts/lib/test-quarantine.json.
+            */
+            "src/__tests__/reliability-interactions/merge-reuse-task-worktree.slow.test.ts",
           ],
           minWorkers: 1,
           maxWorkers: 1,

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -35,6 +35,11 @@
       "file": "packages/cli/src/__tests__/extension-dist-barrel.test.ts",
       "reason": "Full-suite shard 4 (run 29662476909): beforeAll hook timed out at 10s under package-lane load without product-bug evidence (prior FN-8093/FN-8271 rescue). Quarantine on sight per AGENTS.md. Mirrored in packages/cli/vitest.config.ts.",
       "quarantinedAt": "2026-07-18"
+    },
+    {
+      "file": "packages/engine/src/__tests__/reliability-interactions/merge-reuse-task-worktree.slow.test.ts",
+      "reason": "Full-suite engine-slow (run 29663725381): FN-5363 queue-head pollution handoff left leased merge-queue row after merge under load without product-bug evidence. Quarantine on sight per AGENTS.md. Mirrored in packages/engine/vitest.config.ts engine-slow exclude.",
+      "quarantinedAt": "2026-07-18"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Default `createAgentTask` in dashboard `@fusion/engine` mock so planning/subtask create routes return 201 (FN-8277).
- Mock `findRecentTasksBySourceParentTaskId` on github/planning route stores.
- Quarantine `merge-reuse-task-worktree.slow.test.ts` (engine-slow load flake, run 29663725381).

## Evidence
- Prior full green: Full Suite run **29663526777** on #2325.
- Tip red class: routes-github/planning 500 + engine-slow lease residual.

## Test plan
- [x] routes subtask create-tasks / shared branch groups tests green locally
- [ ] Full Suite all 4 shards + engine-slow green on main tip after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task and subtask creation test coverage to correctly handle parent-scoped duplicate checks.
  * Updated test behavior to return reliable task creation results.

* **Tests**
  * Quarantined a flaky integration test from the slow test suite to improve test run reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->