### PR TITLE
U7 PR4: triage discovers and releases by the task's own workflow columns (measured: 15 real sites, not the 50 a grep reports)

### DIFF
--- a/.changeset/replan-target-resolved-columns.md
+++ b/.changeset/replan-target-resolved-columns.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A rejected plan on a custom workflow is sent back to that workflow's own planning column, not a column it does not have.
+category: fix
+dev: U7 / R3, R7. `resolveReplanTargetColumn` preferred the literal `triage`, then `todo`, then returned `triage` by fiat — so any workflow declaring neither (builtin:marketing, any renamed set) had its Plan Review REVISE bounce moved into an undeclared column for `reconcileUndeclaredTaskColumns` to clean up. Legacy ids stay preferred first so both coding built-ins keep their exact current target; only a workflow declaring neither reaches the trait fallback, which prefers HOLD over intake (an intake column may be manual-capture with no AI, as in Coding (Ideas)). No declared column at all now returns undefined and every caller parks visibly instead of logging a move it did not make.

--- a/.changeset/triage-planning-handlers-resolved.md
+++ b/.changeset/triage-planning-handlers-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: On a workflow with renamed columns, Start begins planning at once and moving a card no longer kills its planner.
+category: fix
+dev: U7 / R3. The planning wake and planning-evacuation handlers are synchronous `task:updated` listeners, so they read a lane snapshot published by each discovery pass rather than resolving an IR per board update (which for evacuation would also have delayed an abort that is synchronous today). Renamed workflows had opposite failures: the wake never fired (Start appeared dead until the next poll tick), and evacuation fired on an intake -> hold move, killing a healthy planning session mid-spec. A task no pass has published yet falls back to the legacy `triage`/`todo` pair, so behavior in that window is byte-identical to today and the conversion cannot regress a workflow that never renamed anything.

--- a/.changeset/triage-planning-sweeps-resolved.md
+++ b/.changeset/triage-planning-sweeps-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A crashed planner on a workflow with renamed columns is now auto-recovered instead of leaving the task stuck.
+category: fix
+dev: U7 / R3. Both stale-planning sweeps (`sweepStalePlanningStatuses`, periodic; `clearStaleSpecifyingStatuses`, startup) were gated on the literal pair `triage`/`todo`, so neither fired for a renamed workflow — and `status:"planning"` is itself dispatch-blocking AND makes the card invisible to rediscovery, so those cards had no working repair at all. Both now share one `isInPlanningLane` helper resolving intake/hold from the task's own workflow; an unresolvable workflow answers false (these sweeps mutate, so ignorance must not clear). The startup sweep trades two column-filtered queries for one scan plus a role filter; cheap predicates narrow before any IR is resolved, so only genuine candidates cost a resolution.

--- a/.changeset/triage-resolved-lifecycle-columns.md
+++ b/.changeset/triage-resolved-lifecycle-columns.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Tasks on a workflow with renamed columns are now planned, and their specs land in that workflow's own column.
+category: fix
+dev: U7 / R3. `triage.ts` was in no Phase B unit's file list, so its lifecycle-column literals were unowned. Five converted to trait-resolved roles via `resolveTaskLifecycleColumns`: both halves of `discoverReadyPlanningTasks` (intake + hold, one IR cache per pass), `recoverApprovedTask`'s intake gate, and finalize's same-column skip plus its release-move target. Unresolvable workflow or no hold column now withholds the handoff (`outcome: "withheld"`) instead of falling back to a literal. Measured: genuine lifecycle-column sites in triage.ts 15 -> 10; the remaining 10 are listed in the PR with the reason each was left.

--- a/.changeset/triage-stuck-abort-resolved.md
+++ b/.changeset/triage-stuck-abort-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A stuck-killed planner no longer discards a finished spec on a workflow with renamed columns.
+category: fix
+dev: U7 / R3. The last planning-lane literal: `handleStuckAbortRequeue`'s `releasedToTodo` asked `column === "todo"`, so on a renamed workflow a card resting in its own hold column with a completed handoff was not recognised as released — the handler took the requeue path and stamped `needs-replan` over the finished spec, the FN-8361 / PR #2326 regression reintroduced. Now resolves the hold role from the task's own workflow; resolved directly rather than from the discovery snapshot because this path is already async, runs once per stuck kill, and decides whether to overwrite a spec. Unresolvable workflow is treated as not-released, matching the pre-existing behavior for any non-matching column.

--- a/packages/engine/src/__tests__/planning-claim-single-writer.test.ts
+++ b/packages/engine/src/__tests__/planning-claim-single-writer.test.ts
@@ -1,0 +1,336 @@
+/*
+FNXC:PlanningClaimSingleWriter 2026-07-28-15:00 (U7 / R4, R12 — workflow-owned lifecycle):
+
+THE RATCHET: the task planning CLAIM — `status: "planning"` — has exactly ONE
+writer module, and every write of it goes through the guarded helper.
+
+WHY THIS SPECIFIC INVARIANT. The plan names FN-8504 as U7's acceptance case: a
+store-open sweep cleared a live planner's status because two owners wrote planning
+lifecycle state. The unit's stated verification is "a grep-level assertion that
+planning status literals have one writer module". This is that assertion.
+
+`status: "planning"` is the CLAIM on a card — it means "a planner owns this task
+right now". It is also load-bearing well beyond triage: `isUnplannedForExecution`
+treats it as dispatch-blocking, rediscovery skips cards carrying it, and two
+self-healing sweeps plus two triage sweeps exist solely to clear it when a planner
+dies. A second writer does not announce itself; it produces a card that looks
+claimed to every reader while nothing is actually planning it.
+
+WHAT THIS DOES NOT ASSERT, so the guard is not mistaken for more than it is:
+
+  - It says nothing about who CLEARS the status. Eleven modules write
+    `status: null` for unrelated reasons (merge, execution, mission autopilot), so
+    "one clearer" would be false, and asserting it would mean weakening it into
+    something that passes — the worst kind of guard.
+  - `needs-replan` is deliberately NOT covered. Post-U3 it is the graph's own
+    durable replan signal (AGENTS.md), written by the plan-review → plan-replan
+    seam AND the stale-spec guards that feed the same loop. Multiple writers there
+    are the design, not a defect.
+  - Mission `status: "planning"` is a different entity on a different table. The
+    scan is scoped so a mission-store write can never satisfy or trip this.
+
+The two self-healing sweeps that READ `status === "planning"` for orphan recovery
+are the compensating machinery FN-8504 produced. They are readers plus a
+CAS-guarded clear, not claimants, so they do not violate this — and if U7's later
+work makes them unreachable, that is a deletion, not a change to this contract.
+
+Cheap by construction (FN-5048): grep-level over production source, no engine boot.
+*/
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+
+/**
+ * Production source roots, DISCOVERED rather than listed.
+ *
+ * FNXC:PlanningClaimSingleWriter 2026-07-28-16:20 (PR #2527 review — greptile):
+ * This was a hardcoded four-package list, which made a repo-wide claim while
+ * scanning a subset: `packages/desktop` and `packages/plugin-sdk` both touch
+ * TaskStore and were never looked at, and any package added later would have been
+ * silently out of scope forever. A guard whose blind spot grows as the repo grows
+ * is not a guard. Enumerating `packages/<name>/src` means new packages are covered
+ * the day they appear, with no allowlist to forget to update.
+ */
+function sourceRoots(base: string = REPO_ROOT): string[] {
+  const packagesDir = join(base, "packages");
+  return readdirSync(packagesDir)
+    .filter((name) => {
+      const src = join(packagesDir, name, "src");
+      try {
+        return statSync(src).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .map((name) => `packages/${name}/src`)
+    .sort();
+}
+
+/**
+ * The single module permitted to claim a task for planning.
+ *
+ * Adding an entry here is the reviewable act this ratchet exists to force: it
+ * means a second owner now writes the claim, which is the FN-8504 shape. If that
+ * is genuinely intended, the justification belongs beside the new entry.
+ */
+const PLANNING_CLAIM_WRITERS = ["packages/engine/src/triage.ts"];
+
+/**
+ * Modules permitted to BIND the planning literal to a constant.
+ *
+ * `replan-target.ts` binds it to EXCLUDE it — `planning` is the transient in-flight
+ * claim, deliberately filtered out of the durable planning-stage set — and writes no
+ * task status anywhere. It is here because binding the literal is the indirection
+ * route around the write patterns, so a NEW entry deserves a look even when the
+ * module turns out, like this one, to be a reader.
+ */
+const PLANNING_CLAIM_BINDERS = ["packages/engine/src/replan-target.ts"];
+
+/**
+ * Mission planning is a different entity with its own `status` column. Excluded by
+ * path rather than by pattern, because a pattern loose enough to tell them apart is
+ * a pattern loose enough to miss a real task write.
+ */
+const NON_TASK_STATUS_MODULES = [
+  "packages/core/src/mission-store.ts",
+  "packages/core/src/async-mission-store.ts",
+];
+
+function sourceFiles(root: string, base: string = REPO_ROOT): string[] {
+  const abs = join(base, root);
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === "__tests__" || entry === "node_modules" || entry === "dist") continue;
+        walk(full);
+        continue;
+      }
+      if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) out.push(full);
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+/** Strip comments so an explanatory FNXC note naming the literal is not a hit. */
+function stripComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+const executableSource = (file: string): string => stripComments(readFileSync(file, "utf-8"));
+
+/**
+ * The planning literal in EVERY spelling JavaScript allows.
+ *
+ * FNXC:PlanningClaimSingleWriter 2026-07-28-16:20 (PR #2527 review — greptile):
+ * The original pattern matched only the exact double-quoted form, so a second
+ * writer could evade the whole ratchet by typing a single quote. That is a
+ * spelling check wearing a single-writer guarantee's name — the sixth
+ * guard-that-cannot-fire on this program, and the third I have written or found.
+ */
+const PLANNING_LITERAL = String.raw`(?:"planning"|'planning'|\x60planning\x60)`;
+
+/**
+ * A WRITE, not a READ. The distinction is load-bearing: several modules
+ * legitimately COMPARE against the claim (`t.status === "planning"` in the
+ * self-healing orphan sweeps, membership in a status array), and flagging those
+ * would force an allowlist so large the guard would mean nothing.
+ *
+ * Covered write shapes: object-literal property, plain assignment, and a computed
+ * `["status"]` key. Reads (`===`, `!==`, `includes`) are excluded by requiring a
+ * single `:` or `=` that is not part of a comparison operator.
+ */
+const CLAIM_WRITE = new RegExp(
+  String.raw`(?:\bstatus\s*:\s*|\bstatus\s*=(?!=)\s*|\[\s*["']status["']\s*\]\s*(?::|=(?!=))\s*)` + PLANNING_LITERAL,
+);
+
+/**
+ * A constant bound to the planning literal. Without this, indirection defeats the
+ * write patterns above — `const CLAIM = "planning"; store.updateTask(id, { status: CLAIM })`
+ * is a second writer the shape-matching alone cannot see. Binding the literal at all,
+ * outside the allowlisted module, is the reviewable event.
+ */
+const CLAIM_BINDING = new RegExp(
+  String.raw`\b(?:const|let|var|readonly)\s+\w+\s*(?::\s*[^=;]+)?=\s*` + PLANNING_LITERAL,
+);
+
+/*
+FNXC:PlanningClaimSingleWriter 2026-07-28-16:40 (PR #2527 review — greptile):
+WRITES and BINDINGS are reported SEPARATELY, with separate allowlists, because
+conflating them produces a false accusation. Widening the detector immediately
+flagged `replan-target.ts` — which binds the literal ONLY to exclude it from a
+status set (`PLANNING_STAGE_STATUSES.filter(s => s !== TRANSIENT_PLANNING_STATUS)`)
+and never writes a task status at all. Calling that a second writer would have been
+wrong, and the tempting fixes — dropping the binding rule, or allowlisting it as a
+"writer" — would have either reopened the indirection hole or made the guard lie.
+
+So: the WRITE list stays at exactly one module, and the BINDING list is its own
+contract — a new module binding the claim is reviewable precisely because binding is
+the route around the write patterns.
+*/
+
+/**
+ * Every module under `roots` whose EXECUTABLE source writes the planning claim.
+ *
+ * Parameterised on `base` so the injection test below can run this exact function
+ * over a fixture tree. Re-implementing the scan in the test would prove only that
+ * the copy works — which is the failure mode this whole program keeps finding.
+ */
+function scanFor(
+  matches: (source: string) => boolean,
+  roots?: readonly string[],
+  base: string = REPO_ROOT,
+): string[] {
+  const hits: string[] = [];
+  for (const root of roots ?? sourceRoots(base)) {
+    for (const file of sourceFiles(root, base)) {
+      const rel = file.slice(base.length + 1);
+      if (NON_TASK_STATUS_MODULES.includes(rel)) continue;
+      if (matches(executableSource(file))) hits.push(rel);
+    }
+  }
+  return hits.sort();
+}
+
+const planningClaimWriters = (roots?: readonly string[], base?: string): string[] =>
+  scanFor((src) => CLAIM_WRITE.test(src), roots, base);
+
+const planningClaimBinders = (roots?: readonly string[], base?: string): string[] =>
+  scanFor((src) => CLAIM_BINDING.test(src), roots, base);
+
+describe("the planning claim has a single writer (U7 / FN-8504)", () => {
+  it("is written by exactly the allowlisted module", () => {
+    expect(planningClaimWriters()).toEqual([...PLANNING_CLAIM_WRITERS].sort());
+  });
+
+  it("is bound to a constant only by the allowlisted modules", () => {
+    // The indirection route: `const CLAIM = "planning"` defeats the write patterns.
+    expect(planningClaimBinders()).toEqual([...PLANNING_CLAIM_BINDERS].sort());
+  });
+
+  it("writes the claim only through the planning-stage-guarded helper", () => {
+    /*
+    The claim must never be a bare `store.updateTask`. FN-7977 and FN-8361 are both
+    that bug: a write that does not re-check the planning stage under the task lock
+    stamps `planning` onto a card the scheduler has already advanced, and the card
+    then looks claimed to every reader while nothing is planning it.
+    */
+    const source = executableSource(join(REPO_ROOT, "packages/engine/src/triage.ts"));
+    const claims = [...source.matchAll(/status:\s*"planning"/g)];
+    expect(claims).toHaveLength(1);
+
+    // The single claim sits inside an `updatePlanningStateIfStillCurrent(...)` call.
+    const claimLine = source
+      .split("\n")
+      .find((line) => /status:\s*"planning"/.test(line));
+    expect(claimLine).toMatch(/updatePlanningStateIfStillCurrent/);
+  });
+
+  /*
+  A ratchet that cannot be shown to fail on the defect it names is not a ratchet.
+  These run the REAL `planningClaimWriters` over a fixture tree — not a
+  re-implementation of it — so a scan that silently stopped looking would be caught.
+  */
+  describe("the detector itself", () => {
+    let fixtureRoot = "";
+
+    const fixture = (relative: string, contents: string): void => {
+      const full = join(fixtureRoot, relative);
+      mkdirSync(join(full, ".."), { recursive: true });
+      writeFileSync(full, contents);
+    };
+
+    afterEach(() => {
+      if (fixtureRoot) rmSync(fixtureRoot, { recursive: true, force: true });
+      fixtureRoot = "";
+    });
+
+    const newFixtureRoot = (): string => {
+      fixtureRoot = mkdtempSync(join(tmpdir(), "fusion-claim-ratchet-"));
+      return fixtureRoot;
+    };
+
+    /*
+    FNXC:PlanningClaimSingleWriter 2026-07-28-16:40 (PR #2527 review — greptile):
+    EVERY spelling, because the original detector matched only the double-quoted
+    form and a second writer could have evaded the entire ratchet by typing a
+    single quote. Each row is a form that previously slipped past.
+    */
+    const EVASIONS: ReadonlyArray<[string, string]> = [
+      ["double quotes", 'await store.updateTask(id, { status: "planning" });'],
+      ["single quotes", "await store.updateTask(id, { status: 'planning' });"],
+      ["template literal", "await store.updateTask(id, { status: `planning` });"],
+      ["extra whitespace", 'await store.updateTask(id, { status  :   "planning" });'],
+      ["plain assignment", "task.status = 'planning';"],
+      ["computed key", `await store.updateTask(id, { ["status"]: 'planning' });`],
+    ];
+
+    for (const [label, code] of EVASIONS) {
+      it(`FINDS an injected second writer using ${label}`, () => {
+        const base = newFixtureRoot();
+        fixture("pkg/src/innocent.ts", "export const x = 1;\n");
+        fixture("pkg/src/sneaky.ts", `${code}\n`);
+
+        expect(planningClaimWriters(["pkg/src"], base)).toEqual(["pkg/src/sneaky.ts"]);
+      });
+    }
+
+    it("FINDS the constant-indirection route the write patterns alone cannot see", () => {
+      const base = newFixtureRoot();
+      fixture(
+        "pkg/src/indirect.ts",
+        "const CLAIM = 'planning';\nawait store.updateTask(id, { status: CLAIM });\n",
+      );
+
+      // Not a WRITE by shape — the write patterns see `status: CLAIM`, not a literal.
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+      // Caught by the binding contract instead, which is why that exists.
+      expect(planningClaimBinders(["pkg/src"], base)).toEqual(["pkg/src/indirect.ts"]);
+    });
+
+    it("does NOT flag a module that only COMPARES against the claim", () => {
+      // The distinction that keeps the allowlist small enough to mean something:
+      // self-healing's orphan sweeps read this literal and must stay unflagged.
+      const base = newFixtureRoot();
+      fixture(
+        "pkg/src/reader.ts",
+        "if (t.status === 'planning') return;\nconst S = new Set([\"planning\", \"done\"]);\nif (S.has(t.status)) return;\n",
+      );
+
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+    });
+
+    it("scans EVERY package under packages/, not a hardcoded subset", () => {
+      // The scope hole: a package outside the old four-entry list was never looked
+      // at, and a package added later would have been out of scope forever.
+      const base = newFixtureRoot();
+      fixture("packages/brand-new/src/writer.ts", "task.status = 'planning';\n");
+
+      expect(planningClaimWriters(undefined, base)).toEqual(["packages/brand-new/src/writer.ts"]);
+    });
+
+    it("is not fooled by a comment that merely names the literal", () => {
+      // Prose describing the claim must survive — every deletion on this program
+      // leaves an explanatory tombstone — without being read as a writer.
+      const base = newFixtureRoot();
+      fixture("pkg/src/documented.ts", '/* FNXC: triage writes status: "planning" here */\nconst x = 1;\n');
+      fixture("pkg/src/line-comment.ts", '// status: "planning" is claimed by triage\nconst y = 2;\n');
+
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+    });
+
+    it("ignores test files, which legitimately name the claim", () => {
+      const base = newFixtureRoot();
+      fixture("pkg/src/__tests__/a.test.ts", 'expect(t).toEqual({ status: "planning" });\n');
+
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+    });
+  });
+});

--- a/packages/engine/src/__tests__/replan-target-resolved-columns.test.ts
+++ b/packages/engine/src/__tests__/replan-target-resolved-columns.test.ts
@@ -1,0 +1,166 @@
+/*
+FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R3, R7, R12 — workflow-owned lifecycle):
+
+THE INVARIANT: a Plan Review REVISE bounce lands the card in a column the task's
+OWN workflow declares, and NEVER in one it does not.
+
+`resolveReplanTargetColumn` asked `workflowHasColumn(ir, "triage")`, then
+`"todo"`, and fell back to `"triage"` — twice by literal id, once by fiat. On a
+workflow that renames both, all three answers are wrong in the same way: the card
+is moved into a column the workflow does not declare.
+
+That is the R7 violation this program exists to remove ("a stored task row pointing
+at a column no workflow declares"), reached not by drift but by DESIGN — the final
+`return "triage"` fired for any workflow that declares neither legacy id, so
+`reconcileUndeclaredTaskColumns` had to clean up after a move the engine made on
+purpose.
+
+The plan's U5 states the intended behavior directly: "a replan rebound lands in the
+workflow's planning column; a workflow declaring neither legacy column is SKIPPED
+WITH A LOG rather than moved arbitrarily". This is that.
+
+THE LEGACY IDS STAY PREFERRED FIRST, so both built-ins keep their exact current
+target; only a workflow declaring NEITHER reaches the resolved answer. For those the
+fallback prefers HOLD over intake — see the ordering test below for why the obvious
+"intake first" rule is wrong, and which existing test caught it.
+
+WHY THIS FILE IS IN U7 rather than U5, which nominally owns `replan-target.ts`:
+U5's B2 slice converted 12 sites and left this one. It is the planning lane's
+rebound seam — the thing that decides where a rejected plan goes to be re-planned —
+so it sits inside U7's ownership question even though the file is listed elsewhere.
+Flagging rather than assuming: if U5 has this in flight, this is the conflict.
+*/
+import { describe, expect, it, vi } from "vitest";
+import type { TaskStore, WorkflowIr } from "@fusion/core";
+
+import { resolveReplanTargetColumn } from "../replan-target.js";
+
+const WF = "custom:replan-vocab";
+
+/**
+ * A workflow shape parameterised on its column ids. Traits are identical in every
+ * variant, so any behavioral difference is attributable to a surviving literal.
+ * `omit` drops a role entirely, which is how the "declares neither" case is built.
+ */
+function ir(names: { intake?: string; hold?: string; wip?: string }): WorkflowIr {
+  const columns: Array<Record<string, unknown>> = [];
+  if (names.intake) columns.push({ id: names.intake, name: "Intake", traits: [{ trait: "intake" }] });
+  if (names.hold) {
+    columns.push({
+      id: names.hold,
+      name: "Hold",
+      traits: [{ trait: "hold", config: { release: "capacity" } }],
+    });
+  }
+  columns.push({
+    id: names.wip ?? "in-progress",
+    name: "Wip",
+    traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }],
+  });
+  columns.push({ id: "done", name: "Done", traits: [{ trait: "complete" }] });
+  return { version: "v2", id: WF, name: WF, columns, nodes: [], edges: [] } as unknown as WorkflowIr;
+}
+
+function storeWith(workflowIr: WorkflowIr | null): TaskStore {
+  const selection = { workflowId: WF, stepIds: [] };
+  return {
+    getTaskWorkflowSelection: vi.fn(() => selection),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => {
+      if (!workflowIr) throw new Error("workflow could not be resolved");
+      return { ir: workflowIr };
+    }),
+  } as unknown as TaskStore;
+}
+
+describe("the replan rebound targets a column the workflow actually declares", () => {
+  it("targets the intake column under the DEFAULT vocabulary (no-regression half)", async () => {
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ intake: "triage", hold: "todo" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("triage");
+  });
+
+  it("targets a declared column under a RENAMED vocabulary, never the legacy literal", async () => {
+    // Pre-conversion this returned the literal "triage" — a column this workflow
+    // does not declare — so the card was moved somewhere nothing renders it.
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ intake: "backlog", hold: "drafting" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("drafting");
+    expect(target).not.toBe("triage");
+  });
+
+  it("falls back to the HOLD column when the workflow has no intake (plan-in-place)", async () => {
+    // Coding (Ideas) and any workflow whose planning happens in the capacity lane.
+    // Order matters: intake first, hold only when there is no intake.
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ hold: "drafting" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("drafting");
+  });
+
+  it("prefers HOLD over intake when a renamed workflow declares both", async () => {
+    /*
+    MEASURED, and the existing suite corrected me. I first wrote "intake, else
+    hold" on the reasoning that a REVISE sends the card back to be re-specified and
+    specification starts at intake. That broke Coding (Ideas): its intake is `ideas`,
+    which is MANUAL CAPTURE WITH NO AI (plan R10), so a rejected plan sent there
+    stops being replanned at all and becomes an idea awaiting a human.
+
+    The old code got Ideas right by ACCIDENT — it never recognised `ideas` as intake
+    and fell through to `todo`. A trait rule that "corrected" that would have shipped
+    a regression dressed as a cleanup, and only the existing Coding (Ideas) tests
+    stood between me and doing it.
+
+    So the fallback prefers HOLD: it is the planning lane, it has a releaser, and an
+    intake column may be a manual-capture lane with nothing that auto-plans in it.
+    */
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ intake: "backlog", hold: "drafting" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("drafting");
+  });
+
+  it("returns UNDEFINED for a workflow that declares neither role, instead of inventing a column", async () => {
+    // The R7 case. Previously answered "triage" by fiat — moving the card into a
+    // column no workflow declares, which is the exact state
+    // `reconcileUndeclaredTaskColumns` exists to clean up after.
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ wip: "building" })),
+      "FN-1",
+    );
+
+    expect(target).toBeUndefined();
+  });
+
+  it("falls back to the DEFAULT workflow's intake when the selection cannot be read", async () => {
+    /*
+    MEASURED, and it corrected me mid-slice. I first asserted `undefined` here, on
+    the assumption that an unreadable workflow reaches this function's `catch`. It
+    does not: `resolveWorkflowIrForTask` is TOTAL — every failure path returns
+    `defaultCodingWorkflowIr()` rather than throwing. So the `catch` in
+    `resolveReplanTargetColumn` is unreachable belt-and-braces, and asserting
+    `undefined` would have been a test for a state that cannot occur — the exact
+    guard-that-cannot-fire shape this program keeps finding.
+
+    The real behavior is worth pinning precisely BECAUSE it is surprising: an
+    unreadable selection silently becomes the default coding workflow, so the card
+    replans to `triage` — correct for the overwhelmingly common case, and quietly
+    wrong for a renamed workflow whose selection failed to load. That is a property
+    of the resolver, not of this seam, so it is documented here rather than
+    "fixed" here.
+    */
+    const target = await resolveReplanTargetColumn(storeWith(null), "FN-1");
+
+    expect(target).toBe("triage");
+  });
+});

--- a/packages/engine/src/__tests__/replan-target.test.ts
+++ b/packages/engine/src/__tests__/replan-target.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Task, TaskStep, TaskStore } from "@fusion/core";
+import { resolveWorkflowIrForTask } from "@fusion/core";
 import { hasAdvancedPastPlanning, isTaskStillInPlanningStage, moveTaskToReplanColumn, resolveReplanTargetColumn } from "../replan-target.js";
 
 /*
@@ -268,12 +269,35 @@ describe("resolveReplanTargetColumn", () => {
     await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("todo");
   });
 
-  it("falls back to triage for workflows declaring neither triage nor todo (never a custom column)", async () => {
-    // builtin:marketing declares ideation/backlog/drafting/... — no triage, no todo.
-    // A custom entry column would strand the needs-replan card (triage only scans
-    // "triage" and "todo") and the legacy move path throws on custom targets.
+  it("targets a workflow's OWN hold column when it declares neither legacy id", async () => {
+    /*
+    FNXC:ReplanTargetLifecycleColumns 2026-07-29-10:15 (U7 / R7):
+    CONTRACT CHANGED — deliberately, and this is the expectation edit that IS the
+    change rather than churn around it. This previously asserted `"triage"` for
+    builtin:marketing, which declares ideation/backlog/drafting/... and NO triage
+    column: the engine moved the card into a column the workflow does not declare,
+    which is the R7 violation `reconcileUndeclaredTaskColumns` then cleaned up after.
+
+    Both reasons the old fallback gave for preferring a wrong-but-legacy column are
+    now obsolete, and one of them was removed by an earlier slice of this same unit:
+
+      "triage only scans triage and todo" — no longer true. Discovery resolves the
+      task's own intake/hold roles (U7 PR4), so marketing's `backlog` IS scanned.
+
+      "the legacy move path throws on custom targets" — no longer true either; a
+      move out of a non-legacy source column resolves targets from the task's own
+      workflow adjacency (FN-7591).
+
+    Asserted as "a column this workflow declares" as well as by id, because the id
+    is incidental and the INVARIANT is what matters.
+    */
     const store = storeWithSelection("builtin:marketing");
-    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("triage");
+    const target = await resolveReplanTargetColumn(store, "FN-1");
+
+    expect(target).toBe("backlog");
+    const ir = await resolveWorkflowIrForTask(store as never, "FN-1");
+    expect((ir as unknown as { columns: Array<{ id: string }> }).columns.map((c) => c.id))
+      .toContain(target);
   });
 
   it("falls back to triage when workflow resolution throws", async () => {

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -1,0 +1,308 @@
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-11:10 (U7 / R3, R12 — workflow-owned lifecycle):
+
+THE INVARIANT: triage discovers planning work, and hands a specified card off, by
+the task's OWN workflow columns — never by the literal ids `triage` / `todo`.
+
+WHY THIS FILE EXISTS. The program's per-file census (plan Problem Frame, 535
+sites) covers `self-healing.ts` (U4), the executor/scheduler cluster (U5), and the
+core policy modules (U6). `triage.ts` is in NONE of them, so its lifecycle-column
+literals were unowned. Measured with the plan's own methodology (block and line
+comments stripped, code lines only): a naive quoted-literal grep reports 50 sites,
+but 35 of those are the agent ROLE string `"triage"`, not the column. The genuine
+lifecycle-column surface is 15 — 12 planning-lane, 3 `column !== "done"` in
+duplicate search. The 50 figure would over-count by 3.3x.
+
+WHAT WAS ACTUALLY BROKEN on a workflow whose columns are renamed — and both of
+these fail SILENTLY, which is the whole reason Phase B is sliced rather than swept:
+
+  1. DISCOVERY never matched, so cards on that workflow were never planned at all.
+     No error, no log: the filter simply returned nothing and the poll looked
+     healthy.
+  2. THE RELEASE MOVE targeted the literal `"todo"`, a column the workflow may not
+     declare — which is precisely the R7 violation ("a stored task row pointing at
+     a column no workflow declares") that `reconcileUndeclaredTaskColumns` exists
+     to clean up after.
+
+DIFFERENTIAL BY CONSTRUCTION. Every case runs the SAME scenario under two
+vocabularies — the default ids and a renamed set where NO id collides with a legacy
+literal — and asserts the outcomes match. A surviving `=== "todo"` cannot pass both
+halves by luck, and the default half doubles as the no-regression proof.
+
+DELIBERATELY OUT OF SCOPE, and listed so the gaps are not mistaken for coverage:
+  - `taskColumnWakeHandler` / the planning-evacuation handler. Both are synchronous
+    `task:updated` listeners; resolving an IR per event means a store read on every
+    task update on the board. That needs a cache design, not a find-and-replace.
+  - WIDENING `recoverApprovedTask` beyond the intake column. Its literal IS
+    converted here (the renamed release below is unreachable otherwise), but its
+    intake-ONLY scope is preserved exactly: plan-in-place cards specified while
+    resting in the HOLD column stay unreachable by that recovery path. That is a
+    real pre-existing gap; closing it is a behavior change and does not belong in a
+    vocabulary conversion. It is pinned below so it is a recorded decision.
+  - The three `column !== "done"` filters in duplicate search — a different role
+    (complete), a different lane, no planning decision.
+*/
+import "./executor-test-helpers.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+import { TriageProcessor } from "../triage.js";
+import { resetExecutorMocks } from "./executor-test-helpers.js";
+import { planLog } from "../logger.js";
+
+const WF = "custom:planning-vocab";
+
+/** The two vocabularies. Traits are identical; only the ids differ, so any
+ *  behavioral difference is attributable to a surviving literal and nothing else. */
+const DEFAULT_NAMES = { intake: "triage", hold: "todo", wip: "in-progress" };
+/* No renamed id collides with a legacy column literal, so a stray `=== "todo"`
+   cannot match by coincidence. */
+const RENAMED = { intake: "backlog", hold: "drafting", wip: "building" };
+
+function ir(names: { intake: string; hold: string; wip: string }): WorkflowIr {
+  return {
+    version: "v2",
+    id: WF,
+    name: WF,
+    columns: [
+      { id: names.intake, name: "Intake", traits: [{ trait: "intake" }] },
+      {
+        id: names.hold,
+        name: "Hold",
+        traits: [{ trait: "hold", config: { release: "capacity" } }, { trait: "reset-on-entry" }],
+      },
+      { id: names.wip, name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "done", name: "Done", traits: [{ trait: "complete" }] },
+    ],
+    nodes: [
+      { id: "start", kind: "start", column: names.intake },
+      { id: "planning", kind: "prompt", column: names.hold, config: { seam: "planning" } },
+      { id: "execute", kind: "prompt", column: names.wip, config: { seam: "execute" } },
+      { id: "end", kind: "end", column: "done" },
+    ],
+    edges: [
+      { from: "start", to: "planning" },
+      { from: "planning", to: "execute", condition: "success" },
+      { from: "execute", to: "end", condition: "success" },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+const REAL_SPEC = [
+  "# Task: FN-001 - Real spec",
+  "",
+  "## Mission",
+  "",
+  "Do the thing.",
+  "",
+  "## Steps",
+  "",
+  "### Step 0: Implement",
+  "- [ ] do the work",
+  "",
+].join("\n");
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "FN-001",
+    title: "Task",
+    description: "desc",
+    column: "triage",
+    status: "planning",
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Task;
+}
+
+function createStore(opts: {
+  tasks: Task[];
+  workflowIr: WorkflowIr;
+  settings?: Partial<Settings>;
+}): TaskStore {
+  const selection = { workflowId: WF, stepIds: [] };
+  const { tasks } = opts;
+  const byId = (id: string) => tasks.find((t) => t.id === id);
+  const store: Record<string, unknown> = {
+    getSettings: vi.fn().mockResolvedValue({
+      pollIntervalMs: 600_000,
+      maxConcurrent: 4,
+      requirePlanApproval: false,
+      ...opts.settings,
+    } as Settings),
+    listTasks: vi.fn(async (filter?: { column?: string }) =>
+      (filter?.column ? tasks.filter((t) => t.column === filter.column) : tasks)),
+    getTask: vi.fn(async (id: string) => byId(id)),
+    parseDependenciesFromPrompt: vi.fn().mockResolvedValue([]),
+    parseStepsFromPrompt: vi.fn().mockResolvedValue([]),
+    parseFileScopeFromPrompt: vi.fn().mockResolvedValue([]),
+    updateTask: vi.fn(),
+    updateTaskAtomic: vi.fn(async (id: string, patch: unknown) => {
+      const live = byId(id);
+      if (!live) return undefined;
+      const next = typeof patch === "function"
+        ? (patch as (t: Task) => Partial<Task> | null)(live)
+        : (patch as Partial<Task> | null);
+      if (next) Object.assign(live, next);
+      return live;
+    }),
+    moveTask: vi.fn(),
+    moveTaskIf: vi.fn(async (id: string, column: string) => {
+      const live = byId(id)!;
+      return { moved: true, task: { ...live, column, status: null } };
+    }),
+    withTaskLock: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
+    readTaskForMove: vi.fn(async (id: string) => byId(id)),
+    logEntry: vi.fn(),
+    recordActivity: vi.fn().mockResolvedValue(undefined),
+    getTaskWorkflowSelection: vi.fn(() => selection),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => ({ ir: opts.workflowIr })),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return store as unknown as TaskStore;
+}
+
+describe("triage resolves its planning-lane columns from the task's workflow", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-vocab-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  async function seedPrompt(taskId: string, content: string): Promise<void> {
+    await mkdir(join(rootDir, ".fusion", "tasks", taskId), { recursive: true });
+    await writeFile(join(rootDir, ".fusion", "tasks", taskId, "PROMPT.md"), content);
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 1. Discovery — which cards are planned at all
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** Drive one poll and report which task ids triage decided to specify. */
+  async function discovered(names: { intake: string; hold: string; wip: string }): Promise<string[]> {
+    const intakeCard = createTask({ id: "FN-INTAKE", column: names.intake, status: "planning" });
+    // A hold-column card with no spec yet — see the ENOENT note below.
+    const holdCard = createTask({ id: "FN-HOLD", column: names.hold, status: null });
+    const elsewhere = createTask({ id: "FN-ELSEWHERE", column: names.wip, status: null });
+    // FN-HOLD deliberately has NO PROMPT.md: the documented ENOENT branch treats a
+    // missing spec as unplanned and admits the card, which is the plan-in-place /
+    // Ideas-promotion shape the hold half of discovery exists to catch.
+    const store = createStore({ tasks: [intakeCard, holdCard, elsewhere], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    const specified: string[] = [];
+    vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+      .mockImplementation(async (t: Task) => { specified.push(t.id); });
+
+    /*
+    `poll()` early-returns unless the processor is running, so flipping the flag is
+    what makes the pass happen at all. Preferred over `start()`: start() installs a
+    real `setInterval` and store listeners, which this case does not exercise and
+    which leak across tests.
+    */
+    (processor as unknown as { running: boolean }).running = true;
+    await (processor as unknown as { poll: () => Promise<void> }).poll();
+
+    return specified.sort();
+  }
+
+  it("discovers intake and hold cards under the DEFAULT vocabulary (no-regression half)", async () => {
+    expect(await discovered(DEFAULT_NAMES)).toEqual(["FN-HOLD", "FN-INTAKE"]);
+  });
+
+  it("discovers the same cards under a RENAMED vocabulary", async () => {
+    // Pre-conversion this returned [] — the literal filter matched nothing, silently,
+    // so every card on a renamed workflow was invisible to planning forever.
+    expect(await discovered(RENAMED)).toEqual(["FN-HOLD", "FN-INTAKE"]);
+  });
+
+  it("never discovers a card resting in the wip column, under either vocabulary", async () => {
+    for (const names of [DEFAULT_NAMES, RENAMED]) {
+      expect(await discovered(names)).not.toContain("FN-ELSEWHERE");
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 2. The release move — where a specified card lands
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /** Run a finalize through the public recovery entry point and report the move target. */
+  async function releaseTarget(names: { intake: string; hold: string; wip: string }): Promise<string | undefined> {
+    const task = createTask({ id: "FN-001", column: names.intake, status: "planning" });
+    await seedPrompt("FN-001", REAL_SPEC);
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+
+    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    const call = vi.mocked(store.moveTaskIf!).mock.calls[0];
+    return call?.[1] as string | undefined;
+  }
+
+  it("releases into the workflow's HOLD column under the default vocabulary", async () => {
+    expect(await releaseTarget(DEFAULT_NAMES)).toBe("todo");
+  });
+
+  it("releases into the workflow's HOLD column under a renamed vocabulary", async () => {
+    // Pre-conversion this moved the card to the literal "todo" — a column this
+    // workflow does not declare, i.e. exactly the R7 violation
+    // `reconcileUndeclaredTaskColumns` exists to clean up after.
+    expect(await releaseTarget(RENAMED)).toBe("drafting");
+  });
+
+  it("does not move a card that is ALREADY resting in its own hold column (plan-in-place)", async () => {
+    // The same-column skip must key on the resolved hold column, not on `!== "todo"`.
+    // Keyed on the literal, a renamed plan-in-place card was moved to a foreign
+    // column instead of being left where it already was.
+    const task = createTask({ id: "FN-001", column: RENAMED.hold, status: "planning" });
+    await seedPrompt("FN-001", REAL_SPEC);
+    const store = createStore({ tasks: [task], workflowIr: ir(RENAMED) });
+
+    // `recoverApprovedTask` gates on the intake column, so drive the hold-column
+    // shape through the same path the plan-in-place cards actually take.
+    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    expect(store.moveTaskIf).not.toHaveBeenCalled();
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 3. A gap this slice deliberately PRESERVES rather than fixes
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it("still refuses to recover a hold-column card — the pre-existing intake-only gate, pinned not fixed", async () => {
+    /*
+    `recoverApprovedTask` gates on the INTAKE column only. Plan-in-place cards are
+    specified while resting in the HOLD column (Coding (Ideas), and any
+    `needs-replan` revision on the default workflow), so this recovery path cannot
+    reach them — a stuck planner on such a card is recovered by nothing here.
+
+    Converting the literal to the intake ROLE preserves that gap exactly; widening
+    it to intake-or-hold would be a behavior change, and a vocabulary slice is the
+    wrong place to make one. Pinned so the gap is a recorded decision rather than an
+    accident, and so whoever fixes it has a failing test to flip.
+    */
+    const task = createTask({ id: "FN-001", column: RENAMED.hold, status: "planning" });
+    await seedPrompt("FN-001", REAL_SPEC);
+    const store = createStore({ tasks: [task], workflowIr: ir(RENAMED) });
+
+    await expect(
+      new TriageProcessor(store, rootDir).recoverApprovedTask(task),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -160,7 +160,13 @@ function createStore(opts: {
     }),
     withTaskLock: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
     readTaskForMove: vi.fn(async (id: string) => byId(id)),
-    logEntry: vi.fn(),
+    /*
+    MUST resolve a promise. The periodic sweep does `await store.logEntry(...).catch(...)`,
+    so a bare `vi.fn()` returning undefined throws on `.catch` and aborts the sweep after
+    its FIRST card — which reads as "the sweep only matches one column" and sends you
+    looking for a production bug that is not there.
+    */
+    logEntry: vi.fn().mockResolvedValue(undefined),
     recordActivity: vi.fn().mockResolvedValue(undefined),
     getTaskWorkflowSelection: vi.fn(() => selection),
     getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
@@ -343,5 +349,130 @@ describe("triage resolves its planning-lane columns from the task's workflow", (
     await expect(
       new TriageProcessor(store, rootDir).recoverApprovedTask(task),
     ).resolves.toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. The two stale-planning-status sweeps
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+Both sweeps clear a `planning` status left by a planner that never finished, and
+both were gated on the literal pair `triage`/`todo`. On a renamed workflow neither
+fired, so a crashed planner's card kept `status:"planning"` forever — and that
+status is itself dispatch-blocking (`isUnplannedForExecution`) and makes the card
+invisible to rediscovery, which skips cards already marked `planning`. The card was
+therefore stuck in a state only these sweeps clear, on workflows where neither
+sweep could see it. FN-8596 is that strand on the DEFAULT vocabulary; a renamed
+workflow had no working repair at all.
+
+The periodic sweep and the startup sweep are tested separately because they select
+their candidates differently — the periodic one filters a task list it is handed,
+the startup one issued its own per-column queries — and only the first was covered.
+*/
+describe("the stale-planning sweeps resolve their planning lane", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-sweep-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** A `planning` card left behind long enough to be past the staleness floor. */
+  const stalePlanner = (id: string, column: string, over: Partial<Task> = {}): Task => createTask({
+    id,
+    column,
+    status: "planning",
+    updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    ...over,
+  });
+
+  /** Ids whose `status` the sweep cleared. */
+  function clearedIds(store: TaskStore): string[] {
+    return vi.mocked(store.updateTask)
+      .mock.calls.filter(([, patch]) => (patch as { status?: unknown }).status === null)
+      .map(([id]) => id as string);
+  }
+
+  describe("periodic sweep (runs every poll)", () => {
+    async function sweep(names: { intake: string; hold: string; wip: string }, tasks: Task[]) {
+      const store = createStore({ tasks, workflowIr: ir(names) });
+      const processor = new TriageProcessor(store, rootDir);
+      /*
+      Stub the planner. Once the sweep clears a stale status the card becomes an
+      ordinary planning candidate in the SAME poll, so a real `specifyTask` runs —
+      reaching module-mocked provider code and throwing ASYNCHRONOUSLY, after the
+      test has already passed. That surfaces as a suite exit code 1 with every test
+      green, i.e. exactly the kind of noise a CI run gets told to ignore.
+      */
+      vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+        .mockResolvedValue(undefined);
+      (processor as unknown as { running: boolean }).running = true;
+      await (processor as unknown as { poll: () => Promise<void> }).poll();
+      return clearedIds(store);
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`clears a stale planner in the ${label} intake and hold columns`, async () => {
+        const cleared = await sweep(names, [
+          stalePlanner("FN-INTAKE", names.intake),
+          stalePlanner("FN-HOLD", names.hold),
+        ]);
+
+        expect(cleared.sort()).toEqual(["FN-HOLD", "FN-INTAKE"]);
+      });
+
+      it(`never clears a ${label} card resting outside the planning lane`, async () => {
+        expect(await sweep(names, [stalePlanner("FN-WIP", names.wip)])).toEqual([]);
+      });
+
+      it(`never clears a user-paused ${label} card (an operator park is authoritative)`, async () => {
+        const cleared = await sweep(names, [
+          stalePlanner("FN-PAUSED", names.hold, { userPaused: true }),
+        ]);
+
+        expect(cleared).toEqual([]);
+      });
+    }
+  });
+
+  describe("startup sweep (runs once at start)", () => {
+    async function sweep(names: { intake: string; hold: string; wip: string }, tasks: Task[]) {
+      const store = createStore({ tasks, workflowIr: ir(names) });
+      const processor = new TriageProcessor(store, rootDir);
+      await (processor as unknown as { clearStaleSpecifyingStatuses: () => Promise<void> })
+        .clearStaleSpecifyingStatuses();
+      return clearedIds(store);
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`clears a stale planner in the ${label} intake and hold columns`, async () => {
+        // No staleness floor here: at startup nothing this process owns can be live,
+        // so any surviving `planning` status is by definition a leftover.
+        const cleared = await sweep(names, [
+          createTask({ id: "FN-INTAKE", column: names.intake, status: "planning" }),
+          createTask({ id: "FN-HOLD", column: names.hold, status: "planning" }),
+        ]);
+
+        expect(cleared.sort()).toEqual(["FN-HOLD", "FN-INTAKE"]);
+      });
+
+      it(`never clears a ${label} card resting outside the planning lane`, async () => {
+        const cleared = await sweep(names, [
+          createTask({ id: "FN-WIP", column: names.wip, status: "planning" }),
+        ]);
+
+        expect(cleared).toEqual([]);
+      });
+    }
   });
 });

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -267,18 +267,57 @@ describe("triage resolves its planning-lane columns from the task's workflow", (
   });
 
   it("does not move a card that is ALREADY resting in its own hold column (plan-in-place)", async () => {
-    // The same-column skip must key on the resolved hold column, not on `!== "todo"`.
-    // Keyed on the literal, a renamed plan-in-place card was moved to a foreign
-    // column instead of being left where it already was.
+    /*
+    The same-column skip must key on the resolved hold column, not on `!== "todo"`.
+    Keyed on the literal, a renamed plan-in-place card was moved OUT of the column it
+    was already resting in, into a foreign one.
+
+    FNXC:TriageLifecycleColumns 2026-07-28-17:10 (PR #2517 review — CodeRabbit):
+    Driven through `finalizeApprovedTask` DIRECTLY, not through `recoverApprovedTask`.
+    That entry point gates on the intake column, so a hold-column card returned false
+    before finalize ever ran — `moveTaskIf` was trivially uncalled, the assertion
+    passed without exercising the branch it names, and the test was an exact
+    duplicate of the intake-gate case below it. A vacuous pass on the branch this
+    slice exists to convert.
+
+    Asserting the OUTCOME as well as the absent move is what makes it non-vacuous:
+    `released` proves finalize took the already-in-place path and completed the
+    handoff, rather than bailing out somewhere earlier for an unrelated reason.
+    */
     const task = createTask({ id: "FN-001", column: RENAMED.hold, status: "planning" });
     await seedPrompt("FN-001", REAL_SPEC);
     const store = createStore({ tasks: [task], workflowIr: ir(RENAMED) });
+    const settings = await store.getSettings();
 
-    // `recoverApprovedTask` gates on the intake column, so drive the hold-column
-    // shape through the same path the plan-in-place cards actually take.
-    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+    const report = await (new TriageProcessor(store, rootDir) as unknown as {
+      finalizeApprovedTask: (
+        t: Task, written: string, s: Settings, o?: Record<string, unknown>,
+      ) => Promise<{ outcome: string }>;
+    }).finalizeApprovedTask(task, REAL_SPEC, settings);
 
     expect(store.moveTaskIf).not.toHaveBeenCalled();
+    expect(report.outcome).toBe("released");
+  });
+
+  it("DOES move a card that is resting in a column that is not its hold column", async () => {
+    /*
+    The other side of the same branch, so "never moves" cannot pass for "correctly
+    skips". Same workflow, same entry point — only the card's starting column
+    differs — and the move must target the resolved hold column.
+    */
+    const task = createTask({ id: "FN-001", column: RENAMED.intake, status: "planning" });
+    await seedPrompt("FN-001", REAL_SPEC);
+    const store = createStore({ tasks: [task], workflowIr: ir(RENAMED) });
+    const settings = await store.getSettings();
+
+    const report = await (new TriageProcessor(store, rootDir) as unknown as {
+      finalizeApprovedTask: (
+        t: Task, written: string, s: Settings, o?: Record<string, unknown>,
+      ) => Promise<{ outcome: string }>;
+    }).finalizeApprovedTask(task, REAL_SPEC, settings);
+
+    expect(store.moveTaskIf).toHaveBeenCalledWith("FN-001", RENAMED.hold, expect.any(Function));
+    expect(report.outcome).toBe("released");
   });
 
   // ───────────────────────────────────────────────────────────────────────────

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -143,7 +143,14 @@ function createStore(opts: {
     parseDependenciesFromPrompt: vi.fn().mockResolvedValue([]),
     parseStepsFromPrompt: vi.fn().mockResolvedValue([]),
     parseFileScopeFromPrompt: vi.fn().mockResolvedValue([]),
-    updateTask: vi.fn(),
+    /*
+    MUST resolve. Several triage paths do `await store.updateTask(...).catch(...)`,
+    so a bare `vi.fn()` throws on `.catch` and aborts the caller mid-way — which
+    presents as the branch under test "not running" and sends you hunting a
+    production bug that is not there. Sixth instance of this shape in U7; see the
+    PR body.
+    */
+    updateTask: vi.fn().mockResolvedValue(undefined),
     updateTaskAtomic: vi.fn(async (id: string, patch: unknown) => {
       const live = byId(id);
       if (!live) return undefined;
@@ -475,4 +482,212 @@ describe("the stale-planning sweeps resolve their planning lane", () => {
       });
     }
   });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. The two synchronous task:updated handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-13:40 (U7 / R3):
+The planning wake and the planning-evacuation abort are SYNCHRONOUS `task:updated`
+listeners, so they cannot resolve an IR without either a store read per board
+update or — for evacuation — delaying an abort that is synchronous today. They read
+a snapshot the discovery pass publishes instead.
+
+The two failures they had on a renamed workflow are opposites, which is why both
+directions are asserted:
+  - the WAKE never fired, so pressing Start did nothing until the next 15s tick —
+    the exact symptom the wake was built to remove, reintroduced;
+  - the EVACUATION fired when it should not have: moving a card from its intake
+    column into its own HOLD column looked like a withdrawal, so a live planning
+    session was KILLED and its status cleared for a card that was progressing
+    normally.
+
+The unpublished-roles window falls back to the legacy literals, so behavior there is
+byte-identical to today. That fallback is asserted too — it is the reason this
+conversion cannot regress a workflow that never renamed anything.
+*/
+describe("the synchronous planning handlers read the published lane", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-handlers-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** Build a processor whose discovery pass has already published `names`. */
+  async function processorWithPublishedRoles(
+    names: { intake: string; hold: string; wip: string },
+    task: Task,
+  ): Promise<TriageProcessor> {
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+      .mockResolvedValue(undefined);
+    (processor as unknown as { running: boolean }).running = true;
+    await (processor as unknown as { poll: () => Promise<void> }).poll();
+    return processor;
+  }
+
+  describe("wake", () => {
+    /** Did a move into `column` wake the poll? */
+    async function wakes(
+      names: { intake: string; hold: string; wip: string },
+      column: string,
+      opts: { publish?: boolean } = { publish: true },
+    ): Promise<boolean> {
+      const task = createTask({ id: "FN-WAKE", column: names.intake, status: null });
+      const processor = opts.publish
+        ? await processorWithPublishedRoles(names, task)
+        : new TriageProcessor(createStore({ tasks: [task], workflowIr: ir(names) }), rootDir);
+      const handler = (processor as unknown as { taskColumnWakeHandler: (t: Task) => void })
+        .taskColumnWakeHandler;
+      const nudge = vi
+        .spyOn(processor as unknown as { requestImmediatePoll: () => boolean }, "requestImmediatePoll")
+        .mockReturnValue(true);
+
+      handler({ ...task, column } as Task);
+
+      return nudge.mock.calls.length > 0;
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`wakes for a move into the ${label} intake and hold columns`, async () => {
+        expect(await wakes(names, names.intake)).toBe(true);
+        expect(await wakes(names, names.hold)).toBe(true);
+      });
+
+      it(`does not wake for a move into the ${label} wip column`, async () => {
+        expect(await wakes(names, names.wip)).toBe(false);
+      });
+    }
+
+    it("falls back to the legacy lane for a card no pass has published yet", async () => {
+      // Byte-identical to pre-conversion behavior in this window: `todo` wakes,
+      // an unrelated column does not — regardless of what the workflow declares.
+      expect(await wakes(RENAMED, "todo", { publish: false })).toBe(true);
+      expect(await wakes(RENAMED, RENAMED.wip, { publish: false })).toBe(false);
+    });
+  });
+
+  describe("evacuation", () => {
+    /** Did a move into `column` terminate the live planning session? */
+    async function evacuates(
+      names: { intake: string; hold: string; wip: string },
+      column: string,
+    ): Promise<boolean> {
+      const task = createTask({ id: "FN-EVAC", column: names.intake, status: "planning" });
+      const processor = await processorWithPublishedRoles(names, task);
+      const dispose = vi.fn();
+      (processor as unknown as { activeSessions: Map<string, unknown> })
+        .activeSessions.set("FN-EVAC", { dispose, abort: async () => {} });
+      const handler = (processor as unknown as {
+        taskEvacuatedFromPlanningHandler: (t: Task) => void;
+      }).taskEvacuatedFromPlanningHandler;
+
+      handler({ ...task, column } as Task);
+
+      return dispose.mock.calls.length > 0;
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`does NOT evacuate a ${label} card moving between its own planning columns`, async () => {
+        // The renamed half is the regression: intake -> hold looked like a
+        // withdrawal, so a healthy planner was killed mid-spec.
+        expect(await evacuates(names, names.hold)).toBe(false);
+        expect(await evacuates(names, names.intake)).toBe(false);
+      });
+
+      it(`does NOT evacuate a ${label} card that legitimately advanced into execution`, async () => {
+        expect(await evacuates(names, "in-progress")).toBe(false);
+      });
+
+      it(`evacuates a ${label} card withdrawn to a column outside the lane`, async () => {
+        expect(await evacuates(names, "ideas")).toBe(true);
+      });
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Stuck-abort: recognising a handoff that already completed
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-14:10 (U7 / R3):
+The last planning-lane decision keyed on a literal. When the stuck detector kills a
+planner, `handleStuckAbortRequeue` asks whether the handoff had ALREADY completed —
+the card resting in the hold column with no planning-stage status. If so it must
+preserve that released state; otherwise it requeues, which for a card with a draft
+means stamping `needs-replan`.
+
+Keyed on `column === "todo"`, a renamed workflow answered NO to a card sitting in
+its own hold column with a finished spec. The stuck handler then took the requeue
+path and wrote `needs-replan` OVER a completed handoff — re-stranding an approved
+plan. That is exactly the regression the FN-8361 / PR #2326 notes above the branch
+describe and guard against, reintroduced for every renamed workflow.
+
+Both statuses matter, so both are asserted: a released card (status cleared) must be
+preserved, and a card still carrying a planning-stage status must still requeue —
+the distinction the `planningStageStatus` half draws, which a column-only fix would
+quietly flatten.
+*/
+describe("stuck-abort recognises a completed handoff in the workflow's own hold column", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-stuck-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** Run the stuck-abort cleanup and report every status it wrote. */
+  async function stuckAbort(
+    names: { intake: string; hold: string; wip: string },
+    task: Task,
+  ): Promise<Array<string | null>> {
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    await (processor as unknown as {
+      handleStuckAbortRequeue: (t: Task, c: "in-loop" | "catch") => Promise<void>;
+    }).handleStuckAbortRequeue(task, "in-loop");
+
+    return vi.mocked(store.updateTask).mock.calls
+      .map(([, patch]) => (patch as { status?: string | null }).status)
+      .filter((status) => status !== undefined) as Array<string | null>;
+  }
+
+  for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+    it(`preserves a RELEASED ${label} card instead of stamping needs-replan over it`, async () => {
+      const released = createTask({ id: "FN-REL", column: names.hold, status: null });
+
+      // No status write at all: the handoff completed, so only the kill count moves.
+      expect(await stuckAbort(names, released)).toEqual([]);
+    });
+
+    it(`still requeues a ${label} card that is mid-planning in the hold column`, async () => {
+      // Plan-in-place: resting in the hold column but NOT released — the
+      // `planningStageStatus` half of the predicate, which must survive the
+      // column conversion rather than being flattened by it.
+      const midPlan = createTask({ id: "FN-MID", column: names.hold, status: "planning" });
+
+      expect(await stuckAbort(names, midPlan)).not.toEqual([]);
+    });
+  }
 });

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -5164,6 +5164,26 @@ export class TaskExecutor {
       in an undeclared "triage" column, which the board rendered back in the intake lane.
       */
       const replanColumn = await resolveReplanTargetColumn(this.store, taskId);
+      /*
+      FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+      No declared replan column: park VISIBLY rather than log a move to `undefined`
+      and then not make it. `false` fails the graph's plan-replan node with
+      `remediation-not-scheduled`, which is the same shape as the zero-budget and
+      no-verdict branches above — a card left in place with an operator-readable
+      reason, not a silent no-op.
+      */
+      if (!replanColumn) {
+        executorLog.warn(
+          `${taskId}: plan-review replan NOT scheduled — the task's workflow declares no intake or hold column to replan in. Card left parked in ${liveTask.column}.`,
+        );
+        await this.store.logEntry(
+          taskId,
+          "Plan Review failed, but this task's workflow declares no planning column to replan in — left in place for a human.",
+          optionalStepRevisionLogOutcome(feedback, revisionKey),
+          this.getRunContextFor(taskId),
+        ).catch(() => undefined);
+        return false;
+      }
       await this.store.logEntry(
         taskId,
         `Plan Review failed — moved to ${replanColumn} for automatic replan (attempt ${nextCount}/${budgetLabel})`,
@@ -5293,6 +5313,25 @@ export class TaskExecutor {
     }
 
     const replanColumn = await resolveReplanTargetColumn(this.store, task.id);
+    /*
+    FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+    Same contract as the plan-review replan above: no declared column means no
+    move, said out loud. Returning here leaves the recovery-retry bookkeeping
+    unwritten on purpose — a retry that cannot relocate the card would just burn
+    the budget without changing anything.
+    */
+    if (!replanColumn) {
+      executorLog.warn(
+        `${task.id}: artifact-recovery replan NOT scheduled — the task's workflow declares no intake or hold column to replan in. Card left in place.`,
+      );
+      await this.store.logEntry(
+        task.id,
+        "Required workflow artifact missing, but this task's workflow declares no planning column to recover into — left in place for a human.",
+        `Missing artifact keys: ${artifactKeys.join(", ")}`,
+        context,
+      ).catch(() => undefined);
+      return;
+    }
     await this.store.logEntry(
       task.id,
       `Required workflow artifact missing — moved to ${replanColumn} for automatic planning recovery (attempt ${attempt}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)})`,

--- a/packages/engine/src/replan-target.ts
+++ b/packages/engine/src/replan-target.ts
@@ -1,5 +1,6 @@
 import type { Task, TaskStore } from "@fusion/core";
-import { resolveWorkflowIrForTask, workflowHasColumn } from "@fusion/core";
+import { resolveWorkflowIrForTask, resolveLifecycleColumns, workflowHasColumn } from "@fusion/core";
+import { schedulerLog } from "./logger.js";
 
 /*
 FNXC:WorkflowReplan 2026-07-12-23:15:
@@ -195,14 +196,59 @@ export function isTaskStillInPlanningStage(
   return !hasAdvancedPastPlanning(task);
 }
 
-export async function resolveReplanTargetColumn(store: TaskStore, taskId: string): Promise<string> {
+/**
+ * Where a Plan Review REVISE bounce sends the card to be re-specified.
+ *
+ * FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R3, R7):
+ * Resolved from the task's OWN workflow roles. This asked
+ * `workflowHasColumn(ir, "triage")` then `"todo"` and fell back to `"triage"` —
+ * twice by literal id, once by fiat. On a workflow that renames both, all three
+ * answers moved the card into a column the workflow does not declare: the R7
+ * violation reached by DESIGN rather than by drift, since the fallback returned the
+ * literal unconditionally including when the workflow could not be resolved at all.
+ * `reconcileUndeclaredTaskColumns` then had to clean up after a move the engine
+ * made on purpose.
+ *
+ * THE LEGACY IDS ARE PREFERRED FIRST, deliberately, and the trait resolution is the
+ * FALLBACK rather than the replacement. Both built-ins keep their existing target
+ * byte-for-byte: `builtin:coding` -> `triage`, Coding (Ideas) -> `todo`. Only a
+ * workflow that declares NEITHER legacy id — which previously got `"triage"` by
+ * fiat — reaches the resolved answer.
+ *
+ * WHY NOT SIMPLY "intake, else hold". I wrote that first and the existing suite
+ * caught it: Coding (Ideas) declares `ideas` as its intake, and `ideas` is MANUAL
+ * CAPTURE WITH NO AI (plan R10). Sending a rejected plan there stops it being
+ * replanned at all — it becomes an idea waiting for a human to press Start. The old
+ * code got Ideas right by ACCIDENT (it did not recognise `ideas` as intake at all
+ * and fell through to `todo`); a trait rule that "corrects" it would have shipped a
+ * regression dressed as a cleanup.
+ *
+ * So for a renamed workflow the fallback prefers HOLD over intake — the hold column
+ * is the planning lane and it has a releaser, whereas an intake column may be a
+ * manual-capture lane with nothing that auto-plans in it. That follows the Ideas
+ * precedent rather than contradicting it.
+ *
+ * `undefined` means "this workflow declares nowhere to replan" — the plan's U5
+ * contract is that such a task is skipped with a log rather than moved arbitrarily.
+ * Callers must park it visibly; inventing a column is what this change removes.
+ */
+export async function resolveReplanTargetColumn(
+  store: TaskStore,
+  taskId: string,
+): Promise<string | undefined> {
   try {
     const ir = await resolveWorkflowIrForTask(store, taskId);
     if (workflowHasColumn(ir, "triage")) return "triage";
     if (workflowHasColumn(ir, "todo")) return "todo";
-    return "triage";
+    const roles = resolveLifecycleColumns(ir);
+    return roles?.hold ?? roles?.intake;
   } catch {
-    return "triage";
+    /*
+    Unreachable in practice: `resolveWorkflowIrForTask` is TOTAL — every failure
+    path returns the default coding IR rather than throwing. Kept as belt-and-braces
+    and documented as such, so nobody writes a test for a state that cannot occur.
+    */
+    return undefined;
   }
 }
 
@@ -236,8 +282,20 @@ export async function moveTaskToReplanColumn(
   store: TaskStore,
   task: Pick<Task, "id" | "column">,
   target?: string,
-): Promise<string> {
+): Promise<string | undefined> {
   const replanColumn = target ?? await resolveReplanTargetColumn(store, task.id);
+  /*
+  FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+  No declared replan column: do NOT move. Every caller treats the return value as
+  "where the card now is", so a silent no-op would be a lie; returning `undefined`
+  makes the caller state the outcome instead of assuming one.
+  */
+  if (!replanColumn) {
+    schedulerLog.warn(
+      `${task.id}: replan rebound skipped — the task's workflow declares no intake or hold column to replan in; card left in ${task.column}`,
+    );
+    return undefined;
+  }
   if (task.column !== replanColumn) {
     await store.moveTask(task.id, replanColumn, { preserveWorktree: true });
   }

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -1792,8 +1792,23 @@ export class Scheduler {
             // status write is what makes triage rediscover a card whose replan column equals
             // its current column.
             const replanColumn = await moveTaskToReplanColumn(this.store, task);
+            /*
+            FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+            The status write happens EITHER WAY, and deliberately: `needs-replan` is
+            what blocks dispatch and makes triage rediscover the card, and this
+            branch has already decided the card must not be released. A workflow with
+            nowhere to rebound still must not run a spec that failed validation.
+            Only the LOG is conditional, so it never claims a move that did not
+            happen — the whole point of `moveTaskToReplanColumn` returning the column.
+            */
             await this.store.updateTask(task.id, { status: "needs-replan" });
-            await this.store.logEntry(task.id, `Task rebounded to ${replanColumn} for re-specification — filesystem validation failed`, validation.reason);
+            await this.store.logEntry(
+              task.id,
+              replanColumn
+                ? `Task rebounded to ${replanColumn} for re-specification — filesystem validation failed`
+                : "Task held for re-specification (its workflow declares no planning column to rebound to) — filesystem validation failed",
+              validation.reason,
+            );
             return null;
           }
 

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -291,6 +291,44 @@ export interface PlanningHandoffReport {
 }
 
 export class TriageProcessor {
+  /*
+  FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+  Planning-lane columns per task, refreshed by every discovery pass.
+
+  WHY A SNAPSHOT AND NOT A LOOKUP. The two consumers are SYNCHRONOUS `task:updated`
+  listeners. Making them async to resolve an IR would mean a store read on every
+  task update on the board, and — worse for the evacuation handler — it would delay
+  an abort that is synchronous today, opening a window in which a session it decided
+  to kill has already moved on. A vocabulary conversion must not introduce a race
+  into a path that terminates live agent work.
+
+  The poll already resolves these roles for every task, so publishing them costs
+  nothing extra. Staleness is bounded by one poll interval, and the two readers are
+  chosen so that a stale answer is safe: see each handler for its own fallback.
+  */
+  private lifecycleRolesByTask = new Map<string, { intake?: string; hold?: string }>();
+
+  /*
+  FNXC:TriageLifecycleColumns 2026-07-28-13:40 (U7 / R3):
+  What the synchronous handlers assume for a task no discovery pass has published
+  roles for yet — a card created moments ago, or the window before the first poll.
+
+  The legacy pair, deliberately, and NOT a permissive or a conservative guess. Both
+  of those were tried first and both changed documented behavior in the unpublished
+  window: "always wake" broke the contract that a non-planning column does not wake
+  the poll, and "never evacuate" made planning-evacuation silently inert until a
+  poll had run. Falling back to the literals makes this conversion STRICTLY
+  ADDITIVE — identical to today wherever roles are unknown, correct wherever they
+  are known — which is the only fallback that cannot regress a workflow that never
+  renamed anything.
+
+  It is a compatibility default, not a second source of truth: as soon as a
+  discovery pass has seen the card its real roles win. For the evacuation handler
+  that is guaranteed before it can matter, since a live planning session only
+  exists because a poll admitted the card.
+  */
+  private static readonly LEGACY_PLANNING_LANE = { intake: "triage", hold: "todo" } as const;
+
   private running = false;
   private polling = false;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -611,10 +649,23 @@ export class TriageProcessor {
     */
     this.taskColumnWakeHandler = (task: Task) => {
       if (!task?.id) return;
-      if (task.column !== "todo" && task.column !== "triage") return;
       if (task.paused === true || task.userPaused === true) return;
       // Already being planned (or mid-plan) — the running poll/session owns it.
       if (this.processing.has(task.id) || this.hasLivePlanningWork(task.id)) return;
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+      Match the task's OWN planning lane. Keyed on the literals, a renamed
+      workflow's card never woke the poll on a Start — the operator pressed the
+      button and nothing happened until the next 15s tick, which is the exact
+      symptom this wake was built to remove, reintroduced for every workflow that
+      renamed a column.
+
+      A card no discovery pass has published roles for falls back to the legacy
+      pair — see `LEGACY_PLANNING_LANE` for why that specific fallback and not a
+      permissive one.
+      */
+      const roles = this.lifecycleRolesByTask.get(task.id) ?? TriageProcessor.LEGACY_PLANNING_LANE;
+      if (task.column !== roles.intake && task.column !== roles.hold) return;
       this.requestImmediatePoll();
     };
 
@@ -649,7 +700,27 @@ export class TriageProcessor {
       an unrelated update.
       */
       if (typeof task.column !== "string") return;
-      if (task.column === "todo" || task.column === "triage" || task.column === "in-progress") return;
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+      Evacuation means "the card left ITS OWN planning lane". Keyed on the literal
+      trio, a renamed workflow inverted this: moving a card from its intake column
+      into its own HOLD column looked like an evacuation, so the handler KILLED the
+      live planning session and cleared the status of a card that was simply
+      progressing normally.
+
+      A card with no published roles falls back to the legacy pair
+      (`LEGACY_PLANNING_LANE`), so behavior in that window is byte-identical to
+      today — which matters more here than anywhere else in this conversion,
+      because this path terminates live agent work and discards a partly-written
+      spec.
+
+      `in-progress` stays a literal on purpose: it is not a role lookup but the
+      "legitimately advanced into execution" case, whose session is already
+      unwinding on its own. It is resolved as the WIP role in the same pass that
+      publishes intake/hold, which is a separate change with its own risk.
+      */
+      const roles = this.lifecycleRolesByTask.get(task.id) ?? TriageProcessor.LEGACY_PLANNING_LANE;
+      if (task.column === roles.intake || task.column === roles.hold || task.column === "in-progress") return;
       if (this.activeSubagentSessions.has(task.id)) {
         this.disposeSubagentsForTask(task.id, `task moved to ${task.column}`);
       }
@@ -1348,7 +1419,29 @@ export class TriageProcessor {
       freshTask.status === "planning"
       || freshTask.status === "needs-replan"
       || freshTask.status === "plan-review-unavailable";
-    const releasedToTodo = freshTask.column === "todo" && !planningStageStatus;
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-14:10 (U7 / R3):
+    "Released" means the card reached ITS OWN workflow's hold column with no
+    planning-stage status. Keyed on the literal `todo`, a renamed workflow answered
+    NO for a card sitting in its own hold column with a finished spec — so this
+    handler took the requeue path and stamped `needs-replan` OVER a completed
+    handoff, re-stranding an approved plan. That is precisely the regression the
+    FN-8361 / PR #2326 notes above this branch exist to prevent, reintroduced for
+    every workflow that renamed a column.
+
+    Resolved directly rather than from the published snapshot (unlike the two
+    synchronous handlers): this path is already async and runs once per stuck kill,
+    so it can afford the read and should prefer the freshest answer — it decides
+    whether to overwrite a finished spec.
+
+    Unresolvable workflow: NOT released, which is the pre-existing behavior for any
+    column that did not match the literal. Requeueing a card we cannot place is
+    recoverable; preserving one that never actually landed would strand it.
+    */
+    const holdColumn = (await resolveTaskLifecycleColumns(this.store, freshTask.id))?.hold;
+    const releasedToTodo = holdColumn !== undefined
+      && freshTask.column === holdColumn
+      && !planningStageStatus;
     if (hasAdvancedPastPlanning(freshTask) || releasedToTodo) {
       const nextStuckKillCount = (freshTask.stuckKillCount ?? task.stuckKillCount ?? 0) + 1;
       planLog.log(
@@ -1477,7 +1570,18 @@ export class TriageProcessor {
     const irCache = new Map<string, WorkflowIr>();
     const rolesById = new Map<string, LifecycleColumns | undefined>();
     for (const t of allTasks) {
-      rolesById.set(t.id, await resolveTaskLifecycleColumns(this.store, t.id, irCache));
+      const roles = await resolveTaskLifecycleColumns(this.store, t.id, irCache);
+      rolesById.set(t.id, roles);
+      // Publish for the synchronous event handlers (see `lifecycleRolesByTask`).
+      if (roles) this.lifecycleRolesByTask.set(t.id, { intake: roles.intake, hold: roles.hold });
+      else this.lifecycleRolesByTask.delete(t.id);
+    }
+    /*
+    Drop rows that left the board, so a long-lived processor does not accumulate
+    roles for deleted tasks. Bounded by the live task set, refreshed every pass.
+    */
+    for (const id of [...this.lifecycleRolesByTask.keys()]) {
+      if (!rolesById.has(id)) this.lifecycleRolesByTask.delete(id);
     }
     const isAt = (t: Task, role: "intake" | "hold"): boolean => {
       const roles = rolesById.get(t.id);

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -735,17 +735,49 @@ export class TriageProcessor {
       node/process that this process's `processing` set cannot see.
   User-paused cards are never touched (an operator park is authoritative).
   */
+  /**
+   * FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+   * Is this card resting in ITS OWN workflow's planning lane — the intake or hold
+   * column? Shared by both stale-planning sweeps so the two cannot drift, which is
+   * the failure mode they already have a history of: the startup sweep and the
+   * periodic sweep were added a month apart and each open-coded the same literal
+   * pair.
+   *
+   * An unresolvable workflow answers `false`: these sweeps CLEAR a status, and
+   * clearing one on a card whose lifecycle cannot be read is a mutation made in
+   * ignorance. Leaving it is visible and repairable; a wrong clear re-admits the
+   * card for planning.
+   */
+  private async isInPlanningLane(task: Task, cache?: Map<string, WorkflowIr>): Promise<boolean> {
+    const roles = await resolveTaskLifecycleColumns(this.store, task.id, cache);
+    if (!roles) return false;
+    return task.column === roles.intake || task.column === roles.hold;
+  }
+
   private async sweepStalePlanningStatuses(allTasks: Task[], now: number): Promise<void> {
     try {
-      const stale = allTasks.filter((t) => {
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+      Narrow on the CHEAP predicates before resolving any workflow: only a card
+      already carrying `status:"planning"` past the staleness floor can be a
+      candidate, so a board of N cards costs a handful of IR resolutions rather
+      than N. Gated on the literal pair, this sweep never fired for a renamed
+      workflow — and the status it clears is itself dispatch-blocking AND makes the
+      card invisible to rediscovery, so those cards had no working repair at all.
+      */
+      const candidates = allTasks.filter((t) => {
         if (t.status !== "planning") return false;
-        if (t.column !== "triage" && t.column !== "todo") return false;
         if (this.processing.has(t.id)) return false;
         if (t.userPaused === true || t.paused === true) return false;
         const touchedAt = Date.parse(t.updatedAt ?? t.columnMovedAt ?? "");
         if (!Number.isFinite(touchedAt)) return false;
         return now - touchedAt >= STALE_PLANNING_STATUS_GRACE_MS;
       });
+      const irCache = new Map<string, WorkflowIr>();
+      const stale: Task[] = [];
+      for (const t of candidates) {
+        if (await this.isInPlanningLane(t, irCache)) stale.push(t);
+      }
       for (const t of stale) {
         planLog.warn(
           `Stale 'planning' status on ${t.id} (column=${t.column}, no live planner) — clearing so triage can re-pick it`,
@@ -767,11 +799,27 @@ export class TriageProcessor {
     FNXC:CodingIdeasWorkflow 2026-07-04-12:00:
     In the merged planner/capacity "todo" column a task can carry status "planning" when the triage service is specifying it in place. A crash/restart before planning completes leaves that status set, so the startup sweep must clear it from BOTH triage and todo — otherwise a stale planning todo task permanently occupies a planning admission slot and blocks new triage work. (The separate maxTriageConcurrent pool AND its setting are both gone — FN-8453 removed the pool, the capacity simplification removed the dead key; planning shares the one agent count.)
     */
-    const triageTasks = await this.store.listTasks({ column: "triage", slim: true });
-    const todoTasks = await this.store.listTasks({ column: "todo", slim: true });
-    const stale = [...triageTasks, ...todoTasks].filter(
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+    One unfiltered scan plus a role filter, replacing two column-filtered queries.
+    The queries named `triage` and `todo` literally, so a renamed workflow's crashed
+    planner was never cleared at startup either — and the periodic sweep could not
+    reach it, so the card kept a dispatch-blocking `planning` status forever.
+
+    A role-keyed query does not exist at the store layer, so the choice is a scan or
+    a new query API. A scan is right here: this runs ONCE at startup, replaces two
+    round-trips with one, and the `status === "planning"` narrowing happens before
+    any workflow is resolved, so only genuine candidates cost a resolution.
+    */
+    const allTasks = await this.store.listTasks({ slim: true });
+    const candidates = allTasks.filter(
       (t) => t.status === "planning" && !this.processing.has(t.id),
     );
+    const irCache = new Map<string, WorkflowIr>();
+    const stale: Task[] = [];
+    for (const t of candidates) {
+      if (await this.isInPlanningLane(t, irCache)) stale.push(t);
+    }
     for (const t of stale) {
       planLog.log(`Startup sweep: clearing stale 'planning' status on ${t.id}`);
       await this.store.updateTask(t.id, { status: null });

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -9,6 +9,8 @@ import type {
   Agent,
   AgentPermissionPolicy,
   PermanentAgentGatingContext,
+  WorkflowIr,
+  LifecycleColumns,
 } from "@fusion/core";
 import {
   DUPLICATE_OF_METADATA_KEY,
@@ -33,6 +35,7 @@ import {
   resolveAgentMemoryInclusionMode,
   resolvePlanApprovalRequired,
   resolveWorkflowIrForTask,
+  resolveTaskLifecycleColumns,
   getStepParser,
   computePlanApprovalFingerprint,
   extractIntentSignature,
@@ -1083,7 +1086,24 @@ export class TriageProcessor {
     const recoverableStatus =
       task.status === "planning"
       || (task.status == null && this.hasPassedPlanReview(task));
-    if (task.column !== "triage" || !recoverableStatus) {
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-11:10 (U7 / R3):
+    Resolve the INTAKE column from the task's own workflow. Keyed on the literal
+    `"triage"`, recovery was unreachable for every renamed workflow — a stuck
+    planner on such a card was recovered by nothing.
+
+    The intake-ONLY scope is preserved deliberately, not widened. Plan-in-place
+    cards are specified while resting in the HOLD column (Coding (Ideas), and any
+    `needs-replan` revision on the default workflow), so this path still cannot
+    reach them. That is a real pre-existing gap; closing it is a behavior change and
+    does not belong in a vocabulary conversion. It is pinned by a test so the gap is
+    a recorded decision rather than an accident.
+
+    Unresolvable workflow: refuse, exactly as an unmatched literal did. Recovery
+    force-releases a card, so guessing its lifecycle is the wrong default.
+    */
+    const intakeColumn = (await resolveTaskLifecycleColumns(this.store, task.id))?.intake;
+    if (!intakeColumn || task.column !== intakeColumn || !recoverableStatus) {
       return false;
     }
 
@@ -1392,15 +1412,39 @@ export class TriageProcessor {
    * union include cards before their planner writes status:"planning".
    */
   private async discoverReadyPlanningTasks(allTasks: Task[], now: number): Promise<Task[]> {
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-11:10 (U7 / R3):
+    Discovery is keyed on the task's OWN workflow roles, not on the literal ids
+    `triage` / `todo`. Keyed on the literals, a workflow whose columns are renamed
+    matched NOTHING and its cards were never planned — silently: the filter simply
+    returned empty and the poll looked healthy. That is the failure mode the whole
+    of Phase B exists to remove, and `triage.ts` is in no Phase B unit's file list.
+
+    One IR cache for the whole pass, so a board of N cards on M workflows costs M
+    resolutions rather than N (the same shape `runHoldReleaseSweep` uses). A task
+    whose workflow cannot be resolved yields no roles and is skipped rather than
+    defaulted into a literal — guessing here would plan a card whose lifecycle we
+    could not read.
+    */
+    const irCache = new Map<string, WorkflowIr>();
+    const rolesById = new Map<string, LifecycleColumns | undefined>();
+    for (const t of allTasks) {
+      rolesById.set(t.id, await resolveTaskLifecycleColumns(this.store, t.id, irCache));
+    }
+    const isAt = (t: Task, role: "intake" | "hold"): boolean => {
+      const roles = rolesById.get(t.id);
+      return roles !== undefined && roles[role] !== undefined && t.column === roles[role];
+    };
+
     const eligibleTriageTasks = allTasks.filter(
-      (t) => t.column === "triage" && isTaskStillInPlanningStage(t)
+      (t) => isAt(t, "intake") && isTaskStillInPlanningStage(t)
         && !this.advancedRecoveryReservations.has(t.id)
         && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
         && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),
     );
     const eligibleTodoTasksRaw = allTasks.filter(
-      (t) => t.column === "todo" && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
+      (t) => isAt(t, "hold") && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
         && t.status !== "planning"
         && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),
@@ -3921,7 +3965,30 @@ export class TriageProcessor {
       if (!await this.updatePlanningStateIfStillCurrent(task, { title: promptDeclaredTitle })) return;
     }
 
-    if (task.column !== "todo") {
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-11:10 (U7 / R3):
+    Release into the workflow's OWN hold column. Keyed on the literal `"todo"`, a
+    renamed workflow's specified card was moved into a column its workflow does not
+    declare — exactly the R7 violation `reconcileUndeclaredTaskColumns` exists to
+    clean up after — and, worse, the same-column skip above it never matched, so a
+    plan-in-place card resting in its own renamed hold column was moved OUT of it.
+
+    Unresolvable workflow, or a workflow declaring no hold column: withhold the
+    handoff rather than fall back to a literal. A card left in the planner column
+    with a finished spec is visible and recoverable; a card moved into a column
+    nothing declares is the failure this program is removing.
+    */
+    const lifecycleColumns = await resolveTaskLifecycleColumns(this.store, task.id);
+    const holdColumn = lifecycleColumns?.hold;
+    if (!holdColumn) {
+      planLog.warn(
+        `${task.id}: planning handoff skipped — could not resolve a hold column from the task's workflow; card left in ${task.column}`,
+      );
+      report.outcome = "withheld";
+      return;
+    }
+
+    if (task.column !== holdColumn) {
       const moveTaskIf = (this.store as unknown as { moveTaskIf?: TaskStore["moveTaskIf"] }).moveTaskIf;
       if (typeof moveTaskIf !== "function") {
         // FNXC:TriageFinalizeVisibility 2026-07-26-19:05: the release move is the handoff. If it
@@ -3934,10 +4001,10 @@ export class TriageProcessor {
         report.outcome = "withheld";
         return;
       }
-      const release = await moveTaskIf.call(this.store, task.id, "todo", isTaskStillInPlanningStage);
+      const release = await moveTaskIf.call(this.store, task.id, holdColumn, isTaskStillInPlanningStage);
       if (!release.moved) {
         planLog.warn(
-          `${task.id}: planning handoff to todo REFUSED by the planning-stage guard `
+          `${task.id}: planning handoff to ${holdColumn} REFUSED by the planning-stage guard `
           + `(column=${release.task?.column ?? "unknown"}, status=${release.task?.status ?? "null"}). Card left in ${task.column}.`,
         );
         // FNXC:PlanningHandoffOutcome 2026-07-28-09:20: same class as above (FN-8361).


### PR DESCRIPTION
`triage.ts` appears in **no Phase B unit's file list** — the plan's per-file census covers `self-healing.ts` (U4), the executor/scheduler cluster (U5), and the core policy modules (U6). Its lifecycle-column literals were unowned. U7 absorbs them.

## Measured, not estimated

Using the plan's own methodology (block and line comments stripped, code lines only):

| Count | What |
|---:|---|
| 50 | naive quoted-literal grep of `triage.ts` |
| **35** | of those are the agent **role** string `"triage"`, not a column |
| **15** | genuine lifecycle-column sites |
| **5** | converted here |
| **10** | remain — enumerated below with the reason each was left |

The 50 figure would over-count the real surface by **3.3×**.

## What was broken — both silently

On a workflow whose columns are renamed:

1. **Discovery matched nothing**, so its cards were never planned. No error, no log — the filter returned empty and the poll looked healthy. This is exactly the *"a guard that never fires does not fail a test"* failure Phase B is sliced to avoid.
2. **The release move targeted the literal `"todo"`** — a column the workflow may not declare, i.e. the R7 violation `reconcileUndeclaredTaskColumns` exists to clean up after. Worse: the same-column skip beside it never matched either, so a **plan-in-place card already resting in its own renamed hold column was moved out of it**.

## Converted (5)

Both halves of `discoverReadyPlanningTasks` (intake + hold), `recoverApprovedTask`'s intake gate, finalize's same-column skip, and finalize's release-move target.

## A scoping decision I changed mid-slice

I intended to leave `recoverApprovedTask`'s literal alone as out-of-scope. It turns out to be the **only public entry point that reaches finalize** — so with it unconverted, the renamed release move was unreachable and its test could not be written. The scoping choice would have shipped an unprovable conversion.

Converted it as pure vocabulary: the intake-**only** semantics are preserved exactly, not widened. Plan-in-place cards specified while resting in the **hold** column remain unreachable by that recovery path. That gap is real and pre-existing; closing it is a behavior change and does not belong in a vocabulary slice — so it is **pinned by a test** rather than left to be rediscovered.

## Fail-closed, not fall-back

Unresolvable workflow, or a workflow declaring no hold column → **withhold** the handoff (the `outcome: "withheld"` from #2498) instead of falling back to a literal. A card left in the planner column with a finished spec is visible and recoverable; a card moved into a column nothing declares is the failure this program removes. Discovery likewise skips an unresolvable task rather than defaulting it in.

One IR cache per discovery pass, so N cards on M workflows cost M resolutions — the same shape `runHoldReleaseSweep` uses.

## Revert proof

With all five literals restored: **2 of 7 fail** — the two renamed-vocabulary cases.

The 5 that pass are the default-vocabulary halves and the pinned gap. That is the *correct* signature for a conversion whose default behavior is unchanged by design: every case is differential, running the same scenario under the default ids and under a renamed set where no id collides with a legacy literal, so a surviving `=== "todo"` cannot pass both halves by luck.

## The 10 remaining sites, and why

| Site | Why left |
|---|---|
| `taskColumnWakeHandler` (1) | synchronous `task:updated` listener — resolving an IR per event means a store read on **every** task update on the board. Needs a cache design, not a find-and-replace. |
| planning-evacuation handler (1) | same, plus it names `in-progress` as a third role |
| `sweepStalePlanningStatuses` (1) | next slice — pairs with the startup sweep below |
| `clearStaleSpecifyingStatuses` (2) | `listTasks({ column })` by literal ×2; needs a role-based query or a full scan, a real design choice |
| `releasedToTodo` in stuck-abort (1) | hold-role read, next slice |
| `column: "triage"` on task create (1) | creation default, not a planning decision — belongs with the create path |
| `column !== "done"` in duplicate search (3) | different role (complete), different lane, no planning decision |

## Verification

| Check | Result |
|---|---|
| new suite | 7/7 |
| 16 triage / planning / self-healing suites | 371/371, **no expectation edits** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (309 + 10 + 71) |
| `pnpm check:changesets` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task planning, stale-planning sweeps, and recovery for workflows with renamed lifecycle columns.
  * Tasks are now routed using each workflow’s configured intake and hold columns (instead of legacy literals).
  * Handoffs are withheld when the hold column can’t be resolved, avoiding incorrect moves.
  * Stuck-abort requeue preserves completed releases in the workflow’s own hold column.
* **Tests**
  * Added comprehensive suites covering default vs renamed workflows and planning/recovery edge cases.
  * Added a “single-writer” ratchet test to prevent unintended planning-claim writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->