### PR TITLE
feat(ci): incremental caching for the PR merge-gate jobs (Gate, Build, Typecheck)

### DIFF
--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -247,3 +247,53 @@ jobs:
 
       - name: Run engine-slow with non-empty-execution assertion
         run: node scripts/assert-engine-slow-nonempty.mjs
+
+  # FNXC:CIGateSpeed 2026-07-22-23:30:
+  # Warm the PR gate's incremental build cache from main. The Gate job in
+  # pr-checks.yml restores `gate-dist-*` with restore-keys; caches saved on a
+  # PR merge ref are invisible to other PRs, so without this job every PR's
+  # FIRST gate run builds cold (~6-8 min). Saving main's built dist plus
+  # .fusion/cache/plugin-build-cache.json here lets that first run rebuild only
+  # the packages the PR actually changed. The path list MUST stay byte-identical
+  # to the Gate job's cache block (actions/cache versions caches by path list —
+  # a drifted list makes the caches mutually invisible). Fast CLI packaging
+  # matches the Gate's consumer shape. This is a cache warmer, not a test or
+  # verification step; the blocking Build job on PRs keeps full-build coverage.
+  warm-gate-build-cache:
+    name: Warm gate build cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Compute dist source hash
+        id: dist-hash
+        run: echo "hash=$(node scripts/ensure-test-artifacts.mjs --print-source-hash)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache built dist artifacts (incremental)
+        id: dist-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/core/dist
+            packages/dashboard/dist
+            packages/engine/dist
+            packages/plugin-sdk/dist
+            packages/cli/dist
+            plugins/fusion-plugin-dependency-graph/dist
+            plugins/fusion-plugin-hermes-runtime/dist
+            plugins/fusion-plugin-openclaw-runtime/dist
+            plugins/fusion-plugin-paperclip-runtime/dist
+            .fusion/cache/plugin-build-cache.json
+          key: gate-dist-${{ runner.os }}-${{ steps.dist-hash.outputs.hash }}
+          restore-keys: |
+            gate-dist-${{ runner.os }}-
+
+      - name: Build (incremental against restored cache)
+        run: pnpm build
+        env:
+          FUSION_CLI_FULL_PACKAGE: "0"

--- a/.github/workflows/full-suite.yml
+++ b/.github/workflows/full-suite.yml
@@ -297,3 +297,23 @@ jobs:
         run: pnpm build
         env:
           FUSION_CLI_FULL_PACKAGE: "0"
+
+      # FNXC:CIGateSpeed 2026-07-23-00:05:
+      # Also warm the Typecheck job's tsc incremental buildinfo cache from main
+      # (same PR-invisibility rationale as the dist cache above). The path list
+      # must stay byte-identical to the Typecheck job's cache block in
+      # pr-checks.yml. Restored buildinfo is self-validating — tsc re-checks
+      # anything that changed — so restore-keys is correctness-neutral.
+      - name: Cache TypeScript incremental buildinfo
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist/.tsbuildinfo
+            packages/dashboard/dist/.tsbuildinfo-app
+            plugins/*/dist/.tsbuildinfo
+          key: typecheck-tsbuildinfo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            typecheck-tsbuildinfo-${{ runner.os }}-
+
+      - name: Typecheck (warms incremental buildinfo)
+        run: pnpm typecheck

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,6 +61,27 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
 
+      # FNXC:CIGateSpeed 2026-07-23-00:05:
+      # tsc incremental buildinfo cache. tsconfig.base.json enables
+      # `incremental` with per-package dist/.tsbuildinfo; a restored buildinfo
+      # is SELF-VALIDATING (tsc hashes every input against it and re-checks
+      # whatever changed), so restore-keys can never let a stale check through
+      # — it only shrinks the re-checked set. Cold typecheck was ~4 min of the
+      # PR critical path. Keyed by SHA so every commit saves a fresh snapshot;
+      # restore-keys picks the nearest prior one (same PR, or main via the
+      # warm-gate-build-cache job in full-suite.yml, which must keep an
+      # identical path list — actions/cache versions caches by path list).
+      - name: Cache TypeScript incremental buildinfo
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/dist/.tsbuildinfo
+            packages/dashboard/dist/.tsbuildinfo-app
+            plugins/*/dist/.tsbuildinfo
+          key: typecheck-tsbuildinfo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            typecheck-tsbuildinfo-${{ runner.os }}-
+
       - name: Typecheck
         run: pnpm typecheck
 
@@ -74,6 +95,39 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
+
+      # FNXC:CIGateSpeed 2026-07-23-00:05:
+      # RESTORE-ONLY tap of the gate's incremental dist cache (see the gate
+      # job's cache block for the full safety rationale: `pnpm build` always
+      # runs and reconciles a near-match restore per package by content hash).
+      # Restore-only (actions/cache/restore, never save) because this job runs
+      # FULL CLI packaging (CI=true → desktop + bundled plugins + DTS), and
+      # saving that shape would swap the cache's canonical fast-CLI contents
+      # out from under the Gate job. Full CLI packaging itself is never skipped
+      # regardless of cache state (ensureFullPackageCliPlanned force-plans the
+      # CLI in full mode), so this job's distinctive coverage is preserved.
+      # Path list must stay byte-identical to the gate job's block.
+      - name: Compute dist source hash
+        id: dist-hash
+        run: echo "hash=$(node scripts/ensure-test-artifacts.mjs --print-source-hash)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore built dist artifacts (incremental, restore-only)
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            packages/core/dist
+            packages/dashboard/dist
+            packages/engine/dist
+            packages/plugin-sdk/dist
+            packages/cli/dist
+            plugins/fusion-plugin-dependency-graph/dist
+            plugins/fusion-plugin-hermes-runtime/dist
+            plugins/fusion-plugin-openclaw-runtime/dist
+            plugins/fusion-plugin-paperclip-runtime/dist
+            .fusion/cache/plugin-build-cache.json
+          key: gate-dist-${{ runner.os }}-${{ steps.dist-hash.outputs.hash }}
+          restore-keys: |
+            gate-dist-${{ runner.os }}-
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -124,14 +124,27 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
 
-      # Dist-artifact cache (same contract as full-suite.yml): exact-match
-      # key only, NO restore-keys (stale dist is the known failure mode,
-      # FN-4232/FN-4605), NEVER node_modules (breaks Windows pnpm junctions).
+      # FNXC:CIGateSpeed 2026-07-22-23:30:
+      # Gate-scoped INCREMENTAL dist cache (`gate-dist-*` namespace, distinct from
+      # the shard jobs' exact-match `dist-*` contract). Unlike the shard jobs —
+      # where restore-keys is forbidden because tests consume restored dist
+      # WITHOUT a build (stale dist was the FN-4232/FN-4605 failure mode) — the
+      # gate always runs `pnpm build` after restore. build-workspace.mjs verifies
+      # every package's git content hash against .fusion/cache/plugin-build-cache.json
+      # (cached below alongside dist) and rebuilds anything changed, missing, or
+      # unhashed, so a near-match restore can only speed the build up, never let
+      # stale dist through. Measured before this change: every PR missed the
+      # exact key and paid a full ~6-8 min build for ~45s of actual gate tests.
+      # NEVER add node_modules here (breaks Windows pnpm junctions elsewhere).
+      # The warm-gate-build-cache job in full-suite.yml saves this same cache
+      # (identical path list — actions/cache versions caches by path list, so
+      # the two blocks must stay in sync) on every push to main so a PR's FIRST
+      # gate run restores main's build instead of building cold.
       - name: Compute dist source hash
         id: dist-hash
         run: echo "hash=$(node scripts/ensure-test-artifacts.mjs --print-source-hash)" >> "$GITHUB_OUTPUT"
 
-      - name: Cache built dist artifacts
+      - name: Cache built dist artifacts (incremental)
         id: dist-cache
         uses: actions/cache@v4
         with:
@@ -140,20 +153,34 @@ jobs:
             packages/dashboard/dist
             packages/engine/dist
             packages/plugin-sdk/dist
+            packages/cli/dist
             plugins/fusion-plugin-dependency-graph/dist
             plugins/fusion-plugin-hermes-runtime/dist
             plugins/fusion-plugin-openclaw-runtime/dist
             plugins/fusion-plugin-paperclip-runtime/dist
-          key: dist-${{ runner.os }}-${{ steps.dist-hash.outputs.hash }}
+            .fusion/cache/plugin-build-cache.json
+          key: gate-dist-${{ runner.os }}-${{ steps.dist-hash.outputs.hash }}
+          restore-keys: |
+            gate-dist-${{ runner.os }}-
 
+      # Only seed the mtime-defeating artifact hash-cache on an EXACT hit; on a
+      # restore-keys near-hit the restored dist may be stale for changed
+      # packages, and `pnpm build` below is what reconciles it.
       - name: Seed artifact hash-cache on cache hit
         if: steps.dist-cache.outputs.cache-hit == 'true'
         run: node scripts/ensure-test-artifacts.mjs --seed-artifact-cache
 
-      # Boot smoke needs the full built workspace (CLI dist is not in the
-      # cache list above); cached packages make this incremental-fast.
+      # FNXC:CIGateSpeed 2026-07-22-23:30:
+      # Boot smoke needs the built workspace including the CLI. Fast CLI
+      # packaging (bin.js + extension.js, no desktop/bundled-plugin/DTS staging)
+      # is sufficient for boot smoke + test:gate and is the same shape
+      # `pnpm verify:fast` proves locally; CI=true would otherwise force the
+      # multi-minute full packaging tail on every gate run. Full CLI packaging
+      # coverage stays blocking in the separate Build job.
       - name: Build
         run: pnpm build
+        env:
+          FUSION_CLI_FULL_PACKAGE: "0"
 
       - name: Boot smoke (app starts and serves)
         run: node scripts/boot-smoke.mjs

--- a/packages/cli/src/__tests__/ci-workflow.test.ts
+++ b/packages/cli/src/__tests__/ci-workflow.test.ts
@@ -297,6 +297,68 @@ describe("Merge gate (.github/workflows/pr-checks.yml)", () => {
     ).toBe(true);
   });
 
+  /*
+  FNXC:CIGateSpeed 2026-07-23-00:05:
+  The Build job taps the gate's incremental dist cache RESTORE-ONLY: it runs full CLI
+  packaging (CI=true), and saving that shape would swap the cache's canonical fast-CLI
+  contents out from under the Gate job. Pin restore-only, path parity with the gate block,
+  and that the Build step does NOT opt out of full CLI packaging (that coverage is this
+  job's distinctive value — ensureFullPackageCliPlanned force-plans the CLI in full mode
+  regardless of cache state).
+  */
+  it("build job restores the gate dist cache without saving and keeps full CLI packaging", () => {
+    const buildSteps = workflow.jobs?.build?.steps ?? [];
+    const restoreStep = buildSteps.find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(restoreStep).toBeDefined();
+    expect(restoreStep.uses).toContain("actions/cache/restore");
+    expect(restoreStep.with?.key).toContain("gate-dist-");
+    expect(restoreStep.with?.["restore-keys"]).toContain("gate-dist-");
+
+    const gateCache = (workflow.jobs?.gate?.steps ?? []).find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(restoreStep.with?.path).toBe(gateCache?.with?.path);
+
+    const buildStep = buildSteps.find(
+      (step: any) => step.name === "Build" && typeof step.run === "string" && step.run.includes("pnpm build"),
+    );
+    expect(buildStep).toBeDefined();
+    expect(buildStep.env?.FUSION_CLI_FULL_PACKAGE).toBeUndefined();
+    expect(buildSteps.indexOf(buildStep)).toBeGreaterThan(buildSteps.indexOf(restoreStep));
+  });
+
+  /*
+  FNXC:CIGateSpeed 2026-07-23-00:05:
+  Typecheck caches tsc incremental buildinfo. Restored buildinfo is self-validating (tsc
+  re-checks every input that changed), so restore-keys is correctness-neutral. The cache
+  only works if the dashboard's TWO typecheck programs (tsconfig.json + tsconfig.app.json)
+  keep DISTINCT tsBuildInfoFile paths — both inherit ${configDir}/dist/.tsbuildinfo from
+  tsconfig.base.json otherwise and clobber each other, silently re-checking the full
+  program every run. Pin the cache shape and the distinct app buildinfo path together.
+  */
+  it("typecheck job caches self-validating tsc buildinfo with distinct dashboard paths", () => {
+    const typecheckSteps = workflow.jobs?.typecheck?.steps ?? [];
+    const cacheStep = typecheckSteps.find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(cacheStep).toBeDefined();
+    expect(cacheStep.with?.key).toContain("typecheck-tsbuildinfo-");
+    expect(cacheStep.with?.["restore-keys"]).toContain("typecheck-tsbuildinfo-");
+    expect(cacheStep.with?.path).toContain("packages/*/dist/.tsbuildinfo");
+    expect(cacheStep.with?.path).toContain("packages/dashboard/dist/.tsbuildinfo-app");
+    expect(cacheStep.with?.path).toContain("plugins/*/dist/.tsbuildinfo");
+
+    const typecheckIndex = typecheckSteps.findIndex(
+      (step: any) => typeof step.run === "string" && step.run.includes("pnpm typecheck"),
+    );
+    expect(typecheckIndex).toBeGreaterThan(typecheckSteps.indexOf(cacheStep));
+
+    const appTsconfig = readFileSync(join(workspaceRoot, "packages", "dashboard", "tsconfig.app.json"), "utf-8");
+    expect(appTsconfig).toContain('.tsbuildinfo-app');
+  });
+
   it("keeps contributing docs aligned with the gate contract", () => {
     expect(contributingContent).toContain("pnpm test:full` must be runnable in a clean worktree without requiring a prior `pnpm build`.");
     expect(contributingContent).toContain("`pnpm test:gate` is the merge gate");
@@ -429,6 +491,39 @@ describe("Full suite workflow (.github/workflows/full-suite.yml)", () => {
     );
     expect(warmBuild).toBeDefined();
     expect(warmBuild.env?.FUSION_CLI_FULL_PACKAGE).toBe("0");
+  });
+
+  /*
+  FNXC:CIGateSpeed 2026-07-23-00:05:
+  The warm job also warms the Typecheck job's tsc buildinfo cache (PR caches are
+  invisible to other PRs, so main must seed first-run PRs). Path parity with the
+  Typecheck job's block is load-bearing for the same actions/cache versioning reason
+  as the dist cache.
+  */
+  it("warms the typecheck buildinfo cache from main with a path list identical to the typecheck job's", () => {
+    const warmSteps = workflow.jobs?.["warm-gate-build-cache"]?.steps ?? [];
+    const warmTsCache = warmSteps.find(
+      (step: any) =>
+        typeof step.uses === "string" &&
+        step.uses.startsWith("actions/cache") &&
+        typeof step.with?.key === "string" &&
+        step.with.key.includes("typecheck-tsbuildinfo-"),
+    );
+    expect(warmTsCache).toBeDefined();
+    expect(warmTsCache.with?.["restore-keys"]).toContain("typecheck-tsbuildinfo-");
+
+    const gateWorkflow = loadWorkflow("pr-checks.yml").parsed;
+    const typecheckCache = (gateWorkflow.jobs?.typecheck?.steps ?? []).find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(warmTsCache.with?.path).toBe(typecheckCache?.with?.path);
+    expect(warmTsCache.with?.key).toBe(typecheckCache?.with?.key);
+
+    const warmTypecheck = warmSteps.find(
+      (step: any) => typeof step.run === "string" && step.run.includes("pnpm typecheck"),
+    );
+    expect(warmTypecheck).toBeDefined();
+    expect(warmSteps.indexOf(warmTypecheck)).toBeGreaterThan(warmSteps.indexOf(warmTsCache));
   });
 });
 

--- a/packages/cli/src/__tests__/ci-workflow.test.ts
+++ b/packages/cli/src/__tests__/ci-workflow.test.ts
@@ -186,6 +186,50 @@ describe("Merge gate (.github/workflows/pr-checks.yml)", () => {
   });
 
   /*
+  FNXC:CIGateSpeed 2026-07-22-23:30:
+  The Gate job's dist cache is INCREMENTAL (`gate-dist-*` with restore-keys), which is only
+  safe because `pnpm build` always runs after restore and reconciles a near-match restore via
+  the content-hash skip cache (.fusion/cache/plugin-build-cache.json, cached alongside dist).
+  Pin the coupled invariants so no future edit keeps restore-keys while dropping the build
+  (stale-dist FN-4232/FN-4605), drops the hash-cache path (full rebuild every run), or lets
+  the exact-hit-only seed step fire on a near-hit restore.
+  */
+  it("gate dist cache is incremental and reconciled by a mandatory build", () => {
+    const gateSteps = workflow.jobs?.gate?.steps ?? [];
+    const cacheStep = gateSteps.find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(cacheStep).toBeDefined();
+    expect(cacheStep.with?.key).toContain("gate-dist-");
+    expect(cacheStep.with?.["restore-keys"]).toContain("gate-dist-");
+    expect(cacheStep.with?.path).toContain(".fusion/cache/plugin-build-cache.json");
+    expect(cacheStep.with?.path).toContain("packages/cli/dist");
+    expect(cacheStep.with?.path).not.toContain("node_modules");
+
+    // restore-keys is only safe with the reconciling build; the build must run
+    // AFTER the cache restore and BEFORE boot smoke / gate tests.
+    const buildIndex = gateSteps.findIndex(
+      (step: any) => step.name === "Build" && typeof step.run === "string" && step.run.includes("pnpm build"),
+    );
+    expect(buildIndex).toBeGreaterThan(gateSteps.indexOf(cacheStep));
+    const smokeIndex = gateSteps.findIndex(
+      (step: any) => typeof step.run === "string" && step.run.includes("boot-smoke.mjs"),
+    );
+    expect(smokeIndex).toBeGreaterThan(buildIndex);
+
+    // Fast CLI packaging in the gate (verify:fast shape); the blocking Build
+    // job keeps full CI packaging coverage.
+    expect(gateSteps[buildIndex].env?.FUSION_CLI_FULL_PACKAGE).toBe("0");
+
+    // The mtime-defeating seed must stay exact-hit-only: on a near-hit restore
+    // the dist is stale for changed packages until the build reconciles it.
+    const seedStep = gateSteps.find(
+      (step: any) => typeof step.run === "string" && step.run.includes("--seed-artifact-cache"),
+    );
+    expect(seedStep?.if).toContain("cache-hit == 'true'");
+  });
+
+  /*
   FNXC:CITestGate 2026-06-26-06:40:
   The merge gate is the thin trusted CI surface. ci-workflow.test.ts must pin not only that the Gate job invokes `pnpm test:gate`, but also test:gate's internal composition (guards + engine test:core + cli test:ci-shape) and that engine test:core references the engine-core vitest project — otherwise a rename could hollow the gate while this CI-shape test stays green (FN-7059).
   */
@@ -352,6 +396,39 @@ describe("Full suite workflow (.github/workflows/full-suite.yml)", () => {
         (step: any) => step.name === "Build" || (typeof step.run === "string" && step.run.includes("pnpm build")),
       ),
     ).toBe(false);
+  });
+
+  /*
+  FNXC:CIGateSpeed 2026-07-22-23:30:
+  Caches saved on a PR merge ref are invisible to other PRs, so the gate's
+  incremental `gate-dist-*` cache must be warmed from main or every PR's first
+  gate run builds cold. Pin the warm job's existence AND that its cache path
+  list is byte-identical to the Gate job's — actions/cache versions caches by
+  path list, so a drifted list silently makes the warm cache unrestorable.
+  */
+  it("warms the gate build cache from main with a path list identical to the gate's", () => {
+    const warmSteps = workflow.jobs?.["warm-gate-build-cache"]?.steps ?? [];
+    const warmCache = warmSteps.find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(warmCache).toBeDefined();
+    expect(warmCache.with?.key).toContain("gate-dist-");
+    expect(warmCache.with?.["restore-keys"]).toContain("gate-dist-");
+
+    const gateWorkflow = loadWorkflow("pr-checks.yml").parsed;
+    const gateCache = (gateWorkflow.jobs?.gate?.steps ?? []).find(
+      (step: any) => typeof step.uses === "string" && step.uses.startsWith("actions/cache"),
+    );
+    expect(warmCache.with?.path).toBe(gateCache?.with?.path);
+    expect(warmCache.with?.key).toBe(gateCache?.with?.key);
+
+    // The warm job must actually build (that is what populates dist + the
+    // content-hash cache), in the gate's fast-CLI-packaging shape.
+    const warmBuild = warmSteps.find(
+      (step: any) => typeof step.run === "string" && step.run.includes("pnpm build"),
+    );
+    expect(warmBuild).toBeDefined();
+    expect(warmBuild.env?.FUSION_CLI_FULL_PACKAGE).toBe("0");
   });
 });
 

--- a/packages/dashboard/tsconfig.app.json
+++ b/packages/dashboard/tsconfig.app.json
@@ -1,6 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    /*
+    FNXC:CIGateSpeed 2026-07-23-00:05:
+    tsconfig.base.json points tsBuildInfoFile at ${configDir}/dist/.tsbuildinfo, and
+    configDir is packages/dashboard for BOTH this config and tsconfig.json — so the two
+    `pnpm typecheck` programs clobbered each other's buildinfo and tsc re-checked the
+    full program on every run. A distinct file restores real incremental typechecking
+    (and lets CI cache both files).
+    */
+    "tsBuildInfoFile": "${configDir}/dist/.tsbuildinfo-app",
     "rootDir": "..",
     "jsx": "react-jsx",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Every PR's blocking checks were dominated by redundant full rebuilds, not by tests. Measured on recent runs: the Gate job spent ~6 of its ~7.5 min on a cold `pnpm build` (the exact-key dist cache missed on virtually every PR) for ~45s of actual boot smoke + gate tests; Build ran ~8 min and Typecheck ~4 min, both fully cold every time. Expected end state once the warm job has run on main: all four blocking checks in roughly 2–4 min wall-clock.

### Gate job
- New `gate-dist-*` cache namespace with `restore-keys`, additionally caching `.fusion/cache/plugin-build-cache.json` (build-workspace's per-package content-hash skip cache) and `packages/cli/dist`. The always-run `pnpm build` reconciles a near-match restore by content hash and rebuilds only the packages the PR touched. This is safe *because* the gate builds after restoring — the shard jobs' "no restore-keys" rule (FN-4232/FN-4605 stale-dist incidents) still stands there, since they consume dist without building.
- `FUSION_CLI_FULL_PACKAGE=0` on the gate build: skips the multi-minute CLI desktop/plugins/DTS packaging tail nothing in the gate consumes (same shape `pnpm verify:fast` proves locally). Full CLI packaging coverage stays blocking in the Build job.

### Build job
- Restore-only tap (`actions/cache/restore`) of the same warmed cache. Restore-only because this job runs FULL CLI packaging (`CI=true`) and saving that shape would swap the cache's canonical fast-CLI contents out from under the Gate job. Its distinctive coverage is preserved: `ensureFullPackageCliPlanned` force-plans the CLI in full mode regardless of cache state.

### Typecheck job
- Caches per-package tsc incremental buildinfo — self-validating (tsc hashes every input against it and re-checks whatever changed), so `restore-keys` is correctness-neutral by construction.
- **Fixes a real incrementality bug:** `tsconfig.json` and `tsconfig.app.json` in the dashboard both inherited `${configDir}/dist/.tsbuildinfo` from `tsconfig.base.json`, so the two typecheck programs clobbered each other's buildinfo and re-checked the full program every run — incremental typechecking never worked for the dashboard, in CI or locally. `tsconfig.app.json` now writes `dist/.tsbuildinfo-app`. Measured: dashboard typecheck 44s cold → 5.6s warm.

### Warm job (full-suite.yml, push to main)
- New `warm-gate-build-cache` job saves both caches from main on every push. Caches saved on a PR merge ref are invisible to other PRs, so without this every PR's *first* run would still build/check cold.

## Guardrails

`ci-workflow.test.ts` pins the coupled invariants so they can't drift apart silently:
- restore-keys requires the reconciling `pnpm build` after restore, before boot smoke
- the mtime-defeating seed step stays exact-hit-only
- byte-identical cache path lists between the Gate/Build/warm blocks (actions/cache versions caches by path list — a drifted list makes caches mutually invisible)
- Build stays restore-only and must NOT opt out of full CLI packaging
- Typecheck cache shape + the distinct dashboard app buildinfo path

## Notes

- First PR runs after this lands still build cold until the warm job has run once on main.
- No changeset: CI config + test-only per AGENTS.md.

## Verification

- `ci-workflow.test.ts` + `package-config.test.ts`: 106 tests pass
- Dashboard typecheck run twice locally: 44s cold → 5.6s warm, both `.tsbuildinfo` and `.tsbuildinfo-app` written, exit 0
- Cache block path/key parity verified programmatically across both workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved CI build and type-check performance through incremental caching.
  * Added cache warming from the main branch to speed up pull request checks.
  * Enabled faster CLI packaging during gate validation while retaining full packaging coverage elsewhere.

* **Bug Fixes**
  * Prevented dashboard TypeScript build information from being overwritten, preserving incremental type-checking reliability.

* **Tests**
  * Added coverage to verify CI cache behavior, build ordering, cache paths, and packaging modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->