### PR TITLE
test(dashboard): configure Discussion screenshot fixture

### DIFF
--- a/packages/dashboard/src/__tests__/report-pipeline-screenshots.test.ts
+++ b/packages/dashboard/src/__tests__/report-pipeline-screenshots.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { runReportPipeline, type ReportPipelineDeps, type ReportScreenshot } from "../report-pipeline.js";
 
-const settings = { reportMode: "auto-file" as const, reportRoadmapDedupeEnabled: false, githubTrackingDefaultRepo: "Runfusion/Fusion", githubAuthMode: "token", githubAuthToken: "test" };
+const settings = { reportMode: "auto-file" as const, reportDiscussionCategory: "general", reportRoadmapDedupeEnabled: false, githubTrackingDefaultRepo: "Runfusion/Fusion", githubAuthMode: "token", githubAuthToken: "test" };
 const screenshot: ReportScreenshot = { artifactId: "f1e2d3c4-b5a6-4789-8abc-def012345678", filename: "/Users/alice/private-project/evil[alt](break)!../capture.png", mimeType: "image/png", bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47]) };
 
 function client() {
@@ -10,6 +10,7 @@ function client() {
     searchIssues: vi.fn().mockResolvedValue([]), searchDiscussions: vi.fn().mockResolvedValue([]),
     commentOnIssue: vi.fn().mockResolvedValue({ url: "issue-comment" }), commentOnDiscussion: vi.fn().mockResolvedValue({ url: "discussion-comment" }),
     addIssueReaction: vi.fn(), addDiscussionReaction: vi.fn(),
+    listDiscussionCategories: vi.fn().mockResolvedValue([{ id: "DC_1", name: "General", slug: "general" }]),
     uploadImageAsset: vi.fn().mockResolvedValue({ rawUrl: "https://raw.githubusercontent.com/Runfusion/Fusion/main/.fusion-reports/safe/screenshot.png" }),
   };
 }


### PR DESCRIPTION
## Summary
- configure the screenshot pipeline's Discussion fixture with a valid selected category
- provide category discovery in the fake client so Feedback and Help exercise screenshot upload/embedding instead of returning an availability error

## Test plan
- `CI=true pnpm --filter @fusion/dashboard exec vitest run src/__tests__/report-pipeline-screenshots.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dashboard report-pipeline screenshot test coverage to support general discussion categories.
  * Enhanced the test environment to provide a mocked general discussion category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->