### PR TITLE
fix(engine): respect user-paused dispatch stops

### DIFF
--- a/.changeset/respect-user-paused-dispatch.md
+++ b/.changeset/respect-user-paused-dispatch.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep manually parked tasks out of scheduler and remembered-owner dispatch until explicitly unpaused.
+category: fix
+dev: Treats either paused flag as a dispatch stop and invalidates scheduler candidacy when userPaused changes.

--- a/packages/core/src/__tests__/agent-store-routing-policy.test.ts
+++ b/packages/core/src/__tests__/agent-store-routing-policy.test.ts
@@ -224,6 +224,22 @@ pgTest("task→agent routing policy (issue #2015)", () => {
   });
 
   describe("selectNextTaskForAgent bind compatibility", () => {
+    it("does not select a remembered-owner todo task when only userPaused remains true", async () => {
+      const executor = await agentStore.createAgent({ name: "Exec", role: "executor" });
+      const task = await h.store().createTask({ description: "manually parked work" });
+      await h.store().updateTask(task.id, { assignedAgentId: executor.id });
+      await h.store().moveTask(task.id, "todo");
+      await h.store().moveTask(task.id, "in-progress");
+      await h.store().moveTask(task.id, "todo", { moveSource: "user" });
+
+      const parked = await h.store().getTask(task.id);
+      expect(parked).toMatchObject({ assignedAgentId: executor.id, userPaused: true });
+      expect(parked?.paused).not.toBe(true);
+      await expect(
+        h.store().selectNextTaskForAgent(executor.id, { id: executor.id, role: executor.role }),
+      ).resolves.toBeNull();
+    });
+
     it("does not re-select a mis-bound in-progress implementation task for a role-incompatible agent", async () => {
       const liaison = await agentStore.createAgent({ name: "Liaison", role: "custom" });
       const task = await h.store().createTask({ description: "mis-bound work" });

--- a/packages/core/src/task-store/branch-group-ops.ts
+++ b/packages/core/src/task-store/branch-group-ops.ts
@@ -196,7 +196,10 @@ export async function selectNextTaskForAgentImpl(store: TaskStore, agentId: stri
 
     const roleCompatibleAssignedTasks = assignedTasks.filter(isBindCompatible);
 
-    const todoCandidates = roleCompatibleAssignedTasks.filter((task) => task.column === "todo" && task.paused !== true);
+    /** FNXC:TaskDispatch 2026-07-19-14:40: remembered ownership must not reselect an operator-parked task when `userPaused` remains true but legacy `paused` is false. */
+    const todoCandidates = roleCompatibleAssignedTasks.filter(
+      (task) => task.column === "todo" && task.paused !== true && task.userPaused !== true,
+    );
 
     const readyTodo = todoCandidates
       .filter((task) => {

--- a/packages/engine/src/__tests__/scheduler-auto-claim-invalidation.test.ts
+++ b/packages/engine/src/__tests__/scheduler-auto-claim-invalidation.test.ts
@@ -95,6 +95,7 @@ describe("Scheduler auto-claim snapshot invalidation", () => {
   it.each([
     ["column", { column: "in-progress" }],
     ["paused", { paused: true }],
+    ["userPaused", { userPaused: true }],
     ["assignedAgentId", { assignedAgentId: "agent-1" }],
     ["checkedOutBy", { checkedOutBy: "agent-2" }],
     ["deletedAt", { deletedAt: "2026-01-02T00:00:00.000Z" }],
@@ -111,6 +112,18 @@ describe("Scheduler auto-claim snapshot invalidation", () => {
     expect(invalidate).toHaveBeenCalledTimes(2);
     expect(invalidate).toHaveBeenNthCalledWith(1, "task:created");
     expect(invalidate).toHaveBeenNthCalledWith(2, "task:updated");
+  });
+
+  it("triggers immediate scheduling when a userPaused-only task is unpaused", () => {
+    const { store, emit } = createStore();
+    const scheduler = new Scheduler(store, {});
+    const schedule = vi.spyOn(scheduler, "schedule").mockResolvedValue(undefined);
+    (scheduler as unknown as { running: boolean }).running = true;
+
+    emit("task:updated", createTask({ userPaused: true }));
+    emit("task:updated", createTask({ userPaused: false }));
+
+    expect(schedule).toHaveBeenCalledTimes(1);
   });
 
   it("invalidates on first-sighting task:updated with no stored fingerprint", () => {

--- a/packages/engine/src/__tests__/scheduler-workflow-cutover.test.ts
+++ b/packages/engine/src/__tests__/scheduler-workflow-cutover.test.ts
@@ -135,6 +135,21 @@ describe("Scheduler workflow cutover", () => {
     expect(onSchedule).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-100", column: "in-progress" }));
   });
 
+  it("does not dispatch an operator-parked todo task when only userPaused remains true", async () => {
+    const parked = task({ id: "FN-PAUSED", paused: false, userPaused: true });
+    const store = storeWith([parked]);
+    const onSchedule = vi.fn();
+    const scheduler = new Scheduler(store, { onSchedule });
+    (scheduler as unknown as { running: boolean }).running = true;
+
+    await scheduler.schedule();
+
+    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(store.updateTask).not.toHaveBeenCalled();
+    expect(onSchedule).not.toHaveBeenCalled();
+    expect(parked.column).toBe("todo");
+  });
+
   /*
   FNXC:WorkflowScheduling 2026-07-07-00:00:
   FN-7648 regression: a custom workflow's intake column can be renamed away from

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -132,9 +132,11 @@ function isIgnoredOverlapPath(path: string, ignorePath: string): boolean {
 function computeAutoClaimFingerprint(task: Task): string {
   const dependencies = [...(task.dependencies ?? [])].sort().join(",");
   const sortAt = task.columnMovedAt ?? task.createdAt;
+  /** FNXC:TaskDispatch 2026-07-19-14:40: `userPaused` is a durable operator stop even when legacy `paused` is false; candidacy caching and every dispatch selector must treat either flag as parked. */
   return [
     task.column,
     task.paused === true ? "1" : "0",
+    task.userPaused === true ? "1" : "0",
     task.assignedAgentId ?? "",
     task.checkedOutBy ?? "",
     task.deletedAt ?? "",
@@ -863,7 +865,7 @@ export class Scheduler {
       // When a previously-paused task is unpaused in a schedulable column,
       // trigger a scheduling pass immediately instead of waiting for the next
       // poll interval (up to 15 seconds).
-      if (task.paused) {
+      if (task.paused || task.userPaused) {
         this.pausedTaskIds.add(task.id);
       } else if (this.pausedTaskIds.has(task.id)) {
         // Task was paused, now unpaused — trigger scheduling
@@ -1469,7 +1471,7 @@ export class Scheduler {
 
       const now = Date.now();
       let todo = tasks.filter((t) => {
-        if (t.column !== "todo" || t.paused) return false;
+        if (t.column !== "todo" || t.paused || t.userPaused) return false;
         // Skip tasks with a recovery backoff that hasn't elapsed yet
         if (t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now) return false;
         // FNXC:CodingIdeasWorkflow 2026-07-04-10:45: a todo task with status "planning" is being specified in place by the triage service (merged planner/capacity column in Coding (Ideas)); it must not be dispatched until planning finishes and the status clears.


### PR DESCRIPTION
## Summary

- exclude `userPaused` tasks from the scheduler's todo shortlist
- exclude `userPaused` remembered-owner tasks from assigned-agent selection
- include `userPaused` in scheduler candidacy fingerprints and immediate unpause scheduling
- add a release changeset and regressions for both dispatch surfaces

## Root cause

Fusion preserves `assignedAgentId` as durable ownership when an operator moves active work back to `todo`. That real move path can produce `userPaused: true` while legacy `paused` is unset. Two selectors checked only `paused`, so the scheduler or the remembered owner could immediately pick the manually parked task up again.

## Surface enumeration

- general scheduler todo shortlist
- scheduler candidacy fingerprint and event-driven unpause handling
- assigned-agent/heartbeat task selection
- normal unpaused todo dispatch behavior
- both `paused` and `userPaused` persistence shapes

## Symptom verification

- Original symptom: a manually parked task with remembered ownership can be selected again because `paused !== true`.
- Exact reproduction: assign a task, move it to `in-progress`, then perform a user-sourced move back to `todo` against the real PostgreSQL store.
- Assertion it is gone: the row retains its owner and has `userPaused: true` with `paused !== true`, while `selectNextTaskForAgent` returns null and the scheduler performs no dispatch mutation.

## Validation

- PostgreSQL assigned-agent routing suite: 15/15 passed against PostgreSQL 17.10 (started only for the test and stopped afterward)
- Scheduler workflow/candidacy suites: 46/46 passed
- `@fusion/core` and `@fusion/engine` typechecks passed
- scoped ESLint: no errors
- strict changeset validation passed

## Temporary base

This PR is stacked on #2332 only because current `main` imports `html2canvas` without declaring it, which makes the workspace Typecheck job fail before reaching this change. The diff remains limited to the dispatch fix; after #2332 merges, this PR can target `main` directly.
