### PR TITLE
U7 PR7: stuck-abort recognises a completed handoff — the last planning-lane literal (stacked on #2523)

### DIFF
--- a/.changeset/triage-planning-handlers-resolved.md
+++ b/.changeset/triage-planning-handlers-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: On a workflow with renamed columns, Start begins planning at once and moving a card no longer kills its planner.
+category: fix
+dev: U7 / R3. The planning wake and planning-evacuation handlers are synchronous `task:updated` listeners, so they read a lane snapshot published by each discovery pass rather than resolving an IR per board update (which for evacuation would also have delayed an abort that is synchronous today). Renamed workflows had opposite failures: the wake never fired (Start appeared dead until the next poll tick), and evacuation fired on an intake -> hold move, killing a healthy planning session mid-spec. A task no pass has published yet falls back to the legacy `triage`/`todo` pair, so behavior in that window is byte-identical to today and the conversion cannot regress a workflow that never renamed anything.

--- a/.changeset/triage-stuck-abort-resolved.md
+++ b/.changeset/triage-stuck-abort-resolved.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A stuck-killed planner no longer discards a finished spec on a workflow with renamed columns.
+category: fix
+dev: U7 / R3. The last planning-lane literal: `handleStuckAbortRequeue`'s `releasedToTodo` asked `column === "todo"`, so on a renamed workflow a card resting in its own hold column with a completed handoff was not recognised as released — the handler took the requeue path and stamped `needs-replan` over the finished spec, the FN-8361 / PR #2326 regression reintroduced. Now resolves the hold role from the task's own workflow; resolved directly rather than from the discovery snapshot because this path is already async, runs once per stuck kill, and decides whether to overwrite a spec. Unresolvable workflow is treated as not-released, matching the pre-existing behavior for any non-matching column.

--- a/packages/engine/src/__tests__/planning-claim-single-writer.test.ts
+++ b/packages/engine/src/__tests__/planning-claim-single-writer.test.ts
@@ -1,0 +1,336 @@
+/*
+FNXC:PlanningClaimSingleWriter 2026-07-28-15:00 (U7 / R4, R12 — workflow-owned lifecycle):
+
+THE RATCHET: the task planning CLAIM — `status: "planning"` — has exactly ONE
+writer module, and every write of it goes through the guarded helper.
+
+WHY THIS SPECIFIC INVARIANT. The plan names FN-8504 as U7's acceptance case: a
+store-open sweep cleared a live planner's status because two owners wrote planning
+lifecycle state. The unit's stated verification is "a grep-level assertion that
+planning status literals have one writer module". This is that assertion.
+
+`status: "planning"` is the CLAIM on a card — it means "a planner owns this task
+right now". It is also load-bearing well beyond triage: `isUnplannedForExecution`
+treats it as dispatch-blocking, rediscovery skips cards carrying it, and two
+self-healing sweeps plus two triage sweeps exist solely to clear it when a planner
+dies. A second writer does not announce itself; it produces a card that looks
+claimed to every reader while nothing is actually planning it.
+
+WHAT THIS DOES NOT ASSERT, so the guard is not mistaken for more than it is:
+
+  - It says nothing about who CLEARS the status. Eleven modules write
+    `status: null` for unrelated reasons (merge, execution, mission autopilot), so
+    "one clearer" would be false, and asserting it would mean weakening it into
+    something that passes — the worst kind of guard.
+  - `needs-replan` is deliberately NOT covered. Post-U3 it is the graph's own
+    durable replan signal (AGENTS.md), written by the plan-review → plan-replan
+    seam AND the stale-spec guards that feed the same loop. Multiple writers there
+    are the design, not a defect.
+  - Mission `status: "planning"` is a different entity on a different table. The
+    scan is scoped so a mission-store write can never satisfy or trip this.
+
+The two self-healing sweeps that READ `status === "planning"` for orphan recovery
+are the compensating machinery FN-8504 produced. They are readers plus a
+CAS-guarded clear, not claimants, so they do not violate this — and if U7's later
+work makes them unreachable, that is a deletion, not a change to this contract.
+
+Cheap by construction (FN-5048): grep-level over production source, no engine boot.
+*/
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
+
+/**
+ * Production source roots, DISCOVERED rather than listed.
+ *
+ * FNXC:PlanningClaimSingleWriter 2026-07-28-16:20 (PR #2527 review — greptile):
+ * This was a hardcoded four-package list, which made a repo-wide claim while
+ * scanning a subset: `packages/desktop` and `packages/plugin-sdk` both touch
+ * TaskStore and were never looked at, and any package added later would have been
+ * silently out of scope forever. A guard whose blind spot grows as the repo grows
+ * is not a guard. Enumerating `packages/<name>/src` means new packages are covered
+ * the day they appear, with no allowlist to forget to update.
+ */
+function sourceRoots(base: string = REPO_ROOT): string[] {
+  const packagesDir = join(base, "packages");
+  return readdirSync(packagesDir)
+    .filter((name) => {
+      const src = join(packagesDir, name, "src");
+      try {
+        return statSync(src).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .map((name) => `packages/${name}/src`)
+    .sort();
+}
+
+/**
+ * The single module permitted to claim a task for planning.
+ *
+ * Adding an entry here is the reviewable act this ratchet exists to force: it
+ * means a second owner now writes the claim, which is the FN-8504 shape. If that
+ * is genuinely intended, the justification belongs beside the new entry.
+ */
+const PLANNING_CLAIM_WRITERS = ["packages/engine/src/triage.ts"];
+
+/**
+ * Modules permitted to BIND the planning literal to a constant.
+ *
+ * `replan-target.ts` binds it to EXCLUDE it — `planning` is the transient in-flight
+ * claim, deliberately filtered out of the durable planning-stage set — and writes no
+ * task status anywhere. It is here because binding the literal is the indirection
+ * route around the write patterns, so a NEW entry deserves a look even when the
+ * module turns out, like this one, to be a reader.
+ */
+const PLANNING_CLAIM_BINDERS = ["packages/engine/src/replan-target.ts"];
+
+/**
+ * Mission planning is a different entity with its own `status` column. Excluded by
+ * path rather than by pattern, because a pattern loose enough to tell them apart is
+ * a pattern loose enough to miss a real task write.
+ */
+const NON_TASK_STATUS_MODULES = [
+  "packages/core/src/mission-store.ts",
+  "packages/core/src/async-mission-store.ts",
+];
+
+function sourceFiles(root: string, base: string = REPO_ROOT): string[] {
+  const abs = join(base, root);
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === "__tests__" || entry === "node_modules" || entry === "dist") continue;
+        walk(full);
+        continue;
+      }
+      if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) out.push(full);
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+/** Strip comments so an explanatory FNXC note naming the literal is not a hit. */
+function stripComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+const executableSource = (file: string): string => stripComments(readFileSync(file, "utf-8"));
+
+/**
+ * The planning literal in EVERY spelling JavaScript allows.
+ *
+ * FNXC:PlanningClaimSingleWriter 2026-07-28-16:20 (PR #2527 review — greptile):
+ * The original pattern matched only the exact double-quoted form, so a second
+ * writer could evade the whole ratchet by typing a single quote. That is a
+ * spelling check wearing a single-writer guarantee's name — the sixth
+ * guard-that-cannot-fire on this program, and the third I have written or found.
+ */
+const PLANNING_LITERAL = String.raw`(?:"planning"|'planning'|\x60planning\x60)`;
+
+/**
+ * A WRITE, not a READ. The distinction is load-bearing: several modules
+ * legitimately COMPARE against the claim (`t.status === "planning"` in the
+ * self-healing orphan sweeps, membership in a status array), and flagging those
+ * would force an allowlist so large the guard would mean nothing.
+ *
+ * Covered write shapes: object-literal property, plain assignment, and a computed
+ * `["status"]` key. Reads (`===`, `!==`, `includes`) are excluded by requiring a
+ * single `:` or `=` that is not part of a comparison operator.
+ */
+const CLAIM_WRITE = new RegExp(
+  String.raw`(?:\bstatus\s*:\s*|\bstatus\s*=(?!=)\s*|\[\s*["']status["']\s*\]\s*(?::|=(?!=))\s*)` + PLANNING_LITERAL,
+);
+
+/**
+ * A constant bound to the planning literal. Without this, indirection defeats the
+ * write patterns above — `const CLAIM = "planning"; store.updateTask(id, { status: CLAIM })`
+ * is a second writer the shape-matching alone cannot see. Binding the literal at all,
+ * outside the allowlisted module, is the reviewable event.
+ */
+const CLAIM_BINDING = new RegExp(
+  String.raw`\b(?:const|let|var|readonly)\s+\w+\s*(?::\s*[^=;]+)?=\s*` + PLANNING_LITERAL,
+);
+
+/*
+FNXC:PlanningClaimSingleWriter 2026-07-28-16:40 (PR #2527 review — greptile):
+WRITES and BINDINGS are reported SEPARATELY, with separate allowlists, because
+conflating them produces a false accusation. Widening the detector immediately
+flagged `replan-target.ts` — which binds the literal ONLY to exclude it from a
+status set (`PLANNING_STAGE_STATUSES.filter(s => s !== TRANSIENT_PLANNING_STATUS)`)
+and never writes a task status at all. Calling that a second writer would have been
+wrong, and the tempting fixes — dropping the binding rule, or allowlisting it as a
+"writer" — would have either reopened the indirection hole or made the guard lie.
+
+So: the WRITE list stays at exactly one module, and the BINDING list is its own
+contract — a new module binding the claim is reviewable precisely because binding is
+the route around the write patterns.
+*/
+
+/**
+ * Every module under `roots` whose EXECUTABLE source writes the planning claim.
+ *
+ * Parameterised on `base` so the injection test below can run this exact function
+ * over a fixture tree. Re-implementing the scan in the test would prove only that
+ * the copy works — which is the failure mode this whole program keeps finding.
+ */
+function scanFor(
+  matches: (source: string) => boolean,
+  roots?: readonly string[],
+  base: string = REPO_ROOT,
+): string[] {
+  const hits: string[] = [];
+  for (const root of roots ?? sourceRoots(base)) {
+    for (const file of sourceFiles(root, base)) {
+      const rel = file.slice(base.length + 1);
+      if (NON_TASK_STATUS_MODULES.includes(rel)) continue;
+      if (matches(executableSource(file))) hits.push(rel);
+    }
+  }
+  return hits.sort();
+}
+
+const planningClaimWriters = (roots?: readonly string[], base?: string): string[] =>
+  scanFor((src) => CLAIM_WRITE.test(src), roots, base);
+
+const planningClaimBinders = (roots?: readonly string[], base?: string): string[] =>
+  scanFor((src) => CLAIM_BINDING.test(src), roots, base);
+
+describe("the planning claim has a single writer (U7 / FN-8504)", () => {
+  it("is written by exactly the allowlisted module", () => {
+    expect(planningClaimWriters()).toEqual([...PLANNING_CLAIM_WRITERS].sort());
+  });
+
+  it("is bound to a constant only by the allowlisted modules", () => {
+    // The indirection route: `const CLAIM = "planning"` defeats the write patterns.
+    expect(planningClaimBinders()).toEqual([...PLANNING_CLAIM_BINDERS].sort());
+  });
+
+  it("writes the claim only through the planning-stage-guarded helper", () => {
+    /*
+    The claim must never be a bare `store.updateTask`. FN-7977 and FN-8361 are both
+    that bug: a write that does not re-check the planning stage under the task lock
+    stamps `planning` onto a card the scheduler has already advanced, and the card
+    then looks claimed to every reader while nothing is planning it.
+    */
+    const source = executableSource(join(REPO_ROOT, "packages/engine/src/triage.ts"));
+    const claims = [...source.matchAll(/status:\s*"planning"/g)];
+    expect(claims).toHaveLength(1);
+
+    // The single claim sits inside an `updatePlanningStateIfStillCurrent(...)` call.
+    const claimLine = source
+      .split("\n")
+      .find((line) => /status:\s*"planning"/.test(line));
+    expect(claimLine).toMatch(/updatePlanningStateIfStillCurrent/);
+  });
+
+  /*
+  A ratchet that cannot be shown to fail on the defect it names is not a ratchet.
+  These run the REAL `planningClaimWriters` over a fixture tree — not a
+  re-implementation of it — so a scan that silently stopped looking would be caught.
+  */
+  describe("the detector itself", () => {
+    let fixtureRoot = "";
+
+    const fixture = (relative: string, contents: string): void => {
+      const full = join(fixtureRoot, relative);
+      mkdirSync(join(full, ".."), { recursive: true });
+      writeFileSync(full, contents);
+    };
+
+    afterEach(() => {
+      if (fixtureRoot) rmSync(fixtureRoot, { recursive: true, force: true });
+      fixtureRoot = "";
+    });
+
+    const newFixtureRoot = (): string => {
+      fixtureRoot = mkdtempSync(join(tmpdir(), "fusion-claim-ratchet-"));
+      return fixtureRoot;
+    };
+
+    /*
+    FNXC:PlanningClaimSingleWriter 2026-07-28-16:40 (PR #2527 review — greptile):
+    EVERY spelling, because the original detector matched only the double-quoted
+    form and a second writer could have evaded the entire ratchet by typing a
+    single quote. Each row is a form that previously slipped past.
+    */
+    const EVASIONS: ReadonlyArray<[string, string]> = [
+      ["double quotes", 'await store.updateTask(id, { status: "planning" });'],
+      ["single quotes", "await store.updateTask(id, { status: 'planning' });"],
+      ["template literal", "await store.updateTask(id, { status: `planning` });"],
+      ["extra whitespace", 'await store.updateTask(id, { status  :   "planning" });'],
+      ["plain assignment", "task.status = 'planning';"],
+      ["computed key", `await store.updateTask(id, { ["status"]: 'planning' });`],
+    ];
+
+    for (const [label, code] of EVASIONS) {
+      it(`FINDS an injected second writer using ${label}`, () => {
+        const base = newFixtureRoot();
+        fixture("pkg/src/innocent.ts", "export const x = 1;\n");
+        fixture("pkg/src/sneaky.ts", `${code}\n`);
+
+        expect(planningClaimWriters(["pkg/src"], base)).toEqual(["pkg/src/sneaky.ts"]);
+      });
+    }
+
+    it("FINDS the constant-indirection route the write patterns alone cannot see", () => {
+      const base = newFixtureRoot();
+      fixture(
+        "pkg/src/indirect.ts",
+        "const CLAIM = 'planning';\nawait store.updateTask(id, { status: CLAIM });\n",
+      );
+
+      // Not a WRITE by shape — the write patterns see `status: CLAIM`, not a literal.
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+      // Caught by the binding contract instead, which is why that exists.
+      expect(planningClaimBinders(["pkg/src"], base)).toEqual(["pkg/src/indirect.ts"]);
+    });
+
+    it("does NOT flag a module that only COMPARES against the claim", () => {
+      // The distinction that keeps the allowlist small enough to mean something:
+      // self-healing's orphan sweeps read this literal and must stay unflagged.
+      const base = newFixtureRoot();
+      fixture(
+        "pkg/src/reader.ts",
+        "if (t.status === 'planning') return;\nconst S = new Set([\"planning\", \"done\"]);\nif (S.has(t.status)) return;\n",
+      );
+
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+    });
+
+    it("scans EVERY package under packages/, not a hardcoded subset", () => {
+      // The scope hole: a package outside the old four-entry list was never looked
+      // at, and a package added later would have been out of scope forever.
+      const base = newFixtureRoot();
+      fixture("packages/brand-new/src/writer.ts", "task.status = 'planning';\n");
+
+      expect(planningClaimWriters(undefined, base)).toEqual(["packages/brand-new/src/writer.ts"]);
+    });
+
+    it("is not fooled by a comment that merely names the literal", () => {
+      // Prose describing the claim must survive — every deletion on this program
+      // leaves an explanatory tombstone — without being read as a writer.
+      const base = newFixtureRoot();
+      fixture("pkg/src/documented.ts", '/* FNXC: triage writes status: "planning" here */\nconst x = 1;\n');
+      fixture("pkg/src/line-comment.ts", '// status: "planning" is claimed by triage\nconst y = 2;\n');
+
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+    });
+
+    it("ignores test files, which legitimately name the claim", () => {
+      const base = newFixtureRoot();
+      fixture("pkg/src/__tests__/a.test.ts", 'expect(t).toEqual({ status: "planning" });\n');
+
+      expect(planningClaimWriters(["pkg/src"], base)).toEqual([]);
+    });
+  });
+});

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -143,7 +143,14 @@ function createStore(opts: {
     parseDependenciesFromPrompt: vi.fn().mockResolvedValue([]),
     parseStepsFromPrompt: vi.fn().mockResolvedValue([]),
     parseFileScopeFromPrompt: vi.fn().mockResolvedValue([]),
-    updateTask: vi.fn(),
+    /*
+    MUST resolve. Several triage paths do `await store.updateTask(...).catch(...)`,
+    so a bare `vi.fn()` throws on `.catch` and aborts the caller mid-way — which
+    presents as the branch under test "not running" and sends you hunting a
+    production bug that is not there. Sixth instance of this shape in U7; see the
+    PR body.
+    */
+    updateTask: vi.fn().mockResolvedValue(undefined),
     updateTaskAtomic: vi.fn(async (id: string, patch: unknown) => {
       const live = byId(id);
       if (!live) return undefined;
@@ -609,4 +616,78 @@ describe("the synchronous planning handlers read the published lane", () => {
       });
     }
   });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Stuck-abort: recognising a handoff that already completed
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-14:10 (U7 / R3):
+The last planning-lane decision keyed on a literal. When the stuck detector kills a
+planner, `handleStuckAbortRequeue` asks whether the handoff had ALREADY completed —
+the card resting in the hold column with no planning-stage status. If so it must
+preserve that released state; otherwise it requeues, which for a card with a draft
+means stamping `needs-replan`.
+
+Keyed on `column === "todo"`, a renamed workflow answered NO to a card sitting in
+its own hold column with a finished spec. The stuck handler then took the requeue
+path and wrote `needs-replan` OVER a completed handoff — re-stranding an approved
+plan. That is exactly the regression the FN-8361 / PR #2326 notes above the branch
+describe and guard against, reintroduced for every renamed workflow.
+
+Both statuses matter, so both are asserted: a released card (status cleared) must be
+preserved, and a card still carrying a planning-stage status must still requeue —
+the distinction the `planningStageStatus` half draws, which a column-only fix would
+quietly flatten.
+*/
+describe("stuck-abort recognises a completed handoff in the workflow's own hold column", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-stuck-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** Run the stuck-abort cleanup and report every status it wrote. */
+  async function stuckAbort(
+    names: { intake: string; hold: string; wip: string },
+    task: Task,
+  ): Promise<Array<string | null>> {
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    await (processor as unknown as {
+      handleStuckAbortRequeue: (t: Task, c: "in-loop" | "catch") => Promise<void>;
+    }).handleStuckAbortRequeue(task, "in-loop");
+
+    return vi.mocked(store.updateTask).mock.calls
+      .map(([, patch]) => (patch as { status?: string | null }).status)
+      .filter((status) => status !== undefined) as Array<string | null>;
+  }
+
+  for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+    it(`preserves a RELEASED ${label} card instead of stamping needs-replan over it`, async () => {
+      const released = createTask({ id: "FN-REL", column: names.hold, status: null });
+
+      // No status write at all: the handoff completed, so only the kill count moves.
+      expect(await stuckAbort(names, released)).toEqual([]);
+    });
+
+    it(`still requeues a ${label} card that is mid-planning in the hold column`, async () => {
+      // Plan-in-place: resting in the hold column but NOT released — the
+      // `planningStageStatus` half of the predicate, which must survive the
+      // column conversion rather than being flattened by it.
+      const midPlan = createTask({ id: "FN-MID", column: names.hold, status: "planning" });
+
+      expect(await stuckAbort(names, midPlan)).not.toEqual([]);
+    });
+  }
 });

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -476,3 +476,137 @@ describe("the stale-planning sweeps resolve their planning lane", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. The two synchronous task:updated handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:TriageLifecycleColumns 2026-07-28-13:40 (U7 / R3):
+The planning wake and the planning-evacuation abort are SYNCHRONOUS `task:updated`
+listeners, so they cannot resolve an IR without either a store read per board
+update or — for evacuation — delaying an abort that is synchronous today. They read
+a snapshot the discovery pass publishes instead.
+
+The two failures they had on a renamed workflow are opposites, which is why both
+directions are asserted:
+  - the WAKE never fired, so pressing Start did nothing until the next 15s tick —
+    the exact symptom the wake was built to remove, reintroduced;
+  - the EVACUATION fired when it should not have: moving a card from its intake
+    column into its own HOLD column looked like a withdrawal, so a live planning
+    session was KILLED and its status cleared for a card that was progressing
+    normally.
+
+The unpublished-roles window falls back to the legacy literals, so behavior there is
+byte-identical to today. That fallback is asserted too — it is the reason this
+conversion cannot regress a workflow that never renamed anything.
+*/
+describe("the synchronous planning handlers read the published lane", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-handlers-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** Build a processor whose discovery pass has already published `names`. */
+  async function processorWithPublishedRoles(
+    names: { intake: string; hold: string; wip: string },
+    task: Task,
+  ): Promise<TriageProcessor> {
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+      .mockResolvedValue(undefined);
+    (processor as unknown as { running: boolean }).running = true;
+    await (processor as unknown as { poll: () => Promise<void> }).poll();
+    return processor;
+  }
+
+  describe("wake", () => {
+    /** Did a move into `column` wake the poll? */
+    async function wakes(
+      names: { intake: string; hold: string; wip: string },
+      column: string,
+      opts: { publish?: boolean } = { publish: true },
+    ): Promise<boolean> {
+      const task = createTask({ id: "FN-WAKE", column: names.intake, status: null });
+      const processor = opts.publish
+        ? await processorWithPublishedRoles(names, task)
+        : new TriageProcessor(createStore({ tasks: [task], workflowIr: ir(names) }), rootDir);
+      const handler = (processor as unknown as { taskColumnWakeHandler: (t: Task) => void })
+        .taskColumnWakeHandler;
+      const nudge = vi
+        .spyOn(processor as unknown as { requestImmediatePoll: () => boolean }, "requestImmediatePoll")
+        .mockReturnValue(true);
+
+      handler({ ...task, column } as Task);
+
+      return nudge.mock.calls.length > 0;
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`wakes for a move into the ${label} intake and hold columns`, async () => {
+        expect(await wakes(names, names.intake)).toBe(true);
+        expect(await wakes(names, names.hold)).toBe(true);
+      });
+
+      it(`does not wake for a move into the ${label} wip column`, async () => {
+        expect(await wakes(names, names.wip)).toBe(false);
+      });
+    }
+
+    it("falls back to the legacy lane for a card no pass has published yet", async () => {
+      // Byte-identical to pre-conversion behavior in this window: `todo` wakes,
+      // an unrelated column does not — regardless of what the workflow declares.
+      expect(await wakes(RENAMED, "todo", { publish: false })).toBe(true);
+      expect(await wakes(RENAMED, RENAMED.wip, { publish: false })).toBe(false);
+    });
+  });
+
+  describe("evacuation", () => {
+    /** Did a move into `column` terminate the live planning session? */
+    async function evacuates(
+      names: { intake: string; hold: string; wip: string },
+      column: string,
+    ): Promise<boolean> {
+      const task = createTask({ id: "FN-EVAC", column: names.intake, status: "planning" });
+      const processor = await processorWithPublishedRoles(names, task);
+      const dispose = vi.fn();
+      (processor as unknown as { activeSessions: Map<string, unknown> })
+        .activeSessions.set("FN-EVAC", { dispose, abort: async () => {} });
+      const handler = (processor as unknown as {
+        taskEvacuatedFromPlanningHandler: (t: Task) => void;
+      }).taskEvacuatedFromPlanningHandler;
+
+      handler({ ...task, column } as Task);
+
+      return dispose.mock.calls.length > 0;
+    }
+
+    for (const [label, names] of [["default", DEFAULT_NAMES], ["renamed", RENAMED]] as const) {
+      it(`does NOT evacuate a ${label} card moving between its own planning columns`, async () => {
+        // The renamed half is the regression: intake -> hold looked like a
+        // withdrawal, so a healthy planner was killed mid-spec.
+        expect(await evacuates(names, names.hold)).toBe(false);
+        expect(await evacuates(names, names.intake)).toBe(false);
+      });
+
+      it(`does NOT evacuate a ${label} card that legitimately advanced into execution`, async () => {
+        expect(await evacuates(names, "in-progress")).toBe(false);
+      });
+
+      it(`evacuates a ${label} card withdrawn to a column outside the lane`, async () => {
+        expect(await evacuates(names, "ideas")).toBe(true);
+      });
+    }
+  });
+});

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -1419,7 +1419,29 @@ export class TriageProcessor {
       freshTask.status === "planning"
       || freshTask.status === "needs-replan"
       || freshTask.status === "plan-review-unavailable";
-    const releasedToTodo = freshTask.column === "todo" && !planningStageStatus;
+    /*
+    FNXC:TriageLifecycleColumns 2026-07-28-14:10 (U7 / R3):
+    "Released" means the card reached ITS OWN workflow's hold column with no
+    planning-stage status. Keyed on the literal `todo`, a renamed workflow answered
+    NO for a card sitting in its own hold column with a finished spec — so this
+    handler took the requeue path and stamped `needs-replan` OVER a completed
+    handoff, re-stranding an approved plan. That is precisely the regression the
+    FN-8361 / PR #2326 notes above this branch exist to prevent, reintroduced for
+    every workflow that renamed a column.
+
+    Resolved directly rather than from the published snapshot (unlike the two
+    synchronous handlers): this path is already async and runs once per stuck kill,
+    so it can afford the read and should prefer the freshest answer — it decides
+    whether to overwrite a finished spec.
+
+    Unresolvable workflow: NOT released, which is the pre-existing behavior for any
+    column that did not match the literal. Requeueing a card we cannot place is
+    recoverable; preserving one that never actually landed would strand it.
+    */
+    const holdColumn = (await resolveTaskLifecycleColumns(this.store, freshTask.id))?.hold;
+    const releasedToTodo = holdColumn !== undefined
+      && freshTask.column === holdColumn
+      && !planningStageStatus;
     if (hasAdvancedPastPlanning(freshTask) || releasedToTodo) {
       const nextStuckKillCount = (freshTask.stuckKillCount ?? task.stuckKillCount ?? 0) + 1;
       planLog.log(

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -291,6 +291,44 @@ export interface PlanningHandoffReport {
 }
 
 export class TriageProcessor {
+  /*
+  FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+  Planning-lane columns per task, refreshed by every discovery pass.
+
+  WHY A SNAPSHOT AND NOT A LOOKUP. The two consumers are SYNCHRONOUS `task:updated`
+  listeners. Making them async to resolve an IR would mean a store read on every
+  task update on the board, and — worse for the evacuation handler — it would delay
+  an abort that is synchronous today, opening a window in which a session it decided
+  to kill has already moved on. A vocabulary conversion must not introduce a race
+  into a path that terminates live agent work.
+
+  The poll already resolves these roles for every task, so publishing them costs
+  nothing extra. Staleness is bounded by one poll interval, and the two readers are
+  chosen so that a stale answer is safe: see each handler for its own fallback.
+  */
+  private lifecycleRolesByTask = new Map<string, { intake?: string; hold?: string }>();
+
+  /*
+  FNXC:TriageLifecycleColumns 2026-07-28-13:40 (U7 / R3):
+  What the synchronous handlers assume for a task no discovery pass has published
+  roles for yet — a card created moments ago, or the window before the first poll.
+
+  The legacy pair, deliberately, and NOT a permissive or a conservative guess. Both
+  of those were tried first and both changed documented behavior in the unpublished
+  window: "always wake" broke the contract that a non-planning column does not wake
+  the poll, and "never evacuate" made planning-evacuation silently inert until a
+  poll had run. Falling back to the literals makes this conversion STRICTLY
+  ADDITIVE — identical to today wherever roles are unknown, correct wherever they
+  are known — which is the only fallback that cannot regress a workflow that never
+  renamed anything.
+
+  It is a compatibility default, not a second source of truth: as soon as a
+  discovery pass has seen the card its real roles win. For the evacuation handler
+  that is guaranteed before it can matter, since a live planning session only
+  exists because a poll admitted the card.
+  */
+  private static readonly LEGACY_PLANNING_LANE = { intake: "triage", hold: "todo" } as const;
+
   private running = false;
   private polling = false;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -611,10 +649,23 @@ export class TriageProcessor {
     */
     this.taskColumnWakeHandler = (task: Task) => {
       if (!task?.id) return;
-      if (task.column !== "todo" && task.column !== "triage") return;
       if (task.paused === true || task.userPaused === true) return;
       // Already being planned (or mid-plan) — the running poll/session owns it.
       if (this.processing.has(task.id) || this.hasLivePlanningWork(task.id)) return;
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+      Match the task's OWN planning lane. Keyed on the literals, a renamed
+      workflow's card never woke the poll on a Start — the operator pressed the
+      button and nothing happened until the next 15s tick, which is the exact
+      symptom this wake was built to remove, reintroduced for every workflow that
+      renamed a column.
+
+      A card no discovery pass has published roles for falls back to the legacy
+      pair — see `LEGACY_PLANNING_LANE` for why that specific fallback and not a
+      permissive one.
+      */
+      const roles = this.lifecycleRolesByTask.get(task.id) ?? TriageProcessor.LEGACY_PLANNING_LANE;
+      if (task.column !== roles.intake && task.column !== roles.hold) return;
       this.requestImmediatePoll();
     };
 
@@ -649,7 +700,27 @@ export class TriageProcessor {
       an unrelated update.
       */
       if (typeof task.column !== "string") return;
-      if (task.column === "todo" || task.column === "triage" || task.column === "in-progress") return;
+      /*
+      FNXC:TriageLifecycleColumns 2026-07-28-13:15 (U7 / R3):
+      Evacuation means "the card left ITS OWN planning lane". Keyed on the literal
+      trio, a renamed workflow inverted this: moving a card from its intake column
+      into its own HOLD column looked like an evacuation, so the handler KILLED the
+      live planning session and cleared the status of a card that was simply
+      progressing normally.
+
+      A card with no published roles falls back to the legacy pair
+      (`LEGACY_PLANNING_LANE`), so behavior in that window is byte-identical to
+      today — which matters more here than anywhere else in this conversion,
+      because this path terminates live agent work and discards a partly-written
+      spec.
+
+      `in-progress` stays a literal on purpose: it is not a role lookup but the
+      "legitimately advanced into execution" case, whose session is already
+      unwinding on its own. It is resolved as the WIP role in the same pass that
+      publishes intake/hold, which is a separate change with its own risk.
+      */
+      const roles = this.lifecycleRolesByTask.get(task.id) ?? TriageProcessor.LEGACY_PLANNING_LANE;
+      if (task.column === roles.intake || task.column === roles.hold || task.column === "in-progress") return;
       if (this.activeSubagentSessions.has(task.id)) {
         this.disposeSubagentsForTask(task.id, `task moved to ${task.column}`);
       }
@@ -1477,7 +1548,18 @@ export class TriageProcessor {
     const irCache = new Map<string, WorkflowIr>();
     const rolesById = new Map<string, LifecycleColumns | undefined>();
     for (const t of allTasks) {
-      rolesById.set(t.id, await resolveTaskLifecycleColumns(this.store, t.id, irCache));
+      const roles = await resolveTaskLifecycleColumns(this.store, t.id, irCache);
+      rolesById.set(t.id, roles);
+      // Publish for the synchronous event handlers (see `lifecycleRolesByTask`).
+      if (roles) this.lifecycleRolesByTask.set(t.id, { intake: roles.intake, hold: roles.hold });
+      else this.lifecycleRolesByTask.delete(t.id);
+    }
+    /*
+    Drop rows that left the board, so a long-lived processor does not accumulate
+    roles for deleted tasks. Bounded by the live task set, refreshed every pass.
+    */
+    for (const id of [...this.lifecycleRolesByTask.keys()]) {
+      if (!rolesById.has(id)) this.lifecycleRolesByTask.delete(id);
     }
     const isAt = (t: Task, role: "intake" | "hold"): boolean => {
       const roles = rolesById.get(t.id);


### PR DESCRIPTION
> **Stack: #2517 → #2522 → #2523 → this.** Merge in that order; each retargets cleanly.

## The bug

When the stuck detector kills a planner, `handleStuckAbortRequeue` asks whether the handoff had **already completed** — the card resting in the hold column with no planning-stage status. If so it preserves that released state; otherwise it requeues, which for a card with a draft means stamping `needs-replan`.

Keyed on `column === "todo"`, a renamed workflow answered **no** for a card sitting in its own hold column with a finished spec. The handler took the requeue path and wrote `needs-replan` **over a completed handoff** — re-stranding an approved plan.

That is exactly the regression the FN-8361 / PR #2326 notes sitting directly above this branch exist to prevent, reintroduced for every workflow that renamed a column.

## Resolved directly, not from the snapshot

#2523 added a discovery-published lane snapshot so the two *synchronous* handlers could stay synchronous. This path is different: it is already async, runs once per stuck kill, and decides whether to overwrite a finished spec. It can afford the read and should prefer the freshest answer. The snapshot exists to keep synchronous handlers synchronous — not as a general substitute for resolution.

**Unresolvable workflow** → treated as *not* released, matching the pre-existing behavior for any column that did not match the literal. Requeueing a card whose lifecycle we cannot read is recoverable; preserving one that never actually landed strands it.

## Both halves asserted, not just the column

A released card (status cleared) is preserved **and** a card still carrying a planning-stage status still requeues. A column-only fix would quietly flatten that distinction — which is the plan-in-place case CodeRabbit caught on PR #2326.

## Revert proof

With the literal restored: **1 of 32 fails** — the renamed released case. The default-vocabulary equivalent passes either way, the correct signature for a conversion that changes no existing behavior.

## U7's vocabulary conversion is now complete

This is the last of the **12 planning-lane decision sites** the unit started with. The remaining lifecycle-column literals in `triage.ts` are, exhaustively:

| Site | Why it stays |
|---|---|
| `LEGACY_PLANNING_LANE` | documented compatibility default for the pre-first-poll window (#2523) |
| `in-progress` in the evacuation handler | the "legitimately advanced into execution" case, not a lane lookup |
| `column !== "done"` ×3 in duplicate search | complete role, different lane, no planning decision |
| `column: "triage"` creation default | creation path, not a planning decision |

## Sixth fixture defect of the same family

`updateTask: vi.fn()` returns `undefined`, and several triage paths do `await store.updateTask(...).catch(...)` — so `.catch` threw and aborted the caller mid-branch, presenting as *"the branch under test does not run"*.

Every U7 slice has produced one of these, and every one first looked like a production bug:

| # | Shape | PR |
|---:|---|---|
| 1 | fake ignores its predicate | #2491 |
| 2 | stub ignores its callback | #2498 |
| 3 | default parameter swallows the interesting input | #2506 |
| 4 | stub returns a non-promise into `.catch` | #2522 |
| 5 | harness lets a real agent path run past the assertion (exit 1, all green) | #2522 |
| 6 | stub returns a non-promise into `.catch` | this |

Six for six. If other units are seeing the same, a shared store-fake helper with promise-returning defaults would cost one PR and remove the whole class.

## Verification

| Check | Result |
|---|---|
| suite | 32/32 |
| 13 triage / planning / self-healing / restart suites | 406/406, clean exit, **no expectation edits** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (309 + 10 + 71) |
| `pnpm check:changesets` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
