### PR TITLE
test(engine): complete runtime logger mock

### DIFF
--- a/packages/engine/src/__tests__/runtime-resolution.test.ts
+++ b/packages/engine/src/__tests__/runtime-resolution.test.ts
@@ -22,6 +22,7 @@ import type { PluginRuntimeRegistration } from "@fusion/core";
 // Mock the logger to suppress output during tests
 vi.mock("../logger.js", () => ({
   createLogger: vi.fn(() => ({
+    debug: vi.fn(),
     log: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),


### PR DESCRIPTION
## Summary
- add the missing `debug` method to the runtime-resolution logger mock
- prevent logger calls from short-circuiting runtime selection assertions

## Test plan
- `pnpm --filter @fusion/engine exec vitest run src/__tests__/runtime-resolution.test.ts`
- `pnpm --filter @fusion/engine typecheck`
- `pnpm check:changesets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the runtime-resolution test suite’s mocked logger to also support debug-level messages, alongside existing log, warn, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->