### PR TITLE
fix(ci): full-suite bookkeeping v32 — AgentsView heartbeat mock

### DIFF
--- a/packages/dashboard/app/components/__tests__/agents-view-mobile.test.tsx
+++ b/packages/dashboard/app/components/__tests__/agents-view-mobile.test.tsx
@@ -35,6 +35,13 @@ function extractMobileMediaBlocks(content: string): string {
   return blocks.join("\n");
 }
 
+/*
+FNXC:DashboardTests 2026-07-24-03:15:
+AgentsView imports isAgentHeartbeatEnabled / withAgentHeartbeatEnabled for bulk and
+per-card heartbeat toggles. A wholesale ../../api mock must re-export them or the
+view throws on mount and the tree collapses to an empty <div /> (Board/List/Controls
+queries fail with "no accessible roles").
+*/
 vi.mock("../../api", () => ({
   fetchAgents: vi.fn(),
   fetchAgentStats: vi.fn(),
@@ -48,6 +55,15 @@ vi.mock("../../api", () => ({
   fetchOrgTree: vi.fn(),
   fetchSettings: vi.fn(() => Promise.resolve({ heartbeatMultiplier: 1 })),
   updateSettings: vi.fn(() => Promise.resolve({})),
+  isAgentHeartbeatEnabled: (agent: { runtimeConfig?: { enabled?: boolean } }) =>
+    agent.runtimeConfig?.enabled !== false,
+  withAgentHeartbeatEnabled: (
+    agent: { runtimeConfig?: Record<string, unknown> },
+    enabled: boolean,
+  ) => ({
+    ...agent,
+    runtimeConfig: { ...(agent.runtimeConfig ?? {}), enabled },
+  }),
 }));
 /*
 FNXC:RuntimeFallbackUI 2026-07-11-00:00:


### PR DESCRIPTION
## Summary

Restore main full-suite green after AgentsView started calling `isAgentHeartbeatEnabled` / `withAgentHeartbeatEnabled`.

- **Root cause:** `agents-view-mobile.test.tsx` wholesale-mocks `../../api` without those exports → uncaught exception → empty DOM → missing Board/List/Controls queries.
- **Fix:** add heartbeat helpers to the mock (same contract as AgentDetailView helpers).

## Context

Failing run: https://github.com/Runfusion/Fusion/actions/runs/30062695937  
4 failures in `agents-view-mobile.test.tsx` (dashboard app quality backfill shard).

## Test plan

- [x] `app/components/__tests__/agents-view-mobile.test.tsx` (15 tests)
- [x] `pnpm test:gate` ×2
- [ ] CI PR checks / Full Suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved mobile agents view test coverage by adding heartbeat toggle behavior to the test setup.
  * Documented heartbeat-related dependencies used by bulk and individual agent controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->