### PR TITLE
Fix Windows embedded PostgreSQL 0xC0000142 crashes (issue #2411)

### DIFF
--- a/.changeset/fn-windows-embedded-pg-connection-default.md
+++ b/.changeset/fn-windows-embedded-pg-connection-default.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Lower the embedded PostgreSQL default connection cap to 150 on Windows to prevent 0xC0000142 backend crashes.
+category: fix
+dev: Issue #2411 — embeddedPostgresMaxConnections is now schema-unset; resolveEmbeddedMaxConnections picks win32 150 / else 500, explicit settings still clamp to [32, 2000].

--- a/packages/core/src/__test-utils__/pg-test-harness.ts
+++ b/packages/core/src/__test-utils__/pg-test-harness.ts
@@ -516,10 +516,33 @@ function ensureGoldenTemplate(): Promise<string> {
     // the lock. A sibling fork blocks on pg_advisory_lock until the winner has
     // fully built the golden template and recorded its ready marker.
     await withMaintenanceSql(async (client) => {
-      // Ensure the readiness marker table exists before any read/write of it.
-      await client.unsafe(
-        `CREATE TABLE IF NOT EXISTS ${GOLDEN_MARKER_QUALIFIED} (name text PRIMARY KEY, created_at timestamptz NOT NULL DEFAULT now())`,
-      );
+      /*
+      FNXC:PgTestTemplateDb 2026-07-22-23:45:
+      Ensure the readiness marker table exists before any read/write of it.
+      `CREATE TABLE IF NOT EXISTS` is NOT concurrency-safe in PostgreSQL: two
+      sessions that both observe "not exists" race to insert the table's
+      composite-type row, and the loser aborts with `duplicate key value
+      violates unique constraint "pg_type_typname_nsp_index"`. On a fresh CI
+      cluster the gate's vitest forks all reach this line together on first
+      contact, which turned the merge gate red repo-wide (first seen
+      2026-07-23 01:25 UTC); long-lived local clusters already have the table,
+      so the race never reproduces locally. Serialize the one-time DDL under
+      its own advisory lock (this session already uses session-level advisory
+      locks for the golden build below), and additionally swallow the two
+      benign "lost the race" errors — duplicate_table (42P07) and the pg_type
+      unique violation (23505) — since either one proves a sibling created it.
+      */
+      await client`SELECT pg_advisory_lock(hashtext('fusion_golden_marker_table_ddl'))`;
+      try {
+        await client.unsafe(
+          `CREATE TABLE IF NOT EXISTS ${GOLDEN_MARKER_QUALIFIED} (name text PRIMARY KEY, created_at timestamptz NOT NULL DEFAULT now())`,
+        );
+      } catch (error) {
+        const code = (error as { code?: string }).code;
+        if (code !== "42P07" && code !== "23505") throw error;
+      } finally {
+        await client`SELECT pg_advisory_unlock(hashtext('fusion_golden_marker_table_ddl'))`;
+      }
       // Sweep templates orphaned by crashed/finished processes and drop marker
       // rows whose golden database no longer exists.
       const rows = await client<{ datname: string }[]>`

--- a/packages/core/src/__tests__/postgres/embedded-lifecycle.test.ts
+++ b/packages/core/src/__tests__/postgres/embedded-lifecycle.test.ts
@@ -35,6 +35,9 @@ import {
   DEFAULT_START_TIMEOUT_MS,
   DEFAULT_EMBEDDED_POSTGRES_FLAGS,
   defaultEmbeddedPostgresFlagsFor,
+  resolveEmbeddedMaxConnections,
+  DEFAULT_EMBEDDED_MAX_CONNECTIONS,
+  DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32,
   isDataDirInitialized,
   isWindowsElevatedAdmin,
   normalizeMacosEmbeddedPostgresDylibSymlinks,
@@ -1458,6 +1461,46 @@ describe("embedded-lifecycle: shared-memory-safe postgres flags", () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("embedded-lifecycle: platform-aware max_connections default (issue #2411)", () => {
+  /*
+   * FNXC:PostgresEmbedded 2026-07-22-23:55:
+   * Issue #2411: on Windows each connection is a separate postgres.exe process; a
+   * max_connections=500 cap exhausts the non-interactive desktop heap during
+   * backend spawn bursts and forked backends die with 0xC0000142, taking the
+   * cluster (and dashboard) down. The reporter confirmed stability after lowering
+   * the cap. The UNSET default must therefore be lower on win32 (150) than
+   * elsewhere (500), while an explicit operator setting is honored on every
+   * platform, clamped to [32, 2000].
+   */
+  it.each([
+    ["win32", DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32],
+    ["darwin", DEFAULT_EMBEDDED_MAX_CONNECTIONS],
+    ["linux", DEFAULT_EMBEDDED_MAX_CONNECTIONS],
+  ] as const)("unset resolves the platform default on %s", (platform, expected) => {
+    expect(resolveEmbeddedMaxConnections(undefined, platform)).toBe(expected);
+  });
+
+  it("keeps the win32 default materially below the general default", () => {
+    expect(DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32).toBeLessThan(DEFAULT_EMBEDDED_MAX_CONNECTIONS);
+    expect(DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32).toBeLessThanOrEqual(150);
+  });
+
+  it.each(["win32", "darwin", "linux"] as const)(
+    "an explicit operator setting is honored and clamped to [32, 2000] on %s",
+    (platform) => {
+      expect(resolveEmbeddedMaxConnections(100, platform)).toBe(100);
+      expect(resolveEmbeddedMaxConnections(500, platform)).toBe(500);
+      expect(resolveEmbeddedMaxConnections(5, platform)).toBe(32);
+      expect(resolveEmbeddedMaxConnections(9_999, platform)).toBe(2_000);
+    },
+  );
+
+  it("treats non-integer configured values as unset", () => {
+    expect(resolveEmbeddedMaxConnections(Number.NaN, "win32")).toBe(DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32);
+    expect(resolveEmbeddedMaxConnections(250.5, "linux")).toBe(DEFAULT_EMBEDDED_MAX_CONNECTIONS);
   });
 });
 

--- a/packages/core/src/__tests__/settings-defaults.test.ts
+++ b/packages/core/src/__tests__/settings-defaults.test.ts
@@ -36,8 +36,14 @@ describe("settings defaults invariants", () => {
     expect(isGlobalOnlySettingsKey("localNetworkDiscoveryEnabled")).toBe(true);
   });
 
-  it("keeps the embedded PostgreSQL connection cap global and high by default", () => {
-    expect(DEFAULT_GLOBAL_SETTINGS.embeddedPostgresMaxConnections).toBe(500);
+  it("keeps the embedded PostgreSQL connection cap global and schema-unset so the server resolves a platform-aware default", () => {
+    /*
+    FNXC:PostgresEmbedded 2026-07-22-23:55:
+    Issue #2411: the schema default must stay undefined. getSettings() merges
+    DEFAULT_GLOBAL_SETTINGS, so a concrete value here would look operator-set and
+    defeat resolveEmbeddedMaxConnections' win32-lowered default (150 vs 500).
+    */
+    expect(DEFAULT_GLOBAL_SETTINGS.embeddedPostgresMaxConnections).toBeUndefined();
     expect(GLOBAL_SETTINGS_KEYS).toContain("embeddedPostgresMaxConnections");
     expect(PROJECT_SETTINGS_KEYS).not.toContain("embeddedPostgresMaxConnections");
   });

--- a/packages/core/src/postgres/embedded-lifecycle.ts
+++ b/packages/core/src/postgres/embedded-lifecycle.ts
@@ -684,6 +684,37 @@ export function defaultEmbeddedPostgresFlagsFor(platform: NodeJS.Platform): read
 export const DEFAULT_EMBEDDED_POSTGRES_FLAGS = defaultEmbeddedPostgresFlagsFor(process.platform);
 
 /*
+ * FNXC:PostgresEmbedded 2026-07-22-23:55:
+ * Issue #2411 (operator-confirmed on 0.73.0-beta.2): on Windows every PostgreSQL
+ * connection is a separate postgres.exe process, and standing up backends against a
+ * max_connections=500 cap exhausts the non-interactive desktop heap during connection
+ * bursts. A forked backend then dies in DLL/session init with exception 0xC0000142,
+ * the postmaster terminates all other backends, and the whole embedded cluster — and
+ * with it the dashboard — goes down. The reporter measured stability at a cap of 100
+ * after repeated crashes at 500. Default the cap platform-aware: 150 on win32 (well
+ * above Fusion's own pool usage of ~3 connections per connection set), 500 elsewhere.
+ * An operator-configured embeddedPostgresMaxConnections is always honored, clamped to
+ * [32, 2000] on every platform — the lower win32 number is only the unset default.
+ * This complements, not replaces, the FN-8522 child PATH hardening and single-restart
+ * recovery for the same 0xC0000142 signature.
+ */
+export const DEFAULT_EMBEDDED_MAX_CONNECTIONS = 500;
+export const DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32 = 150;
+export const EMBEDDED_MAX_CONNECTIONS_MIN = 32;
+export const EMBEDDED_MAX_CONNECTIONS_MAX = 2_000;
+
+/** Resolve the effective embedded-cluster max_connections from the optional operator setting. */
+export function resolveEmbeddedMaxConnections(
+  configured: number | undefined,
+  platform: NodeJS.Platform = process.platform,
+): number {
+  if (typeof configured === "number" && Number.isInteger(configured)) {
+    return Math.min(EMBEDDED_MAX_CONNECTIONS_MAX, Math.max(EMBEDDED_MAX_CONNECTIONS_MIN, configured));
+  }
+  return platform === "win32" ? DEFAULT_EMBEDDED_MAX_CONNECTIONS_WIN32 : DEFAULT_EMBEDDED_MAX_CONNECTIONS;
+}
+
+/*
 FNXC:PostgresEmbedded 2026-07-18-00:20:
 GitHub issue #2286: initdb without --encoding inherits the OS locale's
 encoding. On non-UTF-8 Windows locales (Turkish WIN1254 in the report; the

--- a/packages/core/src/postgres/startup-factory.ts
+++ b/packages/core/src/postgres/startup-factory.ts
@@ -397,7 +397,7 @@ async function bootSchemaBackendOnce(
   let resolvedBackend = backend;
   let embeddedDataDir: string | null = null;
   if (backend.mode === "embedded") {
-    const { EmbeddedPostgresLifecycle, defaultEmbeddedDataDir, DEFAULT_EMBEDDED_DATABASE } =
+    const { EmbeddedPostgresLifecycle, defaultEmbeddedDataDir, DEFAULT_EMBEDDED_DATABASE, resolveEmbeddedMaxConnections } =
       await import("./embedded-lifecycle.js");
     const { GlobalSettingsStore } = await import("../global-settings.js");
     // Tests that boot an embedded backend intentionally do not have an
@@ -406,9 +406,17 @@ async function bootSchemaBackendOnce(
     const configuredMaxConnections = process.env.VITEST === "true" && !options.globalSettingsDir
       ? undefined
       : (await new GlobalSettingsStore(options.globalSettingsDir).getSettings()).embeddedPostgresMaxConnections;
-    const maxConnections = Number.isInteger(configuredMaxConnections)
-      ? Math.min(2_000, Math.max(32, configuredMaxConnections!))
-      : 500;
+    /*
+    FNXC:PostgresEmbedded 2026-07-22-23:55:
+    Issue #2411: the unset default is platform-aware (win32 150, else 500) because
+    Windows backends are separate processes and a 500-connection cap exhausts the
+    desktop heap under load, killing forked backends with 0xC0000142 and taking the
+    dashboard down. embeddedPostgresMaxConnections is deliberately undefined in
+    DEFAULT_GLOBAL_SETTINGS so this server-side resolution can see "operator never
+    set it" — a concrete schema default would be merged in by getSettings() and
+    mask the platform choice.
+    */
+    const maxConnections = resolveEmbeddedMaxConnections(configuredMaxConnections);
     const dataDir = resolve(options.embeddedDataDir ?? defaultEmbeddedDataDir());
     embeddedDataDir = dataDir;
     log.log(`startup-factory: starting embedded PostgreSQL (data dir ${dataDir})`);

--- a/packages/core/src/settings-schema.ts
+++ b/packages/core/src/settings-schema.ts
@@ -72,10 +72,18 @@ type ProjectSettingsSchema = Omit<ProjectSettings, MovedProjectSettingsKey | Non
 
 /** Default values for global (user-level) settings. */
 export const DEFAULT_GLOBAL_SETTINGS = {
-  // Embedded PostgreSQL is shared by all local Fusion projects and processes.
-  // Keep this well above the conservative external-pool budget while still
-  // bounded for a local machine.
-  embeddedPostgresMaxConnections: 500,
+  /*
+  FNXC:PostgresEmbedded 2026-07-22-23:55:
+  Embedded PostgreSQL is shared by all local Fusion projects and processes.
+  Deliberately undefined (not 500): getSettings() merges these defaults, so a
+  concrete value here would be indistinguishable from an operator choice and
+  would mask the platform-aware server-side default in
+  resolveEmbeddedMaxConnections (win32 150, else 500). Issue #2411: Windows
+  backends are separate processes; a 500-connection cap exhausts the desktop
+  heap under load and forked backends die with 0xC0000142, taking the embedded
+  cluster and dashboard down.
+  */
+  embeddedPostgresMaxConnections: undefined,
   /*
   FNXC:DashboardTheming 2026-07-03-00:00:
   Fresh installs must follow the operating system theme until the user explicitly chooses Light, Dark, or System. Keep this global default aligned with dashboard and desktop pre-hydration fallbacks.

--- a/packages/dashboard/app/components/SettingsModal.tsx
+++ b/packages/dashboard/app/components/SettingsModal.tsx
@@ -3879,7 +3879,14 @@ export function SettingsModal({
       if (activeSectionResetEntry.scope === "global") {
         const patch: Record<string, unknown> = {};
         for (const key of activeSectionResetEntry.keys) {
-          patch[key] = (DEFAULT_GLOBAL_SETTINGS as Record<string, unknown>)[key];
+          /*
+          FNXC:SettingsReset 2026-07-22-23:55:
+          Issue #2411: global keys whose canonical default is undefined (e.g.
+          embeddedPostgresMaxConnections, resolved platform-aware server-side)
+          must reset via null-as-delete. A literal undefined is dropped by JSON
+          serialization, so the stored value would silently survive the reset.
+          */
+          patch[key] = (DEFAULT_GLOBAL_SETTINGS as Record<string, unknown>)[key] ?? null;
         }
         await updateGlobalSettings(patch);
       } else {

--- a/packages/dashboard/app/components/__tests__/SettingsModal.general.test.tsx
+++ b/packages/dashboard/app/components/__tests__/SettingsModal.general.test.tsx
@@ -1441,9 +1441,15 @@ describe("SettingsModal", () => {
       renderModal({ initialSection: "backups-global" });
       await waitForSettingsModalReady();
 
-      expect(screen.getByLabelText("Embedded PostgreSQL connection cap")).toHaveValue(500);
+      /*
+      FNXC:PostgresEmbedded 2026-07-22-23:55:
+      Issue #2411: the cap is schema-unset so the server can resolve a platform-aware
+      default (win32 150, else 500). The input therefore renders empty ("auto"), not 500.
+      */
+      expect(screen.getByLabelText("Embedded PostgreSQL connection cap")).toHaveValue(null);
+      expect(screen.getByLabelText("Embedded PostgreSQL connection cap")).toHaveAttribute("placeholder", "auto");
       expect(screen.getByTestId("settings-help-embeddedPostgresMaxConnections")).toBeInTheDocument();
-      expect(screen.getByText("Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Default: 500. External PostgreSQL uses its provider's connection limit.").closest(".settings-help-bubble")).toBeTruthy();
+      expect(screen.getByText("Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Unset by default — Fusion picks 500, or 150 on Windows where each connection is a separate process and higher caps can crash backends. External PostgreSQL uses its provider's connection limit.").closest(".settings-help-bubble")).toBeTruthy();
     });
 
     it("saves ephemeral agent toggle in project settings payload", async () => {

--- a/packages/dashboard/app/components/settings/sections/DatabaseBackupsSection.tsx
+++ b/packages/dashboard/app/components/settings/sections/DatabaseBackupsSection.tsx
@@ -50,13 +50,14 @@ export function DatabaseBackupsSection({ form, setForm, backupInfo, backupLoadin
           descriptor={{
             key: "embeddedPostgresMaxConnections",
             label: t("settings.database.embeddedConnectionCap", "Embedded PostgreSQL connection cap"),
-            help: t("settings.database.embeddedConnectionCapHelp", "Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Default: 500. External PostgreSQL uses its provider's connection limit."),
+            help: t("settings.database.embeddedConnectionCapHelp", "Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Unset by default — Fusion picks 500, or 150 on Windows where each connection is a separate process and higher caps can crash backends. External PostgreSQL uses its provider's connection limit."),
             scope: "global",
             min: 32,
             max: 2000,
+            placeholder: t("settings.database.embeddedConnectionCapPlaceholder", "auto"),
           }}
-          value={form.embeddedPostgresMaxConnections ?? 500}
-          onChange={(v) => setForm((f) => ({ ...f, embeddedPostgresMaxConnections: v ?? 500 }))}
+          value={form.embeddedPostgresMaxConnections ?? null}
+          onChange={(v) => setForm((f) => ({ ...f, embeddedPostgresMaxConnections: v ?? undefined }))}
           error={form.embeddedPostgresMaxConnections !== undefined && (form.embeddedPostgresMaxConnections < 32 || form.embeddedPostgresMaxConnections > 2000)
             ? t("settings.database.embeddedConnectionCapError", "Enter a value between 32 and 2,000.")
             : undefined}

--- a/packages/dashboard/app/components/settings/sections/__tests__/settings-default-descriptions.test.tsx
+++ b/packages/dashboard/app/components/settings/sections/__tests__/settings-default-descriptions.test.tsx
@@ -167,7 +167,9 @@ const SETTING_DESCRIPTION_KEYS: Record<string, string> = {
   /*
   FNXC:SettingsDefaults 2026-07-17-13:55:
   FN-8335 restores FN-7505 default-value parity for the surfaced embeddedPostgresMaxConnections
-  control. The English locale description is the canonical rendered SettingsHelpTip copy and states Default: 500.
+  control. Issue #2411 made the schema default undefined (server resolves win32 150 / else 500),
+  so the canonical English copy now uses unset phrasing ("Unset by default — Fusion picks …")
+  and must not make a concrete "Default:" colon claim.
   */
   embeddedPostgresMaxConnections: "database.embeddedConnectionCapHelp",
   // MemorySection

--- a/packages/i18n/locales/en/app.json
+++ b/packages/i18n/locales/en/app.json
@@ -6854,10 +6854,11 @@
       "allProjectResetSuccess": "All project settings reset to defaults"
     },
     "database": {
-      "embeddedConnectionCapHelp": "Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Default: 500. External PostgreSQL uses its provider's connection limit.",
+      "embeddedConnectionCapHelp": "Maximum server connections for Fusion's embedded PostgreSQL. Applies after restarting Fusion. Range: 32–2,000. Unset by default — Fusion picks 500, or 150 on Windows where each connection is a separate process and higher caps can crash backends. External PostgreSQL uses its provider's connection limit.",
       "embeddedConnectionCap": "Embedded PostgreSQL connection cap",
       "embeddedConnectionCapError": "Enter a value between 32 and 2,000.",
-      "advanced": "Advanced database settings"
+      "advanced": "Advanced database settings",
+      "embeddedConnectionCapPlaceholder": "auto"
     },
     "configVersions": {
       "title": "Configuration versions",

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -6839,10 +6839,11 @@
       "allProjectResetSuccess": ""
     },
     "database": {
-      "embeddedConnectionCapHelp": "Máximo de conexiones de servidor para el PostgreSQL integrado de Fusion. Se aplica al reiniciar Fusion. Rango: 32–2.000. Predeterminado: 500. PostgreSQL externo usa el límite de su proveedor.",
+      "embeddedConnectionCapHelp": "Máximo de conexiones de servidor para el PostgreSQL integrado de Fusion. Se aplica al reiniciar Fusion. Rango: 32–2.000. Sin valor establecido por defecto: Fusion elige 500, o 150 en Windows, donde cada conexión es un proceso independiente y límites más altos pueden bloquear los procesos backend. PostgreSQL externo usa el límite de su proveedor.",
       "embeddedConnectionCap": "Límite de conexiones de PostgreSQL integrado",
       "embeddedConnectionCapError": "Introduce un valor entre 32 y 2.000.",
-      "advanced": "Ajustes avanzados de base de datos"
+      "advanced": "Ajustes avanzados de base de datos",
+      "embeddedConnectionCapPlaceholder": "auto"
     },
     "configVersions": {
       "title": "Versiones de configuración",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -6839,10 +6839,11 @@
       "allProjectResetSuccess": ""
     },
     "database": {
-      "embeddedConnectionCapHelp": "Nombre maximal de connexions serveur pour le PostgreSQL embarqué de Fusion. Appliqué après redémarrage de Fusion. Plage : 32–2 000. Par défaut : 500. PostgreSQL externe utilise la limite de son fournisseur.",
+      "embeddedConnectionCapHelp": "Nombre maximal de connexions serveur pour le PostgreSQL embarqué de Fusion. Appliqué après redémarrage de Fusion. Plage : 32–2 000. Non défini par défaut — Fusion choisit 500, ou 150 sous Windows où chaque connexion est un processus séparé et des plafonds plus élevés peuvent faire planter les backends. PostgreSQL externe utilise la limite de son fournisseur.",
       "embeddedConnectionCap": "Plafond de connexions PostgreSQL embarqué",
       "embeddedConnectionCapError": "Saisissez une valeur entre 32 et 2 000.",
-      "advanced": "Paramètres de base de données avancés"
+      "advanced": "Paramètres de base de données avancés",
+      "embeddedConnectionCapPlaceholder": "auto"
     },
     "configVersions": {
       "title": "Versions de configuration",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -6839,10 +6839,11 @@
       "allProjectResetSuccess": ""
     },
     "database": {
-      "embeddedConnectionCapHelp": "Fusion 내장 PostgreSQL의 최대 서버 연결 수. Fusion 재시작 후 적용. 범위: 32–2,000. 기본값: 500. 외부 PostgreSQL은 제공자 연결 한도를 사용합니다.",
+      "embeddedConnectionCapHelp": "Fusion 내장 PostgreSQL의 최대 서버 연결 수. Fusion 재시작 후 적용. 범위: 32–2,000. 기본적으로 미설정 — Fusion이 500을 선택하며, 각 연결이 별도 프로세스인 Windows에서는 150을 사용합니다(높은 한도는 백엔드 충돌을 유발할 수 있음). 외부 PostgreSQL은 제공자 연결 한도를 사용합니다.",
       "embeddedConnectionCap": "내장 PostgreSQL 연결 상한",
       "embeddedConnectionCapError": "32에서 2,000 사이의 값을 입력하세요.",
-      "advanced": "고급 데이터베이스 설정"
+      "advanced": "고급 데이터베이스 설정",
+      "embeddedConnectionCapPlaceholder": "자동"
     },
     "configVersions": {
       "title": "구성 버전",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -6839,10 +6839,11 @@
       "description": ""
     },
     "database": {
-      "embeddedConnectionCapHelp": "Fusion 嵌入式 PostgreSQL 的最大服务器连接数。重启 Fusion 后生效。范围：32–2,000。默认：500。外部 PostgreSQL 使用其提供方的连接限制。",
+      "embeddedConnectionCapHelp": "Fusion 嵌入式 PostgreSQL 的最大服务器连接数。重启 Fusion 后生效。范围：32–2,000。默认未设置 — Fusion 选择 500；在 Windows 上为 150，因为每个连接都是一个独立进程，更高的上限可能导致后端崩溃。外部 PostgreSQL 使用其提供方的连接限制。",
       "embeddedConnectionCap": "嵌入式 PostgreSQL 连接上限",
       "embeddedConnectionCapError": "请输入 32 到 2,000 之间的值。",
-      "advanced": "高级数据库设置"
+      "advanced": "高级数据库设置",
+      "embeddedConnectionCapPlaceholder": "自动"
     },
     "configVersions": {
       "title": "配置版本",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -6839,10 +6839,11 @@
       "allProjectResetSuccess": ""
     },
     "database": {
-      "embeddedConnectionCapHelp": "Fusion 內嵌 PostgreSQL 的最大伺服器連線數。重新啟動 Fusion 後生效。範圍：32–2,000。預設：500。外部 PostgreSQL 使用其提供者的連線限制。",
+      "embeddedConnectionCapHelp": "Fusion 內嵌 PostgreSQL 的最大伺服器連線數。重新啟動 Fusion 後生效。範圍：32–2,000。預設未設定 — Fusion 選擇 500；在 Windows 上為 150，因為每個連線都是一個獨立程序，更高的上限可能導致後端當機。外部 PostgreSQL 使用其提供者的連線限制。",
       "embeddedConnectionCap": "內嵌 PostgreSQL 連線上限",
       "embeddedConnectionCapError": "請輸入 32 到 2,000 之間的值。",
-      "advanced": "進階資料庫設定"
+      "advanced": "進階資料庫設定",
+      "embeddedConnectionCapPlaceholder": "自動"
     },
     "configVersions": {
       "title": "設定版本",


### PR DESCRIPTION
## Summary

Two-part fix for #2411 — Windows embedded PostgreSQL backends dying with exception `0xC0000142` and taking the whole dashboard down.

### 1. Crash hardening + recovery (FN-8522)
- Child-only native `PATH` hardening so forked backends can always resolve their runtime DLLs.
- Non-blocking `.pgrunner` log monitoring (shared read), eliminating the self-inflicted ~30s `sharing violation` retry window at boot.
- Detection of the ordered 0xC0000142 shutdown sequence with a single automatic restart of owned clusters on their resolved port, plus operator diagnostics.

### 2. Platform-aware `max_connections` default (follow-up from [operator report](https://github.com/Runfusion/Fusion/issues/2411#issuecomment-5054900702))
On Windows every PostgreSQL connection is a separate process; the embedded cluster's unconfigured `max_connections=500` cap lets backend spawn bursts exhaust the non-interactive desktop heap, which kills forked backends with exactly `0xC0000142`. The reporter confirmed stability after lowering the cap.

- `embeddedPostgresMaxConnections` is now schema-unset so the server can distinguish "operator never set it" from an explicit choice (`getSettings()` merges schema defaults, which previously pinned 500 unconditionally and made the runtime fallback dead code).
- New `resolveEmbeddedMaxConnections()` resolves the unset default platform-aware: **150 on win32, 500 elsewhere**. Explicit settings are honored on every platform, clamped to [32, 2000] as before.
- Settings UI renders the cap empty ("auto") with platform-aware help copy across all six locales.
- Fixed a latent reset bug this exposed: global "Reset this menu" wrote `undefined` for undefined-default keys, which JSON serialization drops — the stored value silently survived reset. Now uses null-as-delete.

## Testing
- New unit tests for `resolveEmbeddedMaxConnections` (platform defaults, clamping, non-integer handling).
- Updated settings-defaults, default-descriptions, and SettingsModal tests; embedded lifecycle + recovery coverage from FN-8522.
- `@fusion/core` builds clean; changesets included for both parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)