### PR TITLE
U9 baseline: pin merge-region IR config as a dead policy authority (test-only)

### DIFF
--- a/packages/engine/src/__tests__/u9-merge-region-node-config-authority.test.ts
+++ b/packages/engine/src/__tests__/u9-merge-region-node-config-authority.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { BUILTIN_CODING_WORKFLOW_IR, type TaskDetail, type WorkflowIrNode } from "@fusion/core";
+
+import { createDefaultNodeHandlers, createNoopLegacySeams } from "../workflow-node-handlers.js";
+import type { WorkflowNodeExecutionContext } from "../workflow-graph-executor.js";
+
+/*
+FNXC:WorkflowOwnedMerge 2026-07-28-09:40:
+U9 characterization baseline. The built-in coding IR DECLARES merge-region policy
+(`merge-retry.maxAttempts`, `merge-manual-hold.release`, the branch-group rework
+budgets), but no engine code reads any of it: the handlers for those node kinds
+return constants. Merge policy authority today lives in TWO other places —
+`settings.maxAutoMergeRetries` (conflict retries, covered by
+`auto-merge-retry-cap-settings.test.ts`) and `ProjectEngine.MAX_AUTO_MERGE_TRANSIENT_RETRIES`
+(transient retries). The IR is a third, DEAD authority.
+
+That matters because U9's acceptance criterion is "merge policy changes via IR config
+alone, with no code change". A reader looking at the IR would reasonably conclude the
+declared numbers are live. They are not, and nothing currently says so.
+
+These tests pin the CURRENT (config-blind) behavior deliberately. When U9 wires a node
+kind onto its IR config, the matching case here goes RED — that is the test doing its
+job, and the U9 commit must move the kind from `CONFIG_BLIND_MERGE_REGION_KINDS` to a
+real config-driven assertion. Do not "fix" a failure here by loosening the assertion.
+*/
+
+/** Node kinds in the merge region whose handlers ignore `node.config` today. */
+const CONFIG_BLIND_MERGE_REGION_KINDS = [
+  "retry-backoff",
+  "manual-merge-hold",
+  "recovery-router",
+  "branch-group-member-integration",
+  "branch-group-promotion",
+] as const;
+
+function ctx(): WorkflowNodeExecutionContext {
+  return {
+    task: { id: "FN-U9", title: "merge region", description: "" } as TaskDetail,
+    settings: undefined,
+    context: {},
+  };
+}
+
+function nodeOf(kind: string, config: Record<string, unknown> | undefined): WorkflowIrNode {
+  return { id: `${kind}-probe`, kind, column: "in-review", config } as WorkflowIrNode;
+}
+
+describe("U9 baseline: built-in merge-region IR policy config", () => {
+  it("declares merge policy the engine does not read", () => {
+    const nodes = BUILTIN_CODING_WORKFLOW_IR.nodes;
+    const byId = (id: string) => nodes.find((n) => n.id === id);
+
+    // These declarations are the ones a reader would take as authoritative.
+    expect(byId("merge-retry")).toMatchObject({
+      kind: "retry-backoff",
+      config: { policy: "merge", maxAttempts: 3 },
+    });
+    expect(byId("merge-manual-hold")).toMatchObject({
+      kind: "manual-merge-hold",
+      config: { release: "manual" },
+    });
+    expect(byId("branch-group-member-integration")).toMatchObject({
+      config: { reworkRegion: true, maxReworkCycles: 3 },
+    });
+  });
+});
+
+describe("U9 baseline: merge-region handlers are config-blind", () => {
+  const handlers = createDefaultNodeHandlers(createNoopLegacySeams());
+
+  for (const kind of CONFIG_BLIND_MERGE_REGION_KINDS) {
+    it(`\`${kind}\` returns an identical result for contradictory configs`, async () => {
+      const handler = handlers[kind];
+
+      // Two configs that a config-driven handler could not possibly treat alike:
+      // opposite budgets, opposite release modes, disjoint surfaces.
+      const withBuiltinConfig = await handler(
+        nodeOf(kind, { policy: "merge", maxAttempts: 3, release: "manual", maxReworkCycles: 3, surfaces: ["merge", "retry"] }),
+        ctx(),
+      );
+      const withContradictoryConfig = await handler(
+        nodeOf(kind, { policy: "none", maxAttempts: 0, release: "external-event", maxReworkCycles: 999, surfaces: [] }),
+        ctx(),
+      );
+      const withNoConfigAtAll = await handler(nodeOf(kind, undefined), ctx());
+
+      expect(withContradictoryConfig).toEqual(withBuiltinConfig);
+      expect(withNoConfigAtAll).toEqual(withBuiltinConfig);
+    });
+  }
+
+  it("`retry-backoff` succeeds unconditionally, so it enforces no attempt budget", async () => {
+    // maxAttempts: 0 should mean "never retry" to any config-driven implementation.
+    // Today the node succeeds regardless, which is why the real budget has to live
+    // in settings/ProjectEngine. Pinned so U9 cannot silently keep it that way.
+    await expect(handlers["retry-backoff"](nodeOf("retry-backoff", { maxAttempts: 0 }), ctx())).resolves.toEqual({
+      outcome: "success",
+    });
+  });
+
+  it("`manual-merge-hold` parks regardless of its declared release mode", async () => {
+    await expect(
+      handlers["manual-merge-hold"](nodeOf("manual-merge-hold", { release: "external-event" }), ctx()),
+    ).resolves.toEqual({ outcome: "failure", value: "manual-required" });
+  });
+});

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -183,6 +183,11 @@ export default defineConfig({
             "src/__tests__/merger-landed-files-capture.test.ts",
             "src/__tests__/branch-attribution.test.ts",
             /*
+            FNXC:EngineTests 2026-07-28-10:20:
+            Gate admission evidence (U9): this pins which authority actually decides merge-region policy — the built-in IR declares `merge-retry.maxAttempts` / `manual-merge-hold.release` that no handler reads, while the live budgets sit in `settings.maxAutoMergeRetries` and `ProjectEngine.MAX_AUTO_MERGE_TRANSIENT_RETRIES`. Merge is where irreversible work happens, and the drift it guards is SILENT: a handler-only edit can quietly make the dead IR config live (or move the live budget) with no other test failing. Outside the gate the ratchet cannot fire on the defect it exists for. Deterministic and pure — no git subprocesses, no timers, no network, no store; 3 ms of assertions.
+            */
+            "src/__tests__/u9-merge-region-node-config-authority.test.ts",
+            /*
             FNXC:EngineTests 2026-06-23-10:48:
             Workflow columns and workflow graph execution are now the default runtime. Retire the legacy direct-dispatch executor/scheduler gate files and gate the new hold-release plus graph interpreter seams instead.
 


### PR DESCRIPTION
**U9, PR1 of several.** Test-only, no production code touched. This is the characterization baseline the plan's Execution note asks for before the merge lane converts.

## The finding

`builtin-coding-workflow-ir.ts` declares merge-region policy that **no engine code reads**:

| IR declaration | Consumed by |
|---|---|
| `merge-retry` → `{ policy: "merge", maxAttempts: 3 }` | nothing — `retry-backoff` handler is `async () => ({ outcome: "success" })` (`workflow-node-handlers.ts:728`) |
| `merge-manual-hold` → `{ release: "manual" }` | nothing — returns a constant `manual-required` |
| `branch-group-*` → `{ maxReworkCycles: 3 }` | nothing — returns a constant `success` |

Live merge policy authority is elsewhere, on two separate axes:
- **conflict** retries — `settings.maxAutoMergeRetries` (default 3), already covered by `auto-merge-retry-cap-settings.test.ts`
- **transient** retries — `ProjectEngine.MAX_AUTO_MERGE_TRANSIENT_RETRIES = 5` (`project-engine.ts:545`)

So the IR is a **third, dead authority**. These are different axes, not a same-axis contradiction — but a reader looking at the IR would reasonably take the declared numbers as live, and nothing currently says otherwise. U9's acceptance criterion is "merge policy changes via IR config alone, with no code change"; that fails today and this pins why.

## Why characterization rather than a fix

Making these handlers config-driven is a **merge behavior change**, and the `requestMerge` primitive it routes through lives at `executor.ts:7383` — inside U8's blast radius. U9 is sequenced behind U8 precisely so the merge lane converts onto an executor that is already substrate. Landing the behavior change now would change merge semantics on an executor about to be reshaped. It lands inside U9 proper.

When U9 wires a node kind onto its IR config, the matching case here goes **red** and the U9 commit must move that kind out of `CONFIG_BLIND_MERGE_REGION_KINDS`. That is the ratchet working.

## Proof it fails when reverted

A test that passes with the change reverted is not a test. The "change" here is the test itself, so the honest analogue is mutating the characterized production behavior. Three independent mutations, each reverted after measuring:

| Mutation | Result |
|---|---|
| `retry-backoff` honours `config.maxAttempts` (what U9 will do) | **2 failed** / 6 passed |
| `manual-merge-hold` honours `config.release === "external-event"` | **2 failed** / 6 passed |
| IR declaration drift: `maxAttempts: 3` → `7` | **1 failed** / 7 passed |

Measured: 8 tests, 4.16s. `pnpm lint` clean. Tree restored to clean after each mutation.

The assertions are behavioral, not string matches: each handler is invoked with two contradictory configs (opposite budgets, opposite release modes, disjoint surfaces) and asserted to return deep-equal results.

## Six safeguards

This PR changes no production behavior, so no safeguard is altered by it. The full six-row table with test attribution is the required artifact for the **conversion** PR, not this one. Baseline located so far, to be completed and verified by mutation before any conversion lands:

| # | Safeguard | Consulted at (today) | Test attribution |
|---|---|---|---|
| 1 | user pause | `project-engine.ts:645` (`task.paused \|\| task.userPaused`) | not yet verified |
| 2 | `autoMerge:false` | `allowsAutoMergeProcessing` — `project-engine.ts:2797`, `merger.ts:7178` | not yet verified |
| 3 | dependency gating | not yet located | not yet verified |
| 4 | capacity | not yet located | `workflow-column-boundary-capacity.test.ts` (unverified) |
| 5 | merge-proof | `getTaskMergeBlocker` — `project-engine.ts:2609` | `merger-file-scope-invariant.test.ts`, `merger-diff-volume-gate.slow.test.ts` (unverified) |
| 6 | at-most-once merge | `activeMergeTaskId` single-flight — `project-engine.ts:693`/`:2729` | not yet verified |

Rows 3, 4 and all attributions are honestly incomplete rather than asserted — I will not present a table I have not earned.

## Also found, for the coordinator

- **Slice statuses are stale.** S02/S03/S04 in `docs/plans/workflow-owned-merge-stack/` are all marked `draft-stack-handoff` but S04 has **landed** (the merge-region IR nodes above), S03's `claimDueWorkflowWorkItem` is implemented and wired via `workflow-work-processor.ts`, and S02's `projectMergeRequestToWorkflowWorkItem` is implemented with **zero production callers**. S06/S07/S08 are genuinely not started. Doc correction coming as its own small PR.
- **S1 prerequisite verified present, not assumed** — all four store methods live in `store.ts`, migration `0031` in tree. No S1-completion gap.
- **Second control plane into the merge lane:** `self-healing.ts:3198` and `:7200` call `enqueueMerge` directly, bypassing the graph. That needs to become a recovery-fact/wake (the stack's R6) during U9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test suite to cover U9 merge-region behavior across supported workflow node types.
  * Verified merge-region results are consistent across built-in, contradictory, and missing configuration inputs.
  * Documented current behavior for retry backoff (always succeeds) and manual merge hold (fails as manual-required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->