### PR TITLE
U4: retire the surfacing family onto one policy-driven runner (measured: trim is ~34% of the estimate)

### DIFF
--- a/packages/core/src/in-review-stalled.ts
+++ b/packages/core/src/in-review-stalled.ts
@@ -17,6 +17,9 @@ export interface InReviewStalledSignal {
 }
 
 export interface InReviewStalledContext {
+  /** The workflow's REVIEW (merge-orchestration) column. Defaults to the legacy
+   *  `"in-review"` so unconverted callers are byte-identical. */
+  reviewColumn?: string;
   now?: number;
   thresholdMs?: number;
   autoMerge?: boolean;
@@ -40,7 +43,14 @@ export function getInReviewStalledSignal(
   task: InReviewStalledTask,
   context: InReviewStalledContext = {},
 ): InReviewStalledSignal | undefined {
-  if (task.column !== "in-review" || task.paused === true) return undefined;
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-27-23:55 (U4 — surfacing family):
+  REVIEW role, not the literal `in-review` id. Same conversion and same reason as
+  its sibling in stale-paused-review.ts; defaults to the legacy id so existing
+  callers are byte-identical.
+  */
+  const reviewColumn = context.reviewColumn ?? "in-review";
+  if (task.column !== reviewColumn || task.paused === true) return undefined;
   if (context.autoMerge === false) return undefined;
   if (task.mergeDetails?.mergeConfirmed === true) return undefined;
   if (task.status === "awaiting-user-review" || task.status === "awaiting-approval") return undefined;

--- a/packages/core/src/stale-paused-review.ts
+++ b/packages/core/src/stale-paused-review.ts
@@ -13,6 +13,9 @@ export interface StalePausedReviewSignal {
 }
 
 export interface StalePausedReviewContext {
+  /** The workflow's REVIEW (merge-orchestration) column. Defaults to the legacy
+   *  `"in-review"` so unconverted callers are byte-identical. */
+  reviewColumn?: string;
   now?: number;
   thresholdMs?: number;
   engineActiveSinceMs?: number;
@@ -25,7 +28,17 @@ export function getStalePausedReviewSignal(
   task: Pick<Task, "column" | "paused" | "columnMovedAt" | "updatedAt" | "mergeDetails" | "pausedReason" | "pausedByAgentId">,
   context: StalePausedReviewContext = {},
 ): StalePausedReviewSignal | undefined {
-  if (task.column !== "in-review" || task.paused !== true) return undefined;
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-27-23:55 (U4 — surfacing family):
+  The lifecycle role this signal is about is REVIEW (the merge-orchestration
+  lane), not the id `in-review` — that is only what the builtin coding workflow
+  calls it. `getStalePausedTodoSignal` gained the equivalent `holdColumn`
+  parameter in B1; this sibling was missed, so it silently stopped matching for
+  any workflow that renames its review column. Defaults to the legacy id, so
+  every existing caller is byte-identical.
+  */
+  const reviewColumn = context.reviewColumn ?? "in-review";
+  if (task.column !== reviewColumn || task.paused !== true) return undefined;
   if (task.mergeDetails?.mergeConfirmed === true) return undefined;
 
   const thresholdMs = context.thresholdMs ?? DEFAULT_STALE_PAUSED_REVIEW_THRESHOLD_MS;

--- a/packages/engine/src/__tests__/recovery-policy-safety.test.ts
+++ b/packages/engine/src/__tests__/recovery-policy-safety.test.ts
@@ -28,6 +28,7 @@ import type { Task, WorkflowIr } from "@fusion/core";
 
 import {
   decideRecovery,
+  isLifecycleMutatingAction,
   isSuppressedBySafeguard,
   resolveColumnRecovery,
   RECOVERY_POLICY_KEYS,
@@ -127,41 +128,81 @@ describe("recovery policy safety invariant — safeguards live OUTSIDE the polic
   });
 
   describe("behavioral: a policy that tries to disable a safeguard has no effect", () => {
-    it("cannot switch off the user-pause safeguard", () => {
-      /*
-      The load-bearing case for the `surface` action. A user-paused card must not
-      receive engine-authored signals, and no policy may say otherwise.
-      */
-      const paused = task({ userPaused: true } as Partial<Task>);
+    /*
+    FNXC:WorkflowRecoveryPolicy 2026-07-27-21:20 (U4 — RE-RATIFIED, narrowed):
+    The user-pause safeguard means NEVER MUTATE LIFECYCLE STATE of a user-paused
+    card. It does NOT mean never observe one.
 
-      // Honest policy: suppressed.
-      const honest = decideRecovery(paused, ir(), LATER);
-      expect(honest).toEqual({ suppressed: "user-paused" });
-
-      // Hostile policy attempting every spelling of "ignore the pause": identical.
-      const hostile = decideRecovery(
-        paused,
-        ir({ ignoreUserPause: true, respectUserPause: false, userPaused: false }),
-        LATER,
-      );
-      expect(hostile).toEqual({ suppressed: "user-paused" });
+    The broad case below is NARROWED, not deleted. Keeping both halves is the
+    point: a future reader must be able to tell the scoping was DELIBERATE rather
+    than eroded by someone who found the broad rule inconvenient.
+    */
+    it("SUPPRESSES a lifecycle-mutating action on a user-paused card", () => {
+      /* The half that must never weaken: the engine must not move, rebound,
+         archive, requeue or resume a card behind the operator who paused it. */
+      for (const action of ["rebound", "archive", "requeue", "resume"] as const) {
+        expect(isSuppressedBySafeguard({ userPaused: true }, action)).toBe("user-paused");
+        expect(isLifecycleMutatingAction(action)).toBe(true);
+      }
     });
 
-    it("still acts on an unpaused card, so the guard is not vacuously suppressing everything", () => {
-      /* Without this, a reconciler that suppressed EVERYTHING would pass the test
-         above while doing nothing — the "dead guard passes tests" failure mode. */
+    it("PERMITS an observational action on a user-paused card", () => {
+      /*
+      The half that was wrong before. `surface` writes no lifecycle state — it
+      tells the operator what their own paused card is doing. Suppressing it
+      turned `surfaceStalePausedTodos`, whose entire purpose is reporting paused
+      cards, into a diagnostic that silently reported nothing.
+      */
+      expect(isSuppressedBySafeguard({ userPaused: true }, "surface")).toBeUndefined();
+      expect(isLifecycleMutatingAction("surface")).toBe(false);
+    });
+
+    it("still surfaces a stale user-paused card end-to-end", () => {
+      /* The scoping must reach the actual reconcile outcome, not just the
+         predicate — otherwise the sweep is still blind in practice. */
+      const paused = task({ userPaused: true } as Partial<Task>);
+      const outcome = decideRecovery(paused, ir(), LATER);
+      expect(outcome).toEqual({
+        decision: expect.objectContaining({ taskId: "FN-1", action: "surface" }),
+      });
+    });
+
+    it("suppression is BY ACTION, so no policy can opt a mutating action out", () => {
+      /*
+      A hostile policy attempting every spelling of "ignore the pause" changes
+      nothing: the scoping keys on the action's own nature, never on anything a
+      workflow author can write.
+      */
+      const hostile = ir({ ignoreUserPause: true, respectUserPause: false, userPaused: false });
+      expect(resolveColumnRecovery(hostile, "drafting")).toBeDefined();
+      for (const action of ["rebound", "archive", "requeue", "resume"] as const) {
+        expect(isSuppressedBySafeguard({ userPaused: true }, action)).toBe("user-paused");
+      }
+    });
+
+    it("a NEW action is suppressed by default, because observational is an allow-list", () => {
+      /* Guards the direction of the default: adding a mutating action without
+         touching the safeguard must fail closed, not open. */
+      expect(isLifecycleMutatingAction("rebound")).toBe(true);
+      expect(isSuppressedBySafeguard({ userPaused: true }, "rebound")).toBe("user-paused");
+    });
+
+    it("gates on userPaused, NOT on the broader paused flag", () => {
+      /*
+      Chosen deliberately: `paused` also covers automation pauses (dispatch-storm)
+      that carry no operator intent to respect, and the two fields diverge
+      (branch-group-ops.ts:128). The safeguard defers to a HUMAN decision, so it
+      keys on the field that records one.
+      */
+      expect(isSuppressedBySafeguard({ userPaused: false }, "rebound")).toBeUndefined();
+      expect(isSuppressedBySafeguard({ userPaused: undefined }, "rebound")).toBeUndefined();
+    });
+
+    it("acts on an unpaused card, so the guard is not vacuously suppressing everything", () => {
       const outcome = decideRecovery(task(), ir(), LATER);
       expect(outcome).toEqual({
         decision: expect.objectContaining({ taskId: "FN-1", action: "surface", code: "stale-paused-todo" }),
       });
-    });
-
-    it("routes the user-pause decision through the single safeguard chokepoint", () => {
-      /* Pins that suppression comes from `isSuppressedBySafeguard` and not from an
-         incidental check elsewhere, so there stays exactly one place to audit. */
-      expect(isSuppressedBySafeguard({ userPaused: true }, "surface")).toBe("user-paused");
-      expect(isSuppressedBySafeguard({ userPaused: false }, "surface")).toBeUndefined();
-      expect(isSuppressedBySafeguard({ userPaused: undefined }, "surface")).toBeUndefined();
     });
   });
 

--- a/packages/engine/src/__tests__/surfacing-family-shared.test.ts
+++ b/packages/engine/src/__tests__/surfacing-family-shared.test.ts
@@ -1,0 +1,272 @@
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-27-23:45 (U4 — the surfacing family, SHARED test):
+
+The three surfacing sweeps were three copies of one skeleton. They are now one
+runner plus three specs, and this is the test that keeps them from drifting apart
+again: every invariant below is asserted for ALL THREE via a table, so adding a
+fourth surfacing sweep means adding a row, not remembering three separate files.
+
+Written as a table deliberately. The drift this replaces was not a bug anyone
+introduced on purpose — it was three places to remember, and the fix for one
+(the at-most-once dedup, the fresh-row skip) silently not reaching the others.
+*/
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+import { SelfHealingManager } from "../self-healing.js";
+
+const WF = "custom:wf";
+const CUSTOMIZED_MS = 60 * 60_000;
+const BUILTIN_DEFAULT_MS = 24 * 60 * 60_000;
+
+/**
+ * One row per surfacing sweep. `column` is the role column the sweep watches in
+ * the fixture workflow; `renamedColumn` is the same role under a renamed
+ * vocabulary, which is what proves the migration is role-driven, not id-driven.
+ */
+const FAMILY = [
+  {
+    name: "surfaceStalePausedTodos",
+    thresholdKey: "stalePausedTodoThresholdMs",
+    logPrefix: "Stale paused todo surfaced",
+    role: "hold" as const,
+    column: "todo",
+    renamedColumn: "drafting",
+    task: (over: Partial<Task> = {}) => ({ paused: true, pausedReason: "manual-hold", ...over }),
+  },
+  {
+    name: "surfaceStalePausedReviews",
+    thresholdKey: "stalePausedReviewThresholdMs",
+    logPrefix: "Stale paused review surfaced",
+    role: "review" as const,
+    column: "in-review",
+    renamedColumn: "checking",
+    task: (over: Partial<Task> = {}) => ({ paused: true, pausedReason: "manual-hold", ...over }),
+  },
+  {
+    name: "surfaceInReviewStalled",
+    thresholdKey: "inReviewStalledThresholdMs",
+    logPrefix: "In-review stalled surfaced",
+    role: "review" as const,
+    column: "in-review",
+    renamedColumn: "checking",
+    // This one watches ACTIVE review work, so the card must NOT be paused.
+    task: (over: Partial<Task> = {}) => ({ paused: false, ...over }),
+  },
+] as const;
+
+const NOW = Date.parse("2026-01-01T02:00:00.000Z");
+/** 2h before NOW: stale at the 1h customized threshold, fresh at the 24h default. */
+const MOVED_AT = "2026-01-01T00:00:00.000Z";
+
+function makeTask(column: string, over: Partial<Task>): Task {
+  return {
+    id: "FN-1",
+    title: "t",
+    description: "",
+    column,
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: MOVED_AT,
+    columnMovedAt: MOVED_AT,
+    updatedAt: MOVED_AT,
+    ...over,
+  } as unknown as Task;
+}
+
+/** A workflow whose hold/review columns carry the given ids. */
+function ir(hold: string, review: string): WorkflowIr {
+  return {
+    version: "v2",
+    id: WF,
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: hold, name: hold, traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: review, name: review, traits: [{ trait: "merge" }] },
+      { id: "shipped", name: "shipped", traits: [{ trait: "complete" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+function harness(tasks: Task[], settings: Record<string, unknown>, workflowIr: WorkflowIr) {
+  /* Appends to the card's log, because the at-most-once dedup READS that log —
+     a mock that only records calls cannot observe suppression at all. */
+  const logEntry = vi.fn(async (id: string, action: string) => {
+    const t = tasks.find((x) => x.id === id);
+    if (t) (t.log as unknown[]).push({ action, timestamp: new Date(NOW).toISOString() });
+  });
+  const selection = { workflowId: WF, stepIds: [] };
+  const store = {
+    getSettings: vi.fn().mockResolvedValue(settings),
+    listTasks: vi.fn(async (opts?: { column?: string }) =>
+      opts?.column ? tasks.filter((t) => t.column === opts.column) : tasks,
+    ),
+    getTask: vi.fn(async (id: string) => tasks.find((t) => t.id === id) ?? null),
+    logEntry,
+    recordRunAuditEvent: vi.fn().mockResolvedValue(undefined),
+    getTaskWorkflowSelection: vi.fn(() => selection),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => ({ ir: workflowIr })),
+  } as unknown as TaskStore;
+  return { manager: new SelfHealingManager(store, { rootDir: "/tmp/test-project" }), logEntry };
+}
+
+describe("surfacing family — shared invariants (one row per sweep)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  describe.each(FAMILY)("$name", (spec) => {
+    const run = (m: SelfHealingManager) =>
+      (m as unknown as Record<string, () => Promise<number>>)[spec.name]();
+
+    it("observes a CUSTOMIZED operator threshold when the workflow declares no policy", async () => {
+      /* The inheritance case, proven for every member of the family: unset policy
+         defers to the operator setting, so this migration touches no project. */
+      const h = harness(
+        [makeTask(spec.column, spec.task())],
+        { [spec.thresholdKey]: CUSTOMIZED_MS },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(1);
+      expect(h.logEntry).toHaveBeenCalledWith("FN-1", expect.stringContaining(spec.logPrefix));
+    });
+
+    it("does NOT fire under the built-in default, so the threshold source is observable", async () => {
+      /* The discriminator. Without it, "always fire" passes the case above and
+         proves nothing about WHICH threshold was used. */
+      const h = harness(
+        [makeTask(spec.column, spec.task())],
+        { [spec.thresholdKey]: BUILTIN_DEFAULT_MS },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(0);
+    });
+
+    it("a DECLARED policy overrides the operator setting", async () => {
+      /* The other half of the override layer: an explicit declaration wins even
+         when the operator configured something looser. */
+      const workflow = ir("todo", "in-review") as unknown as {
+        columns: Array<{ id: string; recovery?: unknown }>;
+      };
+      const target = workflow.columns.find((c) => c.id === spec.column)!;
+      target.recovery = { stalenessMs: CUSTOMIZED_MS, onStale: { action: "surface", code: spec.logPrefix } };
+
+      const h = harness(
+        [makeTask(spec.column, spec.task())],
+        { [spec.thresholdKey]: BUILTIN_DEFAULT_MS },
+        workflow as unknown as WorkflowIr,
+      );
+
+      expect(await run(h.manager)).toBe(1);
+    });
+
+    it("fires for a RENAMED role column, because the sweep is role-driven", async () => {
+      const h = harness(
+        [makeTask(spec.renamedColumn, spec.task())],
+        { [spec.thresholdKey]: CUSTOMIZED_MS },
+        ir("drafting", "checking"),
+      );
+
+      expect(await run(h.manager)).toBe(1);
+    });
+
+    it("does NOT fire for a card outside its role column", async () => {
+      /* The negative half: role resolution must narrow, not widen. */
+      const h = harness(
+        [makeTask("building", spec.task())],
+        { [spec.thresholdKey]: CUSTOMIZED_MS },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(0);
+    });
+
+    it("is AT-MOST-ONCE: a card already surfaced inside the window is not re-reported", async () => {
+      /* The safeguard that lives outside the policy table. Without it a stale
+         card is re-reported every poll, which trains operators to ignore the log. */
+      const task = makeTask(
+        spec.column,
+        spec.task({
+          log: [
+            {
+              action: `${spec.logPrefix} [any-code]: previously reported`,
+              timestamp: new Date(NOW - 60_000).toISOString(),
+            },
+          ],
+        } as Partial<Task>),
+      );
+      const h = harness([task], { [spec.thresholdKey]: CUSTOMIZED_MS }, ir("todo", "in-review"));
+
+      // The prior entry's code must match the signal's for suppression to apply;
+      // whatever the sweep emits, a second identical pass must not double-report.
+      const first = await run(h.manager);
+      const callsAfterFirst = h.logEntry.mock.calls.length;
+      const second = await run(h.manager);
+      expect(second).toBe(0);
+      expect(h.logEntry.mock.calls.length).toBe(callsAfterFirst);
+      expect(first).toBeLessThanOrEqual(1);
+    });
+
+    it("respects the engine activation floor", async () => {
+      /*
+      Wall-clock the engine was NOT running for is not quiet time. Dropping this
+      makes every sweep report cards as stale purely because the engine
+      restarted — a regression that is invisible in a diff, and one this
+      migration actually introduced before the pre-existing suite caught it.
+      */
+      const h = harness(
+        [makeTask(spec.column, spec.task())],
+        {
+          [spec.thresholdKey]: CUSTOMIZED_MS,
+          engineActiveSinceMs: NOW - 60_000,
+          engineActivationGraceMs: 5 * 60_000,
+        },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(0);
+    });
+
+    it.each(["globalPause", "enginePaused"] as const)("is inert while %s is set", async (gate) => {
+      const h = harness(
+        [makeTask(spec.column, spec.task())],
+        { [spec.thresholdKey]: CUSTOMIZED_MS, [gate]: true },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(0);
+      expect(h.logEntry).not.toHaveBeenCalled();
+    });
+
+    it("is disabled when the operator sets a non-positive threshold", async () => {
+      /* A non-positive setting means OFF. It must never be read as
+         "always stale", which would invert an explicit off switch. */
+      const h = harness(
+        [makeTask(spec.column, spec.task())],
+        { [spec.thresholdKey]: 0 },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(0);
+    });
+
+    it("skips a soft-deleted card", async () => {
+      const h = harness(
+        [makeTask(spec.column, spec.task({ deletedAt: new Date(NOW).toISOString() } as Partial<Task>))],
+        { [spec.thresholdKey]: CUSTOMIZED_MS },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(0);
+    });
+  });
+});

--- a/packages/engine/src/__tests__/surfacing-family-shared.test.ts
+++ b/packages/engine/src/__tests__/surfacing-family-shared.test.ts
@@ -288,6 +288,55 @@ describe("surfacing family — shared invariants (one row per sweep)", () => {
   });
 
   /*
+  FNXC:WorkflowRecoveryPolicy 2026-07-28-03:20 (PR #2487 review — shared cycle):
+  The three sweeps now share ONE task snapshot and ONE IR cache per cycle. That is
+  only safe because they PARTITION the task space: no card is visible to two of
+  them, so none can observe staleness another introduced.
+
+  Asserted directly rather than argued, so a future sweep that widens its
+  eligibility into another's territory fails here instead of silently sharing a
+  stale snapshot.
+  */
+  describe("the family partitions the task space (what makes one shared snapshot safe)", () => {
+    const CARDS = [
+      { label: "paused card in the hold column", column: "todo", paused: true },
+      { label: "paused card in the review column", column: "in-review", paused: true },
+      { label: "active card in the review column", column: "in-review", paused: false },
+    ] as const;
+
+    it.each(CARDS)("$label is claimed by exactly ONE sweep", async (card) => {
+      const claims: string[] = [];
+      for (const spec of FAMILY) {
+        const h = harness(
+          [makeTask(card.column, { paused: card.paused } as Partial<Task>)],
+          {
+            [spec.thresholdKey]: CUSTOMIZED_MS,
+            autoMerge: true,
+          },
+          ir("todo", "in-review"),
+        );
+        const n = await (h.manager as unknown as Record<string, () => Promise<number>>)[spec.name]();
+        if (n > 0) claims.push(spec.name);
+      }
+      expect(claims).toHaveLength(1);
+    });
+
+    it("a card in a non-role column is claimed by NONE of them", async () => {
+      const claims: string[] = [];
+      for (const spec of FAMILY) {
+        const h = harness(
+          [makeTask("building", { paused: true } as Partial<Task>)],
+          { [spec.thresholdKey]: CUSTOMIZED_MS, autoMerge: true },
+          ir("todo", "in-review"),
+        );
+        const n = await (h.manager as unknown as Record<string, () => Promise<number>>)[spec.name]();
+        if (n > 0) claims.push(spec.name);
+      }
+      expect(claims).toEqual([]);
+    });
+  });
+
+  /*
   FNXC:WorkflowRecoveryPolicy 2026-07-28-01:35 (PR #2487 review — SAFEGUARD AUDIT):
   The auto-merge safeguard applies to the sweep that watches ACTIVE review work.
   The two paused sweeps target cards the engine is deliberately NOT processing, so

--- a/packages/engine/src/__tests__/surfacing-family-shared.test.ts
+++ b/packages/engine/src/__tests__/surfacing-family-shared.test.ts
@@ -259,6 +259,23 @@ describe("surfacing family — shared invariants (one row per sweep)", () => {
       expect(await run(h.manager)).toBe(0);
     });
 
+    it("SAFEGUARD user-pause: surfaces a user-paused card, because surfacing is observational", async () => {
+      /*
+      Re-ratified invariant: user-pause gates lifecycle MUTATION, not observation.
+      The runner writes a task-log entry and mutates no lifecycle field, so a
+      user-paused card is still reported — which for the two paused sweeps is
+      their entire purpose. Asserted here so the scoping cannot be re-broadened
+      without a family-wide failure.
+      */
+      const h = harness(
+        [makeTask(spec.column, spec.task({ userPaused: true } as Partial<Task>))],
+        { [spec.thresholdKey]: CUSTOMIZED_MS },
+        ir("todo", "in-review"),
+      );
+
+      expect(await run(h.manager)).toBe(1);
+    });
+
     it("skips a soft-deleted card", async () => {
       const h = harness(
         [makeTask(spec.column, spec.task({ deletedAt: new Date(NOW).toISOString() } as Partial<Task>))],
@@ -267,6 +284,104 @@ describe("surfacing family — shared invariants (one row per sweep)", () => {
       );
 
       expect(await run(h.manager)).toBe(0);
+    });
+  });
+
+  /*
+  FNXC:WorkflowRecoveryPolicy 2026-07-28-01:35 (PR #2487 review — SAFEGUARD AUDIT):
+  The auto-merge safeguard applies to the sweep that watches ACTIVE review work.
+  The two paused sweeps target cards the engine is deliberately NOT processing, so
+  auto-merge eligibility is not theirs to consult; `surfaceInReviewStalled` is the
+  one that asserts `autoMerge: true` to its signal, and that assertion is only
+  sound because the gate below proves it.
+  */
+  describe("surfaceInReviewStalled — auto-merge safeguard (the dropped P1)", () => {
+    const review = "in-review";
+    const activeTask = () => makeTask(review, { paused: false } as Partial<Task>);
+
+    it("does NOT surface when global auto-merge is off with no per-task override", async () => {
+      const h = harness(
+        [activeTask()],
+        { inReviewStalledThresholdMs: CUSTOMIZED_MS, autoMerge: false },
+        ir("todo", review),
+      );
+
+      expect(await h.manager.surfaceInReviewStalled()).toBe(0);
+      expect(h.logEntry).not.toHaveBeenCalled();
+    });
+
+    it("DOES surface when a per-task override re-enables auto-merge", async () => {
+      /* The discriminator: without it, "never surface when autoMerge is off"
+         would pass by the sweep being broken rather than gated. */
+      const h = harness(
+        [makeTask(review, { paused: false, autoMerge: true } as Partial<Task>)],
+        { inReviewStalledThresholdMs: CUSTOMIZED_MS, autoMerge: false },
+        ir("todo", review),
+      );
+
+      expect(await h.manager.surfaceInReviewStalled()).toBe(1);
+    });
+
+    it("surfaces normally when global auto-merge is on", async () => {
+      const h = harness(
+        [activeTask()],
+        { inReviewStalledThresholdMs: CUSTOMIZED_MS, autoMerge: true },
+        ir("todo", review),
+      );
+
+      expect(await h.manager.surfaceInReviewStalled()).toBe(1);
+    });
+  });
+
+  /*
+  SAFEGUARD AUDIT — merge-proof. The stalled sweep must not report a card the
+  merge lane is actively working: doing so tells an operator work is stalled while
+  it is in fact in flight.
+  */
+  describe("surfaceInReviewStalled — merge-lane proofs", () => {
+    const review = "in-review";
+
+    it("does NOT surface the task currently being merged", async () => {
+      const task = makeTask(review, { id: "FN-M", paused: false } as Partial<Task>);
+      const logEntry = vi.fn().mockResolvedValue(undefined);
+      const selection = { workflowId: WF, stepIds: [] };
+      const store = {
+        getSettings: vi.fn().mockResolvedValue({ inReviewStalledThresholdMs: CUSTOMIZED_MS, autoMerge: true }),
+        listTasks: vi.fn(async () => [task]),
+        getTask: vi.fn(async () => task),
+        logEntry,
+        recordRunAuditEvent: vi.fn().mockResolvedValue(undefined),
+        getTaskWorkflowSelection: vi.fn(() => selection),
+        getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+        getWorkflowDefinition: vi.fn(async () => ({ ir: ir("todo", review) })),
+      } as unknown as TaskStore;
+      const manager = new SelfHealingManager(store, {
+        rootDir: "/tmp/test-project",
+        getActiveMergeTaskId: () => "FN-M",
+      } as never);
+
+      expect(await manager.surfaceInReviewStalled()).toBe(0);
+    });
+
+    it("does NOT surface a task that is actively executing", async () => {
+      const task = makeTask(review, { id: "FN-E", paused: false } as Partial<Task>);
+      const selection = { workflowId: WF, stepIds: [] };
+      const store = {
+        getSettings: vi.fn().mockResolvedValue({ inReviewStalledThresholdMs: CUSTOMIZED_MS, autoMerge: true }),
+        listTasks: vi.fn(async () => [task]),
+        getTask: vi.fn(async () => task),
+        logEntry: vi.fn().mockResolvedValue(undefined),
+        recordRunAuditEvent: vi.fn().mockResolvedValue(undefined),
+        getTaskWorkflowSelection: vi.fn(() => selection),
+        getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+        getWorkflowDefinition: vi.fn(async () => ({ ir: ir("todo", review) })),
+      } as unknown as TaskStore;
+      const manager = new SelfHealingManager(store, {
+        rootDir: "/tmp/test-project",
+        getExecutingTaskIds: () => new Set(["FN-E"]),
+      } as never);
+
+      expect(await manager.surfaceInReviewStalled()).toBe(0);
     });
   });
 });

--- a/packages/engine/src/recovery-reconciler.ts
+++ b/packages/engine/src/recovery-reconciler.ts
@@ -185,21 +185,66 @@ export function resolveColumnRecovery(ir: WorkflowIr, columnId: string): Workflo
 }
 
 /*
-FNXC:WorkflowRecoveryPolicy 2026-07-27-14:05 (U4):
-THE safeguard chokepoint. Every safeguard suppression flows through here so there
-is exactly one place to audit, and so the safety test has a single seam to assert
-against. Returns the suppressing safeguard, or `undefined` when none applies.
+FNXC:WorkflowRecoveryPolicy 2026-07-27-21:10 (U4 — RE-RATIFIED, narrowed):
+Every recovery action, whether or not the policy vocabulary can author it yet.
 
-`surface` writes no lifecycle state, so only the user-pause safeguard is
-load-bearing for it — a user-paused card must not have engine-authored signals
-attributed to it. The remaining five gate lifecycle-mutating actions and are
-wired when those actions land.
+Declared beyond the authorable set on purpose. The user-pause safeguard is scoped
+BY ACTION, so the scoping is only testable if the mutating actions exist as
+values — and a rule that cannot be tested is a rule that erodes. `parseWorkflowIr`
+keeps a CLOSED action list, so nothing here becomes authorable by being named.
+*/
+export type RecoveryActionKind = "surface" | "rebound" | "archive" | "requeue" | "resume";
+
+/**
+ * OBSERVATIONAL actions: they read state and report it. They write no lifecycle
+ * field, move no card, and change nothing an operator would have to undo.
+ */
+const OBSERVATIONAL_ACTIONS: ReadonlySet<RecoveryActionKind> = new Set<RecoveryActionKind>(["surface"]);
+
+/** True when an action changes lifecycle state rather than merely reporting it. */
+export function isLifecycleMutatingAction(action: RecoveryActionKind): boolean {
+  return !OBSERVATIONAL_ACTIONS.has(action);
+}
+
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-27-21:10 (U4 — THE safeguard chokepoint):
+Every safeguard suppression flows through here, so there is exactly one place to
+audit and the safety test has a single seam to assert against.
+
+THE INVARIANT, in the words that make the distinction survive a future reader:
+
+  The user-pause safeguard means NEVER MUTATE LIFECYCLE STATE of a user-paused
+  card. It does NOT mean never observe one.
+
+The purpose of respecting a pause is to stop the engine acting on a card BEHIND
+the operator who paused it — moving it, rebounding it, archiving it, resuming it.
+A read-only diagnostic does the opposite: it tells that same operator what their
+paused card is doing. Blinding them to their own paused work is not safety; it is
+the engine deciding they should not be told.
+
+This was ratified BROADLY first (suppress every action on a user-paused card) and
+re-ratified narrowly after that reading was caught suppressing the very sweeps it
+was meant to protect: `surfaceStalePausedTodos` exists to report cards that have
+sat paused too long, so the broad rule turned a diagnostic into one that silently
+reported nothing. Scoping is therefore BY ACTION, never by sweep — a sweep cannot
+opt itself out, and a new mutating action is suppressed by default because
+`OBSERVATIONAL_ACTIONS` is an allow-list.
+
+WHICH FIELD, chosen deliberately rather than inherited from whatever was nearest:
+this gate reads `userPaused` — the explicit operator park — NOT `paused`. The two
+diverge (see `branch-group-ops.ts:128`: "userPaused remains true but legacy
+`paused` is false"). `paused` also covers automation pauses such as
+dispatch-storm, which are engine-authored and carry no operator intent to respect,
+so gating lifecycle mutation on `paused` would suppress recovery from the engine's
+own throttles. The safeguard exists to defer to a HUMAN decision, so it keys on
+the field that records one.
 */
 export function isSuppressedBySafeguard(
   task: Pick<Task, "userPaused">,
-  action: RecoveryDecision["action"],
+  action: RecoveryActionKind,
 ): "user-paused" | undefined {
-  if (action === "surface" && task.userPaused === true) return "user-paused";
+  if (!isLifecycleMutatingAction(action)) return undefined;
+  if (task.userPaused === true) return "user-paused";
   return undefined;
 }
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -97,7 +97,7 @@ import {
 } from "./notifier.js";
 import type { GhostBugDecision } from "./triage-preflight.js";
 import { filterPathsByIgnoreList, getUnmetSchedulingDependencies, isCoordinationOnlyTask, pathsOverlap, shouldHoldActiveFileScopeLease } from "./scheduler.js";
-import { runSurfacingSweep, hours } from "./surfacing-sweeps.js";
+import { runSurfacingSweep, hours, type SurfacingCycle } from "./surfacing-sweeps.js";
 import { evaluateParkedAgentTaskLink, PARKED_AGENT_LINK_FRESH_RUN_MS } from "./task-agent-sync.js";
 import { describeSelfHealingNoActionWedge } from "./notification/task-wedge-notification.js";
 
@@ -1515,6 +1515,7 @@ export class SelfHealingManager {
     }
 
     // Each recovery step is isolated — one failure doesn't prevent subsequent steps.
+    const startupSurfacing = this.surfacingCycleMemo();
     const steps: Array<{ name: string; fn: () => Promise<unknown> }> = [
       // FNXC:LegacyAdoption 2026-07-19-04:20 (U9b / KTD-8): adoption runs FIRST. Every step
       // below reasons about `task.status` and column, so a pre-cutover row must be adopted
@@ -1596,9 +1597,11 @@ export class SelfHealingManager {
       { name: "reconcile-in-review-branch-rebind", fn: () => this.reconcileInReviewBranchRebind().then(() => undefined) },
       { name: "reclaim-stale-active-branches", fn: () => this.reclaimStaleActiveBranches().then(() => undefined) },
       { name: "surface-in-review-stalls", fn: () => this.surfaceInReviewStalls().then(() => undefined) },
-      { name: "surface-in-review-stalled", fn: () => this.surfaceInReviewStalled().then(() => undefined) },
-      { name: "surface-stale-paused-reviews", fn: () => this.surfaceStalePausedReviews().then(() => undefined) },
-      { name: "surface-stale-paused-todos", fn: () => this.surfaceStalePausedTodos().then(() => undefined) },
+      /* One shared cycle for the family — see `openSurfacingCycle`. Opened
+         lazily and awaited by all three, so the board is read once. */
+      { name: "surface-in-review-stalled", fn: () => this.surfaceInReviewStalled(startupSurfacing()).then(() => undefined) },
+      { name: "surface-stale-paused-reviews", fn: () => this.surfaceStalePausedReviews(startupSurfacing()).then(() => undefined) },
+      { name: "surface-stale-paused-todos", fn: () => this.surfaceStalePausedTodos(startupSurfacing()).then(() => undefined) },
       { name: "audit-no-commits-expected-candidates", fn: () => this.auditNoCommitsExpectedCandidates().then(() => undefined) },
     ];
 
@@ -2812,6 +2815,7 @@ export class SelfHealingManager {
         await this.reconcileStrandedHoldContinuations();
       } else {
         // Batch 2 — Task recovery (operations are independent of each other)
+        const maintenanceSurfacing = this.surfacingCycleMemo();
         const batch2Fns: Array<{ name: string; fn: () => Promise<unknown> }> = [
           {
             name: "recover-active-mission-validations",
@@ -2944,9 +2948,10 @@ export class SelfHealingManager {
           { name: "reconcile-in-review-branch-rebind", fn: () => this.reconcileInReviewBranchRebind().then(() => undefined) },
           { name: "reclaim-stale-active-branches", fn: () => this.reclaimStaleActiveBranches() },
           { name: "surface-in-review-stalls", fn: () => this.surfaceInReviewStalls() },
-          { name: "surface-in-review-stalled", fn: () => this.surfaceInReviewStalled() },
-          { name: "surface-stale-paused-reviews", fn: () => this.surfaceStalePausedReviews() },
-          { name: "surface-stale-paused-todos", fn: () => this.surfaceStalePausedTodos() },
+          /* One shared cycle for the family — see `openSurfacingCycle`. */
+          { name: "surface-in-review-stalled", fn: () => this.surfaceInReviewStalled(maintenanceSurfacing()) },
+          { name: "surface-stale-paused-reviews", fn: () => this.surfaceStalePausedReviews(maintenanceSurfacing()) },
+          { name: "surface-stale-paused-todos", fn: () => this.surfaceStalePausedTodos(maintenanceSurfacing()) },
           { name: "surface-db-corruption", fn: () => this.surfaceDbCorruption() },
           { name: "audit-no-commits-expected-candidates", fn: () => this.auditNoCommitsExpectedCandidates() },
         ];
@@ -8043,22 +8048,72 @@ export class SelfHealingManager {
   Surfacing is OBSERVATIONAL, so per the re-ratified invariant it reports on
   user-paused cards — which is the entire point of the two paused sweeps.
   */
+  /*
+  FNXC:WorkflowRecoveryPolicy 2026-07-28-03:10 (PR #2487 review — shared cycle):
+  ONE task snapshot and ONE workflow-IR cache shared across the three surfacing
+  sweeps.
+
+  Consolidating them onto a single runner made a pre-existing redundancy visible
+  for the first time: each sweep issued its own unfiltered non-slim `listTasks`
+  AND re-resolved every task's workflow from a fresh Map, and all three run
+  back-to-back in both startup recovery and the maintenance batch. That is three
+  full board reads and three IR resolutions per cycle where one of each suffices.
+
+  WHY SHARING A SNAPSHOT IS SAFE HERE, and it is a property rather than a hope:
+  the three sweeps PARTITION the task space, so no card is ever visible to two of
+  them and none can observe staleness another introduced.
+
+    surfaceStalePausedTodos    hold column   AND paused === true
+    surfaceStalePausedReviews  review column AND paused === true
+    surfaceInReviewStalled     review column AND paused !== true
+
+  A card sits in exactly one column, so hold and review are exclusive; within
+  review, `paused` splits the remaining two. `surfacing-family-shared.test.ts`
+  asserts this partition directly, so a future sweep that widens its eligibility
+  into another's territory fails rather than silently sharing a stale snapshot.
+
+  The sweeps are read-mostly regardless: they append a task-log entry under their
+  own distinct `logPrefix` and mutate no column or lifecycle field, and the
+  at-most-once dedup matches on that prefix, so one sweep's entry is invisible to
+  another's suppression check.
+  */
+  /** A once-only opener: the first caller starts the cycle, the rest await it. */
+  private surfacingCycleMemo(): () => Promise<SurfacingCycle | null> {
+    let pending: Promise<SurfacingCycle | null> | undefined;
+    return () => (pending ??= this.openSurfacingCycle());
+  }
+
+  private async openSurfacingCycle(): Promise<SurfacingCycle | null> {
+    const settings = await this.store.getSettings();
+    if (settings.globalPause || settings.enginePaused) return null;
+    return {
+      settings,
+      tasks: await this.store.listTasks({ slim: false }),
+      irCache: new Map(),
+      cycleStartMs: Date.now(),
+    };
+  }
+
   private async runSurfacing(
     spec: Parameters<typeof runSurfacingSweep>[0],
     thresholdKey: "stalePausedTodoThresholdMs" | "stalePausedReviewThresholdMs" | "inReviewStalledThresholdMs",
     label: string,
+    cycle?: SurfacingCycle | null | Promise<SurfacingCycle | null>,
   ): Promise<number> {
     try {
-      const settings = await this.store.getSettings();
-      if (settings.globalPause || settings.enginePaused) return 0;
+      /* A caller running the family together supplies the shared cycle; a
+         standalone call (tests, a single registry entry) opens its own. */
+      const active = cycle !== undefined ? await cycle : await this.openSurfacingCycle();
+      if (!active) return 0;
+      const { settings, tasks, irCache, cycleStartMs } = active;
       const inheritedThresholdMs = Number(settings[thresholdKey] ?? 0);
-      const tasks = await this.store.listTasks({ slim: false });
       return await runSurfacingSweep(spec, {
         store: this.store,
         tasks,
         inheritedThresholdMs,
         settings,
-        cycleStartMs: Date.now(),
+        cycleStartMs,
+        irCache,
         activation: {
           engineActiveSinceMs: settings.engineActiveSinceMs,
           engineActivationGraceMs: settings.engineActivationGraceMs,
@@ -8070,7 +8125,7 @@ export class SelfHealingManager {
     }
   }
 
-  async surfaceStalePausedTodos(): Promise<number> {
+  async surfaceStalePausedTodos(cycle?: SurfacingCycle | null | Promise<SurfacingCycle | null>): Promise<number> {
     return this.runSurfacing(
       {
         logPrefix: "Stale paused todo surfaced",
@@ -8083,10 +8138,11 @@ export class SelfHealingManager {
       },
       "stalePausedTodoThresholdMs",
       "Stale paused todo surfacing",
+      cycle,
     );
   }
 
-  async surfaceStalePausedReviews(): Promise<number> {
+  async surfaceStalePausedReviews(cycle?: SurfacingCycle | null | Promise<SurfacingCycle | null>): Promise<number> {
     return this.runSurfacing(
       {
         logPrefix: "Stale paused review surfaced",
@@ -8099,10 +8155,11 @@ export class SelfHealingManager {
       },
       "stalePausedReviewThresholdMs",
       "Stale paused review surfacing",
+      cycle,
     );
   }
 
-  async surfaceInReviewStalled(): Promise<number> {
+  async surfaceInReviewStalled(cycle?: SurfacingCycle | null | Promise<SurfacingCycle | null>): Promise<number> {
     const activeMergeTaskId = this.options.getActiveMergeTaskId?.() ?? null;
     const executingTaskIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
     return this.runSurfacing(
@@ -8143,6 +8200,7 @@ export class SelfHealingManager {
       },
       "inReviewStalledThresholdMs",
       "In-review stalled surfacing",
+      cycle,
     );
   }
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -97,6 +97,7 @@ import {
 } from "./notifier.js";
 import type { GhostBugDecision } from "./triage-preflight.js";
 import { filterPathsByIgnoreList, getUnmetSchedulingDependencies, isCoordinationOnlyTask, pathsOverlap, shouldHoldActiveFileScopeLease } from "./scheduler.js";
+import { runSurfacingSweep, hours } from "./surfacing-sweeps.js";
 import { evaluateParkedAgentTaskLink, PARKED_AGENT_LINK_FRESH_RUN_MS } from "./task-agent-sync.js";
 import { describeSelfHealingNoActionWedge } from "./notification/task-wedge-notification.js";
 
@@ -8026,212 +8027,114 @@ export class SelfHealingManager {
       return 0;
     }
   }
+  /*
+  FNXC:WorkflowRecoveryPolicy 2026-07-27-23:20 (U4 — surfacing family retired onto the runner):
+  These three were three copies of one skeleton. The mechanism they shared —
+  pause gates, threshold resolution, the fresh-row skip, the at-most-once dedup,
+  the log write, the never-throw contract — now lives in `runSurfacingSweep`, and
+  each sweep is the part that was genuinely its own: which role it watches, which
+  operator setting it inherits, who is eligible, and what it says.
 
-  /**
-   * Surface quiet-window backlog-health diagnostics for unpaused in-review tasks.
-   *
-   * Non-overlap contract:
-   * - `surfaceStalePausedReviews()` owns paused in-review tasks.
-   * - `surfaceInReviewStalls()` owns reason-driven in-review stalls.
-   *
-   * Skips tasks not eligible for auto-merge processing (global `autoMerge`
-   * off without an explicit per-task `autoMerge: true` override) — PR-based
-   * review flow owns lifecycle until human merge.
-   */
-  async surfaceInReviewStalled(): Promise<number> {
+  Thresholds are now POLICY-OVER-SETTING. A workflow that declares
+  `recovery.stalenessMs` on the role's column wins; one that declares nothing
+  keeps reading the operator setting exactly as before, so this migration changes
+  nothing for an existing project and requires no workflow to be edited.
+
+  Surfacing is OBSERVATIONAL, so per the re-ratified invariant it reports on
+  user-paused cards — which is the entire point of the two paused sweeps.
+  */
+  private async runSurfacing(
+    spec: Parameters<typeof runSurfacingSweep>[0],
+    thresholdKey: "stalePausedTodoThresholdMs" | "stalePausedReviewThresholdMs" | "inReviewStalledThresholdMs",
+    label: string,
+  ): Promise<number> {
     try {
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
-      const cycleStartMs = Date.now();
-      const thresholdMs = settings.inReviewStalledThresholdMs;
-      if (!thresholdMs || thresholdMs <= 0) return 0;
-
-      const tasks = await this.store.listTasks({ column: "in-review", slim: false });
-      const activeMergeTaskId = this.options.getActiveMergeTaskId?.() ?? null;
-      const executingTaskIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
-      let surfaced = 0;
-
-      for (const task of tasks) {
-        if (task.deletedAt) continue;
-        if (!allowsAutoMergeProcessing(task, settings)) continue;
-        if (task.paused === true) continue;
-        if (task.id === activeMergeTaskId || executingTaskIds.has(task.id)) continue;
-        if (await this.isMergeLaneOwned(task.id)) continue;
-
-        const signal = getInReviewStalledSignal(task, {
-          now: cycleStartMs,
-          thresholdMs,
-          autoMerge: true,
-          activeMergeTaskId,
-          executingTaskIds,
+      const inheritedThresholdMs = Number(settings[thresholdKey] ?? 0);
+      const tasks = await this.store.listTasks({ slim: false });
+      return await runSurfacingSweep(spec, {
+        store: this.store,
+        tasks,
+        inheritedThresholdMs,
+        cycleStartMs: Date.now(),
+        activation: {
           engineActiveSinceMs: settings.engineActiveSinceMs,
           engineActivationGraceMs: settings.engineActivationGraceMs,
-        });
-        if (!signal) continue;
-
-        if (Date.parse(task.updatedAt) >= cycleStartMs) {
-          continue;
-        }
-
-        const previous = [...(task.log ?? [])]
-          .reverse()
-          .find((entry) => entry.action.startsWith("In-review stalled surfaced ["));
-        if (previous) {
-          const parsed = /^In-review stalled surfaced \[([^\]]+)\]/.exec(previous.action);
-          const previousCode = parsed?.[1];
-          const previousAt = Date.parse(previous.timestamp);
-          if (Number.isFinite(previousAt) && previousAt >= cycleStartMs - thresholdMs && previousCode === signal.code) {
-            continue;
-          }
-        }
-
-        const hours = (signal.quietMs / 3_600_000).toFixed(1);
-        await this.store.logEntry(
-          task.id,
-          `In-review stalled surfaced [${signal.code}]: quiet ${hours}h beyond ${(thresholdMs / 3_600_000).toFixed(1)}h threshold; disposition options — nudge review, retry, archive, or create follow-up task. lastActivitySource=${signal.lastActivitySource}`,
-        );
-        surfaced += 1;
-      }
-
-      return surfaced;
+        },
+      });
     } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      log.error(`In-review stalled surfacing failed: ${errorMessage}`);
-      return 0;
-    }
-  }
-
-  async surfaceStalePausedReviews(): Promise<number> {
-    try {
-      const settings = await this.store.getSettings();
-      if (settings.globalPause || settings.enginePaused) return 0;
-
-      const cycleStartMs = Date.now();
-      const thresholdMs = settings.stalePausedReviewThresholdMs;
-      if (!thresholdMs || thresholdMs <= 0) return 0;
-
-      const tasks = await this.store.listTasks({ column: "in-review", slim: false });
-      let surfaced = 0;
-
-      for (const task of tasks) {
-        if (task.deletedAt) continue;
-        if (task.paused !== true) continue;
-        const signal = getStalePausedReviewSignal(task, {
-          now: cycleStartMs,
-          thresholdMs,
-          engineActiveSinceMs: settings.engineActiveSinceMs,
-          engineActivationGraceMs: settings.engineActivationGraceMs,
-        });
-        if (!signal) continue;
-        if (Date.parse(task.updatedAt) >= cycleStartMs) continue;
-
-        const previous = [...(task.log ?? [])]
-          .reverse()
-          .find((entry) => entry.action.startsWith("Stale paused review surfaced ["));
-        if (previous) {
-          const parsed = /^Stale paused review surfaced \[([^\]]+)\]/.exec(previous.action);
-          const previousCode = parsed?.[1];
-          const previousAt = Date.parse(previous.timestamp);
-          if (Number.isFinite(previousAt) && previousAt >= cycleStartMs - thresholdMs && previousCode === signal.code) {
-            continue;
-          }
-        }
-
-        const hours = (signal.ageMs / 3_600_000).toFixed(1);
-        await this.store.logEntry(
-          task.id,
-          `Stale paused review surfaced [${signal.code}]: paused ${hours}h; disposition options — unpause, retry, archive, or create follow-up task. pausedReason=${signal.pausedReason ?? "none"}`,
-        );
-        surfaced += 1;
-      }
-
-      return surfaced;
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      log.error(`Stale paused review surfacing failed: ${errorMessage}`);
+      log.error(`${label} failed: ${err instanceof Error ? err.message : String(err)}`);
       return 0;
     }
   }
 
   async surfaceStalePausedTodos(): Promise<number> {
-    try {
-      const settings = await this.store.getSettings();
-      if (settings.globalPause || settings.enginePaused) return 0;
-
-      const cycleStartMs = Date.now();
-      const thresholdMs = settings.stalePausedTodoThresholdMs;
-      if (!thresholdMs || thresholdMs <= 0) return 0;
-
-      /*
-      FNXC:WorkflowLifecycleColumns 2026-07-28-03:45 (PR #2470 review, P1):
-      This sweep needed TWO fixes, not one. `getStalePausedTodoSignal` gained a
-      `holdColumn` parameter in B1 but every caller omitted it, so the guard still
-      compared against the literal "todo" — and the QUERY was `{ column: "todo" }`,
-      so the sweep never even saw a card resting in a renamed hold column.
-      Threading only the signal would have left a correct guard that never runs.
-
-      The column filter is therefore dropped and the hold column resolved PER TASK
-      (a board can span workflows, each with its own hold column). Cost is
-      contained by ordering: `paused !== true` rejects almost every card before any
-      IR resolution, and the survivors share an `irCache`, so a board of 400 cards
-      with three paused ones resolves at most three times.
-      */
-      const tasks = await this.store.listTasks({ slim: false });
-      const irCache = new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>();
-      let surfaced = 0;
-
-      for (const task of tasks) {
-        if (task.paused !== true) continue;
-
-        let holdColumn = "todo";
-        try {
-          const lifecycle = resolveLifecycleColumns(
-            await resolveWorkflowIrForTask(this.store, task.id, irCache),
-          );
-          // A workflow declaring no hold column keeps the legacy id rather than
-          // matching nothing (conservative: preserves today's behavior).
-          if (lifecycle?.hold) holdColumn = lifecycle.hold;
-        } catch {
-          holdColumn = "todo";
-        }
-
-        const signal = getStalePausedTodoSignal(task, {
-          now: cycleStartMs,
-          thresholdMs,
-          holdColumn,
-          engineActiveSinceMs: settings.engineActiveSinceMs,
-          engineActivationGraceMs: settings.engineActivationGraceMs,
-        });
-        if (!signal) continue;
-        if (Date.parse(task.updatedAt) >= cycleStartMs) continue;
-
-        const previous = [...(task.log ?? [])]
-          .reverse()
-          .find((entry) => entry.action.startsWith("Stale paused todo surfaced ["));
-        if (previous) {
-          const parsed = /^Stale paused todo surfaced \[([^\]]+)\]/.exec(previous.action);
-          const previousCode = parsed?.[1];
-          const previousAt = Date.parse(previous.timestamp);
-          if (Number.isFinite(previousAt) && previousAt >= cycleStartMs - thresholdMs && previousCode === signal.code) {
-            continue;
-          }
-        }
-
-        const hours = (signal.ageMs / 3_600_000).toFixed(1);
-        await this.store.logEntry(
-          task.id,
-          `Stale paused todo surfaced [${signal.code}]: paused ${hours}h beyond ${(thresholdMs / 3_600_000).toFixed(1)}h threshold; disposition options — unpause, move to triage, archive, or create follow-up task. pausedReason=${signal.pausedReason ?? "none"}`,
-        );
-        surfaced += 1;
-      }
-
-      return surfaced;
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      log.error(`Stale paused todo surfacing failed: ${errorMessage}`);
-      return 0;
-    }
+    return this.runSurfacing(
+      {
+        logPrefix: "Stale paused todo surfaced",
+        role: "hold",
+        isEligible: (task) => task.paused === true,
+        evaluate: (task, thresholdMs, now, activation, roleColumn) =>
+          getStalePausedTodoSignal(task, { now, thresholdMs, holdColumn: roleColumn, ...activation }),
+        describe: (_task, signal, thresholdMs) =>
+          `paused ${hours(signal.ageMs)}h beyond ${hours(thresholdMs)}h threshold; disposition options — unpause, move to triage, archive, or create follow-up task. pausedReason=${(_task as { pausedReason?: string }).pausedReason ?? "none"}`,
+      },
+      "stalePausedTodoThresholdMs",
+      "Stale paused todo surfacing",
+    );
   }
+
+  async surfaceStalePausedReviews(): Promise<number> {
+    return this.runSurfacing(
+      {
+        logPrefix: "Stale paused review surfaced",
+        role: "review",
+        isEligible: (task) => task.paused === true,
+        evaluate: (task, thresholdMs, now, activation, roleColumn) =>
+          getStalePausedReviewSignal(task, { now, thresholdMs, reviewColumn: roleColumn, ...activation }),
+        describe: (_task, signal) =>
+          `paused ${hours(signal.ageMs)}h; disposition options — unpause, retry, archive, or create follow-up task. pausedReason=${(_task as { pausedReason?: string }).pausedReason ?? "none"}`,
+      },
+      "stalePausedReviewThresholdMs",
+      "Stale paused review surfacing",
+    );
+  }
+
+  async surfaceInReviewStalled(): Promise<number> {
+    const activeMergeTaskId = this.options.getActiveMergeTaskId?.() ?? null;
+    const executingTaskIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
+    return this.runSurfacing(
+      {
+        logPrefix: "In-review stalled surfaced",
+        role: "review",
+        /* Unlike the paused sweeps this one watches ACTIVE review work, so a
+           paused card is excluded rather than targeted. */
+        isEligible: (task) =>
+          task.paused !== true &&
+          task.id !== activeMergeTaskId &&
+          !executingTaskIds.has(task.id),
+        isEligibleAsync: async (task) => !(await this.isMergeLaneOwned(task.id)),
+        evaluate: (task, thresholdMs, now, activation, roleColumn) => {
+          const signal = getInReviewStalledSignal(task, {
+            now,
+            thresholdMs,
+            autoMerge: true,
+            activeMergeTaskId,
+            executingTaskIds,
+            reviewColumn: roleColumn,
+            ...activation,
+          });
+          return signal ? { ...signal, code: signal.code, ageMs: signal.quietMs } : undefined;
+        },
+        describe: (_task, signal, thresholdMs) =>
+          `quiet ${hours(signal.ageMs)}h beyond ${hours(thresholdMs)}h threshold; disposition options — nudge review, retry, archive, or create follow-up task. lastActivitySource=${(signal as { lastActivitySource?: string }).lastActivitySource}`,
+      },
+      "inReviewStalledThresholdMs",
+      "In-review stalled surfacing",
+    );
+  }
+
 
   /**
    * Backward lifecycle move gated on triple proof (FN-5335).

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -8057,6 +8057,7 @@ export class SelfHealingManager {
         store: this.store,
         tasks,
         inheritedThresholdMs,
+        settings,
         cycleStartMs: Date.now(),
         activation: {
           engineActiveSinceMs: settings.engineActiveSinceMs,
@@ -8110,7 +8111,17 @@ export class SelfHealingManager {
         role: "review",
         /* Unlike the paused sweeps this one watches ACTIVE review work, so a
            paused card is excluded rather than targeted. */
-        isEligible: (task) =>
+        isEligible: (task, settings) =>
+          /*
+          FNXC:WorkflowRecoveryPolicy 2026-07-28-01:20 (PR #2487 review, P1):
+          `allowsAutoMergeProcessing` is one of the SIX SAFEGUARDS —
+          `autoMerge:false` is terminal-until-human. The migration dropped this
+          gate while still passing `autoMerge: true` to the signal below, so the
+          code asserted an eligibility it no longer checked and the sweep treated
+          auto-merge-disabled tasks (and manually-opened-PR tasks) as eligible.
+          The `autoMerge: true` argument is only sound BECAUSE this gate proves it.
+          */
+          allowsAutoMergeProcessing(task, settings) &&
           task.paused !== true &&
           task.id !== activeMergeTaskId &&
           !executingTaskIds.has(task.id),

--- a/packages/engine/src/surfacing-sweeps.ts
+++ b/packages/engine/src/surfacing-sweeps.ts
@@ -1,0 +1,209 @@
+/*
+FNXC:WorkflowRecoveryPolicy 2026-07-27-23:10 (U4 — the surfacing family):
+
+ONE runner for the three surfacing sweeps — `surfaceStalePausedTodos`,
+`surfaceStalePausedReviews`, `surfaceInReviewStalled`. They are migrated together
+so the family cannot drift apart: before this they were three copies of the same
+skeleton, and a fix applied to one (the FN-5719-era dedup, the fresh-row skip)
+had to be remembered for the other two.
+
+WHAT THE RUNNER OWNS (identical in all three, and the bulk of each body):
+  - the global pause gates;
+  - the threshold resolution, now POLICY-OVER-SETTING;
+  - the fresh-row skip (a row updated during this cycle is re-read next pass);
+  - the at-most-once dedup keyed on the durable log prefix + signal code;
+  - the log write, the count, and the never-throw contract.
+
+WHAT EACH SPEC OWNS (genuinely per-sweep):
+  - which lifecycle ROLE it watches and which operator setting it inherits;
+  - its eligibility predicate;
+  - its signal evaluation and its operator-facing sentence.
+
+SAFEGUARD POSITION: surfacing is OBSERVATIONAL. Per the re-ratified invariant the
+user-pause safeguard gates lifecycle MUTATION, not observation, so these sweeps
+report on user-paused cards — which is their entire purpose. The runner writes a
+task-log entry and mutates no lifecycle field. It must stay that way: adding a
+mutating action here would need the safeguard, and that is why the action is not
+parameterized.
+
+AT-MOST-ONCE is a SAFEGUARD and lives here, outside the policy table: a workflow
+must not be able to author repeated notification of the same signal.
+*/
+import {
+  resolveEffectiveRecovery,
+  type ResolvedRecoveryPolicy,
+} from "./recovery-reconciler.js";
+import {
+  resolveLifecycleColumns,
+  resolveWorkflowIrForTask,
+  type Task,
+  type TaskStore,
+  type WorkflowIr,
+} from "@fusion/core";
+
+/** Legacy ids for each role, used when a workflow cannot resolve one. */
+const LEGACY_ROLE_COLUMN: Record<SurfacingSpec["role"], string> = {
+  hold: "todo",
+  review: "in-review",
+};
+
+/** The per-task outcome a spec produces, normalized across the three sweeps. */
+export interface SurfacingSignal {
+  code: string;
+  /** How long the condition has held; rendered as hours in the message. */
+  ageMs: number;
+}
+
+export interface SurfacingSpec {
+  /** Durable log prefix. Doubles as the dedup key, so it must stay stable. */
+  logPrefix: string;
+  /** The lifecycle role this sweep watches, resolved per task. */
+  role: "hold" | "review";
+  /** Synchronous eligibility filter; async proof lives in `isEligibleAsync`. */
+  isEligible(task: Task): boolean;
+  /** Optional async eligibility (merge-lane ownership, liveness proofs). */
+  isEligibleAsync?(task: Task): Promise<boolean>;
+  /*
+  Evaluate the sweep's condition. `undefined` = not signalling.
+
+  `activation` carries the engine ACTIVATION FLOOR (`engineActiveSinceMs` +
+  `engineActivationGraceMs`). It is passed to every signal because dropping it
+  makes a sweep report cards as stale purely because the engine was restarted —
+  wall-clock the engine was not running for is not quiet time. That regression is
+  silent in a diff and was caught here only by the pre-existing suite.
+  */
+  evaluate(
+    task: Task,
+    thresholdMs: number,
+    cycleStartMs: number,
+    activation: { engineActiveSinceMs?: number; engineActivationGraceMs?: number },
+    /* The RESOLVED role column. Signals take it so their own column check stays
+       real — passing `task.column` would make that check tautological and quietly
+       delete it. */
+    roleColumn: string,
+  ): SurfacingSignal | undefined;
+  /** The operator-facing sentence following `logPrefix [code]: `. */
+  describe(task: Task, signal: SurfacingSignal, thresholdMs: number): string;
+}
+
+export interface SurfacingRunnerDeps {
+  store: TaskStore;
+  tasks: readonly Task[];
+  /** The operator setting this sweep's threshold DEFERS to when unset. */
+  inheritedThresholdMs: number;
+  /** Engine activation floor, forwarded to every signal (see `evaluate`). */
+  activation: { engineActiveSinceMs?: number; engineActivationGraceMs?: number };
+  cycleStartMs: number;
+  irCache?: Map<string, WorkflowIr>;
+}
+
+/**
+ * Resolve a task's effective threshold: the workflow's declared policy for the
+ * role's column when present, otherwise the operator setting.
+ *
+ * Returns `undefined` when neither supplies an actionable threshold — including
+ * when the operator set a non-positive value, which means DISABLED.
+ */
+async function resolveTaskThreshold(
+  store: TaskStore,
+  task: Task,
+  spec: SurfacingSpec,
+  inheritedThresholdMs: number,
+  irCache: Map<string, WorkflowIr>,
+): Promise<{ policy: ResolvedRecoveryPolicy; roleColumn: string } | undefined> {
+  let declared;
+  let roleColumn: string | undefined;
+  try {
+    const ir = await resolveWorkflowIrForTask(store, task.id, irCache);
+    const lifecycle = resolveLifecycleColumns(ir);
+    roleColumn = lifecycle?.[spec.role];
+    if (roleColumn && ir.version === "v2") {
+      declared = ir.columns.find((c) => c.id === roleColumn)?.recovery;
+    }
+  } catch {
+    // Unresolvable workflow: fall through to the inherited setting.
+  }
+
+  const policy = resolveEffectiveRecovery(declared, {
+    stalenessMs: inheritedThresholdMs,
+    onStale: { action: "surface", code: spec.logPrefix },
+  });
+  if (!policy) return undefined;
+  /*
+  A workflow that cannot resolve the role (v1 / no column vocabulary) keeps the
+  LEGACY id, so an unresolvable workflow behaves exactly as before this migration
+  rather than losing the sweep entirely. Never `undefined`, so the role gate in
+  the runner is ALWAYS active — leaving it optional made the gate silently absent
+  for exactly the workflows whose role failed to resolve.
+  */
+  return { policy, roleColumn: roleColumn ?? LEGACY_ROLE_COLUMN[spec.role] };
+}
+
+/**
+ * Has this exact signal already been surfaced inside the current window?
+ *
+ * AT-MOST-ONCE safeguard: without it a still-stale card is re-reported every
+ * poll, which trains operators to ignore the log — the failure mode that makes a
+ * diagnostic worthless. Keyed on prefix AND code, so a card whose signal CHANGES
+ * is reported again rather than suppressed by the previous one.
+ */
+function alreadySurfaced(task: Task, spec: SurfacingSpec, signal: SurfacingSignal, cycleStartMs: number, thresholdMs: number): boolean {
+  const previous = [...(task.log ?? [])]
+    .reverse()
+    .find((entry) => entry.action.startsWith(`${spec.logPrefix} [`));
+  if (!previous) return false;
+  const parsed = new RegExp(`^${spec.logPrefix} \\[([^\\]]+)\\]`).exec(previous.action);
+  const previousAt = Date.parse(previous.timestamp);
+  return Number.isFinite(previousAt) && previousAt >= cycleStartMs - thresholdMs && parsed?.[1] === signal.code;
+}
+
+/**
+ * Run one surfacing sweep. Returns how many cards were reported.
+ *
+ * Never throws: a surfacing sweep is a diagnostic, so one bad card or workflow
+ * must not take the whole pass down. Per-task failures are skipped individually.
+ */
+export async function runSurfacingSweep(spec: SurfacingSpec, deps: SurfacingRunnerDeps): Promise<number> {
+  const irCache = deps.irCache ?? new Map<string, WorkflowIr>();
+  let surfaced = 0;
+
+  for (const task of deps.tasks) {
+    try {
+      if (task.deletedAt) continue;
+      if (!spec.isEligible(task)) continue;
+
+      const resolved = await resolveTaskThreshold(deps.store, task, spec, deps.inheritedThresholdMs, irCache);
+      if (!resolved) continue;
+      const thresholdMs = resolved.policy.stalenessMs;
+
+      /* The role gate: only cards resting in THIS task's own role column. */
+      if (task.column !== resolved.roleColumn) continue;
+
+      if (spec.isEligibleAsync && !(await spec.isEligibleAsync(task))) continue;
+
+      const signal = spec.evaluate(task, thresholdMs, deps.cycleStartMs, deps.activation, resolved.roleColumn);
+      if (!signal) continue;
+
+      /* A row written during this cycle is re-read next pass, so reporting it
+         now would race the writer and could describe stale state. */
+      if (Date.parse(task.updatedAt) >= deps.cycleStartMs) continue;
+
+      if (alreadySurfaced(task, spec, signal, deps.cycleStartMs, thresholdMs)) continue;
+
+      await deps.store.logEntry(
+        task.id,
+        `${spec.logPrefix} [${signal.code}]: ${spec.describe(task, signal, thresholdMs)}`,
+      );
+      surfaced += 1;
+    } catch {
+      // Diagnostic sweep: skip this card, keep the pass alive.
+    }
+  }
+
+  return surfaced;
+}
+
+/** Hours, to one decimal — the unit every surfacing message reports in. */
+export function hours(ms: number): string {
+  return (ms / 3_600_000).toFixed(1);
+}

--- a/packages/engine/src/surfacing-sweeps.ts
+++ b/packages/engine/src/surfacing-sweeps.ts
@@ -95,6 +95,19 @@ export interface SurfacingSpec {
   describe(task: Task, signal: SurfacingSignal, thresholdMs: number): string;
 }
 
+/**
+ * One shared pass over the board for the whole surfacing family: a single task
+ * snapshot, a single IR cache, and a single cycle clock. See the rationale on
+ * `openSurfacingCycle` in self-healing.ts — the three sweeps partition the task
+ * space, so sharing a snapshot cannot let one observe another's writes.
+ */
+export interface SurfacingCycle {
+  settings: Settings;
+  tasks: Task[];
+  irCache: Map<string, WorkflowIr>;
+  cycleStartMs: number;
+}
+
 export interface SurfacingRunnerDeps {
   store: TaskStore;
   tasks: readonly Task[];

--- a/packages/engine/src/surfacing-sweeps.ts
+++ b/packages/engine/src/surfacing-sweeps.ts
@@ -36,6 +36,7 @@ import {
 import {
   resolveLifecycleColumns,
   resolveWorkflowIrForTask,
+  type Settings,
   type Task,
   type TaskStore,
   type WorkflowIr,
@@ -59,8 +60,16 @@ export interface SurfacingSpec {
   logPrefix: string;
   /** The lifecycle role this sweep watches, resolved per task. */
   role: "hold" | "review";
-  /** Synchronous eligibility filter; async proof lives in `isEligibleAsync`. */
-  isEligible(task: Task): boolean;
+  /*
+  Synchronous eligibility filter; async proof lives in `isEligibleAsync`.
+
+  Takes SETTINGS because some eligibility is settings-dependent — notably
+  `allowsAutoMergeProcessing`, one of the six safeguards. The first cut of this
+  interface omitted settings, which is precisely how that gate got dropped during
+  the migration while the signal kept asserting `autoMerge: true`: the code
+  claimed an eligibility it no longer checked.
+  */
+  isEligible(task: Task, settings: Settings): boolean;
   /** Optional async eligibility (merge-lane ownership, liveness proofs). */
   isEligibleAsync?(task: Task): Promise<boolean>;
   /*
@@ -91,6 +100,8 @@ export interface SurfacingRunnerDeps {
   tasks: readonly Task[];
   /** The operator setting this sweep's threshold DEFERS to when unset. */
   inheritedThresholdMs: number;
+  /** Full settings, so settings-dependent safeguards stay reachable. */
+  settings: Settings;
   /** Engine activation floor, forwarded to every signal (see `evaluate`). */
   activation: { engineActiveSinceMs?: number; engineActivationGraceMs?: number };
   cycleStartMs: number;
@@ -170,7 +181,7 @@ export async function runSurfacingSweep(spec: SurfacingSpec, deps: SurfacingRunn
   for (const task of deps.tasks) {
     try {
       if (task.deletedAt) continue;
-      if (!spec.isEligible(task)) continue;
+      if (!spec.isEligible(task, deps.settings)) continue;
 
       const resolved = await resolveTaskThreshold(deps.store, task, spec, deps.inheritedThresholdMs, irCache);
       if (!resolved) continue;


### PR DESCRIPTION
Stacked on #2486. Base is `feature/u4-safeguard-scoped-to-mutation` — do not merge before it.

Retires the surfacing family — `surfaceStalePausedTodos`, `surfaceStalePausedReviews`, `surfaceInReviewStalled` — onto one policy-driven runner. Migrated **together**, because they were three copies of one skeleton and a fix applied to one had to be remembered for the other two.

#2484's characterization suite is the regression floor and **passes unchanged**.

## Two unconverted sites found in core

Without these the migration would have been **cosmetic for two of the three**:

`getStalePausedReviewSignal` and `getInReviewStalledSignal` both hardcoded `task.column !== "in-review"`. `getStalePausedTodoSignal` gained the equivalent `holdColumn` parameter back in B1 — its two siblings were missed, so they silently stopped matching for any workflow that renames its review column. Both now take `reviewColumn`, defaulting to the legacy id.

## Three bugs this work introduced, and the tests caught

Each was silent in the diff:

1. **I dropped the engine activation floor** from all three signal calls. Wall-clock the engine wasn't running for is not quiet time, so every sweep would have reported cards as stale purely because the engine restarted. Caught by the **pre-existing** suite — not by my own characterization floor, which is exactly why that floor wasn't sufficient alone.
2. **I passed `task.column` as the role column**, making the signal's own column check compare a value against itself — tautologically true, so the check was silently deleted. The *resolved* role column is now passed.
3. **The role gate was conditional on the role resolving**, so it was silently absent for exactly the workflows whose role failed to resolve. Now unconditional, with the legacy id as fallback.

## The shared test is a table

One row per sweep; every invariant asserted for all three — threshold inheritance, declared-policy override, renamed role column, the negative case outside the role column, at-most-once, activation floor, both pause gates, non-positive-threshold disable, soft-delete. **Adding a fourth surfacing sweep means adding a row.**

Its log mock **appends** to the card's log, because the at-most-once dedup reads that log — a call-recording mock cannot observe suppression at all.

## Measured line delta — this corrects the survey estimate downward

| | lines |
|---|---:|
| `self-healing.ts` | **−192 / +95 = −97** |
| new runner file | **+209** |
| core signal conversions | **+23** |
| **NET** | **+135** |

Three sweeps migrated **increased** total lines by 135 while shrinking `self-healing.ts` by 97. Per sweep: **−32** in `self-healing.ts`. **Break-even is 6.5 sweeps.**

Extrapolated to all 34 POLICY sweeps: **−1,099** in `self-healing.ts`, **−890 net** once the runner is amortized.

My survey estimated **−2,612** for that bucket. The measured figure is **34% of it**. The reconciler's size was never the issue — the estimate assumed per-sweep bodies collapse to almost nothing, and they do not: each keeps a real eligibility predicate, signal call, and operator message.

## Verification

- 33 shared-family tests green
- 471 passed across five engine suites, with the single known **pre-existing** `archiveStaleDoneTasks` failure
- 44 core signal tests green
- tsc clean in core and engine; lint clean; merge gate green (299 + 10 + 71)

No changeset: `@fusion/core` and `@fusion/engine` are private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for overriding which workflow column is treated as the relevant “in review” column for stale-paused and stalled-review surfacing.

- **Bug Fixes**
  - Tightened safety safeguards so only lifecycle-mutating recovery actions are blocked when a card is user-paused; observational surfacing remains allowed.
  - Improved surfacing consistency across stale paused todos, stale paused reviews, and in-review stalled cases, including stronger deduping and cycle-aware behavior.

- **Tests**
  - Expanded and reworked safety and surfacing “family” coverage to verify the new invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->