### PR TITLE
U11: delete the dead isRunnableQueuedOverlapCandidate export (scheduler.ts now has zero live todo literals)

### DIFF
--- a/packages/engine/src/__tests__/reliability-interactions/dual-observe-merge-seam.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/dual-observe-merge-seam.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   computeShadowLeaseParityState,
   getUnmetSchedulingDependencies,
-  isRunnableQueuedOverlapCandidate,
 } from "../../scheduler.js";
 import { ProjectEngine } from "../../project-engine.js";
 import { classifyTransientMergeError } from "../../transient-merge-error-classifier.js";
@@ -138,23 +137,6 @@ describe("FN-5742 dual-observe merge seam", () => {
     expect(unmet).toEqual([]);
   });
 
-  it("does not block unrelated executor dispatch when merge lane is busy", () => {
-    const now = Date.now();
-    const activeScopes = new Map<string, string[]>([["FN-MERGE", ["packages/engine/src/merger.ts"]]]);
-    const todo = {
-      id: "FN-UNRELATED",
-      column: "todo",
-      status: "queued",
-      paused: false,
-      userPaused: false,
-      dependencies: [],
-      nextRecoveryAt: undefined,
-    } as any;
-
-    const runnable = isRunnableQueuedOverlapCandidate(todo, [todo], now, activeScopes, ["docs/architecture.md"]);
-    expect(runnable).toBe(true);
-  });
-
   it("classifies transient merge errors without changing scheduler runnable decisions", () => {
     const transient = classifyTransientMergeError(
       "lease-handoff-failed: target-not-queued while attempting merge handoff",
@@ -170,7 +152,6 @@ describe("FN-5742 dual-observe merge seam", () => {
       dependencies: [],
       nextRecoveryAt: undefined,
     } as any;
-    expect(isRunnableQueuedOverlapCandidate(todo, [todo], Date.now())).toBe(true);
   });
 
   it("shadow dequeue helpers do not touch limbo recovery counters", () => {

--- a/packages/engine/src/__tests__/reliability-interactions/non-progress-churn.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/non-progress-churn.test.ts
@@ -4,7 +4,6 @@ import "../executor-test-helpers.js";
 import type { Task, TaskStore } from "@fusion/core";
 import { TaskExecutor } from "../../executor.js";
 import { SelfHealingManager } from "../../self-healing.js";
-import { isRunnableQueuedOverlapCandidate } from "../../scheduler.js";
 import { StuckTaskDetector } from "../../stuck-task-detector.js";
 
 type MockTaskStore = TaskStore & EventEmitter & {
@@ -290,7 +289,6 @@ describe("reliability interactions: non-progress churn", () => {
     expect(task.steps).toEqual([{ name: "Implement", status: "in-progress" }]);
     expect(task.log?.some((entry) => entry.action.includes("Parked in todo with progress preserved"))).toBe(true);
     expect(store.handoffToReview).not.toHaveBeenCalled();
-    expect(isRunnableQueuedOverlapCandidate(task, [task])).toBe(false);
 
     manager.stop();
   });

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -286,26 +286,6 @@ export function getUnmetSchedulingDependencies(
   });
 }
 
-export function isRunnableQueuedOverlapCandidate(
-  task: Task,
-  tasks: Task[],
-  now = Date.now(),
-  activeScopes?: Map<string, string[]>,
-  scope: string[] = [],
-): boolean {
-  if (task.column !== "todo" || task.status !== "queued") return false;
-  if (task.paused || task.userPaused) return false;
-  if (task.nextRecoveryAt && new Date(task.nextRecoveryAt).getTime() > now) return false;
-  if (getUnmetSchedulingDependencies(task, tasks).length > 0) return false;
-  if (!activeScopes || activeScopes.size === 0) return true;
-
-  if (scope.length === 0) return true;
-  for (const activeScope of activeScopes.values()) {
-    if (!activeScope.length) continue;
-    if (pathsOverlap(scope, activeScope)) return false;
-  }
-  return true;
-}
 
 export function shouldHoldActiveFileScopeLease(
   task: Task,


### PR DESCRIPTION
Based on `main`. **Pure deletion — zero production callers.**

`isRunnableQueuedOverlapCandidate`'s only consumer was the legacy pull-from-todo dispatcher deleted in #2505. The three remaining references were all in tests.

This was `scheduler.ts`'s **last `"todo"` literal in live code**, so removing it rather than converting it is what actually finishes the file — converting a dead predicate would have added a trait lookup nothing calls, and reported U11 progress for a site that cannot execute.

## Why deleting its tests does not lose coverage

Worth checking, because the function carried a real invariant — *"a busy merge lane must not block unrelated dispatch"* — and its own doc comment claims it's a shared contract with self-healing and repair paths.

Two facts settle it:

1. **The overlap logic is still live**, implemented inline inside `runHoldReleaseSweepPass` (`activeScopes`, `overlapIgnorePaths`, `getFilteredFileScope`). The behavior didn't die with the predicate; only this copy of it did.
2. **`scheduler-overlap-starvation.test.ts` exercises that live path** through `scheduler.schedule()`, including *"does not defer ready work behind queued overlap blocked by an active lease"* — the same invariant the deleted test asserted, against code that actually runs.

The doc comment's claim that self-healing *"must use this same predicate"* is **stale**: no self-healing path imports it. That claim outlived the coupling it described.

## The three test references were not equal

Treating them identically would have been wrong:

- **Two were incidental trailing assertions** in tests about other subjects (stuck-loop exhaustion parking; transient merge-error classification). Only the assertion line is removed — each test keeps its real subject.
- **One test's entire subject was this function** (*"does not block unrelated executor dispatch when merge lane is busy"*), so it goes with it; its invariant is covered on the live path per (2).

## Measured

`scheduler.ts` **2,840 → 2,820 = −20**, and it now holds **zero `"todo"` literals in live code**.

Combined with #2505's −929, `scheduler.ts` is down **949 lines** across this unit — all genuine removal, not relocation.

## Verification

582 tests green across the reliability-interactions suite and four scheduler suites; merge gate green (414 + 10 + 71); tsc clean; lint clean.

No changeset: `@fusion/engine` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal task scheduling logic by removing obsolete overlap coordination checks.
  * Preserved existing task progress, parking behavior, logging, and review handling.

* **Tests**
  * Updated reliability checks to align with the streamlined scheduler behavior.
  * Continued validating transient errors, non-progress handling, and correct task dispatch without changing the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->