### PR TITLE
fix(desktop): typecheck streamed model downloads

### DIFF
--- a/.changeset/desktop-stream-typecheck.md
+++ b/.changeset/desktop-stream-typecheck.md
@@ -1,0 +1,6 @@
+---
+"@runfusion/fusion": patch
+---
+summary: Desktop builds now typecheck streamed speech-model downloads across differing ReadableStream library definitions.
+category: fix
+dev: Casts the fetch response body through unknown before treating it as an async byte iterable, preserving runtime behavior while satisfying the desktop TypeScript library surface.

--- a/packages/dashboard/src/stt/model-manager.ts
+++ b/packages/dashboard/src/stt/model-manager.ts
@@ -120,7 +120,7 @@ export function createVoiceModelManager(options: VoiceModelManagerOptions = {}):
         if (!current(g, signal)) return state;
         const total = Number(response.headers.get("content-length")) || undefined;
         const hash = createHash("sha256"); let bytes = 0;
-        for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
+        for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
           if (!current(g, signal)) return state;
           const buffer = Buffer.from(chunk); hash.update(buffer); await file.write(buffer);
           if (!current(g, signal)) return state;


### PR DESCRIPTION
## Summary
- make the fetch response-body cast explicit across DOM and desktop TypeScript library definitions
- preserve the existing async byte-stream runtime behavior

## Test plan
- `pnpm --filter @fusion/dashboard exec vitest run src/stt/__tests__/model-manager.test.ts --reporter=dot`
- `pnpm --filter @fusion/desktop typecheck`
- `pnpm --filter @fusion/dashboard typecheck`
- `node scripts/check-changeset-format.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop build typechecking for streamed speech-model downloads by refining how streamed response bodies are interpreted for TypeScript.
  * Preserved runtime behavior, including streaming, integrity/hash checking, file writing, and cancellation handling.
* **Maintenance**
  * Updated the release metadata so this fix is published with the correct patch classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->