### PR TITLE
fix(ci): research promote tool inventory + 0023 upgrade seed bookkeeping

### DIFF
--- a/packages/core/src/__tests__/postgres/schema-applier.test.ts
+++ b/packages/core/src/__tests__/postgres/schema-applier.test.ts
@@ -48,6 +48,7 @@ import {
   TASK_PROPOSAL_CLAIM_VERSION,
   CONFIGURATION_REVISIONS_VERSION,
   IDEATION_SCHEMA_VERSION,
+  RESEARCH_FEATURE_PROVENANCE_VERSION,
   OWNER_PROJECT_ID_SPLIT_VERSION,
   /*
   FNXC:PostgresSchema 2026-07-16-08:00:
@@ -1083,7 +1084,8 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       missing relation project.missions.
       */
       CREATE TABLE project.missions (id text PRIMARY KEY);
-      CREATE TABLE project.mission_features (id text PRIMARY KEY);
+      /* slice_id required before 0023 research provenance unique index can attach. */
+      CREATE TABLE project.mission_features (id text PRIMARY KEY, slice_id text);
       CREATE TABLE project.automations (
         id text PRIMARY KEY,
         name text NOT NULL,
@@ -1166,6 +1168,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
       IDEATION_SCHEMA_VERSION,
+      RESEARCH_FEATURE_PROVENANCE_VERSION,
     ]);
     expect((await applySchemaBaseline(ctx.db, { pluginHooks: [] })).applied).toBe(false);
   });
@@ -1214,6 +1217,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
       IDEATION_SCHEMA_VERSION,
+      RESEARCH_FEATURE_PROVENANCE_VERSION,
     ]);
   });
 
@@ -1351,6 +1355,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
       IDEATION_SCHEMA_VERSION,
+      RESEARCH_FEATURE_PROVENANCE_VERSION,
     ]);
   });
 
@@ -1413,6 +1418,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
       IDEATION_SCHEMA_VERSION,
+      RESEARCH_FEATURE_PROVENANCE_VERSION,
     ]);
   });
 
@@ -1475,6 +1481,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       TASK_PROPOSAL_CLAIM_VERSION,
       CONFIGURATION_REVISIONS_VERSION,
       IDEATION_SCHEMA_VERSION,
+      RESEARCH_FEATURE_PROVENANCE_VERSION,
     ]);
   });
 });

--- a/packages/engine/src/__tests__/heartbeat-executor.test.ts
+++ b/packages/engine/src/__tests__/heartbeat-executor.test.ts
@@ -3284,10 +3284,13 @@ describe("executeHeartbeat", () => {
 
       FNXC:Ideation 2026-07-18-14:05:
       FN-8295 mounts createIdeationTools (5 tools) immediately after missions on task-scoped and no-task heartbeats. Count rose 58→63.
+
+      FNXC:ResearchMissionBridge 2026-07-18-16:35:
+      FN-8297 adds fn_research_promote_finding on the Mission tool surface (after feature_link_task). Count rose 63→64.
       */
       // fn_artifact_register/list/view, agent config/provisioning, mission hierarchy, ideation, goals/evaluations/identity,
       // task read discovery (incl. logs_read), workflow discovery/authoring, task promotion, bounded research, clarification, web fetch, memory, and fn_heartbeat_done.
-      expect(callArgs.customTools).toHaveLength(63);
+      expect(callArgs.customTools).toHaveLength(64);
       expect(callArgs.customTools!.map((tool) => tool.name)).toEqual([
         "fn_task_create",
         "fn_task_log",
@@ -3319,6 +3322,7 @@ describe("executeHeartbeat", () => {
         "fn_feature_update",
         "fn_feature_delete",
         "fn_feature_link_task",
+        "fn_research_promote_finding",
         "fn_ideation_list",
         "fn_ideation_show",
         "fn_ideation_start",


### PR DESCRIPTION
## Summary
- Heartbeat customTools inventory includes `fn_research_promote_finding` (64 tools).
- Schema-applier bookkeeping for migration `0023` research feature provenance.
- Seed upgrade fixtures include `mission_features.slice_id` for the unique index.

## Evidence
- Full greens earlier this session: **29662309385** (#2323), **29663526777** (#2325), **29664692957** (#2327).
- Tip red after FN-8297: heartbeat 63→64 + schema upgrade seed.

## Test plan
- [x] heartbeat expected-tools + schema upgrade tests green locally
- [ ] Full Suite all shards green on tip after merge