### PR TITLE
U7 PR5: both stale-planning sweeps resolve their lane — a crashed planner is recoverable on any workflow (stacked on #2517)

### DIFF
--- a/.changeset/triage-planning-sweeps-resolved.md
+++ b/.changeset/triage-planning-sweeps-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A crashed planner on a workflow with renamed columns is now auto-recovered instead of leaving the task stuck.
+category: fix
+dev: U7 / R3. Both stale-planning sweeps (`sweepStalePlanningStatuses`, periodic; `clearStaleSpecifyingStatuses`, startup) were gated on the literal pair `triage`/`todo`, so neither fired for a renamed workflow — and `status:"planning"` is itself dispatch-blocking AND makes the card invisible to rediscovery, so those cards had no working repair at all. Both now share one `isInPlanningLane` helper resolving intake/hold from the task's own workflow; an unresolvable workflow answers false (these sweeps mutate, so ignorance must not clear). The startup sweep trades two column-filtered queries for one scan plus a role filter; cheap predicates narrow before any IR is resolved, so only genuine candidates cost a resolution.

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -160,7 +160,13 @@ function createStore(opts: {
     }),
     withTaskLock: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
     readTaskForMove: vi.fn(async (id: string) => byId(id)),
-    logEntry: vi.fn(),
+    /*
+    MUST resolve a promise. The periodic sweep does `await store.logEntry(...).catch(...)`,
+    so a bare `vi.fn()` returning undefined throws on `.catch` and aborts the sweep after
+    its FIRST card — which reads as "the sweep only matches one column" and sends you
+    looking for a production bug that is not there.
+    */
+    logEntry: vi.fn().mockResolvedValue(undefined),
     recordActivity: vi.fn().mockResolvedValue(undefined),
     getTaskWorkflowSelection: vi.fn(() => selection),
     getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
@@ -343,5 +349,130 @@ describe("triage resolves its planning-lane columns from the task's workflow", (
     await expect(
       new TriageProcessor(store, rootDir).recoverApprovedTask(task),
     ).resolves.toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. The two stale-planning-status sweeps
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+Both sweeps clear a `planning` status left by a planner that never finished, and
+both were gated on the literal pair `triage`/`todo`. On a renamed workflow neither
+fired, so a crashed planner's card kept `status:"planning"` forever — and that
+status is itself dispatch-blocking (`isUnplannedForExecution`) and makes the card
+invisible to rediscovery, which skips cards already marked `planning`. The card was
+therefore stuck in a state only these sweeps clear, on workflows where neither
+sweep could see it. FN-8596 is that strand on the DEFAULT vocabulary; a renamed
+workflow had no working repair at all.
+
+The periodic sweep and the startup sweep are tested separately because they select
+their candidates differently — the periodic one filters a task list it is handed,
+the startup one issued its own per-column queries — and only the first was covered.
+*/
+describe("the stale-planning sweeps resolve their planning lane", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-sweep-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** A `planning` card left behind long enough to be past the staleness floor. */
+  const stalePlanner = (id: string, column: string, over: Partial<Task> = {}): Task => createTask({
+    id,
+    column,
+    status: "planning",
+    updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    ...over,
+  });
+
+  /** Ids whose `status` the sweep cleared. */
+  function clearedIds(store: TaskStore): string[] {
+    return vi.mocked(store.updateTask)
+      .mock.calls.filter(([, patch]) => (patch as { status?: unknown }).status === null)
+      .map(([id]) => id as string);
+  }
+
+  describe("periodic sweep (runs every poll)", () => {
+    async function sweep(names: { intake: string; hold: string; wip: string }, tasks: Task[]) {
+      const store = createStore({ tasks, workflowIr: ir(names) });
+      const processor = new TriageProcessor(store, rootDir);
+      /*
+      Stub the planner. Once the sweep clears a stale status the card becomes an
+      ordinary planning candidate in the SAME poll, so a real `specifyTask` runs —
+      reaching module-mocked provider code and throwing ASYNCHRONOUSLY, after the
+      test has already passed. That surfaces as a suite exit code 1 with every test
+      green, i.e. exactly the kind of noise a CI run gets told to ignore.
+      */
+      vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+        .mockResolvedValue(undefined);
+      (processor as unknown as { running: boolean }).running = true;
+      await (processor as unknown as { poll: () => Promise<void> }).poll();
+      return clearedIds(store);
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`clears a stale planner in the ${label} intake and hold columns`, async () => {
+        const cleared = await sweep(names, [
+          stalePlanner("FN-INTAKE", names.intake),
+          stalePlanner("FN-HOLD", names.hold),
+        ]);
+
+        expect(cleared.sort()).toEqual(["FN-HOLD", "FN-INTAKE"]);
+      });
+
+      it(`never clears a ${label} card resting outside the planning lane`, async () => {
+        expect(await sweep(names, [stalePlanner("FN-WIP", names.wip)])).toEqual([]);
+      });
+
+      it(`never clears a user-paused ${label} card (an operator park is authoritative)`, async () => {
+        const cleared = await sweep(names, [
+          stalePlanner("FN-PAUSED", names.hold, { userPaused: true }),
+        ]);
+
+        expect(cleared).toEqual([]);
+      });
+    }
+  });
+
+  describe("startup sweep (runs once at start)", () => {
+    async function sweep(names: { intake: string; hold: string; wip: string }, tasks: Task[]) {
+      const store = createStore({ tasks, workflowIr: ir(names) });
+      const processor = new TriageProcessor(store, rootDir);
+      await (processor as unknown as { clearStaleSpecifyingStatuses: () => Promise<void> })
+        .clearStaleSpecifyingStatuses();
+      return clearedIds(store);
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`clears a stale planner in the ${label} intake and hold columns`, async () => {
+        // No staleness floor here: at startup nothing this process owns can be live,
+        // so any surviving `planning` status is by definition a leftover.
+        const cleared = await sweep(names, [
+          createTask({ id: "FN-INTAKE", column: names.intake, status: "planning" }),
+          createTask({ id: "FN-HOLD", column: names.hold, status: "planning" }),
+        ]);
+
+        expect(cleared.sort()).toEqual(["FN-HOLD", "FN-INTAKE"]);
+      });
+
+      it(`never clears a ${label} card resting outside the planning lane`, async () => {
+        const cleared = await sweep(names, [
+          createTask({ id: "FN-WIP", column: names.wip, status: "planning" }),
+        ]);
+
+        expect(cleared).toEqual([]);
+      });
+    }
   });
 });

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -735,17 +735,49 @@ export class TriageProcessor {
       node/process that this process's `processing` set cannot see.
   User-paused cards are never touched (an operator park is authoritative).
   */
+  /**
+   * FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+   * Is this card resting in ITS OWN workflow's planning lane — the intake or hold
+   * column? Shared by both stale-planning sweeps so the two cannot drift, which is
+   * the failure mode they already have a history of: the startup sweep and the
+   * periodic sweep were added a month apart and each open-coded the same literal
+   * pair.
+   *
+   * An unresolvable workflow answers `false`: these sweeps CLEAR a status, and
+   * clearing one on a card whose lifecycle cannot be read is a mutation made in
+   * ignorance. Leaving it is visible and repairable; a wrong clear re-admits the
+   * card for planning.
+   */
+  private async isInPlanningLane(task: Task, cache?: Map<string, WorkflowIr>): Promise<boolean> {
+    const roles = await resolveTaskLifecycleColumns(this.store, task.id, cache);
+    if (!roles) return false;
+    return task.column === roles.intake || task.column === roles.hold;
+  }
+
   private async sweepStalePlanningStatuses(allTasks: Task[], now: number): Promise<void> {
     try {
-      const stale = allTasks.filter((t) => {
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+      Narrow on the CHEAP predicates before resolving any workflow: only a card
+      already carrying `status:"planning"` past the staleness floor can be a
+      candidate, so a board of N cards costs a handful of IR resolutions rather
+      than N. Gated on the literal pair, this sweep never fired for a renamed
+      workflow — and the status it clears is itself dispatch-blocking AND makes the
+      card invisible to rediscovery, so those cards had no working repair at all.
+      */
+      const candidates = allTasks.filter((t) => {
         if (t.status !== "planning") return false;
-        if (t.column !== "triage" && t.column !== "todo") return false;
         if (this.processing.has(t.id)) return false;
         if (t.userPaused === true || t.paused === true) return false;
         const touchedAt = Date.parse(t.updatedAt ?? t.columnMovedAt ?? "");
         if (!Number.isFinite(touchedAt)) return false;
         return now - touchedAt >= STALE_PLANNING_STATUS_GRACE_MS;
       });
+      const irCache = new Map<string, WorkflowIr>();
+      const stale: Task[] = [];
+      for (const t of candidates) {
+        if (await this.isInPlanningLane(t, irCache)) stale.push(t);
+      }
       for (const t of stale) {
         planLog.warn(
           `Stale 'planning' status on ${t.id} (column=${t.column}, no live planner) — clearing so triage can re-pick it`,
@@ -767,11 +799,27 @@ export class TriageProcessor {
     FNXC:CodingIdeasWorkflow 2026-07-04-12:00:
     In the merged planner/capacity "todo" column a task can carry status "planning" when the triage service is specifying it in place. A crash/restart before planning completes leaves that status set, so the startup sweep must clear it from BOTH triage and todo — otherwise a stale planning todo task permanently occupies a planning admission slot and blocks new triage work. (The separate maxTriageConcurrent pool AND its setting are both gone — FN-8453 removed the pool, the capacity simplification removed the dead key; planning shares the one agent count.)
     */
-    const triageTasks = await this.store.listTasks({ column: "triage", slim: true });
-    const todoTasks = await this.store.listTasks({ column: "todo", slim: true });
-    const stale = [...triageTasks, ...todoTasks].filter(
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-12:30 (U7 / R3):
+    One unfiltered scan plus a role filter, replacing two column-filtered queries.
+    The queries named `triage` and `todo` literally, so a renamed workflow's crashed
+    planner was never cleared at startup either — and the periodic sweep could not
+    reach it, so the card kept a dispatch-blocking `planning` status forever.
+
+    A role-keyed query does not exist at the store layer, so the choice is a scan or
+    a new query API. A scan is right here: this runs ONCE at startup, replaces two
+    round-trips with one, and the `status === "planning"` narrowing happens before
+    any workflow is resolved, so only genuine candidates cost a resolution.
+    */
+    const allTasks = await this.store.listTasks({ slim: true });
+    const candidates = allTasks.filter(
       (t) => t.status === "planning" && !this.processing.has(t.id),
     );
+    const irCache = new Map<string, WorkflowIr>();
+    const stale: Task[] = [];
+    for (const t of candidates) {
+      if (await this.isInPlanningLane(t, irCache)) stale.push(t);
+    }
     for (const t of stale) {
       planLog.log(`Startup sweep: clearing stale 'planning' status on ${t.id}`);
       await this.store.updateTask(t.id, { status: null });


### PR DESCRIPTION
> **Stacked on #2517.** Base is `feature/u7-triage-resolved-columns`, not `main` — merge #2517 first and this retargets cleanly. Cut that way because both touch the same imports in `triage.ts` and the same new test file; on `main` it would have been a guaranteed conflict.

## The bug

`sweepStalePlanningStatuses` (periodic) and `clearStaleSpecifyingStatuses` (startup) both clear a `planning` status left by a planner that never finished. Both were gated on the literal pair `triage`/`todo`, so on a renamed workflow **neither fired**.

**Why that is worse than an ordinary missed sweep.** `status: "planning"` is itself dispatch-blocking (`isUnplannedForExecution` returns true for it) *and* makes the card invisible to rediscovery, which skips cards already marked `planning`. So the card was stuck in a state that **only these two sweeps clear**, on workflows where **neither sweep could see it**. FN-8596 is that strand on the default vocabulary, where at least the sweeps exist. A renamed workflow had no working repair at all.

## The fix

One shared `isInPlanningLane` helper resolving intake/hold from the task's own workflow. Shared deliberately: the two sweeps were added a month apart and each open-coded the same literal pair — that drift is what this consolidates.

**Fail-closed.** An unresolvable workflow answers `false`. These sweeps *clear* a status, and clearing one on a card whose lifecycle cannot be read is a mutation made in ignorance: leaving it is visible and repairable, a wrong clear silently re-admits the card for planning.

**Cost.** Cheap predicates narrow *before* any workflow is resolved — only a card already carrying `status: "planning"` (past the staleness floor, in the periodic case) can be a candidate, so a board of N cards costs a handful of IR resolutions, not N. The startup sweep trades two column-filtered queries for one scan plus a role filter: a role-keyed query does not exist at the store layer, and a scan is right for a once-at-startup pass that now makes **one** round-trip instead of two.

## Revert proof

With both sweeps back on the literal pair: **2 of 17 fail** — the two renamed cases. Default-vocabulary and user-paused cases pass either way, which is the correct signature for a conversion that changes no default behavior.

## Two fixture defects found here, both of which read as production bugs

**1. `logEntry: vi.fn()` returns `undefined`,** and the periodic sweep does `await store.logEntry(...).catch(...)` — so `.catch` threw and aborted the sweep after its **first** card. That reads exactly like *"the sweep only matches one column"* and sends you hunting a production bug that is not there.

**2. The sweep harness let `poll()` reach the real `specifyTask`.** Once the sweep clears a stale status the card becomes an ordinary planning candidate *in the same poll*. It reached module-mocked provider code and threw **asynchronously**, after the tests had already passed — surfacing as suite **exit code 1 with every test green**, i.e. precisely the noise a CI run gets told to ignore. Caught only by not waving away a nonzero exit on a green run.

That is now five fixture defects across five U7 slices, every one of which first presented as a plausible production bug. Running list, in case it is worth a shared convention rather than each of us rediscovering it: a fake that ignores its predicate (#2491), a stub that ignores its callback (#2498), a default parameter that swallows the interesting input (#2506), a stub that returns a non-promise into `.catch` (here), and a harness that lets a real agent path run past the assertion (here).

## Measured

| | |
|---|---:|
| lifecycle-column literal sites in `triage.ts`, before this PR | 45 |
| after | 42 |
| **genuine** lifecycle-column sites since U7 started | **15 → 7** |

## Verification

| Check | Result |
|---|---|
| suite | 17/17 |
| 14 triage / planning / self-healing / restart suites | 416/416, clean exit code, **no expectation edits** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (309 + 10 + 71) |
| `pnpm check:changesets` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
