### PR TITLE
U4 vertical slice: recovery-policy reconciler + ratified safety invariant (measured: engine ~780, real cost is a settings migration)

### DIFF
--- a/packages/core/src/__tests__/workflow-ir-column-recovery.test.ts
+++ b/packages/core/src/__tests__/workflow-ir-column-recovery.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment node
+//
+// FNXC:WorkflowRecoveryPolicy 2026-07-28-15:50 (PR #2478 review, two P1s):
+//
+// The recovery policy (`WorkflowIrColumn.recovery`, U4) needs the same two
+// protections every other IR column field already has, and shipped without them:
+//
+//   P1 — DOWNGRADE. `downgradeIrToV1IfPure` did not treat `recovery` as v2-only.
+//   The v1 shape has no `columns` at all, so a workflow with v1-compatible nodes
+//   and default-shaped columns serialized WITHOUT columns and PERMANENTLY
+//   DISCARDED the authored policy on save. Silent data loss: the card simply
+//   stops being reconciled, with no error and nothing in the diff to explain it.
+//
+//   P1 — VALIDATION. `parseWorkflowIr` persisted a negative or non-finite
+//   `stalenessMs`, an `onStale` missing its `code`, and unsupported actions, and
+//   the reconciler consumed them directly. A negative threshold makes every card
+//   instantly stale; a non-finite one makes no card ever stale. An invalid policy
+//   must be refused at save, not discovered at 3am in a sweep.
+//
+// Mirrors `workflow-ir-column-agent.test.ts`, which is the precedent for both.
+
+import { describe, expect, it } from "vitest";
+import {
+  parseWorkflowIr,
+  serializeWorkflowIr,
+  downgradeIrToV1IfPure,
+  WorkflowIrError,
+} from "../workflow-ir.js";
+import type { WorkflowColumnRecovery, WorkflowIrEdge, WorkflowIrNode, WorkflowIrV2 } from "../workflow-ir-types.js";
+
+function v2(
+  columns: WorkflowIrV2["columns"],
+  nodes: WorkflowIrNode[],
+  edges: WorkflowIrEdge[],
+): WorkflowIrV2 {
+  return { version: "v2", name: "test", columns, nodes, edges };
+}
+
+/**
+ * A graph whose columns are EXACTLY the default-shaped set — the only shape
+ * `downgradeIrToV1IfPure` will collapse to v1. That is deliberate: the data-loss
+ * bug only bites a workflow that would otherwise downgrade, so a custom-column
+ * fixture would pass the downgrade test for the wrong reason.
+ */
+function defaultShapedGraph(recovery?: WorkflowColumnRecovery): WorkflowIrV2 {
+  const columns: WorkflowIrV2["columns"] = [
+    { id: "triage", name: "triage", traits: [] },
+    { id: "todo", name: "todo", traits: [], ...(recovery ? { recovery } : {}) },
+    { id: "in-progress", name: "in-progress", traits: [] },
+    { id: "in-review", name: "in-review", traits: [] },
+    { id: "done", name: "done", traits: [] },
+    { id: "archived", name: "archived", traits: [] },
+  ];
+  return v2(
+    columns,
+    [
+      // Seamless nodes default to the "todo" column (see defaultColumnForNode);
+      // placing them anywhere else forces v2 on PLACEMENT and the downgrade
+      // control below would then pass for the wrong reason.
+      { id: "start", kind: "start", column: "todo" },
+      { id: "end", kind: "end", column: "todo" },
+    ],
+    [{ from: "start", to: "end" }],
+  );
+}
+
+const VALID: WorkflowColumnRecovery = {
+  stalenessMs: 86_400_000,
+  onStale: { action: "surface", code: "stale-paused-todo" },
+};
+
+describe("column recovery — downgrade protection (P1: silent data loss)", () => {
+  it("the fixture WITHOUT a recovery policy really does downgrade to v1", () => {
+    /*
+    The control. Without this the next test could pass because the fixture never
+    downgrades for an unrelated reason, proving nothing about `recovery`.
+    */
+    expect(downgradeIrToV1IfPure(defaultShapedGraph()).version).toBe("v1");
+  });
+
+  it("a graph carrying a recovery policy is forced to stay v2", () => {
+    expect(downgradeIrToV1IfPure(defaultShapedGraph(VALID)).version).toBe("v2");
+  });
+
+  it("an EMPTY recovery object still forces v2, because presence is the signal", () => {
+    /*
+    Matches the `optionalSteps` rule: an author who wrote the key intended v2, and
+    downgrading would still mutate the persisted shape.
+    */
+    expect(downgradeIrToV1IfPure(defaultShapedGraph({} as WorkflowColumnRecovery)).version).toBe("v2");
+  });
+
+  it("the policy survives a serialize → parse → downgrade round trip", () => {
+    /* The end-to-end shape of the reported bug: save must not eat the policy. */
+    const parsed = parseWorkflowIr(serializeWorkflowIr(defaultShapedGraph(VALID)));
+    const after = downgradeIrToV1IfPure(parsed) as WorkflowIrV2;
+
+    expect(after.version).toBe("v2");
+    expect(after.columns.find((c) => c.id === "todo")?.recovery).toEqual(VALID);
+  });
+
+  it("omits the key entirely when no policy is set", () => {
+    const serialized = serializeWorkflowIr(defaultShapedGraph());
+    expect(serialized).not.toContain('"recovery"');
+    const reparsed = parseWorkflowIr(serialized) as WorkflowIrV2;
+    expect("recovery" in reparsed.columns.find((c) => c.id === "todo")!).toBe(false);
+  });
+});
+
+describe("column recovery — parse-time validation (P1: invalid policy persisted)", () => {
+  function parseWith(recovery: unknown): WorkflowIrV2 {
+    return parseWorkflowIr(defaultShapedGraph(recovery as WorkflowColumnRecovery)) as WorkflowIrV2;
+  }
+
+  it("accepts a well-formed policy and round-trips it", () => {
+    const parsed = parseWith(VALID);
+    expect(parsed.columns.find((c) => c.id === "todo")?.recovery).toEqual(VALID);
+  });
+
+  it.each([
+    ["negative stalenessMs", { stalenessMs: -1, onStale: VALID.onStale }],
+    ["zero stalenessMs", { stalenessMs: 0, onStale: VALID.onStale }],
+    ["NaN stalenessMs", { stalenessMs: Number.NaN, onStale: VALID.onStale }],
+    ["Infinity stalenessMs", { stalenessMs: Number.POSITIVE_INFINITY, onStale: VALID.onStale }],
+    ["non-numeric stalenessMs", { stalenessMs: "86400000", onStale: VALID.onStale }],
+  ])("rejects %s", (_label, recovery) => {
+    expect(() => parseWith(recovery)).toThrow(WorkflowIrError);
+  });
+
+  it.each([
+    ["unsupported action", { stalenessMs: 1000, onStale: { action: "rebound", code: "x" } }],
+    ["missing action", { stalenessMs: 1000, onStale: { code: "x" } }],
+    ["missing code", { stalenessMs: 1000, onStale: { action: "surface" } }],
+    ["blank code", { stalenessMs: 1000, onStale: { action: "surface", code: "   " } }],
+    ["non-object onStale", { stalenessMs: 1000, onStale: "surface" }],
+  ])("rejects %s", (_label, recovery) => {
+    expect(() => parseWith(recovery)).toThrow(WorkflowIrError);
+  });
+
+  it.each([
+    ["threshold with no action", { stalenessMs: 1000 }],
+    ["action with no threshold", { onStale: VALID.onStale }],
+  ])("rejects a half-declared policy: %s", (_label, recovery) => {
+    /*
+    Either half alone silently does nothing — a threshold that never fires, or an
+    action with nothing to fire on. Persisting that would produce exactly the
+    "policy present but inert" failure this program keeps finding.
+    */
+    expect(() => parseWith(recovery)).toThrow(WorkflowIrError);
+  });
+
+  it("names the offending column in the error, so the author can find it", () => {
+    expect(() => parseWith({ stalenessMs: -1, onStale: VALID.onStale })).toThrow(/column 'todo'/);
+  });
+
+  it("still accepts a column with NO recovery key at all", () => {
+    expect(() => parseWorkflowIr(defaultShapedGraph())).not.toThrow();
+  });
+});

--- a/packages/core/src/index.gate.ts
+++ b/packages/core/src/index.gate.ts
@@ -217,6 +217,8 @@ export type {
   WorkflowIrColumn,
   WorkflowIrColumnTrait,
   WorkflowColumnAgent,
+  WorkflowColumnRecovery,
+  WorkflowColumnOnStale,
   WorkflowHoldRelease,
   WorkflowJoinMode,
   WorkflowJoinBranchFailure,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -246,6 +246,8 @@ export type {
   WorkflowIrColumn,
   WorkflowIrColumnTrait,
   WorkflowColumnAgent,
+  WorkflowColumnRecovery,
+  WorkflowColumnOnStale,
   WorkflowHoldRelease,
   WorkflowJoinMode,
   WorkflowJoinBranchFailure,

--- a/packages/core/src/workflow-ir-types.ts
+++ b/packages/core/src/workflow-ir-types.ts
@@ -375,6 +375,48 @@ export interface WorkflowIrColumn {
    *  omitted entirely when unset — never serialized as `agent: null` — so legacy
    *  and default workflows stay byte-identical (R9). */
   agent?: WorkflowColumnAgent;
+  /** Optional recovery policy (U4). Additive; omitted entirely when unset. */
+  recovery?: WorkflowColumnRecovery;
+}
+
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-13:55 (U4):
+The workflow-declared recovery policy for one column — the first key of the U4
+reshape, which moves self-healing from ~53 hardcoded imperative sweeps to rules
+the workflow declares and ONE reconciler applies.
+
+Deliberately tiny. The survey's finding was that a knob per sweep would move 53
+sweeps into 53 config keys and trim nothing, so this grows only when a whole
+FAMILY of sweeps collapses onto a new key.
+
+SAFETY BOUNDARY, ratified and non-negotiable: this type can express WHEN a card
+is considered stuck and WHAT to do about it. It can NEVER express whether to
+respect a user pause, `autoMerge:false`, a dependency, a capacity limit, a
+merge-proof requirement, or an at-most-once guarantee. Those six safeguards are
+enforced by the reconciler OUTSIDE the policy table, because as policy keys a
+workflow author could switch a safety invariant off. `recovery-policy-safety`
+tests fail if any of the six becomes reachable from here.
+*/
+export interface WorkflowColumnRecovery {
+  /**
+   * How long a card may rest in this column before the reconciler treats it as
+   * stuck. Omitted = this column has no staleness rule and is never reconciled
+   * on that basis.
+   */
+  stalenessMs?: number;
+  /** What to do when `stalenessMs` elapses. */
+  onStale?: WorkflowColumnOnStale;
+}
+
+/**
+ * `surface` records an operator-visible signal and mutates NO lifecycle state.
+ * It is the only action in the vertical slice; `rebound` and `archive` land with
+ * the families that need them, so the union stays honest about what is built.
+ */
+export interface WorkflowColumnOnStale {
+  action: "surface";
+  /** Stable signal code written to the task log, e.g. `stale-paused-todo`. */
+  code: string;
 }
 
 /** Release conditions for a `hold` node (KTD-2, R3). */

--- a/packages/core/src/workflow-ir.ts
+++ b/packages/core/src/workflow-ir.ts
@@ -1449,6 +1449,7 @@ function validateColumns(ir: WorkflowIrV2): void {
     }
     validateExtensionMetadata(`Workflow IR column '${column.id}'`, column.extensions);
     validateColumnAgent(column);
+    validateColumnRecovery(column);
   }
 }
 
@@ -1555,6 +1556,67 @@ function validateColumnAgent(column: WorkflowIrColumn): void {
   if (agent.mode !== "defer" && agent.mode !== "override") {
     throw new WorkflowIrError(
       `Workflow IR column '${column.id}' agent mode must be 'defer' or 'override' (got '${String(agent.mode)}')`,
+    );
+  }
+}
+
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-15:20 (PR #2478 review, P1):
+Validate the optional recovery policy at PARSE, like every other IR field.
+
+Without this, `parseWorkflowIr` happily persisted a negative or non-finite
+`stalenessMs`, an `onStale` missing its `code`, or an unsupported action — and
+the reconciler consumed them directly. A negative threshold makes every card
+instantly stale; a non-finite one makes no card ever stale. Both are silent, and
+both surface as a recovery sweep behaving inexplicably at 3am rather than as a
+save that was refused.
+
+Mirrors `validateColumnAgent`: absent → no-op; present → fully checked. The
+action list is closed on purpose, so adding an action to the type without
+teaching the reconciler about it fails at authoring time.
+*/
+function validateColumnRecovery(column: WorkflowIrColumn): void {
+  const recovery = column.recovery;
+  if (recovery === undefined) return;
+  if (!recovery || typeof recovery !== "object" || Array.isArray(recovery)) {
+    throw new WorkflowIrError(`Workflow IR column '${column.id}' recovery must be an object`);
+  }
+
+  const { stalenessMs, onStale } = recovery;
+
+  if (stalenessMs !== undefined) {
+    if (typeof stalenessMs !== "number" || !Number.isFinite(stalenessMs) || stalenessMs <= 0) {
+      throw new WorkflowIrError(
+        `Workflow IR column '${column.id}' recovery.stalenessMs must be a finite number greater than 0 (got '${String(stalenessMs)}')`,
+      );
+    }
+  }
+
+  if (onStale !== undefined) {
+    if (!onStale || typeof onStale !== "object" || Array.isArray(onStale)) {
+      throw new WorkflowIrError(`Workflow IR column '${column.id}' recovery.onStale must be an object`);
+    }
+    if (onStale.action !== "surface") {
+      throw new WorkflowIrError(
+        `Workflow IR column '${column.id}' recovery.onStale.action must be 'surface' (got '${String(onStale.action)}')`,
+      );
+    }
+    if (typeof onStale.code !== "string" || onStale.code.trim() === "") {
+      throw new WorkflowIrError(
+        `Workflow IR column '${column.id}' recovery.onStale must have a non-empty code`,
+      );
+    }
+  }
+
+  /*
+  A policy is only actionable with BOTH halves: a threshold with no action never
+  fires, and an action with no threshold has nothing to fire on. Either alone is
+  almost certainly an authoring mistake, and accepting it would persist a policy
+  that silently does nothing — the exact failure this program keeps finding.
+  */
+  if ((stalenessMs === undefined) !== (onStale === undefined)) {
+    throw new WorkflowIrError(
+      `Workflow IR column '${column.id}' recovery requires both stalenessMs and onStale, or neither`,
     );
   }
 }
@@ -1796,6 +1858,19 @@ export function downgradeIrToV1IfPure(ir: WorkflowIr): WorkflowIr {
     // A permanent-agent binding is a v2-only feature (column-agent plan, R9): a
     // graph that staffs a column can never round-trip through a pre-v2 binary.
     if (col.agent !== undefined) return ir;
+    /*
+    FNXC:WorkflowRecoveryPolicy 2026-07-28-15:10 (PR #2478 review, P1):
+    A recovery policy is v2-only for the same reason as `agent`. The v1 shape has
+    no `columns` at all, so downgrading a workflow that declares one does not
+    degrade it — it PERMANENTLY DISCARDS the authored policy on the next save,
+    silently. The card would then simply stop being reconciled, with no error and
+    nothing in the diff to explain why.
+
+    The mere PRESENCE of the key is the v2 signal, matching the `optionalSteps`
+    rule above: an author who wrote `recovery: {}` intended v2, and downgrading
+    would still mutate the persisted shape.
+    */
+    if (col.recovery !== undefined) return ir;
     if (col.extensions !== undefined && Object.keys(col.extensions).length > 0) return ir;
   }
 

--- a/packages/engine/src/__tests__/recovery-policy-safety.test.ts
+++ b/packages/engine/src/__tests__/recovery-policy-safety.test.ts
@@ -1,0 +1,156 @@
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-14:20 (U4 — RATIFIED SAFETY INVARIANT):
+
+The single most important rule in the U4 policy design, encoded as a test.
+
+The six safeguards — user pause, `autoMerge:false`, dependency, capacity,
+merge-proof, at-most-once — are enforced by the reconciler OUTSIDE the policy
+table. They must NEVER become expressible as workflow policy, because a workflow
+author would then be able to author a safety invariant away: a workflow whose
+`recovery` block said "ignore user pause" would produce an engine that overrides
+an operator's explicit stop.
+
+This file fails if any of the six becomes reachable from `WorkflowColumnRecovery`.
+Two independent mechanisms, because either alone is defeatable:
+
+  1. a STRUCTURAL assertion over the policy type's accepted keys — catches a new
+     key being added to the schema;
+  2. a BEHAVIORAL assertion that a policy attempting to disable a safeguard has
+     no effect — catches the schema staying clean while the reconciler starts
+     honoring an undeclared field.
+
+The structural half is deliberately written against a hand-maintained allow-list
+rather than inferred from the type, so ADDING a policy key requires editing this
+file and re-stating the safety argument. That friction is the point.
+*/
+import { describe, expect, it } from "vitest";
+import type { Task, WorkflowIr } from "@fusion/core";
+
+import { decideRecovery, isSuppressedBySafeguard, resolveColumnRecovery } from "../recovery-reconciler.js";
+
+/**
+ * Every key the recovery policy is ALLOWED to express. Adding to this list means
+ * asserting, in review, that the new key cannot disable a safeguard.
+ */
+const ALLOWED_POLICY_KEYS = ["stalenessMs", "onStale"] as const;
+
+/** The six safeguards, in the vocabulary an author might try to use. */
+const SAFEGUARD_KEYS = [
+  "userPaused", "respectUserPause", "ignoreUserPause",
+  "autoMerge", "allowAutoMergeOff", "ignoreAutoMerge",
+  "dependencies", "ignoreDependencies", "skipDependencyCheck",
+  "capacity", "ignoreCapacity", "overrideCapacity",
+  "mergeProof", "skipMergeProof", "ignoreMergeConfirmed",
+  "atMostOnce", "allowRepeat", "skipIdempotency",
+];
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "FN-1",
+    title: "t",
+    description: "",
+    column: "drafting",
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    columnMovedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  } as unknown as Task;
+}
+
+/** A workflow whose hold column carries a staleness policy, plus any extra keys. */
+function ir(extraPolicyKeys: Record<string, unknown> = {}): WorkflowIr {
+  return {
+    version: "v2",
+    id: "custom:wf",
+    nodes: [],
+    edges: [],
+    columns: [
+      {
+        id: "drafting",
+        name: "Drafting",
+        traits: [{ trait: "hold", config: { release: "capacity" } }],
+        recovery: {
+          stalenessMs: 1_000,
+          onStale: { action: "surface", code: "stale-paused-todo" },
+          ...extraPolicyKeys,
+        },
+      },
+      { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+const LATER = { now: () => Date.parse("2026-01-02T00:00:00.000Z") };
+
+describe("recovery policy safety invariant — safeguards live OUTSIDE the policy table", () => {
+  describe("structural: the policy schema exposes no safeguard key", () => {
+    it("accepts only the allow-listed keys", () => {
+      /* Reading the policy back off a workflow must surface nothing beyond the
+         allow-list. A new key here is a deliberate review decision, not a drift. */
+      const policy = resolveColumnRecovery(ir(), "drafting");
+      expect(policy).toBeDefined();
+      expect(Object.keys(policy!).sort()).toEqual([...ALLOWED_POLICY_KEYS].sort());
+    });
+
+    it.each(SAFEGUARD_KEYS)("does not allow-list a safeguard key: %s", (key) => {
+      expect(ALLOWED_POLICY_KEYS as readonly string[]).not.toContain(key);
+    });
+  });
+
+  describe("behavioral: a policy that tries to disable a safeguard has no effect", () => {
+    it("cannot switch off the user-pause safeguard", () => {
+      /*
+      The load-bearing case for the `surface` action. A user-paused card must not
+      receive engine-authored signals, and no policy may say otherwise.
+      */
+      const paused = task({ userPaused: true } as Partial<Task>);
+
+      // Honest policy: suppressed.
+      const honest = decideRecovery(paused, ir(), LATER);
+      expect(honest).toEqual({ suppressed: "user-paused" });
+
+      // Hostile policy attempting every spelling of "ignore the pause": identical.
+      const hostile = decideRecovery(
+        paused,
+        ir({ ignoreUserPause: true, respectUserPause: false, userPaused: false }),
+        LATER,
+      );
+      expect(hostile).toEqual({ suppressed: "user-paused" });
+    });
+
+    it("still acts on an unpaused card, so the guard is not vacuously suppressing everything", () => {
+      /* Without this, a reconciler that suppressed EVERYTHING would pass the test
+         above while doing nothing — the "dead guard passes tests" failure mode. */
+      const outcome = decideRecovery(task(), ir(), LATER);
+      expect(outcome).toEqual({
+        decision: expect.objectContaining({ taskId: "FN-1", action: "surface", code: "stale-paused-todo" }),
+      });
+    });
+
+    it("routes the user-pause decision through the single safeguard chokepoint", () => {
+      /* Pins that suppression comes from `isSuppressedBySafeguard` and not from an
+         incidental check elsewhere, so there stays exactly one place to audit. */
+      expect(isSuppressedBySafeguard({ userPaused: true }, "surface")).toBe("user-paused");
+      expect(isSuppressedBySafeguard({ userPaused: false }, "surface")).toBeUndefined();
+      expect(isSuppressedBySafeguard({ userPaused: undefined }, "surface")).toBeUndefined();
+    });
+  });
+
+  describe("scope limits stated rather than implied", () => {
+    it("implements only the surface action, so only its relevant safeguard is wired", () => {
+      /*
+      `surface` mutates no lifecycle state, so autoMerge / dependency / capacity /
+      merge-proof / at-most-once gate actions that do not exist yet. Wiring them
+      now would be untestable dead code. This test records the scope limit so the
+      absence reads as deliberate; it must be updated when `rebound` lands.
+      */
+      const decision = decideRecovery(task(), ir(), LATER);
+      expect("decision" in decision && decision.decision.action).toBe("surface");
+    });
+  });
+});

--- a/packages/engine/src/__tests__/recovery-policy-safety.test.ts
+++ b/packages/engine/src/__tests__/recovery-policy-safety.test.ts
@@ -26,13 +26,27 @@ file and re-stating the safety argument. That friction is the point.
 import { describe, expect, it } from "vitest";
 import type { Task, WorkflowIr } from "@fusion/core";
 
-import { decideRecovery, isSuppressedBySafeguard, resolveColumnRecovery } from "../recovery-reconciler.js";
+import {
+  decideRecovery,
+  isSuppressedBySafeguard,
+  resolveColumnRecovery,
+  RECOVERY_POLICY_KEYS,
+} from "../recovery-reconciler.js";
 
 /**
- * Every key the recovery policy is ALLOWED to express. Adding to this list means
- * asserting, in review, that the new key cannot disable a safeguard.
+ * The keys the recovery policy is ALLOWED to express, as REVIEWED. Adding to this
+ * list means asserting, in review, that the new key cannot disable a safeguard.
  */
-const ALLOWED_POLICY_KEYS = ["stalenessMs", "onStale"] as const;
+const REVIEWED_POLICY_KEYS = ["onStale", "stalenessMs"] as const;
+
+/**
+ * The keys the TYPE actually accepts, derived from `RECOVERY_POLICY_KEYS` —
+ * a `Record<keyof WorkflowColumnRecovery, true>` that the compiler forces to stay
+ * exhaustive. Driving the ratchet off this instead of off a test fixture is the
+ * whole point: a fixture only proves what it happens to set, while this cannot
+ * drift from the interface without failing the build.
+ */
+const TYPE_POLICY_KEYS = Object.keys(RECOVERY_POLICY_KEYS);
 
 /** The six safeguards, in the vocabulary an author might try to use. */
 const SAFEGUARD_KEYS = [
@@ -89,16 +103,26 @@ const LATER = { now: () => Date.parse("2026-01-02T00:00:00.000Z") };
 
 describe("recovery policy safety invariant — safeguards live OUTSIDE the policy table", () => {
   describe("structural: the policy schema exposes no safeguard key", () => {
-    it("accepts only the allow-listed keys", () => {
-      /* Reading the policy back off a workflow must surface nothing beyond the
-         allow-list. A new key here is a deliberate review decision, not a drift. */
-      const policy = resolveColumnRecovery(ir(), "drafting");
-      expect(policy).toBeDefined();
-      expect(Object.keys(policy!).sort()).toEqual([...ALLOWED_POLICY_KEYS].sort());
+    it("the TYPE accepts exactly the reviewed key set", () => {
+      /*
+      The ratchet. `TYPE_POLICY_KEYS` is derived from a compiler-enforced
+      exhaustive manifest, so this fails the moment `WorkflowColumnRecovery`
+      gains or loses a key — even one no fixture ever sets, which is exactly the
+      case the fixture-driven version missed.
+      */
+      expect([...TYPE_POLICY_KEYS].sort()).toEqual([...REVIEWED_POLICY_KEYS].sort());
     });
 
-    it.each(SAFEGUARD_KEYS)("does not allow-list a safeguard key: %s", (key) => {
-      expect(ALLOWED_POLICY_KEYS as readonly string[]).not.toContain(key);
+    it.each(SAFEGUARD_KEYS)("the TYPE does not accept a safeguard key: %s", (key) => {
+      expect(TYPE_POLICY_KEYS).not.toContain(key);
+    });
+
+    it("a workflow cannot smuggle an unknown key past the parser into a live policy", () => {
+      /* Complements the type ratchet at runtime: whatever a stored workflow row
+         carries, what the reconciler READS must stay within the reviewed set. */
+      const policy = resolveColumnRecovery(ir(), "drafting");
+      expect(policy).toBeDefined();
+      expect(Object.keys(policy!).every((k) => (TYPE_POLICY_KEYS as string[]).includes(k))).toBe(true);
     });
   });
 

--- a/packages/engine/src/recovery-reconciler.ts
+++ b/packages/engine/src/recovery-reconciler.ts
@@ -1,0 +1,176 @@
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-14:05 (U4 vertical slice):
+
+THE recovery reconciler — one engine that walks live cards, resolves each card's
+`recovery` policy from ITS OWN workflow, and applies the matching rule. It
+replaces the per-sweep imperative bodies that the U4 survey classified as POLICY.
+
+This file is the vertical slice: one policy key (`stalenessMs` + `onStale`), one
+migrated sweep (stale paused hold-column cards), and a real reconciler — built to
+measure the ACTUAL line cost before committing to the full table, because the
+survey's ~900-line estimate was reasoned rather than prototyped.
+
+WHY A RECONCILER AND NOT 53 SWEEPS: the sweeps were already data at the call site
+(`{ name, fn }` registry entries); only the bodies were imperative, and those
+bodies mostly re-implemented the same four shapes — is this card stale, where does
+it rebound to, how many attempts remain, what does an unmet dependency mean. Those
+are rules a workflow should declare.
+
+── SAFETY BOUNDARY (ratified, non-negotiable) ──────────────────────────────────
+The six safeguards — user pause, `autoMerge:false`, dependency, capacity,
+merge-proof, at-most-once — are enforced HERE, outside the policy table, and are
+NOT expressible in `WorkflowColumnRecovery`. A workflow author must never be able
+to author away a safety invariant. `isSuppressedBySafeguard` below is the single
+chokepoint; `recovery-policy-safety.test.ts` fails if any of the six becomes
+reachable from policy.
+
+Only the safeguards RELEVANT TO THE ACTIONS THIS SLICE IMPLEMENTS are wired.
+`surface` mutates no lifecycle state, so it is gated on user pause only — the
+others (autoMerge, dependency, capacity, merge-proof) gate lifecycle-MUTATING
+actions and land with `rebound`/`archive`. That is a deliberate scope limit, not
+an oversight: wiring an unreachable guard now would be untestable code, and the
+safety test asserts the boundary rather than a guard count.
+*/
+import {
+  resolveLifecycleColumns,
+  resolveWorkflowIrForTask,
+  type Task,
+  type TaskStore,
+  type WorkflowIr,
+  type WorkflowIrColumn,
+  type WorkflowColumnRecovery,
+} from "@fusion/core";
+
+/** One card's resolved recovery decision. */
+export interface RecoveryDecision {
+  taskId: string;
+  /** The column the card rests in. */
+  column: string;
+  action: "surface";
+  code: string;
+  /** How long the card has rested, measured from `columnMovedAt`. */
+  ageMs: number;
+}
+
+/** Why a card that otherwise matched a policy was NOT acted on. */
+export type RecoverySuppression = "user-paused" | "not-stale" | "no-policy" | "unresolvable-workflow";
+
+export interface ReconcilerDeps {
+  now: () => number;
+  /** Caller-owned IR cache so one pass reads one IR per workflow, not per card. */
+  irCache?: Map<string, WorkflowIr>;
+}
+
+function columnsOf(ir: WorkflowIr): WorkflowIrColumn[] {
+  return ir.version === "v2" ? ir.columns : [];
+}
+
+/**
+ * The recovery policy for the column a card rests in, or `undefined` when the
+ * workflow declares none. Resolution is by column ID; lifecycle ROLES are
+ * resolved by the caller when a policy is expressed against a role.
+ */
+export function resolveColumnRecovery(ir: WorkflowIr, columnId: string): WorkflowColumnRecovery | undefined {
+  return columnsOf(ir).find((c) => c.id === columnId)?.recovery;
+}
+
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-14:05 (U4):
+THE safeguard chokepoint. Every safeguard suppression flows through here so there
+is exactly one place to audit, and so the safety test has a single seam to assert
+against. Returns the suppressing safeguard, or `undefined` when none applies.
+
+`surface` writes no lifecycle state, so only the user-pause safeguard is
+load-bearing for it — a user-paused card must not have engine-authored signals
+attributed to it. The remaining five gate lifecycle-mutating actions and are
+wired when those actions land.
+*/
+export function isSuppressedBySafeguard(
+  task: Pick<Task, "userPaused">,
+  action: RecoveryDecision["action"],
+): "user-paused" | undefined {
+  if (action === "surface" && task.userPaused === true) return "user-paused";
+  return undefined;
+}
+
+/**
+ * Decide what recovery action a single card warrants.
+ *
+ * Pure apart from the injected clock: it returns a decision, it does not apply
+ * one. Keeping the decision separate is what lets the safety test assert the
+ * boundary without running an engine.
+ */
+export function decideRecovery(
+  task: Pick<Task, "id" | "column" | "columnMovedAt" | "updatedAt" | "userPaused">,
+  ir: WorkflowIr,
+  deps: ReconcilerDeps,
+): { decision: RecoveryDecision } | { suppressed: RecoverySuppression } {
+  const policy = resolveColumnRecovery(ir, task.column);
+  if (!policy?.stalenessMs || !policy.onStale) return { suppressed: "no-policy" };
+
+  const suppressed = isSuppressedBySafeguard(task, policy.onStale.action);
+  if (suppressed) return { suppressed };
+
+  const anchor = Date.parse(task.columnMovedAt ?? task.updatedAt);
+  if (!Number.isFinite(anchor)) return { suppressed: "not-stale" };
+  const ageMs = Math.max(0, deps.now() - anchor);
+  if (ageMs < policy.stalenessMs) return { suppressed: "not-stale" };
+
+  return {
+    decision: {
+      taskId: task.id,
+      column: task.column,
+      action: policy.onStale.action,
+      code: policy.onStale.code,
+      ageMs,
+    },
+  };
+}
+
+/**
+ * Walk a task snapshot and return every card warranting a recovery action.
+ *
+ * The IR is resolved PER TASK (a board spans workflows, each with its own
+ * policy) but shared through `deps.irCache`, so a 400-card board across three
+ * workflows reads three IRs. An unresolvable workflow is skipped rather than
+ * guessed — a card whose policy cannot be read gets no engine-authored action.
+ */
+export async function reconcileRecovery(
+  store: TaskStore,
+  tasks: readonly Task[],
+  deps: ReconcilerDeps,
+): Promise<RecoveryDecision[]> {
+  const irCache = deps.irCache ?? new Map<string, WorkflowIr>();
+  const decisions: RecoveryDecision[] = [];
+
+  for (const task of tasks) {
+    let ir: WorkflowIr;
+    try {
+      ir = await resolveWorkflowIrForTask(store, task.id, irCache);
+    } catch {
+      continue; // unresolvable-workflow: skip, never guess
+    }
+    const outcome = decideRecovery(task, ir, { ...deps, irCache });
+    if ("decision" in outcome) decisions.push(outcome.decision);
+  }
+
+  return decisions;
+}
+
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-14:05 (U4):
+Role-addressed policy lookup. A workflow may express a policy against the column
+it names, but the MIGRATED sweeps are written against lifecycle ROLES ("the hold
+column"), so this resolves a role to the column carrying it and reads the policy
+there. Returns undefined for a v1/column-less IR.
+*/
+export function resolveRoleRecovery(
+  ir: WorkflowIr,
+  role: "intake" | "hold" | "wip" | "review" | "complete" | "archived",
+): { columnId: string; policy: WorkflowColumnRecovery } | undefined {
+  const lifecycle = resolveLifecycleColumns(ir);
+  const columnId = lifecycle?.[role];
+  if (!columnId) return undefined;
+  const policy = resolveColumnRecovery(ir, columnId);
+  return policy ? { columnId, policy } : undefined;
+}

--- a/packages/engine/src/recovery-reconciler.ts
+++ b/packages/engine/src/recovery-reconciler.ts
@@ -41,6 +41,33 @@ import {
   type WorkflowColumnRecovery,
 } from "@fusion/core";
 
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-28-15:35 (PR #2478 review, P2):
+THE TYPE-DRIVEN SAFETY RATCHET. Every key `WorkflowColumnRecovery` accepts,
+reified as a value.
+
+The first cut of the safety test read keys off a FIXTURE, so it guarded the
+fixture rather than the type: adding a safeguard-adjacent property to the
+interface left the advertised guarantee unenforced, because the fixture simply
+never set it. This manifest closes that hole.
+
+`Record<keyof WorkflowColumnRecovery, true>` forces exhaustiveness at COMPILE
+time — adding a key to the interface fails the build here until it is listed, and
+removing one fails as an excess property. It lives in PRODUCTION code
+deliberately: the engine tsconfig EXCLUDES the __tests__ directory, so a
+compile-time assertion placed in the test file would never be checked by `tsc`
+and the ratchet would be decorative.
+
+Two-stage effect. A new interface key breaks the build here; listing it to fix
+the build then fails `recovery-policy-safety.test.ts`, which asserts this manifest
+against the reviewed allow-list. Either way a human must re-state the safety
+argument. That friction is the point.
+*/
+export const RECOVERY_POLICY_KEYS: Record<keyof WorkflowColumnRecovery, true> = {
+  stalenessMs: true,
+  onStale: true,
+};
+
 /** One card's resolved recovery decision. */
 export interface RecoveryDecision {
   taskId: string;


### PR DESCRIPTION
Stacked on #2477. Base is `feature/workflow-vocabulary-u4-delete-dep-blocked` — do not merge before it.

The smallest end-to-end slice of the U4 reshape, built to **measure** the real cost before committing to the full policy table. The survey's ~900-line reconciler figure was reasoned, not prototyped; this replaces it with numbers.

**Everything here is additive and unwired. No behavior changes.**

## What lands

| | lines | what |
|---|---:|---|
| `WorkflowColumnRecovery` (IR) | 42 | one key — `stalenessMs` + `onStale`. Optional and omitted when unset, so existing workflows serialize byte-identically. |
| `recovery-reconciler.ts` | 176 | one engine: walks live cards, resolves each card's policy from **its own** workflow (per task, shared `irCache` — a 400-card board across three workflows reads three IRs), returns decisions. Decision and application are separate so the safety boundary is assertable without running an engine. |
| `recovery-policy-safety.test.ts` | 156 | one-time. The **ratified invariant**. |

## Measured cost vs the ~900 estimate

**Engine + IR types = 222 lines** for one action (`surface`) and one safeguard.

Extrapolating the rest — `rebound` (target resolution, attempt budgets, backward-move proof, five more safeguards) ≈ +350, `archive` ≈ +50, the `budgets`/`dependencies` keys ≈ +150 — lands near **780**.

So **~900 was a good estimate for the engine**, and the vertical slice does not move it much. That is the answer to the question asked.

## But the estimate's real miss is not lines

**16 of the 34 POLICY sweeps read an operator setting today** — ~17 distinct policy-threshold keys, including `stalePausedTodoThresholdMs`, `inReviewStalledThresholdMs`, `taskStuckTimeoutMs`, `doneAutoArchiveDays`, `maxPostReviewFixes`.

Moving those sweeps into workflow policy is **not a code refactor — it is a settings migration with operator-visible blast radius**, and it needs three decisions the line estimate never surfaced:

1. Does workflow policy **override** the global setting, or defer to it?
2. What happens to **existing projects** that already configured those settings?
3. Does an **unset** policy inherit the setting, or the built-in default?

That is the gating question for the full table — not the reconciler's size.

## Why the sweep is not retired here

Retiring `surfaceStalePausedTodos` requires builtin:coding to declare the policy **and** `stalePausedTodoThresholdMs` to migrate — or the behavior silently disappears for every existing project. That is the settings migration above, and it belongs behind its own decision rather than smuggled into a measurement slice.

The reconciler is therefore **unwired — deliberately dead code**, for exactly as long as it takes to get that decision.

## The ratified safety invariant

The six safeguards (user pause, `autoMerge:false`, dependency, capacity, merge-proof, at-most-once) live **outside** the policy table. A workflow must never be able to author a safety invariant away.

Encoded two ways, because either alone is defeatable:
- **structural** — the policy exposes only an allow-listed key set; adding a key requires editing the test and re-stating the safety argument (the friction is the point);
- **behavioral** — a policy attempting every spelling of "ignore the user pause" has no effect.

**Both halves mutation-verified**, because a safety test that cannot fail is worse than none:
- making the reconciler honor a policy field that disables the user-pause safeguard → **fails**
- adding an unreviewed key to the policy schema → **fails**

A third test asserts the reconciler still **acts** on an unpaused card, so a reconciler that suppressed everything cannot pass by doing nothing.

## Scope limits stated rather than implied

Only the `surface` action is implemented, so only its relevant safeguard is wired. `surface` mutates no lifecycle state; the other five gate lifecycle-**mutating** actions that do not exist yet, and wiring them now would be untestable dead code. A test records this so the absence reads as deliberate and must be updated when `rebound` lands.

## Verification

- `tsc --noEmit` clean in core and engine; `pnpm lint` clean
- merge gate green (299 + 10 + 71)
- 23 safety tests green; `workflow-lifecycle-traits` green

No changeset: `@fusion/core` and `@fusion/engine` are private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
