### PR TITLE
fix(i18n): restore secondary locale key parity

### DIFF
--- a/.changeset/sync-heartbeat-locale-parity.md
+++ b/.changeset/sync-heartbeat-locale-parity.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep secondary locale catalogs in sync with heartbeat controls and settings provenance labels.
+category: fix
+dev: Synchronize all five secondary app catalogs with the authored English key structure so untranslated values fall back cleanly to English.

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -5981,7 +5981,8 @@
       "reportDiscussionCategoryHelp": "Obligatoria al enviar a Discusiones de GitHub. Las categorías se cargan desde el repositorio configurado.",
       "reportDiscussionCategorySelect": "Selecciona una categoría de discusión",
       "reportDiscussionCategoryUnavailable": "Las categorías de discusión no están disponibles para el repositorio configurado.",
-      "reportDiscussionCategoryEmpty": "No hay categorías de discusión disponibles para el repositorio configurado."
+      "reportDiscussionCategoryEmpty": "No hay categorías de discusión disponibles para el repositorio configurado.",
+      "reportTargetByActionHelp": ""
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6027,7 +6028,11 @@
       "skipConfirmationDialogs": "",
       "skipConfirmationDialogsHint": "",
       "enableProactiveTaskChat": "",
-      "enableProactiveTaskChatHint": ""
+      "enableProactiveTaskChatHint": "",
+      "releaseChannel": "",
+      "releaseChannelHelp": "",
+      "channelStable": "",
+      "channelBeta": ""
     },
     "globalModels": {
       "allow": "",
@@ -7837,7 +7842,12 @@
       "createdVia": "Creado mediante",
       "parentTaskOf": "",
       "createdToUndo": "",
-      "undoTask": ""
+      "undoTask": "",
+      "creatingAgent": "",
+      "importedFrom": "",
+      "nearDuplicateOf": "",
+      "parentTask": "",
+      "title": ""
     },
     "recoveryState": "Estado de recuperación",
     "refine": {

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -5981,7 +5981,8 @@
       "reportDiscussionCategoryHelp": "Obligatoire pour envoyer vers les Discussions GitHub. Les catégories sont chargées depuis le dépôt configuré.",
       "reportDiscussionCategorySelect": "Sélectionnez une catégorie de discussion",
       "reportDiscussionCategoryUnavailable": "Les catégories de discussion ne sont pas disponibles pour le dépôt configuré.",
-      "reportDiscussionCategoryEmpty": "Aucune catégorie de discussion n’est disponible pour le dépôt configuré."
+      "reportDiscussionCategoryEmpty": "Aucune catégorie de discussion n’est disponible pour le dépôt configuré.",
+      "reportTargetByActionHelp": ""
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6027,7 +6028,11 @@
       "skipConfirmationDialogs": "",
       "skipConfirmationDialogsHint": "",
       "enableProactiveTaskChat": "",
-      "enableProactiveTaskChatHint": ""
+      "enableProactiveTaskChatHint": "",
+      "releaseChannel": "",
+      "releaseChannelHelp": "",
+      "channelStable": "",
+      "channelBeta": ""
     },
     "globalModels": {
       "allow": "",
@@ -7837,7 +7842,12 @@
       "createdVia": "Créé via",
       "parentTaskOf": "",
       "createdToUndo": "",
-      "undoTask": ""
+      "undoTask": "",
+      "creatingAgent": "",
+      "importedFrom": "",
+      "nearDuplicateOf": "",
+      "parentTask": "",
+      "title": ""
     },
     "recoveryState": "État de récupération",
     "refine": {

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -1128,7 +1128,24 @@
     "notGranted": "Not granted",
     "toggleCapabilityGrant": "Toggle explicit grant for {{permission}}",
     "capabilityPermissionsUpdated": "Capability grants updated",
-    "capabilityPermissionsFailed": "Failed to update capability grants: {{error}}"
+    "capabilityPermissionsFailed": "Failed to update capability grants: {{error}}",
+    "disableHeartbeat": "",
+    "enableHeartbeat": "",
+    "heartbeatActionForAgent": "",
+    "heartbeatUpdating": "",
+    "heartbeatEnabledForAgent": "",
+    "heartbeatUpdateFailed": "",
+    "enableAllHeartbeats": "",
+    "disableAllHeartbeats": "",
+    "enableAllHeartbeatsConfirm": "",
+    "disableAllHeartbeatsConfirm": "",
+    "noHeartbeatsToEnable": "",
+    "noHeartbeatsToDisable": "",
+    "enableHeartbeatsSummary": "",
+    "disableHeartbeatsSummary": "",
+    "enableHeartbeatsCountHint": "",
+    "disableHeartbeatsCountHint": "",
+    "bulkFailures": ""
   },
   "app": {
     "backendError": {
@@ -5964,7 +5981,8 @@
       "reportDiscussionCategoryHelp": "Required when filing to GitHub Discussions. Categories are loaded from the configured repository.",
       "reportDiscussionCategorySelect": "토론 카테고리 선택",
       "reportDiscussionCategoryUnavailable": "Discussion categories are unavailable for the configured repository.",
-      "reportDiscussionCategoryEmpty": "No Discussion categories are available for the configured repository."
+      "reportDiscussionCategoryEmpty": "No Discussion categories are available for the configured repository.",
+      "reportTargetByActionHelp": ""
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6010,7 +6028,11 @@
       "skipConfirmationDialogs": "",
       "skipConfirmationDialogsHint": "",
       "enableProactiveTaskChat": "",
-      "enableProactiveTaskChatHint": ""
+      "enableProactiveTaskChatHint": "",
+      "releaseChannel": "",
+      "releaseChannelHelp": "",
+      "channelStable": "",
+      "channelBeta": ""
     },
     "globalModels": {
       "allow": "",
@@ -7820,7 +7842,12 @@
       "createdVia": "생성 경로",
       "parentTaskOf": "",
       "createdToUndo": "",
-      "undoTask": ""
+      "undoTask": "",
+      "creatingAgent": "",
+      "importedFrom": "",
+      "nearDuplicateOf": "",
+      "parentTask": "",
+      "title": ""
     },
     "recoveryState": "복구 상태",
     "refine": {

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -1128,7 +1128,24 @@
     "notGranted": "Not granted",
     "toggleCapabilityGrant": "Toggle explicit grant for {{permission}}",
     "capabilityPermissionsUpdated": "Capability grants updated",
-    "capabilityPermissionsFailed": "Failed to update capability grants: {{error}}"
+    "capabilityPermissionsFailed": "Failed to update capability grants: {{error}}",
+    "disableHeartbeat": "",
+    "enableHeartbeat": "",
+    "heartbeatActionForAgent": "",
+    "heartbeatUpdating": "",
+    "heartbeatEnabledForAgent": "",
+    "heartbeatUpdateFailed": "",
+    "enableAllHeartbeats": "",
+    "disableAllHeartbeats": "",
+    "enableAllHeartbeatsConfirm": "",
+    "disableAllHeartbeatsConfirm": "",
+    "noHeartbeatsToEnable": "",
+    "noHeartbeatsToDisable": "",
+    "enableHeartbeatsSummary": "",
+    "disableHeartbeatsSummary": "",
+    "enableHeartbeatsCountHint": "",
+    "disableHeartbeatsCountHint": "",
+    "bulkFailures": ""
   },
   "app": {
     "backendError": {
@@ -5964,7 +5981,8 @@
       "reportDiscussionCategoryHelp": "Required when filing to GitHub Discussions. Categories are loaded from the configured repository.",
       "reportDiscussionCategorySelect": "选择讨论类别",
       "reportDiscussionCategoryUnavailable": "Discussion categories are unavailable for the configured repository.",
-      "reportDiscussionCategoryEmpty": "No Discussion categories are available for the configured repository."
+      "reportDiscussionCategoryEmpty": "No Discussion categories are available for the configured repository.",
+      "reportTargetByActionHelp": ""
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6010,7 +6028,11 @@
       "skipConfirmationDialogs": "",
       "skipConfirmationDialogsHint": "",
       "enableProactiveTaskChat": "",
-      "enableProactiveTaskChatHint": ""
+      "enableProactiveTaskChatHint": "",
+      "releaseChannel": "",
+      "releaseChannelHelp": "",
+      "channelStable": "",
+      "channelBeta": ""
     },
     "globalModels": {
       "allow": "",
@@ -7820,7 +7842,12 @@
       "createdVia": "通过…创建",
       "parentTaskOf": "",
       "createdToUndo": "",
-      "undoTask": ""
+      "undoTask": "",
+      "creatingAgent": "",
+      "importedFrom": "",
+      "nearDuplicateOf": "",
+      "parentTask": "",
+      "title": ""
     },
     "recoveryState": "恢复状态",
     "refine": {

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -1128,7 +1128,24 @@
     "notGranted": "Not granted",
     "toggleCapabilityGrant": "Toggle explicit grant for {{permission}}",
     "capabilityPermissionsUpdated": "Capability grants updated",
-    "capabilityPermissionsFailed": "Failed to update capability grants: {{error}}"
+    "capabilityPermissionsFailed": "Failed to update capability grants: {{error}}",
+    "disableHeartbeat": "",
+    "enableHeartbeat": "",
+    "heartbeatActionForAgent": "",
+    "heartbeatUpdating": "",
+    "heartbeatEnabledForAgent": "",
+    "heartbeatUpdateFailed": "",
+    "enableAllHeartbeats": "",
+    "disableAllHeartbeats": "",
+    "enableAllHeartbeatsConfirm": "",
+    "disableAllHeartbeatsConfirm": "",
+    "noHeartbeatsToEnable": "",
+    "noHeartbeatsToDisable": "",
+    "enableHeartbeatsSummary": "",
+    "disableHeartbeatsSummary": "",
+    "enableHeartbeatsCountHint": "",
+    "disableHeartbeatsCountHint": "",
+    "bulkFailures": ""
   },
   "app": {
     "backendError": {
@@ -5964,7 +5981,8 @@
       "reportDiscussionCategoryHelp": "Required when filing to GitHub Discussions. Categories are loaded from the configured repository.",
       "reportDiscussionCategorySelect": "選擇討論分類",
       "reportDiscussionCategoryUnavailable": "Discussion categories are unavailable for the configured repository.",
-      "reportDiscussionCategoryEmpty": "No Discussion categories are available for the configured repository."
+      "reportDiscussionCategoryEmpty": "No Discussion categories are available for the configured repository.",
+      "reportTargetByActionHelp": ""
     },
     "globalGeneral": {
       "andShowsUpdateNoticesInTheCLIAnd": "",
@@ -6010,7 +6028,11 @@
       "skipConfirmationDialogs": "",
       "skipConfirmationDialogsHint": "",
       "enableProactiveTaskChat": "",
-      "enableProactiveTaskChatHint": ""
+      "enableProactiveTaskChatHint": "",
+      "releaseChannel": "",
+      "releaseChannelHelp": "",
+      "channelStable": "",
+      "channelBeta": ""
     },
     "globalModels": {
       "allow": "",
@@ -7820,7 +7842,12 @@
       "createdVia": "通過…建立",
       "parentTaskOf": "",
       "createdToUndo": "",
-      "undoTask": ""
+      "undoTask": "",
+      "creatingAgent": "",
+      "importedFrom": "",
+      "nearDuplicateOf": "",
+      "parentTask": "",
+      "title": ""
     },
     "recoveryState": "恢復狀態",
     "refine": {


### PR DESCRIPTION
## Summary
- synchronize all five secondary app locale catalogs with the authored English key structure
- restore fallback entries for heartbeat controls, release-channel settings, report targeting, and task provenance labels
- add a patch changeset for the catalog parity fix

## Test Plan
- `pnpm i18n:status`
- `pnpm --filter @fusion/i18n test` (29 tests)
- `pnpm --filter @fusion/dashboard exec vitest run app/components/__tests__/AgentsView.test.tsx --silent=passed-only --reporter=dot` (138 tests)
- `pnpm check:changesets`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localization consistency for heartbeat controls, capability settings, release-channel configuration, reporting guidance, and task provenance details.
  - Added missing translation entries across Spanish, French, Korean, Simplified Chinese, and Traditional Chinese locales.
  - Untranslated values now fall back cleanly to the authored English text structure, preventing missing or inconsistent labels in supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->