### PR TITLE
U7 PR6: the synchronous planning handlers read a published lane snapshot (stacked on #2522)

### DIFF
--- a/.changeset/triage-planning-handlers-resolved.md
+++ b/.changeset/triage-planning-handlers-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: On a workflow with renamed columns, Start begins planning at once and moving a card no longer kills its planner.
+category: fix
+dev: U7 / R3. The planning wake and planning-evacuation handlers are synchronous `task:updated` listeners, so they read a lane snapshot published by each discovery pass rather than resolving an IR per board update (which for evacuation would also have delayed an abort that is synchronous today). Renamed workflows had opposite failures: the wake never fired (Start appeared dead until the next poll tick), and evacuation fired on an intake -> hold move, killing a healthy planning session mid-spec. A task no pass has published yet falls back to the legacy `triage`/`todo` pair, so behavior in that window is byte-identical to today and the conversion cannot regress a workflow that never renamed anything.

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -437,3 +437,137 @@ describe("the stale-planning sweeps resolve their planning lane", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. The two synchronous task:updated handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-13:40 (U7 / R3):
+The planning wake and the planning-evacuation abort are SYNCHRONOUS `task:updated`
+listeners, so they cannot resolve an IR without either a store read per board
+update or — for evacuation — delaying an abort that is synchronous today. They read
+a snapshot the discovery pass publishes instead.
+
+The two failures they had on a renamed workflow are opposites, which is why both
+directions are asserted:
+  - the WAKE never fired, so pressing Start did nothing until the next 15s tick —
+    the exact symptom the wake was built to remove, reintroduced;
+  - the EVACUATION fired when it should not have: moving a card from its intake
+    column into its own HOLD column looked like a withdrawal, so a live planning
+    session was KILLED and its status cleared for a card that was progressing
+    normally.
+
+The unpublished-roles window falls back to the legacy literals, so behavior there is
+byte-identical to today. That fallback is asserted too — it is the reason this
+conversion cannot regress a workflow that never renamed anything.
+*/
+describe("the synchronous planning handlers read the published lane", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-handlers-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** Build a processor whose discovery pass has already published `names`. */
+  async function processorWithPublishedRoles(
+    names: { intake: string; hold: string; wip: string },
+    task: Task,
+  ): Promise<TriageProcessor> {
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+      .mockResolvedValue(undefined);
+    (processor as unknown as { running: boolean }).running = true;
+    await (processor as unknown as { poll: () => Promise<void> }).poll();
+    return processor;
+  }
+
+  describe("wake", () => {
+    /** Did a move into `column` wake the poll? */
+    async function wakes(
+      names: { intake: string; hold: string; wip: string },
+      column: string,
+      opts: { publish?: boolean } = { publish: true },
+    ): Promise<boolean> {
+      const task = createTask({ id: "FN-WAKE", column: names.intake, status: null });
+      const processor = opts.publish
+        ? await processorWithPublishedRoles(names, task)
+        : new TriageProcessor(createStore({ tasks: [task], workflowIr: ir(names) }), rootDir);
+      const handler = (processor as unknown as { taskColumnWakeHandler: (t: Task) => void })
+        .taskColumnWakeHandler;
+      const nudge = vi
+        .spyOn(processor as unknown as { requestImmediatePoll: () => boolean }, "requestImmediatePoll")
+        .mockReturnValue(true);
+
+      handler({ ...task, column } as Task);
+
+      return nudge.mock.calls.length > 0;
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`wakes for a move into the ${label} intake and hold columns`, async () => {
+        expect(await wakes(names, names.intake)).toBe(true);
+        expect(await wakes(names, names.hold)).toBe(true);
+      });
+
+      it(`does not wake for a move into the ${label} wip column`, async () => {
+        expect(await wakes(names, names.wip)).toBe(false);
+      });
+    }
+
+    it("falls back to the legacy lane for a card no pass has published yet", async () => {
+      // Byte-identical to pre-conversion behavior in this window: `todo` wakes,
+      // an unrelated column does not — regardless of what the workflow declares.
+      expect(await wakes(RENAMED, "todo", { publish: false })).toBe(true);
+      expect(await wakes(RENAMED, RENAMED.wip, { publish: false })).toBe(false);
+    });
+  });
+
+  describe("evacuation", () => {
+    /** Did a move into `column` terminate the live planning session? */
+    async function evacuates(
+      names: { intake: string; hold: string; wip: string },
+      column: string,
+    ): Promise<boolean> {
+      const task = createTask({ id: "FN-EVAC", column: names.intake, status: "planning" });
+      const processor = await processorWithPublishedRoles(names, task);
+      const dispose = vi.fn();
+      (processor as unknown as { activeSessions: Map<string, unknown> })
+        .activeSessions.set("FN-EVAC", { dispose, abort: async () => {} });
+      const handler = (processor as unknown as {
+        taskEvacuatedFromPlanningHandler: (t: Task) => void;
+      }).taskEvacuatedFromPlanningHandler;
+
+      handler({ ...task, column } as Task);
+
+      return dispose.mock.calls.length > 0;
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`does NOT evacuate a ${label} card moving between its own planning columns`, async () => {
+        // The renamed half is the regression: intake -> hold looked like a
+        // withdrawal, so a healthy planner was killed mid-spec.
+        expect(await evacuates(names, names.hold)).toBe(false);
+        expect(await evacuates(names, names.intake)).toBe(false);
+      });
+
+      it(`does NOT evacuate a ${label} card that legitimately advanced into execution`, async () => {
+        expect(await evacuates(names, "in-progress")).toBe(false);
+      });
+
+      it(`evacuates a ${label} card withdrawn to a column outside the lane`, async () => {
+        expect(await evacuates(names, "ideas")).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -291,6 +291,44 @@ export interface PlanningHandoffReport {
 }
 
 export class TriageProcessor {
+  /*
+  FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+  Planning-lane columns per task, refreshed by every discovery pass.
+
+  WHY A SNAPSHOT AND NOT A LOOKUP. The two consumers are SYNCHRONOUS `task:updated`
+  listeners. Making them async to resolve an IR would mean a store read on every
+  task update on the board, and — worse for the evacuation handler — it would delay
+  an abort that is synchronous today, opening a window in which a session it decided
+  to kill has already moved on. A vocabulary conversion must not introduce a race
+  into a path that terminates live agent work.
+
+  The poll already resolves these roles for every task, so publishing them costs
+  nothing extra. Staleness is bounded by one poll interval, and the two readers are
+  chosen so that a stale answer is safe: see each handler for its own fallback.
+  */
+  private lifecycleRolesByTask = new Map<string, { intake?: string; hold?: string }>();
+
+  /*
+  FNXC:TriageLifecycleColumns 2026-07-28-13:40 (U7 / R3):
+  What the synchronous handlers assume for a task no discovery pass has published
+  roles for yet — a card created moments ago, or the window before the first poll.
+
+  The legacy pair, deliberately, and NOT a permissive or a conservative guess. Both
+  of those were tried first and both changed documented behavior in the unpublished
+  window: "always wake" broke the contract that a non-planning column does not wake
+  the poll, and "never evacuate" made planning-evacuation silently inert until a
+  poll had run. Falling back to the literals makes this conversion STRICTLY
+  ADDITIVE — identical to today wherever roles are unknown, correct wherever they
+  are known — which is the only fallback that cannot regress a workflow that never
+  renamed anything.
+
+  It is a compatibility default, not a second source of truth: as soon as a
+  discovery pass has seen the card its real roles win. For the evacuation handler
+  that is guaranteed before it can matter, since a live planning session only
+  exists because a poll admitted the card.
+  */
+  private static readonly LEGACY_PLANNING_LANE = { intake: "triage", hold: "todo" } as const;
+
   private running = false;
   private polling = false;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -611,10 +649,23 @@ export class TriageProcessor {
     */
     this.taskColumnWakeHandler = (task: Task) => {
       if (!task?.id) return;
-      if (task.column !== "todo" && task.column !== "triage") return;
       if (task.paused === true || task.userPaused === true) return;
       // Already being planned (or mid-plan) — the running poll/session owns it.
       if (this.processing.has(task.id) || this.hasLivePlanningWork(task.id)) return;
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+      Match the task's OWN planning lane. Keyed on the literals, a renamed
+      workflow's card never woke the poll on a Start — the operator pressed the
+      button and nothing happened until the next 15s tick, which is the exact
+      symptom this wake was built to remove, reintroduced for every workflow that
+      renamed a column.
+
+      A card no discovery pass has published roles for falls back to the legacy
+      pair — see `LEGACY_PLANNING_LANE` for why that specific fallback and not a
+      permissive one.
+      */
+      const roles = this.lifecycleRolesByTask.get(task.id) ?? TriageProcessor.LEGACY_PLANNING_LANE;
+      if (task.column !== roles.intake && task.column !== roles.hold) return;
       this.requestImmediatePoll();
     };
 
@@ -649,7 +700,27 @@ export class TriageProcessor {
       an unrelated update.
       */
       if (typeof task.column !== "string") return;
-      if (task.column === "todo" || task.column === "triage" || task.column === "in-progress") return;
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+      Evacuation means "the card left ITS OWN planning lane". Keyed on the literal
+      trio, a renamed workflow inverted this: moving a card from its intake column
+      into its own HOLD column looked like an evacuation, so the handler KILLED the
+      live planning session and cleared the status of a card that was simply
+      progressing normally.
+
+      A card with no published roles falls back to the legacy pair
+      (`LEGACY_PLANNING_LANE`), so behavior in that window is byte-identical to
+      today — which matters more here than anywhere else in this conversion,
+      because this path terminates live agent work and discards a partly-written
+      spec.
+
+      `in-progress` stays a literal on purpose: it is not a role lookup but the
+      "legitimately advanced into execution" case, whose session is already
+      unwinding on its own. It is resolved as the WIP role in the same pass that
+      publishes intake/hold, which is a separate change with its own risk.
+      */
+      const roles = this.lifecycleRolesByTask.get(task.id) ?? TriageProcessor.LEGACY_PLANNING_LANE;
+      if (task.column === roles.intake || task.column === roles.hold || task.column === "in-progress") return;
       if (this.activeSubagentSessions.has(task.id)) {
         this.disposeSubagentsForTask(task.id, `task moved to ${task.column}`);
       }
@@ -1477,7 +1548,18 @@ export class TriageProcessor {
     const irCache = new Map<string, WorkflowIr>();
     const rolesById = new Map<string, LifecycleColumns | undefined>();
     for (const t of allTasks) {
-      rolesById.set(t.id, await resolveTaskLifecycleColumns(this.store, t.id, irCache));
+      const roles = await resolveTaskLifecycleColumns(this.store, t.id, irCache);
+      rolesById.set(t.id, roles);
+      // Publish for the synchronous event handlers (see `lifecycleRolesByTask`).
+      if (roles) this.lifecycleRolesByTask.set(t.id, { intake: roles.intake, hold: roles.hold });
+      else this.lifecycleRolesByTask.delete(t.id);
+    }
+    /*
+    Drop rows that left the board, so a long-lived processor does not accumulate
+    roles for deleted tasks. Bounded by the live task set, refreshed every pass.
+    */
+    for (const id of [...this.lifecycleRolesByTask.keys()]) {
+      if (!rolesById.has(id)) this.lifecycleRolesByTask.delete(id);
     }
     const isAt = (t: Task, role: "intake" | "hold"): boolean => {
       const roles = rolesById.get(t.id);


### PR DESCRIPTION
> **Stacked: #2517 → #2522 → this.** Base is `feature/u7-planning-sweeps-resolved-columns`. Merge in that order and each retargets cleanly.

## Two opposite failures

The planning **wake** and the planning-**evacuation** abort are synchronous `task:updated` listeners. On a renamed workflow they broke in opposite directions:

- **The wake never fired.** Pressing Start did nothing until the next 15s tick — the exact symptom the wake was built to remove, reintroduced for every workflow that renamed a column.
- **The evacuation fired when it must not.** Moving a card from its intake column into its own **hold** column looked like a withdrawal, so a live planning session was **killed** and its status cleared for a card that was progressing normally.

## Why a snapshot, not a lookup

Both handlers are synchronous. Resolving an IR inside them means a store read on **every** task update on the board — and for evacuation it would delay an abort that is synchronous today, opening a window in which the session it decided to kill has already moved on. **A vocabulary conversion must not introduce a race into a path that terminates live agent work.**

The discovery pass already resolves these roles for every task, so publishing them costs nothing extra.

## The fallback, which I got wrong twice before landing it

| Attempt | Broke |
|---|---|
| unknown roles **wake** (permissive) | the documented contract that a non-planning column does not wake the poll |
| unknown roles **do not evacuate** (conservative) | planning-evacuation went silently inert until a poll had run |

Both were caught by **existing tests failing** — which is the correct outcome. Those tests encode contracts, and editing their expectations would have been the wrong fix.

Falling back to the legacy `triage`/`todo` pair makes the conversion **strictly additive**: identical to today wherever roles are unknown, correct wherever they are known. It is a compatibility default, not a second source of truth — real roles win as soon as a pass has seen the card, which for evacuation is guaranteed before it can matter, since a live planning session only exists because a poll admitted the card.

`in-progress` deliberately stays a literal in the evacuation handler: it is not a lane lookup but the "legitimately advanced into execution" case. Resolving it as the WIP role is a separate change with its own risk.

## Revert proof

With both handlers back on the literals: **2 of 28 fail** — the two renamed cases. Every default-vocabulary case *and the fallback case* pass either way, which is the signature of a conversion that changes no existing behavior.

## Measurement correction

I first wrote "42 → 40 literal sites" in the commit. **Measured against the parent, it is 42 → 42**: this removes two literal-bearing lines and adds the `LEGACY_PLANNING_LANE` constant (which carries both), plus keeps the deliberate `in-progress`. A raw literal count is the wrong instrument here and the number would simply have been false. Corrected in the commit message before pushing.

The honest measure is **decision sites**. Of the 7 lifecycle-column lines left in `triage.ts`:

| Count | Site | Status |
|---:|---|---|
| 1 | `LEGACY_PLANNING_LANE` | documented compatibility default — not a decision |
| 1 | `in-progress` in evacuation | retained deliberately |
| 1 | `releasedToTodo` in stuck-abort | **the last unconverted planning-lane decision** |
| 3 | `column !== "done"` in duplicate search | complete role, different lane |
| 1 | `column: "triage"` create default | creation path, not a planning decision |

So of the **12 planning-lane decision sites this unit started with, one remains** — named here rather than left to be discovered.

## Verification

| Check | Result |
|---|---|
| suite | 28/28 |
| 14 triage / planning / self-healing / restart suites | 408/408, clean exit, **no expectation edits to any existing test** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (309 + 10 + 71) |
| `pnpm check:changesets` | clean (first attempt was a 146-char summary; the linter caught it) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
