### PR TITLE
Phase A3: the in-txn capacity invariant does NOT hold — root-caused, ratcheted, not fixed

### DIFF
--- a/packages/core/src/__tests__/postgres/workflow-capacity-invariant.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/workflow-capacity-invariant.pg.test.ts
@@ -1,0 +1,200 @@
+/*
+FNXC:WorkflowCapacity 2026-07-27-20:10 (Phase A3 — workflow-owned lifecycle):
+GROUND TRUTH for the in-transaction column-capacity invariant.
+
+`workflow-capacity.ts` states the enforcement "runs INSIDE `moveTaskInternal`'s
+transaction and is NEVER bypassable (not a guard — runs regardless of
+bypassGuards/recoveryRehome/moveSource)". Phase A2 observed the opposite: with
+`maxConcurrent: 1` and an occupied wip column, a second move into that column
+was ACCEPTED. This suite establishes which is true, by test.
+
+RESULT: the invariant does NOT hold for default-workflow tasks, for TWO
+independent reasons, each proven separately below.
+
+  R1. THE POOL-ID SENTINEL MISMATCH (the live defect).
+      `moves.ts:319` resolves the pool for a task with no workflow selection as
+          (await getTaskWorkflowSelectionAsync(id))?.workflowId ?? "builtin:coding"
+      while the counter buckets rows with no selection under
+          row.wid ?? DEFAULT_WORKFLOW_POOL_ID          // "__default-workflow__"
+      (`countActiveInCapacitySlotAsyncImpl`). The two sentinels differ, so for a
+      no-selection task the check asks for occupants of a pool that no occupant
+      is ever bucketed into: the count comes back 0 and the limit can never bind.
+      The SECOND enforcement point — the hold/release sweep at
+      `hold-release.ts:116` — uses `?? DEFAULT_WORKFLOW_POOL_ID` and is correct,
+      so the two points disagree about pool identity. That is precisely what the
+      module docstring claims is impossible ("the two enforcement points can
+      never disagree on what a limit *is*, only on the live count").
+
+  R2. THE `useWorkflow` GATE (why the live path is unaffected either way).
+      The whole in-txn capacity block sits inside
+      `if (useWorkflow && workflowIr && fromColumn !== toColumn)` (moves.ts:921),
+      and `useWorkflow` reads the raw `experimentalFeatures.workflowColumns` key
+      that nothing in production sets. So on the LIVE path the check does not run
+      at all — R1 is latent there and becomes reachable the moment the paths
+      converge onto the flag-ON side.
+
+The discriminating experiment is the third case: giving the tasks an EXPLICIT
+`builtin:coding` selection makes both sentinels agree, and the rejection appears.
+That is what distinguishes a sentinel bug from "capacity is simply not wired".
+
+STATUS: these tests document TODAY'S behavior and fail if it changes. The two
+that pin the defect are named `DEFECT:` and assert the wrong-but-current outcome
+deliberately — flipping them to expect rejection is the fix's acceptance test.
+Fixing is NOT done here: turning enforcement on changes scheduling for every
+project (the graph column boundary parks on `capacity-exhausted`), so the blast
+radius is reported for an operator decision first.
+*/
+
+import { afterEach, beforeEach, expect, it, beforeAll, afterAll } from "vitest";
+import {
+  pgDescribe,
+  createSharedPgTaskStoreTestHarness,
+  type SharedPgTaskStoreHarness,
+} from "../../__test-utils__/pg-test-harness.js";
+
+const pgTest = pgDescribe;
+
+pgTest("in-transaction column capacity — ground truth (Phase A3)", () => {
+  const h: SharedPgTaskStoreHarness = createSharedPgTaskStoreTestHarness({
+    prefix: "fusion_capacity_truth",
+  });
+
+  beforeAll(h.beforeAll);
+  beforeEach(h.beforeEach);
+  afterEach(h.afterEach);
+  afterAll(h.afterAll);
+
+  /*
+  Force the move path, then PROVE the flip took effect. Carried over from A2,
+  where two silent forcing failures (project-scoped write of a global key, then
+  a merge that never cleared the previous value) produced nine and seven
+  tautological "passes" respectively. A both-paths suite without this probe
+  reports what it assumed, not what happened.
+  */
+  async function setPath(path: "inline" | "hooks"): Promise<void> {
+    const store = h.store();
+    await store.updateGlobalSettings(
+      path === "hooks"
+        ? { experimentalFeatures: { workflowColumns: true } }
+        : { experimentalFeatures: { workflowColumns: false } },
+    );
+    const probe = await store.createTask({ description: `path probe ${path}` });
+    const err = await store
+      .moveTask(probe.id, "not-a-column-any-workflow-declares")
+      .then(() => null, (e: unknown) => e as Error);
+    expect(err, `${path}: probe move should have been rejected`).toBeInstanceOf(Error);
+    expect(err!.message, `${path} path not active`).toContain(
+      path === "hooks" ? "Unknown column for this workflow" : "Valid targets:",
+    );
+    await store.deleteTask(probe.id);
+  }
+
+  /** Occupy the wip column with one card, then try to move a second in.
+   *  Returns the rejection (or null when the move was accepted). */
+  async function fillWipThenAdmitSecond(
+    opts: { selectWorkflow?: string } = {},
+  ): Promise<{ error: Error | null; secondColumn: string | undefined }> {
+    const store = h.store();
+
+    const holder = await store.createTask({ description: "capacity holder" });
+    if (opts.selectWorkflow) await store.selectTaskWorkflow(holder.id, opts.selectWorkflow);
+    await store.moveTask(holder.id, "todo");
+    await store.moveTask(holder.id, "in-progress");
+
+    const contender = await store.createTask({ description: "capacity contender" });
+    if (opts.selectWorkflow) await store.selectTaskWorkflow(contender.id, opts.selectWorkflow);
+    await store.moveTask(contender.id, "todo");
+    const error = await store
+      .moveTask(contender.id, "in-progress")
+      .then(() => null, (e: unknown) => e as Error);
+
+    return { error, secondColumn: (await store.getTask(contender.id))?.column };
+  }
+
+  it("DEFECT (R2): on the LIVE inline path the in-txn capacity check cannot run at all", async () => {
+    // Not a surprise, but it is the reason the defect is latent rather than
+    // active today: the whole block is inside `if (useWorkflow && …)`.
+    const store = h.store();
+    await store.updateSettings({ maxConcurrent: 1 });
+    await setPath("inline");
+
+    const { error, secondColumn } = await fillWipThenAdmitSecond();
+
+    expect(error).toBeNull();
+    expect(secondColumn).toBe("in-progress"); // limit of 1, two occupants
+  });
+
+  it("DEFECT (R1): flag-ON, a NO-SELECTION task still slips the limit — the pool sentinels disagree", async () => {
+    /*
+    THE ACTUAL BUG. `moves.ts:319` asks the counter for pool "builtin:coding";
+    `countActiveInCapacitySlotAsyncImpl` buckets no-selection rows under
+    "__default-workflow__". No occupant is ever counted, so the limit cannot
+    bind. Flip this expectation to a rejection when the sentinel is fixed.
+    */
+    const store = h.store();
+    await store.updateSettings({ maxConcurrent: 1 });
+    await setPath("hooks");
+
+    const { error, secondColumn } = await fillWipThenAdmitSecond();
+
+    expect(error).toBeNull();
+    expect(secondColumn).toBe("in-progress");
+  });
+
+  it("DISCRIMINATOR: with an EXPLICIT builtin:coding selection the sentinels agree and the limit BINDS", async () => {
+    /*
+    This is what proves R1 is a sentinel mismatch rather than "capacity is not
+    wired". Same settings, same columns, same limit — the ONLY change is that
+    both tasks now carry a selection row, so `row.wid` is "builtin:coding" and
+    matches what moves.ts asked for. The occupant is counted and the move is
+    refused with the typed code the graph column boundary parks on.
+    */
+    const store = h.store();
+    await store.updateSettings({ maxConcurrent: 1 });
+    await setPath("hooks");
+
+    const { error, secondColumn } = await fillWipThenAdmitSecond({ selectWorkflow: "builtin:coding" });
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as unknown as { rejection?: { code?: string } }).rejection?.code).toBe(
+      "capacity-exhausted",
+    );
+    expect(secondColumn).toBe("todo"); // refused, stays put
+  });
+
+  /*
+  THE INVARIANT RATCHET.
+
+  The three cases above document today's behavior, so they stay green while the
+  defect exists — which on its own would let the defect live forever unnoticed.
+  This case states the invariant AS WRITTEN in `workflow-capacity.ts`
+  ("enforcement ... is NEVER bypassable") and is marked `it.fails`, so:
+
+      today  — the body fails (no rejection), therefore `it.fails` PASSES and CI
+               stays green while honestly recording that the invariant is broken;
+      fixed  — the body passes, `it.fails` FAILS, and whoever lands the sentinel
+               fix is forced to delete the `.fails` marker and the two `DEFECT:`
+               expectations above.
+
+  That is the "test that fails today if the invariant is broken" the unit asks
+  for, in the only shape that does not park a permanently-red test in CI. An
+  invariant nobody can prove is an invariant nobody has; this is the proof
+  obligation, written down.
+  */
+  it.fails(
+    "INVARIANT (currently BROKEN): a move into a full capacity column is refused, even with no workflow selection",
+    async () => {
+      const store = h.store();
+      await store.updateSettings({ maxConcurrent: 1 });
+      await setPath("hooks");
+
+      const { error, secondColumn } = await fillWipThenAdmitSecond();
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as unknown as { rejection?: { code?: string } }).rejection?.code).toBe(
+        "capacity-exhausted",
+      );
+      expect(secondColumn).toBe("todo");
+    },
+  );
+});


### PR DESCRIPTION
**Stacked on #2468**, which is stacked on #2467. Base is `feature/workflow-move-path-convergence`.

**Answer: the A2 observation was real. The documented invariant is broken.** Not a false alarm, not a harness artifact.

`workflow-capacity.ts` states enforcement "runs INSIDE `moveTaskInternal`'s transaction and is **NEVER bypassable** (not a guard — runs regardless of bypassGuards/recoveryRehome/moveSource)". It does not hold for default-workflow tasks, for two independent reasons.

## R1 — Pool-id sentinel mismatch (the defect)

| Site | Sentinel for "no workflow selection" |
|---|---|
| `moves.ts:319` (in-txn check, **asks**) | `?? "builtin:coding"` |
| `countActiveInCapacitySlotAsyncImpl` (**answers**) | `?? DEFAULT_WORKFLOW_POOL_ID` → `"__default-workflow__"` |
| `hold-release.ts:116` (sweep, second enforcement point) | `?? DEFAULT_WORKFLOW_POOL_ID` ✅ |

The check asks for occupants of a pool that no occupant is ever bucketed into, so the count comes back `0` and the limit can never bind. The sweep is correct, so the two enforcement points **disagree about pool identity** — precisely what the module docstring says is impossible ("the two enforcement points can never disagree on what a limit *is*, only on the live count").

Note the shape of the bug: it is not a missing check. The check runs, queries correctly, and returns a confidently wrong answer.

## R2 — The `useWorkflow` gate

The whole block sits inside `if (useWorkflow && workflowIr && fromColumn !== toColumn)` (`moves.ts:921`), and `useWorkflow` reads the raw `experimentalFeatures.workflowColumns` key nothing in production sets. **On the live path the check cannot run at all**, so R1 is latent today and becomes reachable the moment A2 converges onto the flag-ON side.

## How this was established, not guessed

Three of my assumptions failed earlier in this program, so this one is pinned by a **discriminating experiment** rather than a code reading:

| Case | Path | Selection | Result |
|---|---|---|---|
| DEFECT (R2) | inline (live) | none | accepted — check cannot run |
| DEFECT (R1) | hooks | none | accepted — sentinels disagree |
| **DISCRIMINATOR** | hooks | explicit `builtin:coding` | **refused, `capacity-exhausted`** |

The third case changes nothing but sentinel agreement. That rules out "capacity is simply not wired" and isolates the cause to the mismatch.

Both-path forcing reuses A2's `assertPathActive` probe. Without it this suite would silently run one path twice and report a tautology — the failure mode that produced sixteen false passes across A2's two harness bugs.

## The deliverable: an invariant ratchet

The three cases above assert today's wrong behavior, so on their own they would let the defect live forever. A fourth case states the invariant **as written** and is marked `it.fails`:

- **today** — the body fails, so `it.fails` passes; CI stays green while honestly recording the breach;
- **when fixed** — the body passes, `it.fails` *fails*, forcing whoever lands the fix to flip it and the two `DEFECT:` expectations.

That is "a test that fails if the invariant is broken" in the only shape that does not park a permanently-red test in CI.

## Blast radius (step 4) — why I did not fix it

The fix is one line: make `moves.ts:319` use `DEFAULT_WORKFLOW_POOL_ID`, matching the sweep. The consequences are not one line.

**Today: zero.** `useWorkflow` is false everywhere, so the corrected check still cannot run on the live path. The sentinel fix is safe to land in isolation.

**At A2 convergence: every default-workflow task move into `in-progress` becomes capacity-checked against `maxConcurrent` (default 2), for the first time.** Affected movers:

- **The graph column boundary** catches `capacity-exhausted` and *parks the run*. Runs that previously proceeded would begin suspending — this is a scheduling behavior change across every project, not an error path.
- **`executor.ts`, `project-engine.ts`, `pr-comment-handler.ts`** each move tasks into `in-progress` and would begin seeing a rejection they have never seen.
- **Operator drags and the promote route** would start refusing beyond `maxConcurrent`.

Scheduler-side admission (`maxConcurrent`) is a separate, still-live control, so this is not "capacity is unenforced today" — it is "the store-level check the graph and promote paths are written against returns 0 and never binds".

**Recommendation:** land the sentinel fix on its own (provably inert today), with the ratchet flipped in the same commit, *before* A2 convergence — so convergence does not simultaneously switch paths and switch on a previously-dead enforcement.

## Verification

4 cases green against real PostgreSQL (3 passed + 1 expected-fail), path flip proven live on every case. `pnpm lint` and `tsc --noEmit` green.

## Follow-up: both "not verified" items are now answered

Recorded here rather than left as open questions, since this is where anyone investigating capacity will look.

**1. Does the sync/SQLite counter carry the same mismatch? — YES, identically, but it is unreachable.**

`countActiveInCapacitySlotSyncImpl` (`project-store-ops.ts:767`) buckets rows the same way as the async one:

```ts
const effectiveWorkflowId = row.wid ?? TaskStore.DEFAULT_WORKFLOW_POOL_ID;
```

So it disagrees with `moves.ts:319` in exactly the same way. **However** its only caller is the public `TaskStore.countActiveInCapacitySlotSync` wrapper, which has no in-repo caller at all — it is dead API surface. The mismatch is real but currently unreachable, which makes it a landmine for whoever wires it up rather than an active defect. Fixing the sentinel should fix both call sites together.

**2. Are custom workflows with an explicit numeric `limit` affected? — NO, and this is already proven by the discriminator above.**

The mismatch fires **only when the selection row is absent** — that is what the `??` fallback is for. A custom workflow necessarily *has* a selection row; that is what makes it custom. The DISCRIMINATOR case adds an explicit selection and the rejection appears, which is exactly the custom-workflow shape. So the defect is scoped to **no-selection (default-workflow) tasks only**.

The explicit-numeric-`limit` question turns out to be orthogonal: `resolveColumnBudgetKey` returning `col:${columnId}` decides *which columns share a budget*, not which pool id is passed to the counter. It does not interact with the sentinel at all.

Net effect on blast radius: **narrower than first stated.** Only default-workflow (no-selection) tasks slip the limit today. Custom-workflow tasks are already enforced — meaning the fix does not switch enforcement on for them, it only closes the gap for the default workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for workflow column capacity enforcement during transactions.
  * Documented scenarios where capacity limits are bypassed, including tasks without workflow selection.
  * Verified that explicit workflow selection correctly rejects moves when capacity is exhausted.
  * Added a tracked failing test for the expected invariant once enforcement is corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->