### PR TITLE
fix: make Fusion 0.73 multi-node routing reliable

### DIFF
--- a/.changeset/calm-nodes-share.md
+++ b/.changeset/calm-nodes-share.md
@@ -4,4 +4,4 @@
 
 summary: Preserve a shared project identity when registering the same repository on another node.
 category: fix
-dev: POST /api/projects accepts projectId and rejects marker or registry identity conflicts.
+dev: POST /api/projects accepts projectId, rejects identity conflicts, and projectId-only backend boots resolve the registered path.

--- a/.changeset/calm-nodes-share.md
+++ b/.changeset/calm-nodes-share.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Preserve a shared project identity when registering the same repository on another node.
+category: fix
+dev: POST /api/projects accepts projectId and rejects marker or registry identity conflicts.

--- a/.changeset/sharp-pears-route.md
+++ b/.changeset/sharp-pears-route.md
@@ -6,4 +6,4 @@
 
 summary: Assigned work in shared-PostgreSQL deployments now runs only on its selected Fusion node.
 category: fix
-dev: Adds fail-closed `FUSION_NODE_ID` process identity, scheduler ownership gates in both dispatch paths, concrete winner persistence for unpinned work, and executor/continuation defense-in-depth checks.
+dev: Adds fail-closed `FUSION_NODE_ID` process identity, scheduler ownership gates before node-local preflight in both dispatch paths, triage-planner ownership checks, concrete winner persistence for unpinned work, and executor/continuation defense-in-depth checks.

--- a/.changeset/sharp-pears-route.md
+++ b/.changeset/sharp-pears-route.md
@@ -1,0 +1,9 @@
+---
+"@fusion/core": patch
+"@fusion/engine": patch
+"@runfusion/fusion": patch
+---
+
+summary: Assigned work in shared-PostgreSQL deployments now runs only on its selected Fusion node.
+category: fix
+dev: Adds fail-closed `FUSION_NODE_ID` process identity, scheduler ownership gates in both dispatch paths, concrete winner persistence for unpinned work, and executor/continuation defense-in-depth checks.

--- a/docs/multi-project.md
+++ b/docs/multi-project.md
@@ -61,9 +61,10 @@ Legacy SQLite paths (`~/.fusion/fusion-central.db`, `<repo>/.fusion/fusion.db`) 
 1. Provision one Postgres (local Docker, RDS, Supabase, etc.).
 2. On **every** Fusion node: `export DATABASE_URL=...` (same URL). If you use PgBouncer/Supavisor in transaction mode, also set `DATABASE_MIGRATION_URL` to a direct (non-pooled) connection for schema work.
 3. Register projects and nodes so they appear in shared `central.projects` / `central.nodes`.
-4. For each host, set `project_node_path_mappings` so that host’s absolute checkout path is recorded for each project.
-5. Run `fn serve` / the engine on each node. Task IDs and settings are shared via Postgres; checkout exclusivity uses `task_claims`; abandoned-owner recovery uses `MeshLeaseManager`.
-6. Keep provider credentials (`auth.json`) in mind: they are still file-local unless you use auth-sync. Task filesystem blobs under `.fusion/tasks/{ID}/` remain on the node that materializes them until a later blob strategy.
+4. On every process, set `FUSION_NODE_ID` to that host's exact registered node ID. Startup fails when the configured ID does not exist; this prevents one process from silently executing another node's assigned work.
+5. For each host, set `project_node_path_mappings` so that host’s absolute checkout path is recorded for each project.
+6. Run `fn serve` / the engine on each node. Task IDs and settings are shared via Postgres; checkout exclusivity uses `task_claims`; abandoned-owner recovery uses `MeshLeaseManager`.
+7. Keep provider credentials (`auth.json`) in mind: they are still file-local unless you use auth-sync. Task filesystem blobs under `.fusion/tasks/{ID}/` remain on the node that materializes them until a later blob strategy.
 
 What is **not** multi-node via shared DB alone:
 

--- a/docs/shared-mesh-protocol.md
+++ b/docs/shared-mesh-protocol.md
@@ -127,8 +127,9 @@ Short form:
 
 1. Same external `DATABASE_URL` on every node.
 2. Register nodes/projects + path mappings per host.
-3. Run engines; claims enforce exclusive execution.
-4. Expect worktrees/auth/blobs to remain node-local unless you opt into auth-sync or a future blob store.
+3. Set each process's `FUSION_NODE_ID` to its exact registered node ID.
+4. Run engines; node-aware scheduler gates and claims enforce exclusive execution.
+5. Expect worktrees/auth/blobs to remain node-local unless you opt into auth-sync or a future blob store.
 
 ## 10. Historical note
 

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -2826,8 +2826,7 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
     //
     if (centralCoreForMesh) {
       try {
-        const nodes = await centralCoreForMesh.listNodes();
-        const localNode = nodes.find((node) => node.type === "local");
+        const localNode = await centralCoreForMesh.getRuntimeNode();
         if (localNode) {
           localNodeIdForMesh = localNode.id;
           await centralCoreForMesh.updateNode(localNode.id, { status: "online" });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1135,8 +1135,7 @@ export async function runServe(
 
   try {
     if (centralCore) {
-      const nodes = await centralCore.listNodes();
-      const localNode = nodes.find((node) => node.type === "local");
+      const localNode = await centralCore.getRuntimeNode();
       if (localNode) {
         localNodeId = localNode.id;
         await centralCore.updateNode(localNode.id, { status: "online" });

--- a/packages/core/src/__tests__/postgres/startup-project-root-resolution.test.ts
+++ b/packages/core/src/__tests__/postgres/startup-project-root-resolution.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveProjectRootForBackend } from "../../postgres/startup-factory.js";
+
+function migrationDb(rows: Array<{ path: string }> = []) {
+  return {
+    execute: vi.fn(async () => rows),
+  };
+}
+
+describe("startup-factory projectId-only root resolution", () => {
+  it("resolves a registered project path before constructing a projectId-bound store", async () => {
+    const db = migrationDb([{ path: "C:\\BESA\\besa-suite" }]);
+
+    await expect(resolveProjectRootForBackend(
+      db as never,
+      "",
+      "proj_f2c9d44f12524e93",
+    )).resolves.toBe("C:\\BESA\\besa-suite");
+    expect(db.execute).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an explicit root authoritative without consulting the registry", async () => {
+    const db = migrationDb([{ path: "C:\\wrong" }]);
+
+    await expect(resolveProjectRootForBackend(
+      db as never,
+      "C:\\BESA\\explicit",
+      "proj_f2c9d44f12524e93",
+    )).resolves.toBe("C:\\BESA\\explicit");
+    expect(db.execute).not.toHaveBeenCalled();
+  });
+
+  it("preserves the existing not-found path when the id is not registered", async () => {
+    const db = migrationDb();
+
+    await expect(resolveProjectRootForBackend(
+      db as never,
+      "",
+      "proj_ffffffffffffffff",
+    )).resolves.toBe("");
+  });
+});

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -396,6 +396,18 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   }
 
   /**
+   * Resolve the node represented by this process.
+   *
+   * FUSION_NODE_ID provides deterministic identity when multiple processes
+   * share one PostgreSQL control plane. Without it, the historical first-local
+   * node behavior remains available for single-node installations.
+   */
+  async getRuntimeNode(): Promise<NodeConfig | undefined> {
+    this.ensureInitialized();
+    return this.getLocalNode();
+  }
+
+  /**
    * Check if the central infrastructure is initialized.
    */
   isInitialized(): boolean {
@@ -2327,7 +2339,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
       return this.nodeDiscovery;
     }
 
-    const localNode = (await this.listNodes()).find((node) => node.type === "local");
+    const localNode = await this.getLocalNode();
     if (!localNode) {
       throw new Error("Local node not found");
     }
@@ -3614,6 +3626,19 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   }
 
   private async getLocalNode(): Promise<NodeConfig | undefined> {
+    const configuredNodeId = process.env.FUSION_NODE_ID?.trim();
+    if (configuredNodeId) {
+      const configuredNode = this.backendMode
+        ? await asyncCentralCore.getNode(this.backendHandle, configuredNodeId)
+        : await this.getNode(configuredNodeId);
+      if (!configuredNode) {
+        throw new Error(
+          `Configured Fusion runtime node not found: FUSION_NODE_ID=${configuredNodeId}`,
+        );
+      }
+      return configuredNode;
+    }
+
     if (this.backendMode) {
       return asyncCentralCore.getLocalNode(this.backendHandle);
     }

--- a/packages/core/src/postgres/migration-stamping.ts
+++ b/packages/core/src/postgres/migration-stamping.ts
@@ -491,3 +491,26 @@ export async function lookupRegisteredProjectIdByPath(
     return undefined;
   }
 }
+
+/**
+ * Resolve the filesystem path that belongs to a central-registry project id.
+ *
+ * Project-id-only backend boots need the path before constructing TaskStore:
+ * the path anchors filesystem state while the id remains the PostgreSQL
+ * partition key. Lookup failures intentionally preserve the existing
+ * not-found behavior in the caller.
+ */
+export async function lookupRegisteredProjectPathById(
+  db: MigrationDb,
+  projectId: string,
+): Promise<string | undefined> {
+  if (!projectId) return undefined;
+  try {
+    const rows = (await db.execute(
+      sql`SELECT path FROM central.projects WHERE id = ${projectId} LIMIT 1`,
+    )) as Array<{ path: string }>;
+    return rows[0]?.path;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/postgres/startup-factory.ts
+++ b/packages/core/src/postgres/startup-factory.ts
@@ -66,6 +66,7 @@ import {
 import { runLoadedPluginSchemaInitHooks, type LoadedPluginSchemaContract } from "./plugin-schema-hook.js";
 import {
   lookupRegisteredProjectIdByPath,
+  lookupRegisteredProjectPathById,
   ProjectPartitionRekeyError,
   rekeyFallbackProjectPartition,
   selectDegradedBindTarget,
@@ -785,6 +786,21 @@ export function shouldUsePostgresBackend(
 }
 
 /**
+ * Resolve the filesystem anchor for a backend boot without weakening the
+ * project id's role as the PostgreSQL partition key.
+ */
+export async function resolveProjectRootForBackend(
+  db: PostgresJsDatabase<Record<string, never>>,
+  explicitRootDir: string,
+  projectId?: string,
+): Promise<string> {
+  if (explicitRootDir || !projectId) {
+    return explicitRootDir;
+  }
+  return (await lookupRegisteredProjectPathById(db, projectId)) ?? "";
+}
+
+/**
  * Construct a PostgreSQL-backed TaskStore for the current environment.
  *
  * FNXC:BackendFlip 2026-06-26-14:20:
@@ -840,7 +856,7 @@ export async function createTaskStoreForBackend(
       "createTaskStoreForBackend: rootDir is required when projectId is not provided",
     );
   }
-  const rootDir = options.rootDir ?? "";
+  let rootDir = options.rootDir ?? "";
 
   /*
   FNXC:FasterStartup 2026-07-14-23:55:
@@ -877,6 +893,12 @@ export async function createTaskStoreForBackend(
     embeddedRuntimeUrl,
     embeddedOwnsProcess,
   } = boot;
+
+  rootDir = await resolveProjectRootForBackend(
+    connections.migration,
+    rootDir,
+    options.projectId,
+  );
 
   /*
   FNXC:PostgresMigration 2026-07-10:
@@ -1240,7 +1262,7 @@ export async function createTaskStoreForBackend(
   let taskStore: TaskStore;
   try {
     const constructT0 = Date.now();
-    if (options.projectId && !options.rootDir) {
+    if (options.projectId && !rootDir) {
       taskStore = await TaskStore.getOrCreateForProject(
         options.projectId,
         undefined,

--- a/packages/dashboard/app/api/projects.ts
+++ b/packages/dashboard/app/api/projects.ts
@@ -124,6 +124,8 @@ export interface ActivityFeedEntry {
 export interface ProjectCreateInput {
   name: string;
   path: string;
+  /** Preserve a shared project identity when registering the same repository on another node. */
+  projectId?: string;
   isolationMode?: "in-process" | "child-process";
   nodeId?: string;
   gitSetupMode?: "existing" | "init" | "clone";

--- a/packages/dashboard/src/routes/__tests__/project-registration-identity-route.test.ts
+++ b/packages/dashboard/src/routes/__tests__/project-registration-identity-route.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+
+import express from "express";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeProjectIdentity } from "@fusion/core";
+import { request } from "../../test-request.js";
+import { registerProjectRoutes } from "../register-project-routes.js";
+
+vi.mock("../../project-store-resolver.js", () => ({
+  getOrCreateProjectStore: vi.fn().mockRejectedValue(new Error("not needed by this route test")),
+  evictProjectStore: vi.fn(),
+}));
+
+const temporaryRoots: string[] = [];
+
+function createProjectRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "fusion-project-identity-route-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function appFor(options?: { registeredProjectId?: string }) {
+  const ensureProjectForPath = vi.fn(async (input: {
+    path: string;
+    name: string;
+    identity?: { id: string; createdAt: string };
+  }) => {
+    const now = "2026-07-29T12:00:00.000Z";
+    return {
+      project: {
+        id: options?.registeredProjectId ?? input.identity?.id ?? "proj_aaaaaaaaaaaaaaaa",
+        name: input.name,
+        path: input.path,
+        status: "initializing" as const,
+        isolationMode: "in-process" as const,
+        createdAt: now,
+        updatedAt: now,
+        lastActivityAt: now,
+      },
+      reattached: Boolean(input.identity),
+      outcome: "existing" as const,
+    };
+  });
+  const updateProject = vi.fn(async (id: string) => {
+    const ensured = ensureProjectForPath.mock.results.at(-1)?.value;
+    const result = ensured ? await ensured : undefined;
+    return { ...result?.project, id, status: "active" as const };
+  });
+
+  const router = express.Router();
+  registerProjectRoutes({
+    router,
+    options: {
+      centralCore: {
+        ensureProjectForPath,
+        updateProject,
+        isInitialized: () => true,
+      },
+    },
+    runtimeLogger: {
+      warn: vi.fn(),
+      child: () => ({ warn: vi.fn() }),
+    },
+    prioritizeProjectsForCurrentDirectory: vi.fn((projects) => projects),
+    rethrowAsApiError: (error: unknown) => {
+      throw error;
+    },
+  } as never);
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api", router);
+  app.use((
+    error: { statusCode?: number; status?: number; message?: string; details?: unknown },
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    res.status(error.statusCode ?? error.status ?? 500).json({
+      error: error.message,
+      details: error.details,
+    });
+  });
+
+  return { app, ensureProjectForPath };
+}
+
+async function register(app: express.Express, path: string, projectId: string) {
+  return request(
+    app,
+    "POST",
+    "/api/projects",
+    JSON.stringify({ name: "besa-suite", path, projectId, skipGitInit: true }),
+    { "content-type": "application/json" },
+  );
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("project registration identity contract", () => {
+  const sharedProjectId = "proj_f2c9d44f12524e93";
+
+  it("registers an unmarked remote path with the explicitly requested shared project id", async () => {
+    const root = createProjectRoot();
+    const { app, ensureProjectForPath } = appFor();
+
+    const response = await register(app, root, sharedProjectId);
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toBe(sharedProjectId);
+    expect(ensureProjectForPath).toHaveBeenCalledWith(expect.objectContaining({
+      path: root,
+      identity: expect.objectContaining({ id: sharedProjectId }),
+    }));
+  });
+
+  it("accepts a requested id that matches the on-disk identity", async () => {
+    const root = createProjectRoot();
+    const fusionDir = join(root, ".fusion");
+    mkdirSync(fusionDir, { recursive: true });
+    writeProjectIdentity(fusionDir, {
+      id: sharedProjectId,
+      createdAt: "2026-07-29T11:00:00.000Z",
+    });
+    const { app, ensureProjectForPath } = appFor();
+
+    const response = await register(app, root, sharedProjectId);
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toBe(sharedProjectId);
+    expect(ensureProjectForPath).toHaveBeenCalledWith(expect.objectContaining({
+      identity: expect.objectContaining({ id: sharedProjectId }),
+    }));
+  });
+
+  it("rejects a requested id that conflicts with the on-disk identity", async () => {
+    const root = createProjectRoot();
+    const fusionDir = join(root, ".fusion");
+    mkdirSync(fusionDir, { recursive: true });
+    writeProjectIdentity(fusionDir, {
+      id: "proj_1111111111111111",
+      createdAt: "2026-07-29T11:00:00.000Z",
+    });
+    const { app, ensureProjectForPath } = appFor();
+
+    const response = await register(app, root, sharedProjectId);
+
+    expect(response.status).toBe(409);
+    expect(ensureProjectForPath).not.toHaveBeenCalled();
+  });
+
+  it("rejects a registry result that silently maps the path to another id", async () => {
+    const root = createProjectRoot();
+    const { app } = appFor({ registeredProjectId: "proj_2222222222222222" });
+
+    const response = await register(app, root, sharedProjectId);
+
+    expect(response.status).toBe(409);
+  });
+
+  it("rejects malformed requested project ids before registry access", async () => {
+    const root = createProjectRoot();
+    const { app, ensureProjectForPath } = appFor();
+
+    const response = await register(app, root, "not-a-project-id");
+
+    expect(response.status).toBe(400);
+    expect(ensureProjectForPath).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/routes/__tests__/register-task-workflow-routes.move-bypassguards.test.ts
+++ b/packages/dashboard/src/routes/__tests__/register-task-workflow-routes.move-bypassguards.test.ts
@@ -26,6 +26,10 @@ describe("task move route — bypassGuards is not forwardable", () => {
       getRootDir: vi.fn(() => process.cwd()),
       getTask: vi.fn(async () => ({ id: "FN-001", column: "todo" })),
       getSettings: vi.fn(async () => ({})),
+      getPluginStore: vi.fn(() => ({
+        init: vi.fn(async () => undefined),
+        listPlugins: vi.fn(async () => []),
+      })),
       moveTask,
     } as unknown as TaskStore;
 
@@ -41,12 +45,95 @@ describe("task move route — bypassGuards is not forwardable", () => {
       { "content-type": "application/json" },
     );
 
-    expect(res.status).toBe(200);
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(moveTask).toHaveBeenCalledTimes(1);
     const passedOptions = moveTask.mock.calls[0][2] as Record<string, unknown> | undefined;
     // The route constructs its own options; the injected fields must not leak.
     expect(passedOptions?.bypassGuards).toBeUndefined();
     // The route hardcodes moveSource: "user" — the body's "engine" is ignored.
     expect(passedOptions?.moveSource).toBe("user");
+  });
+
+  it("does not allocate the dashboard host worktree for a node-pinned task", async () => {
+    const moveTask = vi.fn(async (_id: string, column: string, _options?: Record<string, unknown>) => ({
+      id: "FN-002",
+      column,
+      nodeId: "node-pc3",
+      dependencies: [],
+      steps: [],
+      currentStep: 0,
+    }));
+
+    const store: TaskStore = {
+      getRootDir: vi.fn(() => "/workspace"),
+      getTask: vi.fn(async () => ({
+        id: "FN-002",
+        column: "todo",
+        nodeId: "node-pc3",
+      })),
+      getSettings: vi.fn(async () => ({})),
+      getPluginStore: vi.fn(() => ({
+        init: vi.fn(async () => undefined),
+        listPlugins: vi.fn(async () => []),
+      })),
+      moveTask,
+    } as unknown as TaskStore;
+
+    const app = express();
+    app.use(express.json());
+    app.use("/api", createApiRoutes(store));
+
+    const res = await REQUEST(
+      app,
+      "POST",
+      "/api/tasks/FN-002/move",
+      JSON.stringify({ column: "in-progress" }),
+      { "content-type": "application/json" },
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(moveTask).toHaveBeenCalledTimes(1);
+    const passedOptions = moveTask.mock.calls[0][2] as Record<string, unknown> | undefined;
+    expect(passedOptions?.allocateWorktree).toBeUndefined();
+  });
+
+  it("does not allocate the dashboard host worktree for a project-default node", async () => {
+    const moveTask = vi.fn(async (_id: string, column: string, _options?: Record<string, unknown>) => ({
+      id: "FN-003",
+      column,
+      dependencies: [],
+      steps: [],
+      currentStep: 0,
+    }));
+
+    const store: TaskStore = {
+      getRootDir: vi.fn(() => "/workspace"),
+      getTask: vi.fn(async () => ({
+        id: "FN-003",
+        column: "todo",
+      })),
+      getSettings: vi.fn(async () => ({ defaultNodeId: "node-pc3" })),
+      getPluginStore: vi.fn(() => ({
+        init: vi.fn(async () => undefined),
+        listPlugins: vi.fn(async () => []),
+      })),
+      moveTask,
+    } as unknown as TaskStore;
+
+    const app = express();
+    app.use(express.json());
+    app.use("/api", createApiRoutes(store));
+
+    const res = await REQUEST(
+      app,
+      "POST",
+      "/api/tasks/FN-003/move",
+      JSON.stringify({ column: "in-progress" }),
+      { "content-type": "application/json" },
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const passedOptions = moveTask.mock.calls[0][2] as Record<string, unknown> | undefined;
+    expect(passedOptions?.allocateWorktree).toBeUndefined();
   });
 });

--- a/packages/dashboard/src/routes/register-project-routes.ts
+++ b/packages/dashboard/src/routes/register-project-routes.ts
@@ -256,6 +256,7 @@ export const registerProjectRoutes: ApiRouteRegistrar = (ctx) => {
    *   path: string,
    *   isolationMode?: "in-process" | "child-process",
    *   nodeId?: string,
+   *   projectId?: string,
    *   gitSetupMode?: "existing" | "init" | "clone",
    *   cloneUrl?: string,
    *   workspaceMode?: boolean,
@@ -265,7 +266,17 @@ export const registerProjectRoutes: ApiRouteRegistrar = (ctx) => {
    */
   router.post("/projects", async (req, res) => {
     try {
-      const { name, path, isolationMode = "in-process", nodeId, cloneUrl, gitSetupMode, workspaceMode, taskPrefix } = req.body;
+      const {
+        name,
+        path,
+        isolationMode = "in-process",
+        nodeId,
+        projectId,
+        cloneUrl,
+        gitSetupMode,
+        workspaceMode,
+        taskPrefix,
+      } = req.body;
 
       if (!name || typeof name !== "string" || !name.trim()) {
         throw badRequest("name is required and must be a non-empty string");
@@ -276,9 +287,16 @@ export const registerProjectRoutes: ApiRouteRegistrar = (ctx) => {
       if (!["in-process", "child-process"].includes(isolationMode)) {
         throw badRequest("isolationMode must be 'in-process' or 'child-process'");
       }
+      if (projectId !== undefined && (
+        typeof projectId !== "string"
+        || !/^proj_[a-f0-9]{16}$/.test(projectId)
+      )) {
+        throw badRequest("projectId must use the format 'proj_' followed by 16 lowercase hexadecimal characters");
+      }
 
       const normalizedName = name.trim();
       const normalizedPath = path.trim();
+      const requestedProjectId = projectId as string | undefined;
       let normalizedCloneUrl: string | undefined;
       let normalizedGitSetupMode: "existing" | "init" | "clone" | undefined;
 
@@ -434,16 +452,31 @@ export const registerProjectRoutes: ApiRouteRegistrar = (ctx) => {
       }
 
       const activeProjectWithOutcome = await withCentralCore(async (central) => {
-        const identity = readProjectIdentity(fusionDirPath);
+        const storedIdentity = readProjectIdentity(fusionDirPath);
+        if (requestedProjectId && storedIdentity && storedIdentity.id !== requestedProjectId) {
+          throw new ApiError(409, "project-identity-mismatch", {
+            requestedProjectId,
+            storedProjectId: storedIdentity.id,
+          });
+        }
+        const identity = storedIdentity ?? (requestedProjectId
+          ? { id: requestedProjectId, createdAt: new Date().toISOString() }
+          : undefined);
         const ensured = await central.ensureProjectForPath({
           path: normalizedPath,
-          identity: identity ?? undefined,
+          identity,
           name: normalizedName,
           isolationMode,
           nodeId,
           skipGitInit,
         });
         const project = ensured.project;
+        if (requestedProjectId && project.id !== requestedProjectId) {
+          throw new ApiError(409, "project-registry-identity-mismatch", {
+            requestedProjectId,
+            registeredProjectId: project.id,
+          });
+        }
 
         // Activate the project (registration sets it to 'initializing')
         const activeProject = await central.updateProject(project.id, { status: "active" });

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -1731,9 +1731,24 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
         const existing = await scopedStore.getTask(req.params.id);
         if (existing) {
           const settings = await scopedStore.getSettings();
-          const rootDir = scopedStore.getRootDir();
-          allocateWorktree = (reservedNames) =>
-            planTaskWorktreePath(existing, rootDir, settings.worktreeNaming, reservedNames, settings);
+          /*
+          FNXC:MultiNodeRouting 2026-07-28-23:55:
+          A dashboard API request can originate on the VPS while the task is
+          pinned to a Windows worker. Reserving with the dashboard store's
+          rootDir in that case persisted `/workspace/.worktrees/...` into the
+          shared task row, so the remote executor inherited a path that only
+          exists on the VPS. For any explicit task or project node route, leave
+          allocation to the gated executor on the owning node. Legacy unpinned
+          single-host moves keep the existing transaction-locked reservation.
+          */
+          const hasNodeRoute = [existing.nodeId, settings.defaultNodeId].some(
+            (nodeId) => typeof nodeId === "string" && nodeId.trim().length > 0,
+          );
+          if (!hasNodeRoute) {
+            const rootDir = scopedStore.getRootDir();
+            allocateWorktree = (reservedNames) =>
+              planTaskWorktreePath(existing, rootDir, settings.worktreeNaming, reservedNames, settings);
+          }
         }
       }
 

--- a/packages/engine/src/__tests__/effective-node.test.ts
+++ b/packages/engine/src/__tests__/effective-node.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveEffectiveNode } from "../effective-node.js";
+import {
+  canDispatchEffectiveNode,
+  canExecuteTaskOnNode,
+  materializeExecutionNodeId,
+  resolveEffectiveNode,
+} from "../effective-node.js";
 
 describe("resolveEffectiveNode", () => {
   it.each([
@@ -62,5 +67,44 @@ describe("resolveEffectiveNode", () => {
       nodeId: "node-task",
       source: "task-override",
     });
+  });
+});
+
+describe("multi-node dispatch ownership", () => {
+  const assigned = { nodeId: "node-pc1", source: "task-override" as const };
+  const unpinned = { nodeId: undefined, source: "local" as const };
+
+  it("allows only the matching identified process to dispatch assigned work", () => {
+    expect(canDispatchEffectiveNode(assigned, "node-pc1")).toBe(true);
+    expect(canDispatchEffectiveNode(assigned, "node-vps")).toBe(false);
+  });
+
+  it("preserves legacy behavior when the process has no configured identity", () => {
+    expect(canDispatchEffectiveNode(assigned, undefined)).toBe(true);
+  });
+
+  it("allows unpinned work on any identified process and materializes the winner", () => {
+    expect(canDispatchEffectiveNode(unpinned, "node-pc1")).toBe(true);
+    expect(materializeExecutionNodeId(unpinned, "node-pc1")).toBe("node-pc1");
+  });
+
+  it("keeps an explicit assignment when persisting the execution node", () => {
+    expect(materializeExecutionNodeId(assigned, "node-vps")).toBe("node-pc1");
+    expect(materializeExecutionNodeId(unpinned, undefined)).toBeNull();
+  });
+
+  it("rejects event execution when persisted ownership belongs to another node", () => {
+    expect(
+      canExecuteTaskOnNode(
+        { nodeId: "node-pc1", effectiveNodeId: "node-pc1" },
+        "node-vps",
+      ),
+    ).toBe(false);
+    expect(
+      canExecuteTaskOnNode(
+        { nodeId: undefined, effectiveNodeId: "node-pc1" },
+        "node-pc1",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/engine/src/__tests__/executor-prompt.test.ts
+++ b/packages/engine/src/__tests__/executor-prompt.test.ts
@@ -1025,6 +1025,84 @@ describe("TaskExecutor pause behavior", () => {
     expect(store.logEntry).toHaveBeenCalledWith("FN-001", "Resuming execution after unpause", undefined, undefined);
   });
 
+  it("does not resume a foreign-node task when the update event omits its node binding", async () => {
+    const store = createMockStore();
+    store.getTask.mockResolvedValue({
+      id: "FN-001",
+      paused: undefined,
+      column: "in-progress",
+      nodeId: "node-pc3",
+      description: "Remote task",
+      title: "Remote task",
+      dependencies: [],
+      steps: [],
+      currentStep: 0,
+      log: [],
+      prompt: "# test\n## Steps\n### Step 0: Preflight\n- [ ] check",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    mockedCreateFnAgent.mockImplementation(async () => ({
+      session: {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        dispose: vi.fn(),
+      },
+    }) as any);
+
+    new TaskExecutor(store, "/tmp/test", {
+      getLocalNodeId: () => "node-pc1",
+    });
+
+    store._trigger("task:updated", {
+      id: "FN-001",
+      paused: undefined,
+      column: "in-progress",
+      description: "Remote task",
+      title: "Remote task",
+      dependencies: [],
+      steps: [],
+      currentStep: 0,
+      log: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(store.getTask).toHaveBeenCalledWith("FN-001");
+    expect(mockedCreateFnAgent).not.toHaveBeenCalled();
+    expect(store.logEntry).not.toHaveBeenCalledWith(
+      "FN-001",
+      "Resuming execution after unpause",
+      undefined,
+      undefined,
+    );
+  });
+
+  it("does not execute a foreign-node task when the move event omits its node binding", async () => {
+    const store = createMockStore();
+    store.getTask.mockResolvedValue(createMockTaskDetail({
+      nodeId: "node-pc3",
+    }));
+    const executor = new TaskExecutor(store, "/tmp/test", {
+      getLocalNodeId: () => "node-pc1",
+    });
+    const executeSpy = vi.spyOn(executor, "execute").mockResolvedValue(undefined);
+
+    store._trigger("task:moved", {
+      task: createMockTaskDetail({ nodeId: undefined }),
+      from: "todo",
+      to: "in-progress",
+      source: "user",
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(store.getTask).toHaveBeenCalledWith("FN-001");
+    expect(executeSpy).not.toHaveBeenCalled();
+  });
+
   it("does not resume unpaused in-progress task while global pause is active", async () => {
     const store = createMockStore();
     store.getSettings.mockResolvedValue({

--- a/packages/engine/src/__tests__/executor-prompt.test.ts
+++ b/packages/engine/src/__tests__/executor-prompt.test.ts
@@ -1103,6 +1103,26 @@ describe("TaskExecutor pause behavior", () => {
     expect(executeSpy).not.toHaveBeenCalled();
   });
 
+  it("does not enter the workflow graph when direct dispatch targets a foreign node", async () => {
+    const store = createMockStore();
+    const remoteTask = createMockTaskDetail({
+      column: "in-progress",
+      nodeId: "node-pc3",
+      effectiveNodeId: "node-pc3",
+    });
+    store.getTask.mockResolvedValue(remoteTask);
+    const executor = new TaskExecutor(store, "/tmp/test", {
+      getLocalNodeId: () => "node-pc1",
+    });
+
+    await executor.execute(remoteTask);
+
+    expect(store.getTask).toHaveBeenCalledWith("FN-001");
+    expect(store.getSettings).not.toHaveBeenCalled();
+    expect(store.updateTask).not.toHaveBeenCalled();
+    expect(mockedCreateFnAgent).not.toHaveBeenCalled();
+  });
+
   it("does not resume unpaused in-progress task while global pause is active", async () => {
     const store = createMockStore();
     store.getSettings.mockResolvedValue({

--- a/packages/engine/src/__tests__/executor-worktree.test.ts
+++ b/packages/engine/src/__tests__/executor-worktree.test.ts
@@ -2327,6 +2327,51 @@ describe("TaskExecutor dependency-based worktree creation", () => {
     expect(worktreeAddCalls[0][0]).toContain('"codex/erp-mvp-foundation"');
   });
 
+  it("does not reinterpret an explicit task baseBranch as a dependency squash import", async () => {
+    const store = createMockStore();
+    store._setRow("BESA-BASE", {
+      baseBranch: "codex/erp-mvp-foundation",
+      executionStartBranch: null,
+    });
+    store.getSettings.mockResolvedValue({
+      worktreeRebaseBeforeMerge: false,
+    } as any);
+    const executor = new TaskExecutor(store, "/tmp/test");
+    const resolvedBase = "95e8ef22e00e229e2591d445ccf6b6c72f2e89a5";
+    const ambientRootHead = "5dd2ff03e7befd8e9a6d767fd32b1233817e2422";
+    vi.spyOn(executor as any, "resolveWorktreeStartPoint").mockResolvedValue(resolvedBase);
+    const createSpy = vi.spyOn(executor as any, "tryCreateWorktree").mockResolvedValue({
+      path: "/tmp/test/.worktrees/besa-base",
+      branch: "fusion/besa-base",
+    });
+    vi.spyOn(executor as any, "rebaseNewWorktreeOntoRemote").mockResolvedValue(undefined);
+    mockedExecSync.mockImplementation((cmd: any) => {
+      if (String(cmd).includes("git rev-parse HEAD")) return Buffer.from(ambientRootHead);
+      if (String(cmd).includes("git merge-base --is-ancestor")) {
+        throw new Error("not an ancestor");
+      }
+      return Buffer.from("");
+    });
+
+    await (executor as any).createWorktree(
+      "fusion/besa-base",
+      "/tmp/test/.worktrees/besa-base",
+      "BESA-BASE",
+      "codex/erp-mvp-foundation",
+    );
+
+    expect(createSpy).toHaveBeenCalledWith(
+      "fusion/besa-base",
+      "/tmp/test/.worktrees/besa-base",
+      "BESA-BASE",
+      resolvedBase,
+      0,
+      0,
+      false,
+      expect.any(Object),
+    );
+  });
+
   it("creates worktree from integration branch when baseBranch is not set", async () => {
     const store = createMockStore();
     const executor = new TaskExecutor(store, "/tmp/test");

--- a/packages/engine/src/__tests__/executor-worktree.test.ts
+++ b/packages/engine/src/__tests__/executor-worktree.test.ts
@@ -1785,6 +1785,98 @@ describe("TaskExecutor worktree recovery", () => {
     );
   });
 
+  it("fast-forwards a reused branch that is strictly behind the requested start point", async () => {
+    const store = createMockStore();
+    mockedExistsSync.mockReturnValue(false);
+
+    mockedExecSync.mockImplementation((cmd: string | string[]) => {
+      const command = typeof cmd === "string" ? cmd : cmd[0];
+      if (command.includes('git worktree add -b "fusion/fn-050"')) {
+        const error: any = new Error("fatal: a branch named 'fusion/fn-050' already exists");
+        error.stderr = Buffer.from("fatal: a branch named 'fusion/fn-050' already exists");
+        throw error;
+      }
+      if (command.includes('git rev-parse --verify "fusion/fn-050^{commit}"')) {
+        return Buffer.from("1111111111111111111111111111111111111111\n");
+      }
+      if (command.includes('git rev-parse --verify "2222222222222222222222222222222222222222^{commit}"')) {
+        return Buffer.from("2222222222222222222222222222222222222222\n");
+      }
+      return Buffer.from("");
+    });
+
+    const executor = new TaskExecutor(store, "/tmp/test");
+    const result = await (executor as any).tryCreateWorktree(
+      "fusion/fn-050",
+      "/tmp/test/.worktrees/swift-falcon",
+      "FN-050",
+      "2222222222222222222222222222222222222222",
+      0,
+      0,
+      false,
+      {},
+    );
+
+    expect(result).toEqual({
+      path: "/tmp/test/.worktrees/swift-falcon",
+      branch: "fusion/fn-050",
+    });
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      "git branch -f 'fusion/fn-050' '2222222222222222222222222222222222222222'",
+      expect.any(Object),
+    );
+    expect(store.logEntry).toHaveBeenCalledWith(
+      "FN-050",
+      expect.stringContaining("Fast-forwarded stale existing branch fusion/fn-050"),
+      expect.stringContaining("1111111 -> 2222222"),
+    );
+  });
+
+  it("preserves a reused branch when it is not an ancestor of the requested start point", async () => {
+    const store = createMockStore();
+    mockedExistsSync.mockReturnValue(false);
+
+    mockedExecSync.mockImplementation((cmd: string | string[]) => {
+      const command = typeof cmd === "string" ? cmd : cmd[0];
+      if (command.includes('git worktree add -b "fusion/fn-050"')) {
+        const error: any = new Error("fatal: a branch named 'fusion/fn-050' already exists");
+        error.stderr = Buffer.from("fatal: a branch named 'fusion/fn-050' already exists");
+        throw error;
+      }
+      if (command.includes('git rev-parse --verify "fusion/fn-050^{commit}"')) {
+        return Buffer.from("3333333333333333333333333333333333333333\n");
+      }
+      if (command.includes('git rev-parse --verify "2222222222222222222222222222222222222222^{commit}"')) {
+        return Buffer.from("2222222222222222222222222222222222222222\n");
+      }
+      if (command.includes("git merge-base --is-ancestor")) {
+        const error: any = new Error("not an ancestor");
+        error.status = 1;
+        throw error;
+      }
+      return Buffer.from("");
+    });
+
+    const executor = new TaskExecutor(store, "/tmp/test");
+    await (executor as any).tryCreateWorktree(
+      "fusion/fn-050",
+      "/tmp/test/.worktrees/swift-falcon",
+      "FN-050",
+      "2222222222222222222222222222222222222222",
+      0,
+      0,
+      false,
+      {},
+    );
+
+    expect(mockedExecSync.mock.calls.some(([command]) => String(command).startsWith("git branch -f "))).toBe(false);
+    expect(store.logEntry).not.toHaveBeenCalledWith(
+      "FN-050",
+      expect.stringContaining("Fast-forwarded stale existing branch"),
+      expect.anything(),
+    );
+  });
+
   it("runs git worktree prune before branch deletion for stale references", async () => {
     const store = createMockStore();
     let callCount = 0;

--- a/packages/engine/src/__tests__/executor-worktree.test.ts
+++ b/packages/engine/src/__tests__/executor-worktree.test.ts
@@ -2283,7 +2283,7 @@ describe("TaskExecutor dependency-based worktree creation", () => {
     } as any);
   });
 
-  it("creates worktree from baseBranch when set on task", async () => {
+  it("creates worktree from executionStartBranch when set on task", async () => {
     const store = createMockStore();
     const executor = new TaskExecutor(store, "/tmp/test");
 
@@ -2305,6 +2305,26 @@ describe("TaskExecutor dependency-based worktree creation", () => {
     );
     expect(worktreeAddCalls.length).toBeGreaterThan(0);
     expect(worktreeAddCalls[0][0]).toContain("fusion/fn-059");
+  });
+
+  it("creates a fresh worktree from the task's explicit baseBranch when executionStartBranch is absent", async () => {
+    const store = createMockStore();
+    const executor = new TaskExecutor(store, "/tmp/test");
+
+    store._setRow("FN-060B", {
+      baseBranch: "codex/erp-mvp-foundation",
+      executionStartBranch: null,
+    });
+    await executor.execute(makeTask({
+      id: "FN-060B",
+      baseBranch: "codex/erp-mvp-foundation",
+    }));
+
+    const worktreeAddCalls = mockedExecSync.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("worktree add -b"),
+    );
+    expect(worktreeAddCalls.length).toBeGreaterThan(0);
+    expect(worktreeAddCalls[0][0]).toContain('"codex/erp-mvp-foundation"');
   });
 
   it("creates worktree from integration branch when baseBranch is not set", async () => {

--- a/packages/engine/src/__tests__/notification-service.test.ts
+++ b/packages/engine/src/__tests__/notification-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
+import { TaskDeletedError } from "@fusion/core";
 import type { ChatRoomMessage, Message, NotificationProvider, Settings, Task } from "@fusion/core";
 import { NotificationService } from "../notification/notification-service.js";
 import { NtfyNotificationProvider } from "../notification/ntfy-provider.js";
@@ -1257,6 +1258,30 @@ describe("NotificationService", () => {
 
     expect(claimTaskWedgeNotificationEpisode).not.toHaveBeenCalled();
     expect(sendNotification).not.toHaveBeenCalledWith("task-wedged", expect.anything());
+    await service.stop();
+  });
+
+  it("contains a wedge-episode claim that races task soft-delete", async () => {
+    const store = createStore({ ntfyEnabled: false });
+    const claimTaskWedgeNotificationEpisode = vi
+      .fn()
+      .mockRejectedValue(new TaskDeletedError("BESA-006", "2026-07-28T17:06:14.804Z"));
+    (store as any).claimTaskWedgeNotificationEpisode = claimTaskWedgeNotificationEpisode;
+    const service = new NotificationService(store as any);
+    await service.start();
+
+    store.emit("task:updated", task({
+      id: "BESA-006",
+      column: "in-progress",
+      status: "in-progress",
+    }));
+
+    await vi.waitFor(() => {
+      expect(claimTaskWedgeNotificationEpisode).toHaveBeenCalledWith("BESA-006", null);
+      expect(schedulerLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining("BESA-006 wedge notification skipped"),
+      );
+    });
     await service.stop();
   });
 

--- a/packages/engine/src/__tests__/scheduler-workflow-cutover.test.ts
+++ b/packages/engine/src/__tests__/scheduler-workflow-cutover.test.ts
@@ -207,6 +207,23 @@ describe("Scheduler workflow cutover", () => {
     expect(assignedElsewhere.column).toBe("todo");
   });
 
+  it("does not validate or replan another node's task against the local filesystem", async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    const assignedElsewhere = task({ id: "FN-REMOTE-MISSING", nodeId: "node-pc3" });
+    const store = storeWith([assignedElsewhere]);
+    const scheduler = new Scheduler(store, {
+      localNodeId: "node-vps",
+    });
+    (scheduler as unknown as { running: boolean }).running = true;
+
+    await scheduler.schedule();
+
+    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(store.updateTask).not.toHaveBeenCalled();
+    expect(store.logEntry).not.toHaveBeenCalled();
+    expect(assignedElsewhere.column).toBe("todo");
+  });
+
   it("dispatches matching assigned work and persists the concrete node", async () => {
     const assignedHere = task({ id: "FN-LOCAL", nodeId: "node-pc1" });
     const store = storeWith([assignedHere]);

--- a/packages/engine/src/__tests__/scheduler-workflow-cutover.test.ts
+++ b/packages/engine/src/__tests__/scheduler-workflow-cutover.test.ts
@@ -190,6 +190,50 @@ describe("Scheduler workflow cutover", () => {
     expect(onSchedule).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-100", column: "in-progress" }));
   });
 
+  it("leaves work assigned to another configured node in todo", async () => {
+    const assignedElsewhere = task({ id: "FN-REMOTE", nodeId: "node-pc1" });
+    const store = storeWith([assignedElsewhere]);
+    const onSchedule = vi.fn();
+    const scheduler = new Scheduler(store, {
+      localNodeId: "node-vps",
+      onSchedule,
+    });
+    (scheduler as unknown as { running: boolean }).running = true;
+
+    await scheduler.schedule();
+
+    expect(store.moveTaskIf).not.toHaveBeenCalled();
+    expect(onSchedule).not.toHaveBeenCalled();
+    expect(assignedElsewhere.column).toBe("todo");
+  });
+
+  it("dispatches matching assigned work and persists the concrete node", async () => {
+    const assignedHere = task({ id: "FN-LOCAL", nodeId: "node-pc1" });
+    const store = storeWith([assignedHere]);
+    const onSchedule = vi.fn();
+    const scheduler = new Scheduler(store, {
+      localNodeId: "node-pc1",
+      onSchedule,
+    });
+    (scheduler as unknown as { running: boolean }).running = true;
+
+    await scheduler.schedule();
+
+    expect(store.moveTaskIf).toHaveBeenCalledWith(
+      "FN-LOCAL",
+      "in-progress",
+      expect.any(Function),
+      expect.any(Object),
+    );
+    expect(store.updateTask).toHaveBeenCalledWith(
+      "FN-LOCAL",
+      expect.objectContaining({ effectiveNodeId: "node-pc1" }),
+    );
+    expect(onSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "FN-LOCAL", effectiveNodeId: "node-pc1" }),
+    );
+  });
+
   it("does not dispatch an operator-parked todo task when only userPaused remains true", async () => {
     const parked = task({ id: "FN-PAUSED", paused: false, userPaused: true });
     const store = storeWith([parked]);

--- a/packages/engine/src/__tests__/triage.test.ts
+++ b/packages/engine/src/__tests__/triage.test.ts
@@ -1716,6 +1716,39 @@ Planner rewrote mission without the raw request.
   });
 
   describe("poll ordering", () => {
+    it("does not dispatch planning for a task pinned to another shared-db node", async () => {
+      const tasks: Task[] = [
+        createTriageTask({ id: "FN-FOREIGN-NODE", nodeId: "node-remote" }),
+        createTriageTask({ id: "FN-LOCAL-NODE", nodeId: "node-local" }),
+      ];
+      const triageStore = createMockStore({
+        listTasks: vi.fn().mockResolvedValue(tasks),
+        getSettings: vi.fn().mockResolvedValue({
+          maxConcurrent: 10,
+          maxTriageConcurrent: 10,
+          pollIntervalMs: 10_000,
+          groupOverlappingFiles: false,
+          autoMerge: true,
+        }),
+      });
+      const triageProcessor = new TriageProcessor(
+        triageStore,
+        rootDir,
+        { localNodeId: "node-local" },
+      );
+      const specifySpy = vi
+        .spyOn(triageProcessor, "specifyTask")
+        .mockResolvedValue(undefined);
+
+      (triageProcessor as any).running = true;
+      await (triageProcessor as any).poll();
+
+      expect(specifySpy).toHaveBeenCalledTimes(1);
+      expect(specifySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "FN-LOCAL-NODE" }),
+      );
+    });
+
     it("dispatches eligible triage tasks by createdAt asc", async () => {
       const tasks: Task[] = [
         createTriageTask({

--- a/packages/engine/src/__tests__/workflow-graph-merge-region-collapse.test.ts
+++ b/packages/engine/src/__tests__/workflow-graph-merge-region-collapse.test.ts
@@ -130,6 +130,33 @@ describe("WorkflowGraphExecutor merge-region collapse", () => {
     expectNoRawMergeRegionVisits(result.visitedNodeIds);
   });
 
+  it("parks autoMerge:false tasks at the manual hold without invoking the merge seam", async () => {
+    const calls: string[] = [];
+    const prompt = createPrompt({
+      merge: () => {
+        calls.push("merge");
+        return { outcome: "failure" as const, value: "merge-unavailable" };
+      },
+    });
+    const executor = new WorkflowGraphExecutor({ handlers: { prompt } });
+
+    const result = await executor.run(
+      { ...task, autoMerge: false },
+      { ...settings, autoMerge: true },
+      BUILTIN_CODING_WORKFLOW_IR,
+    );
+
+    expect(result.outcome).toBe("success");
+    expect(calls).toEqual([]);
+    expect(result.visitedNodeIds).toEqual([
+      ...SUCCESS_PATH.slice(0, SUCCESS_PATH.indexOf("merge")),
+      "merge-manual-hold",
+    ]);
+    expect(result.context["node:merge-manual-hold:outcome"]).toBe("failure");
+    expect(result.context["node:merge-manual-hold:value"]).toBe("manual-required");
+    expect(result.visitedNodeIds).not.toContain("post-merge-verification");
+  });
+
   it("does not collapse to merge when review fails before the merge-policy region", async () => {
     const calls: string[] = [];
     const prompt = createPrompt({

--- a/packages/engine/src/__tests__/worktree-db-hydrate.test.ts
+++ b/packages/engine/src/__tests__/worktree-db-hydrate.test.ts
@@ -1,28 +1,45 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { hydrateWorktreeDb } from "../worktree-db-hydrate.js";
 
 describe("hydrateWorktreeDb", () => {
-  it("uses shared PostgreSQL storage without reading a worktree-local database", async () => {
+  it("uses shared PostgreSQL storage and mirrors the task prompt into the worktree", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "fusion-worktree-hydrate-"));
+    const rootDir = join(tempDir, "repo");
+    const worktreePath = join(tempDir, "worktree");
+    const sourceTaskDir = join(rootDir, ".fusion", "tasks", "FN-1");
+    await mkdir(sourceTaskDir, { recursive: true });
+    await mkdir(worktreePath, { recursive: true });
+    await writeFile(join(sourceTaskDir, "PROMPT.md"), "# FN-1\n\n### Step 0: Preflight\n", "utf8");
     const getTask = vi.fn();
     const warn = vi.fn();
 
-    const result = await hydrateWorktreeDb({
-      rootDir: "/repo",
-      worktreePath: "/worktrees/FN-1",
-      taskId: "FN-1",
-      store: { getTask },
-      logger: { warn },
-    });
+    try {
+      const result = await hydrateWorktreeDb({
+        rootDir,
+        worktreePath,
+        taskId: "FN-1",
+        store: { getTask },
+        logger: { warn },
+      });
 
-    expect(result).toEqual({
-      tasksCopied: 0,
-      documentsCopied: 0,
-      artifactsCopied: 0,
-      degraded: false,
-      reason: "postgres_shared_store",
-    });
-    expect(getTask).not.toHaveBeenCalled();
-    expect(warn).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        tasksCopied: 0,
+        documentsCopied: 1,
+        artifactsCopied: 0,
+        degraded: false,
+        reason: "postgres_shared_store",
+      });
+      expect(
+        await readFile(join(worktreePath, ".fusion", "tasks", "FN-1", "PROMPT.md"), "utf8"),
+      ).toBe("# FN-1\n\n### Step 0: Preflight\n");
+      expect(getTask).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("classifies the project root without attempting hydration", async () => {
@@ -36,5 +53,32 @@ describe("hydrateWorktreeDb", () => {
 
     expect(result.reason).toBe("root_worktree");
     expect(result.degraded).toBe(false);
+  });
+
+  it("keeps shared storage ready when a task prompt has not been created yet", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "fusion-worktree-hydrate-"));
+    const rootDir = join(tempDir, "repo");
+    const worktreePath = join(tempDir, "worktree");
+    await mkdir(worktreePath, { recursive: true });
+
+    try {
+      const result = await hydrateWorktreeDb({
+        rootDir,
+        worktreePath,
+        taskId: "FN-2",
+        store: { getTask: vi.fn() },
+        logger: { warn: vi.fn() },
+      });
+
+      expect(result).toEqual({
+        tasksCopied: 0,
+        documentsCopied: 0,
+        artifactsCopied: 0,
+        degraded: false,
+        reason: "postgres_shared_store",
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/engine/src/effective-node.ts
+++ b/packages/engine/src/effective-node.ts
@@ -25,3 +25,45 @@ export function resolveEffectiveNode(
 
   return { nodeId: undefined, source: "local" };
 }
+
+/**
+ * Return whether this process may dispatch work for the resolved node.
+ *
+ * An unset local node id preserves the single-process/legacy behavior. Once a
+ * process declares its identity, an explicit task or project node assignment
+ * is fail-closed and only the matching process may move the task to execution.
+ */
+export function canDispatchEffectiveNode(
+  effectiveNode: EffectiveNode,
+  localNodeId: string | undefined,
+): boolean {
+  return !localNodeId || !effectiveNode.nodeId || effectiveNode.nodeId === localNodeId;
+}
+
+/**
+ * Persist the concrete process node for otherwise-unpinned work in a shared
+ * control plane so later workflow continuations remain on the dispatch winner.
+ */
+export function materializeExecutionNodeId(
+  effectiveNode: EffectiveNode,
+  localNodeId: string | undefined,
+): string | null {
+  return effectiveNode.nodeId ?? localNodeId ?? null;
+}
+
+/**
+ * Defense-in-depth gate for event- and continuation-driven execution after the
+ * scheduler has persisted a concrete node. The task override covers the brief
+ * move-event window before post-dispatch metadata is written.
+ */
+export function canExecuteTaskOnNode(
+  task: Pick<Task, "effectiveNodeId" | "nodeId">,
+  localNodeId: string | undefined,
+): boolean {
+  const assignedNodeId = isSetNodeId(task.effectiveNodeId)
+    ? task.effectiveNodeId
+    : isSetNodeId(task.nodeId)
+      ? task.nodeId
+      : undefined;
+  return !localNodeId || !assignedNodeId || assignedNodeId === localNodeId;
+}

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -15,6 +15,7 @@ import { readFile, rm, writeFile } from "node:fs/promises";
 import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings, WorkflowStep, MissionStore, AsyncMissionStore, Slice, AgentState, AgentCapability, RunMutationContext, AgentHeartbeatConfig, Agent, AgentMemoryInclusionMode, ProjectSettings, MergeResult, WorkflowIrNode, WorkflowIrNodeKind, WorkflowStepResult as CoreWorkflowStepResult, ThinkingLevel } from "@fusion/core";
 import { getUnmetSchedulingDependencies } from "./scheduler.js";
 import { RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel } from "@fusion/core";
+import { canExecuteTaskOnNode } from "./effective-node.js";
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
@@ -1575,6 +1576,8 @@ export function getExecutorSystemPrompt(settings: Settings): string {
 
 
 export interface TaskExecutorOptions {
+  /** Returns this process's configured node identity for dispatch ownership checks. */
+  getLocalNodeId?: () => string | undefined;
   semaphore?: AgentSemaphore;
   /** Worktree pool for recycling idle worktrees across tasks. */
   pool?: WorktreePool;
@@ -3144,6 +3147,12 @@ export class TaskExecutor {
     store.on("task:moved", ({ task, from, to, source }) => {
       executorLog.log(`[event:task:moved] ${task.id}: ${from} → ${to}`);
       if (to === "in-progress") {
+        if (!canExecuteTaskOnNode(task, this.options.getLocalNodeId?.())) {
+          executorLog.debug(
+            `[event:task:moved] Skipping execute() for ${task.id} — assigned to ${task.effectiveNodeId ?? task.nodeId}`,
+          );
+          return;
+        }
         this.userCanceledTaskIds.delete(task.id);
         if (this.recoveringCompleted.has(task.id)) {
           executorLog.log(`[event:task:moved] Skipping execute() for ${task.id} — completed-task recovery in progress`);

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -17847,10 +17847,21 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
    * resolved SHA of the dep's tip — that's what gets squash-merged.
    */
   private async planSquashImportFromDep(
-    _taskId: string,
+    taskId: string,
     depTip: string,
     originalStartPoint: string | undefined,
   ): Promise<{ depTip: string; mainBase: string; label: string } | null> {
+    /*
+     * Only scheduler-derived dependency starts belong on the squash-import path.
+     * An explicit task.baseBranch is an operator-selected integration baseline and
+     * must remain the actual worktree start point; treating it like a sibling task
+     * branch silently replaces it with the ambient root HEAD.
+     */
+    const task = await this.store.getTask(taskId).catch(() => null);
+    if (!task?.executionStartBranch?.trim()) {
+      return null;
+    }
+
     let settings;
     try {
       settings = await this.store.getSettings();

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -2958,6 +2958,17 @@ export class TaskExecutor {
     this.resumingUnpaused.add(task.id);
     let handoffOwnsClaim = false;
     try {
+      const latestTask = await this.store.getTask(task.id);
+      if (latestTask.status === "failed") {
+        return false;
+      }
+      if (!canExecuteTaskOnNode(latestTask, this.options.getLocalNodeId?.())) {
+        executorLog.debug(
+          `[event:task:updated] Skipping unpause resume for ${latestTask.id} — assigned to ${latestTask.effectiveNodeId ?? latestTask.nodeId}`,
+        );
+        return false;
+      }
+
       const pauseLabel = await this.getExecutionPauseLabel();
       if (pauseLabel) {
         executorLog.log(`Skipping unpause resume for ${task.id} — ${pauseLabel} active`);
@@ -2977,7 +2988,7 @@ export class TaskExecutor {
       }
 
       this.approvalSuspended.delete(task.id);
-      if (this.isTaskWorkComplete(task) && !task.mergeDetails) {
+      if (this.isTaskWorkComplete(latestTask) && !latestTask.mergeDetails) {
         /*
         FNXC:ExecutorResume 2026-07-21-23:06:
         recoverCompletedTask refuses when resumingUnpaused still holds the id.
@@ -2988,7 +2999,7 @@ export class TaskExecutor {
         this.recoveringCompleted.add(task.id);
         handoffOwnsClaim = true; // prevent finally from double-deleting a already-cleared claim
         executorLog.log(`${task.id} unpaused with completed work and no session — recovering directly to in-review`);
-        void this.recoverCompletedTask(task)
+        void this.recoverCompletedTask(latestTask)
           .catch((err) => executorLog.error(`Failed to recover completed unpaused task ${task.id}:`, err))
           .finally(() => this.recoveringCompleted.delete(task.id));
         return true;
@@ -2996,7 +3007,7 @@ export class TaskExecutor {
 
       executorLog.log(`Unpaused ${task.id} in-progress with no session — resuming execution`);
       try {
-        await this.clearResumeFailureState(task);
+        await this.clearResumeFailureState(latestTask);
         await this.store.updateTask(task.id, {
           resumeLimboCount: 0,
           resumeLimboTipSha: null,
@@ -3008,7 +3019,7 @@ export class TaskExecutor {
         executorLog.warn(`${task.id} clearResumeFailureState failed during unpause: ${clearErr instanceof Error ? clearErr.message : String(clearErr)}`);
       }
       handoffOwnsClaim = true;
-      this.execute(task)
+      this.execute(latestTask)
         .catch((err) => executorLog.error(`Failed to resume unpaused ${task.id}:`, err))
         .finally(() => this.resumingUnpaused.delete(task.id));
       // execute().finally owns resumingUnpaused release from here.
@@ -3171,7 +3182,14 @@ export class TaskExecutor {
             executorLog.log(`[event:task:moved] Awaiting pending disposal for ${task.id} before dispatch`);
             await pending;
           }
-          const taskForExecution = await this.resetMergeStateIfNeeded(task, from);
+          const latestTask = await this.store.getTask(task.id);
+          if (!canExecuteTaskOnNode(latestTask, this.options.getLocalNodeId?.())) {
+            executorLog.debug(
+              `[event:task:moved] Skipping execute() for ${latestTask.id} after authoritative read — assigned to ${latestTask.effectiveNodeId ?? latestTask.nodeId}`,
+            );
+            return;
+          }
+          const taskForExecution = await this.resetMergeStateIfNeeded(latestTask, from);
           await this.execute(taskForExecution);
         })().catch((err) =>
           executorLog.error(`Failed to start ${task.id}:`, err),

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -18362,6 +18362,54 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
     return false;
   }
 
+  /**
+   * A retry may find the task branch left behind by an earlier no-change run.
+   * Reusing that ref verbatim can silently start the new worktree from an old
+   * base. Advance it only when Git proves that its tip is an ancestor of the
+   * requested start point; a divergent branch or one with task commits is
+   * intentionally preserved.
+   */
+  private async fastForwardStaleExistingBranch(
+    branch: string,
+    startPoint: string | undefined,
+    taskId: string,
+  ): Promise<void> {
+    if (!startPoint) return;
+
+    try {
+      const [{ stdout: branchStdout }, { stdout: startStdout }] = await Promise.all([
+        execAsync(`git rev-parse --verify "${branch}^{commit}"`, { cwd: this.rootDir }),
+        execAsync(`git rev-parse --verify "${startPoint}^{commit}"`, { cwd: this.rootDir }),
+      ]);
+      const branchTip = branchStdout.trim();
+      const startTip = startStdout.trim();
+      if (!branchTip || !startTip || branchTip === startTip) return;
+
+      try {
+        await execAsync(
+          `git merge-base --is-ancestor ${this.quoteShellArg(branchTip)} ${this.quoteShellArg(startTip)}`,
+          { cwd: this.rootDir },
+        );
+      } catch {
+        return;
+      }
+
+      await execAsync(
+        `git branch -f ${this.quoteShellArg(branch)} ${this.quoteShellArg(startTip)}`,
+        { cwd: this.rootDir },
+      );
+      await this.store.logEntry(
+        taskId,
+        `Fast-forwarded stale existing branch ${branch} to requested worktree base`,
+        `${branchTip.slice(0, 7)} -> ${startTip.slice(0, 7)}`,
+      );
+    } catch (error: unknown) {
+      executorLog.warn(
+        `${taskId}: could not align existing branch ${branch} with requested base; preserving it (${error instanceof Error ? error.message : String(error)})`,
+      );
+    }
+  }
+
   private async tryCreateWorktree(
     branch: string,
     path: string,
@@ -18545,6 +18593,7 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
 
       // Try creating from existing branch (branch might already exist)
       try {
+        await this.fastForwardStaleExistingBranch(branch, startPoint, taskId);
         await createFromExistingBranch();
         executorLog.log(`Worktree created from existing branch: ${path}`);
         await installGuardOrCleanup();

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -11083,6 +11083,24 @@ export class TaskExecutor {
     this.graphRouting.add(task.id);
     let graphRunnerOwnsClaim = false;
     try {
+      /*
+      FNXC:SharedDbNodeRouting 2026-07-29-04:05:
+      Every direct and delayed execution continuation must re-check authoritative
+      node ownership before graph entry. Event listeners and the scheduler already
+      gate their normal dispatch paths, but recovery callbacks can call execute()
+      directly on every process sharing PostgreSQL. Without this final boundary a
+      foreign node can read an empty node-local PROMPT.md and move the live owner's
+      task back to triage while that owner is already editing its worktree.
+      */
+      const latestTask = await this.store.getTask(task.id);
+      if (!canExecuteTaskOnNode(latestTask, this.options.getLocalNodeId?.())) {
+        executorLog.log(
+          `Skipping direct execute() for ${latestTask.id} — assigned to ${latestTask.effectiveNodeId ?? latestTask.nodeId}`,
+        );
+        return;
+      }
+      task = latestTask;
+
       await this.clearStalePauseAbortBeforeDispatch(task);
       if (await this.blockOuterDispatchWhenDependenciesUnmet(task)) {
         // FNXC:GlobalConcurrencyControls 2026-07-14-18:30: release any scheduler pre-held slot when outer dispatch aborts before agent work starts.

--- a/packages/engine/src/notification/notification-service.ts
+++ b/packages/engine/src/notification/notification-service.ts
@@ -268,7 +268,22 @@ export class NotificationService {
     only operator notification; dispatch-time suppression below covers races.
     */
     if (wedge) this.cancelPendingFailureNotification(task.id, "classified-terminal-wedge");
-    if (!transientFailure) void this.maybeNotifyTaskWedge(task, wedge);
+    if (!transientFailure) {
+      /*
+      FNXC:TaskWedgeNotifications 2026-07-28-19:10:
+      task:updated listeners are synchronous but wedge episode persistence is
+      intentionally fire-and-forget. A task may be soft-deleted immediately
+      after the update (for example a routing smoke cleanup) while the durable
+      claim is still awaiting its task lock. Contain that best-effort
+      notification failure here so a TaskDeletedError or store outage cannot
+      become an unhandled rejection that terminates the Fusion daemon.
+      */
+      void this.maybeNotifyTaskWedge(task, wedge).catch((error) => {
+        schedulerLog.warn(
+          `[notify] ${task.id} wedge notification skipped: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    }
     void this.maybeSuppressTransientFailedNotification(task, `status=${task.status ?? "undefined"}`);
 
     /*

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -58,6 +58,7 @@ import { MissionExecutionLoop } from "../mission-execution-loop.js";
 import { TriageProcessor } from "../triage.js";
 import { EphemeralWorkerManager } from "../ephemeral-worker-manager.js";
 import { validateProjectNodeMapping } from "../node-dispatch-validation.js";
+import { canExecuteTaskOnNode } from "../effective-node.js";
 import { attachAgentLinkSync } from "../task-agent-sync.js";
 import { createRunAuditor, generateSyntheticRunId } from "../run-audit.js";
 import { setImmediate as setImmediateCb } from "node:timers";
@@ -281,6 +282,7 @@ export class InProcessRuntime
   private backendShutdown?: () => Promise<void>;
   private scheduler!: Scheduler;
   private executor!: TaskExecutor;
+  private localNodeId?: string;
   private worktreePool!: WorktreePool;
   private globalSemaphore?: AgentSemaphore;
   private projectSemaphore?: ScopedAgentSemaphore;
@@ -450,6 +452,15 @@ export class InProcessRuntime
           );
         }
       }
+
+      /*
+      FNXC:MultiNodeRouting 2026-07-28-14:45:
+      Resolve process identity before constructing schedulers, lease managers,
+      and executors. FUSION_NODE_ID is fail-closed in CentralCore, preventing a
+      shared-database process from silently impersonating the first local row.
+      */
+      const runtimeNode = await this.centralCore.getRuntimeNode();
+      this.localNodeId = runtimeNode?.id;
 
       this.messageStore = new MessageStoreClass(null, { asyncLayer: messageLayer });
 
@@ -697,6 +708,7 @@ export class InProcessRuntime
         getExecutingTaskIds: () => this.executor?.getExecutingTaskIds() ?? new Set<string>(),
         centralClaimStore: this.leaseCentralClaimStore,
         projectId: this.config.projectId,
+        localNodeId: this.localNodeId,
       });
 
       const autoClaimSnapshotManager = new AutoClaimSnapshotManager({ taskStore: this.taskStore });
@@ -718,6 +730,7 @@ export class InProcessRuntime
         missionAutopilot,
         missionExecutionLoop,
         leaseManager: this.leaseManager,
+        localNodeId: this.localNodeId,
         onTaskFailed: (taskId) => {
           if (missionAutopilot) {
             void missionAutopilot.handleTaskFailure(taskId);
@@ -834,6 +847,7 @@ export class InProcessRuntime
 
       const prNodeGithubOps = this.config.prNodeGithubOps;
       const executorOptions: TaskExecutorOptions = {
+        getLocalNodeId: () => this.localNodeId,
         semaphore: this.projectSemaphore,
         pool: this.worktreePool,
         usageLimitPauser: this.usageLimitPauser,
@@ -1191,6 +1205,12 @@ export class InProcessRuntime
         if (!chatLayer2) throw new Error("Self-healing ChatStore requires the project PostgreSQL AsyncDataLayer");
         this.chatStore ??= new ChatStore(chatLayer2);
       }
+      /*
+      FNXC:MultiNodeRouting 2026-07-28-14:45:
+      The fail-closed runtime identity resolved before scheduler construction is
+      also the lease attribution identity. A shared-database process must never
+      fall back to another node's row for recovery decisions.
+      */
       this.selfHealingManager = new SelfHealingManager(this.taskStore, {
         rootDir: this.config.workingDirectory,
         agentStore: this.agentStore,
@@ -2008,6 +2028,9 @@ export class InProcessRuntime
           continue;
         }
         if (resolved.kind !== "actionable") continue;
+        if (!canExecuteTaskOnNode(resolved.task, this.localNodeId)) {
+          continue;
+        }
         void this.executor.execute(resolved.task).catch((error) => {
           runtimeLog.error(`Workflow continuation ${resolved.item.id} failed:`, error);
         });

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -1101,6 +1101,7 @@ export class InProcessRuntime
         this.taskStore,
         this.config.workingDirectory,
         {
+          localNodeId: this.localNodeId,
           semaphore: this.projectSemaphore,
           stuckTaskDetector: this.stuckTaskDetector,
           usageLimitPauser: this.usageLimitPauser,

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -1774,6 +1774,23 @@ export class Scheduler {
       for (const taskId of ordered) {
         const task = tasks.find((t) => t.id === taskId)!;
 
+        /*
+        FNXC:MultiNodeRouting 2026-07-28-17:37:
+        Route before every node-local preflight. A foreign task's PROMPT.md and
+        worktree live under that node's mapped project path; validating them
+        here would falsely rebound a healthy remote task to triage before the
+        later dispatch gate runs. Explicit task/project assignments therefore
+        remain completely untouched by non-owning shared-DB schedulers.
+        */
+        if (
+          !canDispatchEffectiveNode(
+            resolveEffectiveNode(task, settings),
+            this.options.localNodeId,
+          )
+        ) {
+          continue;
+        }
+
         if (task.checkedOutBy && this.options.leaseManager) {
           const recovered = await this.options.leaseManager.recoverAbandonedLease(
             task.id,
@@ -2580,6 +2597,22 @@ export class Scheduler {
         now: () => Date.now(),
         reserveSlot: async (task): Promise<SlotReservation | null> => {
           let reservedScope = false;
+
+          /*
+          FNXC:MultiNodeRouting 2026-07-28-17:38:
+          The workflow hold/release sweep reaches filesystem and replan logic
+          before its final dispatch gate. Reject foreign assignments at the
+          reservation boundary so a non-owning node cannot mutate their column,
+          status, logs, leases, or local planning files.
+          */
+          if (
+            !canDispatchEffectiveNode(
+              resolveEffectiveNode(task, settings),
+              this.options.localNodeId,
+            )
+          ) {
+            return null;
+          }
 
           /*
           FNXC:WorkflowScheduling 2026-07-07-00:00:

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -34,7 +34,12 @@ import { schedulerLog } from "./logger.js";
 import { type PrMonitor, type PrComment } from "./pr-monitor.js";
 import { reconcileMissionFeatureState } from "./mission-feature-sync.js";
 import { evaluateSpecStaleness, getPromptPath } from "./spec-staleness.js";
-import { resolveEffectiveNode, type EffectiveNode } from "./effective-node.js";
+import {
+  canDispatchEffectiveNode,
+  materializeExecutionNodeId,
+  resolveEffectiveNode,
+  type EffectiveNode,
+} from "./effective-node.js";
 import { applyUnavailableNodePolicy, decideOwningNodeHandoff } from "./node-routing-policy.js";
 import type { NodeDispatchValidationResult } from "./node-dispatch-validation.js";
 import type { MeshLeaseManager } from "./mesh-lease-manager.js";
@@ -2181,6 +2186,17 @@ export class Scheduler {
           }
         }
 
+        /*
+        FNXC:MultiNodeRouting 2026-07-28-14:45:
+        Shared-PostgreSQL schedulers all observe the same todo rows. Once a
+        process has an explicit node identity, only the process matching the
+        effective task/project assignment may win dispatch. Unpinned work
+        remains a normal cross-node race and is materialized to the winner.
+        */
+        if (!canDispatchEffectiveNode(effectiveNode, this.options.localNodeId)) {
+          continue;
+        }
+
         if (latestSettings.ephemeralAgentsEnabled === false && !freshTask.assignedAgentId) {
           if (!this.options.agentStore) {
             if (!loggedMissingAgentStoreThisPass) {
@@ -2305,7 +2321,7 @@ export class Scheduler {
           status: null,
           blockedBy: null,
           executionStartBranch: baseBranch ?? undefined,
-          effectiveNodeId: effectiveNode.nodeId ?? null,
+          effectiveNodeId: materializeExecutionNodeId(effectiveNode, this.options.localNodeId),
           effectiveNodeSource: effectiveNode.source,
           mergeRetries: 0,
         });
@@ -2813,6 +2829,16 @@ export class Scheduler {
             }
           }
 
+          /*
+          FNXC:MultiNodeRouting 2026-07-28-14:45:
+          Mirror the legacy dispatch gate in the workflow hold/release path.
+          Otherwise workflow-native tasks could still be reserved and started
+          by a scheduler whose configured node id does not own the assignment.
+          */
+          if (!canDispatchEffectiveNode(effectiveNode, this.options.localNodeId)) {
+            return null;
+          }
+
           if (latestSettings.ephemeralAgentsEnabled === false && !freshTask.assignedAgentId) {
             /*
             FNXC:WorkflowScheduling 2026-06-23-22:33:
@@ -3072,7 +3098,7 @@ export class Scheduler {
             baseBranch: this.resolveBaseBranch(freshTask, tasks),
             dispatchStormCount: nextDispatchStormCount,
             dispatchTimestamp,
-            effectiveNodeId: effectiveNode.nodeId ?? null,
+            effectiveNodeId: materializeExecutionNodeId(effectiveNode, this.options.localNodeId),
             effectiveNodeSource: effectiveNode.source,
             task: freshTask,
           });

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -189,10 +189,16 @@ import { accumulateSessionTokenUsage } from "./session-token-usage.js";
 import { finalizePlanningSegment, startPlanningSegment } from "@fusion/core";
 import type { AgentActionGateContext } from "./agent-action-gate.js";
 import { buildAgentGatedActionSummary } from "./permanent-agent-gating.js";
+import {
+  canDispatchEffectiveNode,
+  resolveEffectiveNode,
+} from "./effective-node.js";
 
 
 export interface TriageProcessorOptions {
   pollIntervalMs?: number;
+  /** Fixed identity of this process in a shared PostgreSQL control plane. */
+  localNodeId?: string;
   semaphore?: AgentSemaphore;
   /**
    * FNXC:ProviderRateLimitIsolation 2026-07-21-18:00:
@@ -397,6 +403,7 @@ export class TriageProcessor {
         const tasks = await this.discoverReadyPlanningTasks(
           await this.store.listTasks({ slim: true, includeArchived: false }),
           now,
+          settings,
         );
         return tasks.filter((task) => !this.coordinatorAdmittedTaskIds.has(task.id)).map((task) => ({
           taskId: task.id, projectId: this.rootDir, createdAt: task.createdAt,
@@ -1105,9 +1112,14 @@ export class TriageProcessor {
    * refresh. Keeping the seed-prompt checks here makes the cross-lane admission
    * union include cards before their planner writes status:"planning".
    */
-  private async discoverReadyPlanningTasks(allTasks: Task[], now: number): Promise<Task[]> {
+  private async discoverReadyPlanningTasks(
+    allTasks: Task[],
+    now: number,
+    settings: Pick<Settings, "defaultNodeId">,
+  ): Promise<Task[]> {
     const eligibleTriageTasks = allTasks.filter(
       (t) => t.column === "triage" && isTaskStillInPlanningStage(t)
+        && canDispatchEffectiveNode(resolveEffectiveNode(t, settings), this.options.localNodeId)
         && !this.advancedRecoveryReservations.has(t.id)
         && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
@@ -1115,6 +1127,7 @@ export class TriageProcessor {
     );
     const eligibleTodoTasksRaw = allTasks.filter(
       (t) => t.column === "todo" && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
+        && canDispatchEffectiveNode(resolveEffectiveNode(t, settings), this.options.localNodeId)
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
         && t.status !== "planning"
         && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),
@@ -1199,7 +1212,7 @@ export class TriageProcessor {
         this.idleSemaphoreLeakCandidateSince = result.candidateSinceMs;
       }
 
-      const triageTasks = await this.discoverReadyPlanningTasks(allTasks, now);
+      const triageTasks = await this.discoverReadyPlanningTasks(allTasks, now, settings);
 
       /*
       FNXC:ConcurrencyAdmission 2026-08-03-12:00:
@@ -1333,6 +1346,34 @@ export class TriageProcessor {
       this.coordinatorAdmittedTaskIds.delete(task.id);
       return;
     }
+
+    /*
+    FNXC:MultiNodeRouting 2026-07-28-17:35:
+    Triage is an execution surface independent of Scheduler. Shared-PostgreSQL
+    runtimes all observe the same planning rows, so re-check the authoritative
+    task immediately before claiming it. The poll filter avoids needless
+    admission attempts; this gate also closes stale-snapshot and direct-call
+    paths before status, logs, sessions, or PROMPT.md can be mutated.
+    */
+    let routingTask: Task = task;
+    try {
+      routingTask = await this.store.getTask(task.id) ?? task;
+    } catch {
+      // Preserve legacy/single-process behavior if the authoritative refresh
+      // itself is unavailable; existing planning error handling remains owner.
+    }
+    const routingSettings = await this.store.getSettings();
+    if (
+      !canDispatchEffectiveNode(
+        resolveEffectiveNode(routingTask, routingSettings),
+        this.options.localNodeId,
+      )
+    ) {
+      dropPreHeldExecutorSlot(task.id, this.options.semaphore);
+      this.coordinatorAdmittedTaskIds.delete(task.id);
+      return;
+    }
+
     this.processing.add(task.id);
     this.processingSince.set(task.id, Date.now());
 

--- a/packages/engine/src/workflow-graph-executor.ts
+++ b/packages/engine/src/workflow-graph-executor.ts
@@ -1135,6 +1135,26 @@ export class WorkflowGraphExecutor {
           continue;
         }
         if (target && isMergeRegionKind(target.kind)) {
+          /*
+           * A manual-review task must stop at the graph-authored manual merge
+           * hold before the legacy merge-region collapse. Collapsing the
+           * `merge-gate` unconditionally bypasses its auto-merge decision and
+           * calls the merge seam even when `autoMerge:false`; on a worker-only
+           * daemon without a merge requester that becomes `merge-unavailable`
+           * and bounces a reviewed task back to execution.
+           */
+          const autoMerge = task.autoMerge !== false && settings?.autoMerge !== false;
+          if (!autoMerge) {
+            const manualHoldNode = ir.nodes.find((candidate) => candidate.kind === "manual-merge-hold") ?? target;
+            const boundary = await this.deps.columnBoundary?.onNodeEntry(manualHoldNode);
+            if (boundary?.kind === "suspended") throw new WorkflowGraphSuspended(boundary);
+            visitedNodeIds.push(manualHoldNode.id);
+            context[`node:${manualHoldNode.id}:outcome`] = "failure";
+            context[`node:${manualHoldNode.id}:value`] = "manual-required";
+            this.deps.logTaskEntry?.("Workflow merge parked for manual review (autoMerge=false)");
+            aggregate = { outcome: "success", value: "manual-required" };
+            break;
+          }
           aggregate = await runLegacyMergeSeam(target);
           if (aggregate.outcome === "failure") break;
           /*

--- a/packages/engine/src/worktree-acquisition.ts
+++ b/packages/engine/src/worktree-acquisition.ts
@@ -262,10 +262,10 @@ export async function acquireTaskWorktree(opts: AcquireTaskWorktreeOptions): Pro
     && backend.kind !== "worktrunk"
     && settings.worktrunk?.enabled !== true;
   const allowSiblingBranchRename = settings.executorAllowSiblingBranchRename === true;
-  const baseBranch = task.executionStartBranch || null;
+  const baseBranch = task.executionStartBranch || task.baseBranch || null;
   /*
    * FNXC:WorktreeIsolation 2026-07-01-08:35:
-   * Fresh task worktrees must never inherit the project root checkout's ambient HEAD. The root checkout can temporarily point at a sibling task branch/commit during merge or recovery work, so an omitted `git worktree add -b ... <startPoint>` contaminates new task branches with unrelated task commits. Use the task's explicit executionStartBranch when present; otherwise pin creation to the resolved integration branch.
+   * Fresh task worktrees must never inherit the project root checkout's ambient HEAD. The root checkout can temporarily point at a sibling task branch/commit during merge or recovery work, so an omitted `git worktree add -b ... <startPoint>` contaminates new task branches with unrelated task commits. Use the scheduler-persisted executionStartBranch when present, then the task's explicit baseBranch, and otherwise pin creation to the resolved project integration branch.
    */
   const freshStartPoint = baseBranch ?? await resolveIntegrationBranch(rootDir, settings, { logger: logger ?? console });
 

--- a/packages/engine/src/worktree-db-hydrate.ts
+++ b/packages/engine/src/worktree-db-hydrate.ts
@@ -1,4 +1,6 @@
 import type { TaskStore } from "@fusion/core";
+import { copyFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
 
 export interface HydrateWorktreeDbParams {
   rootDir: string;
@@ -20,19 +22,44 @@ export interface HydrateWorktreeDbResult {
  * FNXC:PostgresWorktreeStorage 2026-07-14-18:35:
  * Executor worktrees share the project-scoped PostgreSQL store. Worktree
  * acquisition must never create, open, or copy a local `.fusion/fusion.db`;
- * task, document, and artifact visibility comes from the shared store and its
- * project identity. The function remains as the acquisition seam so existing
- * callers can record storage readiness without maintaining a SQLite fallback.
+ * task rows, documents, and artifacts come from the shared store and its
+ * project identity. PROMPT.md remains a file-backed task contract, however, so
+ * mirror that one authoritative artifact before worktree-local task reads run.
  */
 export async function hydrateWorktreeDb({
   rootDir,
   worktreePath,
+  taskId,
 }: HydrateWorktreeDbParams): Promise<HydrateWorktreeDbResult> {
+  if (rootDir === worktreePath) {
+    return {
+      tasksCopied: 0,
+      documentsCopied: 0,
+      artifactsCopied: 0,
+      degraded: false,
+      reason: "root_worktree",
+    };
+  }
+
+  const sourcePrompt = join(rootDir, ".fusion", "tasks", taskId, "PROMPT.md");
+  const destinationTaskDir = join(worktreePath, ".fusion", "tasks", taskId);
+  let documentsCopied = 0;
+
+  try {
+    await mkdir(destinationTaskDir, { recursive: true });
+    await copyFile(sourcePrompt, join(destinationTaskDir, "PROMPT.md"));
+    documentsCopied = 1;
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+
   return {
     tasksCopied: 0,
-    documentsCopied: 0,
+    documentsCopied,
     artifactsCopied: 0,
     degraded: false,
-    reason: rootDir === worktreePath ? "root_worktree" : "postgres_shared_store",
+    reason: "postgres_shared_store",
   };
 }


### PR DESCRIPTION
## What changed

- enforce shared-PostgreSQL node affinity across scheduling, planning, event resume, and direct execution
- defer routed worktree allocation to the owning node and preserve explicit task/worktree baselines
- contain notification soft-delete races and preserve manual review boundaries
- preserve a caller-supplied shared project identity during remote registration
- resolve registered project roots for project-ID-only backend startup

## Why

Fusion 0.73 nodes could be individually healthy while still using separate project identities or local embedded databases. In that state, a task assigned with `nodeId` was not reliably visible to, or exclusively dispatched by, the intended worker.

## Impact

Multiple Fusion 0.73 schedulers can now observe one shared PostgreSQL task set and only the matching identified process dispatches explicitly assigned work. Remote nodes retain the shared project ID and can start project-scoped backends from the registered local path.

## Validation

- Core regression test: 3 passed
- Dashboard regression tests: 8 passed
- Engine tests added by this branch: 21 passed
- Core, dashboard server/app, and engine TypeScript checks passed
- Live three-node smoke: identical task set on all nodes; create on the control node, update on a remote worker, and delete propagation verified without model execution or source changes

## Known local test-environment note

A broader Windows-only selection produced 496 passes and 17 failures in older worktree tests whose fixtures expect POSIX `/tmp/...` paths while the implementation returns normalized Windows paths. The 21 regression tests introduced by this branch pass; no dependency allowlist or lockfile changes were made.
