### PR TITLE
fix(i18n): restore auto-update locale parity

### DIFF
--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -6043,6 +6043,8 @@
       "enableProactiveTaskChatHint": "",
       "releaseChannel": "",
       "releaseChannelHelp": "",
+      "autoUpdateAndRestart": "",
+      "autoUpdateAndRestartHelp": "",
       "channelStable": "",
       "channelBeta": "",
       "agentToolOutputLimit": "",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -6043,6 +6043,8 @@
       "enableProactiveTaskChatHint": "",
       "releaseChannel": "",
       "releaseChannelHelp": "",
+      "autoUpdateAndRestart": "",
+      "autoUpdateAndRestartHelp": "",
       "channelStable": "",
       "channelBeta": "",
       "agentToolOutputLimit": "",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -6043,6 +6043,8 @@
       "enableProactiveTaskChatHint": "",
       "releaseChannel": "",
       "releaseChannelHelp": "",
+      "autoUpdateAndRestart": "",
+      "autoUpdateAndRestartHelp": "",
       "channelStable": "",
       "channelBeta": "",
       "agentToolOutputLimit": "",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -6043,6 +6043,8 @@
       "enableProactiveTaskChatHint": "",
       "releaseChannel": "",
       "releaseChannelHelp": "",
+      "autoUpdateAndRestart": "",
+      "autoUpdateAndRestartHelp": "",
       "channelStable": "",
       "channelBeta": "",
       "agentToolOutputLimit": "",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -6043,6 +6043,8 @@
       "enableProactiveTaskChatHint": "",
       "releaseChannel": "",
       "releaseChannelHelp": "",
+      "autoUpdateAndRestart": "",
+      "autoUpdateAndRestartHelp": "",
       "channelStable": "",
       "channelBeta": "",
       "agentToolOutputLimit": "",


### PR DESCRIPTION
## Summary
- restore the two auto-update settings keys in all five secondary locale catalogs
- keep generated locale structure aligned with the authored English catalog

## Test plan
- `pnpm i18n:status`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added new settings text keys for “automatic updates and restart” (and its help text) in Spanish, French, Korean, Simplified Chinese, and Traditional Chinese.
  * The new values are placeholders (currently empty), so the UI may show missing/blank text until translations are completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->