### PR TITLE
fix(core): restore validating mission recovery

### DIFF
--- a/.changeset/restore-mission-validation-recovery.md
+++ b/.changeset/restore-mission-validation-recovery.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Resume mission features that were interrupted during validation after an engine restart.
+category: fix
+dev: Shares one feature-loop transition contract across synchronous and PostgreSQL mission stores.

--- a/packages/core/src/__tests__/mission-store.sync-loop-transition.test.ts
+++ b/packages/core/src/__tests__/mission-store.sync-loop-transition.test.ts
@@ -1,0 +1,43 @@
+/*
+FNXC:MissionRecovery 2026-07-19-15:30:
+The synchronous MissionStore remains a supported transition surface even though
+PostgreSQL owns persistence. Exercise its real transition method so the shared
+feature-loop table cannot drift from AsyncMissionStore recovery behavior.
+*/
+
+import { describe, expect, it, vi } from "vitest";
+import type { Database } from "../db.js";
+import { MissionStore } from "../mission-store.js";
+import type { MissionFeature } from "../mission-types.js";
+
+describe("MissionStore synchronous loop transitions", () => {
+  it("allows startup recovery to move an interrupted validation back to implementing", () => {
+    const db = {
+      prepare: vi.fn().mockReturnValue({ get: vi.fn().mockReturnValue(undefined) }),
+      bumpLastModified: vi.fn(),
+    } as unknown as Database;
+    const store = new MissionStore("/tmp/fusion-mission-store-test", db);
+    const feature: MissionFeature = {
+      id: "F-RECOVERY",
+      sliceId: "SL-RECOVERY",
+      title: "Interrupted validation",
+      status: "in-progress",
+      loopState: "validating",
+      implementationAttemptCount: 1,
+      createdAt: "2026-07-19T00:00:00.000Z",
+      updatedAt: "2026-07-19T00:00:00.000Z",
+    };
+
+    vi.spyOn(store, "getFeature").mockReturnValue(feature);
+    const updateFeature = vi.spyOn(store, "updateFeature").mockImplementation((_id, updates) => ({
+      ...feature,
+      ...updates,
+    }));
+
+    expect(store.transitionLoopState(feature.id, "implementing")).toMatchObject({
+      id: feature.id,
+      loopState: "implementing",
+    });
+    expect(updateFeature).toHaveBeenCalledWith(feature.id, { loopState: "implementing" });
+  });
+});

--- a/packages/core/src/__tests__/postgres/mission-store.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/mission-store.pg.test.ts
@@ -317,6 +317,23 @@ pgTest("MissionStore (PostgreSQL backend mode)", () => {
     expect((await m.getFeature(fix.id))?.loopState).toBe("needs_fix");
   });
 
+  it("allows startup recovery to move an interrupted validation back to implementing", async () => {
+    const m = missions();
+    const mission = await m.createMission({ title: "Interrupted validation" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "Feature" });
+
+    await m.transitionLoopState(feature.id, "implementing");
+    await m.startValidatorRun(feature.id, "scheduled");
+    expect((await m.getFeature(feature.id))?.loopState).toBe("validating");
+
+    await expect(m.transitionLoopState(feature.id, "implementing")).resolves.toMatchObject({
+      id: feature.id,
+      loopState: "implementing",
+    });
+  });
+
   it("allows exactly one terminal validator transition when completion races the stale reaper", async () => {
     const primary = missions();
     const competing = new AsyncMissionStore(h.layer(), h.store());

--- a/packages/core/src/async-mission-store.ts
+++ b/packages/core/src/async-mission-store.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from "node:events";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import * as schema from "./postgres/schema/index.js";
 import type { AsyncDataLayer } from "./postgres/data-layer.js";
-import { normalizeMissionAssertionType } from "./mission-types.js";
+import { FEATURE_LOOP_TRANSITIONS, normalizeMissionAssertionType } from "./mission-types.js";
 import type {
   Mission,
   Milestone,
@@ -1230,8 +1230,8 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
     const feature = await getFeature(this.db, featureId);
     if (!feature) throw new Error(`Feature ${featureId} not found`);
     const current = feature.loopState ?? "idle";
-    const valid: Record<FeatureLoopState, FeatureLoopState[]> = { idle: ["implementing"], implementing: ["validating"], validating: ["needs_fix", "passed", "blocked"], needs_fix: ["implementing"], passed: [], blocked: [] };
-    if (!valid[current].includes(newState)) throw new Error(`Invalid loop state transition from '${current}' to '${newState}'. Allowed transitions from '${current}': ${valid[current].join(", ") || "none"}`);
+    const allowedNextStates = FEATURE_LOOP_TRANSITIONS[current];
+    if (!allowedNextStates.includes(newState)) throw new Error(`Invalid loop state transition from '${current}' to '${newState}'. Allowed transitions from '${current}': ${allowedNextStates.join(", ") || "none"}`);
     if (newState === "implementing" && (feature.implementationAttemptCount ?? 0) >= DEFAULT_IMPLEMENTATION_RETRY_BUDGET) {
       await this.updateFeature(featureId, { loopState: "blocked" });
       throw new Error(`Feature ${featureId} has exhausted its retry budget (${DEFAULT_IMPLEMENTATION_RETRY_BUDGET} attempts). Transitioning to 'blocked' state.`);

--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -14,7 +14,7 @@
 import { EventEmitter } from "node:events";
 import type { Database } from "./db.js";
 import { fromJson, toJson, toJsonNullable } from "./db.js";
-import { normalizeMissionAssertionType } from "./mission-types.js";
+import { FEATURE_LOOP_TRANSITIONS, normalizeMissionAssertionType } from "./mission-types.js";
 import type { Goal, GoalStatus } from "./goal-types.js";
 import type {
   Mission,
@@ -3303,6 +3303,7 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
    * Valid transitions:
    * - idle → implementing
    * - implementing → validating
+   * - validating → implementing (startup recovery)
    * - validating → needs_fix
    * - validating → passed
    * - validating → blocked
@@ -3325,16 +3326,7 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
     const currentState = feature.loopState ?? "idle";
 
     // Validate the transition
-    const validTransitions: Record<FeatureLoopState, FeatureLoopState[]> = {
-      idle: ["implementing"],
-      implementing: ["validating"],
-      validating: ["needs_fix", "passed", "blocked"],
-      needs_fix: ["implementing"],
-      passed: [],
-      blocked: [],
-    };
-
-    const allowedNextStates = validTransitions[currentState] || [];
+    const allowedNextStates = FEATURE_LOOP_TRANSITIONS[currentState] || [];
     if (!allowedNextStates.includes(newState)) {
       throw new Error(
         `Invalid loop state transition from '${currentState}' to '${newState}'. ` +

--- a/packages/core/src/mission-types.ts
+++ b/packages/core/src/mission-types.ts
@@ -37,6 +37,19 @@ export type FeatureStatus = (typeof FEATURE_STATUSES)[number];
 export const FEATURE_LOOP_STATES = ["idle", "implementing", "validating", "needs_fix", "passed", "blocked"] as const;
 export type FeatureLoopState = (typeof FEATURE_LOOP_STATES)[number];
 
+/**
+ * FNXC:MissionRecovery 2026-07-19-14:30:
+ * Startup recovery re-drives work interrupted during validation by moving the feature back to implementing. Both mission-store backends must share this transition table so recovery cannot be accepted by the engine but rejected by persistence.
+ */
+export const FEATURE_LOOP_TRANSITIONS: Readonly<Record<FeatureLoopState, readonly FeatureLoopState[]>> = {
+  idle: ["implementing"],
+  implementing: ["validating"],
+  validating: ["implementing", "needs_fix", "passed", "blocked"],
+  needs_fix: ["implementing"],
+  passed: [],
+  blocked: [],
+};
+
 /** Status values for a validator run */
 export const VALIDATOR_RUN_STATUSES = ["running", "passed", "failed", "blocked", "error"] as const;
 export type ValidatorRunStatus = (typeof VALIDATOR_RUN_STATUSES)[number];


### PR DESCRIPTION
## Summary

- allow `validating → implementing` in the feature-loop lifecycle for startup recovery
- share one transition table between synchronous and PostgreSQL mission stores
- retain the existing implementation retry-budget guard on the recovery transition
- add a release changeset and real PostgreSQL regression coverage

## Root cause

`MissionExecutionLoop.recoverActiveMissions()` intentionally moves a feature interrupted during validation back to `implementing` before re-driving its completed task. Both mission-store backends rejected that transition, so every restart logged `Invalid loop state transition from 'validating' to 'implementing'` and left the feature stranded.

## Surface enumeration

- synchronous `MissionStore.transitionLoopState`
- PostgreSQL `AsyncMissionStore.transitionLoopState`
- startup recovery through `MissionExecutionLoop.recoverActiveMissions`
- retry-budget enforcement for every transition into `implementing`

## Symptom verification

- Original symptom: restart recovery catches and logs an invalid-transition error for a `validating` feature.
- Exact reproduction: create a feature in PostgreSQL, enter `implementing`, start validation, then invoke the recovery transition back to `implementing`.
- Assertion it is gone: the real store resolves the transition and persists `loopState: "implementing"`.

## Validation

- PostgreSQL mission-store suite: 20/20 passed against PostgreSQL 17.10 (started only for the test and stopped afterward)
- synchronous MissionStore recovery regression: 1/1 passed
- Mission execution-loop suite: 67/67 passed
- `@fusion/core` typecheck passed
- scoped ESLint: no errors
- strict changeset validation passed

## Temporary base

This PR is stacked on #2332 only because current `main` imports `html2canvas` without declaring it, which makes the workspace Typecheck job fail before reaching this change. The diff remains limited to the recovery fix; after #2332 merges, this PR can target `main` directly.
