### PR TITLE
docs(U9): correct the safeguard baseline — safeguards 1 and 4 are NOT covered

### DIFF
--- a/docs/plans/workflow-owned-merge-stack/u9-safeguard-baseline.md
+++ b/docs/plans/workflow-owned-merge-stack/u9-safeguard-baseline.md
@@ -20,8 +20,8 @@ this program has already shipped four guards that looked like enforcement and we
 not. The first version of this document made that same mistake in its own
 measurement; see Methodology.
 
-**Result: four of the six safeguards are covered. Safeguards 1 (user pause) and 4
-(capacity single-flight) have no test coverage at all.**
+**Result: five of the six safeguards are covered. Safeguard 1 (user pause) has no
+test coverage at all.**
 
 ## The six safeguards
 
@@ -39,27 +39,33 @@ measurement; see Methodology.
 | 1 | **user pause** | `project-engine.ts:645` merge admission filter | 11 | 11 | **0** | **NOT COVERED** |
 | 2 | **`autoMerge:false`** | `project-engine.ts:2797` `allowsAutoMergeProcessing` | 0 | 9 | **9** | covered |
 | 3 | **dependency gating** | `task-merge.ts:402` unresolved-dependency reason | 0 | 5 | **5** | covered |
-| 4 | **capacity** | `project-engine.ts:3178` single-flight `mergeRunning` | 10 | 10 | **0** | **NOT COVERED** |
+| 4 | **capacity** | `project-engine.ts:3178` single-flight `mergeRunning` | 0 | 1 | **1** | covered — `merge-single-flight-invariant.test.ts` |
 | 5a | **merge-proof** (pre-enqueue) | `project-engine.ts:2609` `getTaskMergeBlocker` consult | 0 | 1 | **1** | covered, thin |
 | 5b | **merge-proof** (file scope) | `merger-file-scope.ts:200` `FileScopeViolationError` | 0 | 6 | **6** | covered |
 | 6 | **at-most-once** | `project-engine.ts:2730` `mergeActive` dedupe | 0 | 3 | **3** | covered |
 
-**Four of six hold. Two do not.**
+**Five of six hold. One does not: safeguard 1.**
 
-### Safeguards 1 and 4 have NO test coverage
+### Safeguard 1 has NO test coverage
 
-Deleting the user-pause filter from merge admission, or the single-flight guard
-from the merge pump, produces **zero new test failures** anywhere in the merge,
-project-engine, self-healing, or concurrency suites.
+Deleting the user-pause filter from merge admission produces **zero new test
+failures** — verified against a deliberately wide selection (`project-engine`,
+`merge-single-flight-invariant`, `concurrency`, `merge-active-status`,
+`merge-reclaim-policy`, `merger-merge-lifecycle`).
 
-- **Safeguard 1** is the one re-ratified in #2486: never MUTATE lifecycle state of
-  a user-paused card. Removing `task.paused || task.userPaused` from the admission
-  provider admits a user-paused card into the merge pump — and nothing fails.
-- **Safeguard 4** is the single-flight guard that makes merge serialized. Removing
-  it permits concurrent `drainMergeQueue` entry — and nothing fails.
+Safeguard 1 is the one re-ratified in #2486: never MUTATE lifecycle state of a
+user-paused card. Removing `task.paused || task.userPaused` from the admission
+provider admits a user-paused card into the merge pump — and nothing fails. The
+guard exists and works today; what is missing is any test that would notice if it
+stopped. That is precisely the state U9 must not convert on top of.
 
-Both are guards that exist and work today; what is missing is any test that would
-notice if they stopped. That is precisely the state U9 must not convert on top of.
+> **Row 4 corrected 2026-07-28 (third pass, #2520 review — greptile P1).** Capacity
+> single-flight IS covered, by `merge-single-flight-invariant.test.ts` (landed in
+> #2502, "capacity, part 1"). My row-4 run reported it uncovered because **that file
+> was not in the selection** — methodology error #2 below, committed *after* I wrote
+> error #2 down. The lesson is not "widen once"; it is that a NOT-COVERED verdict
+> needs a deliberate search for existing coverage by name, not just a wider run of
+> whatever files came to mind.
 
 Named tests for the four that do hold are in the delta output; rows 2 and 6 are
 `project-engine.test.ts`, row 3 is core's `task-merge.test.ts`, row 5b is
@@ -68,11 +74,16 @@ case.
 
 ## Gate coverage
 
-Of the test files proving the four surviving safeguards, **only
-`merger-merge-lifecycle.test.ts` is in the `engine-core` merge-gate allow-list**,
-and it is not the file that proves any of them — rows 2/5a/6 rest on
-`project-engine.test.ts` and row 3 on core's `task-merge.test.ts`, neither of which
-is in the gate (the core gate is two PG tests via `test:pg-gate`).
+At the time of measurement, of the files proving these safeguards **only
+`merger-merge-lifecycle.test.ts` was in the `engine-core` allow-list**, and it is
+not the file that proves any of them — rows 2/5a/6 rest on `project-engine.test.ts`,
+row 3 on core's `task-merge.test.ts`, row 4 on `merge-single-flight-invariant.test.ts`.
+
+**Being fixed in #2526:** `project-engine.test.ts` and
+`merge-single-flight-invariant.test.ts` are admitted to the gate, which brings rows
+1, 2, 4, 5a and 6 into blocking CI for +~1.0s (5.19–5.51s → 6.18–6.32s against a
+~60s ceiling). Row 3 stays outside — core's gate is two PG tests via `test:pg-gate`
+and admitting a non-PG core file is a separate change.
 
 Per AGENTS.md the gate is thin and trusted; a red non-blocking run is "information,
 not a merge stopper". So **no safeguard on this table is currently defended by
@@ -87,10 +98,13 @@ same family of error this program is trying to stamp out.
    because the mutated run showed failures. The selection was already red. **A
    mutation run must diff fail-SETS against a baseline of the identical selection
    and report only NEW failures.**
-2. **Too-narrow selection.** An earlier pass measured rows 1 and 3 at zero
-   failures and I nearly filed both as gaps; widening changed row 3. Narrow runs
-   cannot prove absence — but see (1), because widening is also how the
-   pre-existing red crept in. Both directions need the baseline diff.
+2. **Too-narrow selection — twice.** An earlier pass measured rows 1 and 3 at zero
+   and I nearly filed both as gaps; widening changed row 3. Then row 4 was filed as
+   NOT COVERED because `merge-single-flight-invariant.test.ts` was not in the
+   selection — an error I made *after* writing this very item down. Widening the run
+   is not the fix. **A NOT-COVERED verdict requires a deliberate search for existing
+   coverage by name** (`ls`/grep the suite for the guard's concept) before the
+   verdict is allowed to stand.
 3. **A harness whose parser silently matched nothing.** The delta harness's regex
    required a `|project|` segment in vitest's `FAIL` line. Core's config does not
    emit one, so for `@fusion/core` it parsed **zero** failures at both baseline and

--- a/docs/plans/workflow-owned-merge-stack/u9-safeguard-baseline.md
+++ b/docs/plans/workflow-owned-merge-stack/u9-safeguard-baseline.md
@@ -13,73 +13,94 @@ U9 converts review and merge onto graph nodes. Merge is where irreversible thing
 happen, so the conversion needs a baseline that is **verified, not asserted**: for
 each safeguard, where it is consulted today, and which test actually proves it.
 
-Every row below was verified by **mutation** — break the guard in production code,
-run the cited tests, confirm they go red, restore. A cited test that does not fail
-is not evidence, and this program has already shipped four guards that looked like
-enforcement and were not.
+Every row below was verified by **mutation delta** — record the failing-test set at
+baseline, break the guard in production code, re-run the identical selection, and
+report only the NEW failures. A cited test that does not fail is not evidence, and
+this program has already shipped four guards that looked like enforcement and were
+not. The first version of this document made that same mistake in its own
+measurement; see Methodology.
+
+**Result: four of the six safeguards are covered. Safeguards 1 (user pause) and 4
+(capacity single-flight) have no test coverage at all.**
 
 ## The six safeguards
 
-| # | Safeguard | Consulted at | Mutation applied | Result | Proven by |
-|---|---|---|---|---|---|
-| 1 | **user pause** | `project-engine.ts:645` — merge admission provider filters `task.paused \|\| task.userPaused` | dropped both pause checks | **11 failed** / 1865 passed | `merge-error-recovery.test.ts`, `self-healing.test.ts` |
-| 2 | **`autoMerge:false`** | `project-engine.ts:2797` — `allowsAutoMergeProcessing(task, settings) \|\| isLiveSharedBranchGroupMemberIntegration(...)` | forced `return true` | **9 failed** / 250 passed | `automerge-toggle-legacy-advisory.test.ts`, `executor-live-branch-group-auto-merge-hold.test.ts`, `merger-merge-lifecycle.test.ts`, `project-engine.test.ts` |
-| 3 | **dependency gating** | `task-merge.ts:402` — `getTaskCompletionBlocker` returns the unresolved-dependency reason | returned `undefined` | **5 failed** / 94 passed | `packages/core/.../task-merge.test.ts` |
-| 4 | **capacity** | `project-engine.ts:3178` — `if (this.mergeRunning) return;` single-flight merge pump | removed the guard | **11 failed** / 1445 passed | `merge-error-recovery.test.ts`, `project-engine.test.ts` |
-| 5a | **merge-proof** (pre-enqueue) | `project-engine.ts:2609` — `if (this.options.getTaskMergeBlocker?.(task)) return false;` | removed the consult | **1 failed** / 272 passed | `project-engine.test.ts` — a single test |
-| 5b | **merge-proof** (file scope) | `merger-file-scope.ts:200` — `throw new FileScopeViolationError(...)` | removed the throw | **6 failed** / 172 passed | `merger-file-scope-invariant.test.ts` |
-| 6 | **at-most-once merge** | `project-engine.ts:2730` — `mergeActive` membership rejects a duplicate enqueue | let the duplicate through | **3 failed** / 263 passed | `merge-active-status.test.ts`, `merger-merge-lifecycle.test.ts`, `project-engine.test.ts` |
+> **CORRECTED 2026-07-28 (second pass).** The first version of this table was
+> **wrong for rows 1 and 4**, and wrong in the exact way this program keeps
+> producing: it reported the ABSOLUTE failure count under mutation with **no
+> baseline**. `merge-error-recovery.test.ts` (10) and `self-healing.test.ts` (1)
+> are **already red on clean `main`**, so the "11 failed" I credited to the row 1
+> mutation was pre-existing red — the mutation added nothing. Every row below is
+> now a **delta**: failing-test SET at baseline vs under mutation, reporting only
+> NEW failures, with each new failure named.
 
-All six hold. Nothing here is currently broken.
+| # | Safeguard | Consulted at | Baseline fails | Mutated fails | **NEW** | Verdict |
+|---|---|---|---|---|---|---|
+| 1 | **user pause** | `project-engine.ts:645` merge admission filter | 11 | 11 | **0** | **NOT COVERED** |
+| 2 | **`autoMerge:false`** | `project-engine.ts:2797` `allowsAutoMergeProcessing` | 0 | 9 | **9** | covered |
+| 3 | **dependency gating** | `task-merge.ts:402` unresolved-dependency reason | 0 | 5 | **5** | covered |
+| 4 | **capacity** | `project-engine.ts:3178` single-flight `mergeRunning` | 10 | 10 | **0** | **NOT COVERED** |
+| 5a | **merge-proof** (pre-enqueue) | `project-engine.ts:2609` `getTaskMergeBlocker` consult | 0 | 1 | **1** | covered, thin |
+| 5b | **merge-proof** (file scope) | `merger-file-scope.ts:200` `FileScopeViolationError` | 0 | 6 | **6** | covered |
+| 6 | **at-most-once** | `project-engine.ts:2730` `mergeActive` dedupe | 0 | 3 | **3** | covered |
 
-## The two findings that matter for U9
+**Four of six hold. Two do not.**
 
-### 1. One of nine safeguard test files runs in blocking CI
+### Safeguards 1 and 4 have NO test coverage
 
-Of the nine test files above, **exactly one — `merger-merge-lifecycle.test.ts` — is in
-the `engine-core` merge-gate allow-list.** The core gate is two PG tests
-(`test:pg-gate`), and `task-merge.test.ts` is not among them.
+Deleting the user-pause filter from merge admission, or the single-flight guard
+from the merge pump, produces **zero new test failures** anywhere in the merge,
+project-engine, self-healing, or concurrency suites.
 
-Per AGENTS.md the merge gate is "thin and trusted": CI blocks on Lint, Typecheck,
-Build, and Gate, and "a red non-blocking run is information, not a merge stopper."
+- **Safeguard 1** is the one re-ratified in #2486: never MUTATE lifecycle state of
+  a user-paused card. Removing `task.paused || task.userPaused` from the admission
+  provider admits a user-paused card into the merge pump — and nothing fails.
+- **Safeguard 4** is the single-flight guard that makes merge serialized. Removing
+  it permits concurrent `drainMergeQueue` entry — and nothing fails.
 
-So today a change that breaks **user pause on merge admission, dependency gating,
-capacity single-flight, or the file-scope invariant** does not block a PR. It goes
-red in full-suite, after the merge.
+Both are guards that exist and work today; what is missing is any test that would
+notice if they stopped. That is precisely the state U9 must not convert on top of.
 
-That is a safe-enough posture for a lane nobody is rewriting. It is the wrong
-posture for the lane U9 is about to rewrite. **Recommendation: admit the
-highest-value safeguard tests to the gate before the conversion begins**, with the
-budget cost measured rather than assumed (the gate's stated ceiling is ~60s
-wall-clock; engine-core is currently 5.36s).
+Named tests for the four that do hold are in the delta output; rows 2 and 6 are
+`project-engine.test.ts`, row 3 is core's `task-merge.test.ts`, row 5b is
+`merger-file-scope-invariant.test.ts`, row 5a is a single `project-engine.test.ts`
+case.
 
-### 2. Safeguard 5a rests on a single non-gate test
+## Gate coverage
 
-Removing the pre-enqueue merge-blocker consult fails exactly **one** test, in
-`engine-default`. Of the six safeguards it has the thinnest coverage, and it is one
-of the two flagged destructive-risk. Its sibling 5b (file scope) is well covered at
-6 tests, so the *invariant* is not unguarded — but the specific consult that keeps a
-blocked task out of the queue in the first place very nearly is.
+Of the test files proving the four surviving safeguards, **only
+`merger-merge-lifecycle.test.ts` is in the `engine-core` merge-gate allow-list**,
+and it is not the file that proves any of them — rows 2/5a/6 rest on
+`project-engine.test.ts` and row 3 on core's `task-merge.test.ts`, neither of which
+is in the gate (the core gate is two PG tests via `test:pg-gate`).
 
-## Methodology note — read this before trusting a "no failures" result
+Per AGENTS.md the gate is thin and trusted; a red non-blocking run is "information,
+not a merge stopper". So **no safeguard on this table is currently defended by
+blocking CI.**
 
-Rows 1 and 3 **initially measured zero failures** and looked like coverage gaps.
-Both were wrong: the test selection was too narrow. Widening row 1 from three files
-to the `project-engine|merge|concurrency|self-healing` set turned 0 failures into 11.
-Row 3's real coverage lives in `@fusion/core`'s suite, which an engine-only
-`--filter` never runs.
+## Methodology — three ways I got this wrong
 
-Two rules follow, and they cost an hour to learn:
+Recorded because each produced a confident, wrong result, and all three are the
+same family of error this program is trying to stamp out.
 
-- **A narrow mutation run cannot prove absence of coverage.** Widen before
-  concluding a gap exists, and say which selection produced the number.
-- **Cross-package guards need cross-package runs.** `packages/engine/vitest.config.ts`
-  aliases `@fusion/core` to *source*, so a core mutation is live in engine tests —
-  but the tests that actually assert on it may sit in the core package, which
-  `pnpm --filter @fusion/engine` will not run.
+1. **Absolute counts with no baseline.** Rows 1 and 4 were reported as covered
+   because the mutated run showed failures. The selection was already red. **A
+   mutation run must diff fail-SETS against a baseline of the identical selection
+   and report only NEW failures.**
+2. **Too-narrow selection.** An earlier pass measured rows 1 and 3 at zero
+   failures and I nearly filed both as gaps; widening changed row 3. Narrow runs
+   cannot prove absence — but see (1), because widening is also how the
+   pre-existing red crept in. Both directions need the baseline diff.
+3. **A harness whose parser silently matched nothing.** The delta harness's regex
+   required a `|project|` segment in vitest's `FAIL` line. Core's config does not
+   emit one, so for `@fusion/core` it parsed **zero** failures at both baseline and
+   mutation and printed "NOT COVERED" for row 3 — which is in fact covered by 5
+   tests. A verification tool that reports success without checking anything is
+   worse than no tool; it has to be tested against a known-failing case before its
+   output is trusted.
 
-Harness used: mutate → run cited tests → record → restore, asserting the patch
-actually applied (a silently non-applying patch reports a false "no failures").
+Harness: baseline run → assert patch applied (a no-op patch is an abort, not a
+pass) → mutated run → `comm -13` the sorted fail-sets → restore → assert clean.
 
 ## What this baseline does not cover
 


### PR DESCRIPTION
**U9, PR4.** Docs-only correction to a document already on `main` (#2511). No changeset.

## I got #2511 wrong, and it matters

#2511's table claimed all six merge safeguards were verified. **Two of them were not**, and the error is the same family this program exists to stamp out: I reported the **absolute** failure count under mutation, with **no baseline**.

`merge-error-recovery.test.ts` (10 failures) and `self-healing.test.ts` (1) are **already red on clean `main`**. The "11 failed" I credited to the row 1 mutation *was that pre-existing red*. The mutation added nothing. I even flagged the identical `11 failed` on rows 1 and 3 as "a red flag" in my own notes and then did not chase it.

## Re-measured as deltas

Baseline fail-SET vs mutated fail-SET on the identical selection, reporting only NEW failures, each named:

| # | Safeguard | Baseline | Mutated | **NEW** | Verdict |
|---|---|---|---|---|---|
| 1 | user pause | 11 | 11 | **0** | **NOT COVERED** |
| 2 | `autoMerge:false` | 0 | 9 | **9** | covered |
| 3 | dependency gating | 0 | 5 | **5** | covered |
| 4 | capacity single-flight | 10 | 10 | **0** | **NOT COVERED** |
| 5a | merge-proof (pre-enqueue) | 0 | 1 | **1** | covered, thin |
| 5b | file-scope | 0 | 6 | **6** | covered |
| 6 | at-most-once | 0 | 3 | **3** | covered |

**Four hold. Two do not.**

- **Safeguard 1** is the pause invariant re-ratified in #2486. Removing `task.paused || task.userPaused` from the merge admission provider admits a **user-paused card into the merge pump** — and nothing fails.
- **Safeguard 4** is the single-flight guard that serializes merge. Removing it permits concurrent `drainMergeQueue` entry — and nothing fails.

Both guards **work correctly today**. What is missing is any test that would notice if they stopped. That is exactly the state U9 must not convert on top of — and #2511 said the opposite.

## Also corrected: nothing here is defended by blocking CI

The one gate-admitted file (`merger-merge-lifecycle.test.ts`) is not the file that proves any surviving row. Rows 2/5a/6 rest on `project-engine.test.ts`, row 3 on core's `task-merge.test.ts` — neither is in the gate (core's gate is two PG tests via `test:pg-gate`).

## Three distinct ways the first pass was wrong

All recorded in the doc, because each produced a confident wrong answer:

1. **Absolute counts with no baseline** — rows 1 and 4. A mutation run must diff fail-sets and report only new failures.
2. **Too-narrow selection** — an earlier pass measured rows 1 and 3 at zero and I nearly filed two false gaps. Widening fixed row 3 but is also how the pre-existing red crept in. Both directions need the baseline diff.
3. **A harness that silently matched nothing** — the delta harness's regex required a `|project|` segment in vitest's `FAIL` line. `@fusion/core` does not emit one, so it parsed **zero** failures at both baseline and mutation and printed "NOT COVERED" for row 3, which is covered by 5 tests. A verification tool that reports success without checking anything is worse than no tool; it must be tested against a known-failing case first.

The harness now aborts on a no-op patch, asserts a clean restore, and I validated its parser against a known-failing run before trusting it.

## Next

**PR5 writes the missing tests for safeguards 1 and 4**, then gate admission. Neither should wait for U8 — they guard code that exists today, and the conversion needs them in place first. That is the reversible call I'm making rather than asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)