### PR TITLE
U7 PR9: the replan rebound targets a column the workflow declares, instead of inventing `triage` (stacked on #2517)

### DIFF
--- a/.changeset/replan-target-resolved-columns.md
+++ b/.changeset/replan-target-resolved-columns.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A rejected plan on a custom workflow is sent back to that workflow's own planning column, not a column it does not have.
+category: fix
+dev: U7 / R3, R7. `resolveReplanTargetColumn` preferred the literal `triage`, then `todo`, then returned `triage` by fiat — so any workflow declaring neither (builtin:marketing, any renamed set) had its Plan Review REVISE bounce moved into an undeclared column for `reconcileUndeclaredTaskColumns` to clean up. Legacy ids stay preferred first so both coding built-ins keep their exact current target; only a workflow declaring neither reaches the trait fallback, which prefers HOLD over intake (an intake column may be manual-capture with no AI, as in Coding (Ideas)). No declared column at all now returns undefined and every caller parks visibly instead of logging a move it did not make.

--- a/packages/engine/src/__tests__/replan-target-resolved-columns.test.ts
+++ b/packages/engine/src/__tests__/replan-target-resolved-columns.test.ts
@@ -1,0 +1,166 @@
+/*
+FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R3, R7, R12 — workflow-owned lifecycle):
+
+THE INVARIANT: a Plan Review REVISE bounce lands the card in a column the task's
+OWN workflow declares, and NEVER in one it does not.
+
+`resolveReplanTargetColumn` asked `workflowHasColumn(ir, "triage")`, then
+`"todo"`, and fell back to `"triage"` — twice by literal id, once by fiat. On a
+workflow that renames both, all three answers are wrong in the same way: the card
+is moved into a column the workflow does not declare.
+
+That is the R7 violation this program exists to remove ("a stored task row pointing
+at a column no workflow declares"), reached not by drift but by DESIGN — the final
+`return "triage"` fired for any workflow that declares neither legacy id, so
+`reconcileUndeclaredTaskColumns` had to clean up after a move the engine made on
+purpose.
+
+The plan's U5 states the intended behavior directly: "a replan rebound lands in the
+workflow's planning column; a workflow declaring neither legacy column is SKIPPED
+WITH A LOG rather than moved arbitrarily". This is that.
+
+THE LEGACY IDS STAY PREFERRED FIRST, so both built-ins keep their exact current
+target; only a workflow declaring NEITHER reaches the resolved answer. For those the
+fallback prefers HOLD over intake — see the ordering test below for why the obvious
+"intake first" rule is wrong, and which existing test caught it.
+
+WHY THIS FILE IS IN U7 rather than U5, which nominally owns `replan-target.ts`:
+U5's B2 slice converted 12 sites and left this one. It is the planning lane's
+rebound seam — the thing that decides where a rejected plan goes to be re-planned —
+so it sits inside U7's ownership question even though the file is listed elsewhere.
+Flagging rather than assuming: if U5 has this in flight, this is the conflict.
+*/
+import { describe, expect, it, vi } from "vitest";
+import type { TaskStore, WorkflowIr } from "@fusion/core";
+
+import { resolveReplanTargetColumn } from "../replan-target.js";
+
+const WF = "custom:replan-vocab";
+
+/**
+ * A workflow shape parameterised on its column ids. Traits are identical in every
+ * variant, so any behavioral difference is attributable to a surviving literal.
+ * `omit` drops a role entirely, which is how the "declares neither" case is built.
+ */
+function ir(names: { intake?: string; hold?: string; wip?: string }): WorkflowIr {
+  const columns: Array<Record<string, unknown>> = [];
+  if (names.intake) columns.push({ id: names.intake, name: "Intake", traits: [{ trait: "intake" }] });
+  if (names.hold) {
+    columns.push({
+      id: names.hold,
+      name: "Hold",
+      traits: [{ trait: "hold", config: { release: "capacity" } }],
+    });
+  }
+  columns.push({
+    id: names.wip ?? "in-progress",
+    name: "Wip",
+    traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }],
+  });
+  columns.push({ id: "done", name: "Done", traits: [{ trait: "complete" }] });
+  return { version: "v2", id: WF, name: WF, columns, nodes: [], edges: [] } as unknown as WorkflowIr;
+}
+
+function storeWith(workflowIr: WorkflowIr | null): TaskStore {
+  const selection = { workflowId: WF, stepIds: [] };
+  return {
+    getTaskWorkflowSelection: vi.fn(() => selection),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => {
+      if (!workflowIr) throw new Error("workflow could not be resolved");
+      return { ir: workflowIr };
+    }),
+  } as unknown as TaskStore;
+}
+
+describe("the replan rebound targets a column the workflow actually declares", () => {
+  it("targets the intake column under the DEFAULT vocabulary (no-regression half)", async () => {
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ intake: "triage", hold: "todo" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("triage");
+  });
+
+  it("targets a declared column under a RENAMED vocabulary, never the legacy literal", async () => {
+    // Pre-conversion this returned the literal "triage" — a column this workflow
+    // does not declare — so the card was moved somewhere nothing renders it.
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ intake: "backlog", hold: "drafting" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("drafting");
+    expect(target).not.toBe("triage");
+  });
+
+  it("falls back to the HOLD column when the workflow has no intake (plan-in-place)", async () => {
+    // Coding (Ideas) and any workflow whose planning happens in the capacity lane.
+    // Order matters: intake first, hold only when there is no intake.
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ hold: "drafting" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("drafting");
+  });
+
+  it("prefers HOLD over intake when a renamed workflow declares both", async () => {
+    /*
+    MEASURED, and the existing suite corrected me. I first wrote "intake, else
+    hold" on the reasoning that a REVISE sends the card back to be re-specified and
+    specification starts at intake. That broke Coding (Ideas): its intake is `ideas`,
+    which is MANUAL CAPTURE WITH NO AI (plan R10), so a rejected plan sent there
+    stops being replanned at all and becomes an idea awaiting a human.
+
+    The old code got Ideas right by ACCIDENT — it never recognised `ideas` as intake
+    and fell through to `todo`. A trait rule that "corrected" that would have shipped
+    a regression dressed as a cleanup, and only the existing Coding (Ideas) tests
+    stood between me and doing it.
+
+    So the fallback prefers HOLD: it is the planning lane, it has a releaser, and an
+    intake column may be a manual-capture lane with nothing that auto-plans in it.
+    */
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ intake: "backlog", hold: "drafting" })),
+      "FN-1",
+    );
+
+    expect(target).toBe("drafting");
+  });
+
+  it("returns UNDEFINED for a workflow that declares neither role, instead of inventing a column", async () => {
+    // The R7 case. Previously answered "triage" by fiat — moving the card into a
+    // column no workflow declares, which is the exact state
+    // `reconcileUndeclaredTaskColumns` exists to clean up after.
+    const target = await resolveReplanTargetColumn(
+      storeWith(ir({ wip: "building" })),
+      "FN-1",
+    );
+
+    expect(target).toBeUndefined();
+  });
+
+  it("falls back to the DEFAULT workflow's intake when the selection cannot be read", async () => {
+    /*
+    MEASURED, and it corrected me mid-slice. I first asserted `undefined` here, on
+    the assumption that an unreadable workflow reaches this function's `catch`. It
+    does not: `resolveWorkflowIrForTask` is TOTAL — every failure path returns
+    `defaultCodingWorkflowIr()` rather than throwing. So the `catch` in
+    `resolveReplanTargetColumn` is unreachable belt-and-braces, and asserting
+    `undefined` would have been a test for a state that cannot occur — the exact
+    guard-that-cannot-fire shape this program keeps finding.
+
+    The real behavior is worth pinning precisely BECAUSE it is surprising: an
+    unreadable selection silently becomes the default coding workflow, so the card
+    replans to `triage` — correct for the overwhelmingly common case, and quietly
+    wrong for a renamed workflow whose selection failed to load. That is a property
+    of the resolver, not of this seam, so it is documented here rather than
+    "fixed" here.
+    */
+    const target = await resolveReplanTargetColumn(storeWith(null), "FN-1");
+
+    expect(target).toBe("triage");
+  });
+});

--- a/packages/engine/src/__tests__/replan-target.test.ts
+++ b/packages/engine/src/__tests__/replan-target.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Task, TaskStep, TaskStore } from "@fusion/core";
+import { resolveWorkflowIrForTask } from "@fusion/core";
 import { hasAdvancedPastPlanning, isTaskStillInPlanningStage, moveTaskToReplanColumn, resolveReplanTargetColumn } from "../replan-target.js";
 
 /*
@@ -268,12 +269,35 @@ describe("resolveReplanTargetColumn", () => {
     await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("todo");
   });
 
-  it("falls back to triage for workflows declaring neither triage nor todo (never a custom column)", async () => {
-    // builtin:marketing declares ideation/backlog/drafting/... — no triage, no todo.
-    // A custom entry column would strand the needs-replan card (triage only scans
-    // "triage" and "todo") and the legacy move path throws on custom targets.
+  it("targets a workflow's OWN hold column when it declares neither legacy id", async () => {
+    /*
+    FNXC:ReplanTargetLifecycleColumns 2026-07-29-10:15 (U7 / R7):
+    CONTRACT CHANGED — deliberately, and this is the expectation edit that IS the
+    change rather than churn around it. This previously asserted `"triage"` for
+    builtin:marketing, which declares ideation/backlog/drafting/... and NO triage
+    column: the engine moved the card into a column the workflow does not declare,
+    which is the R7 violation `reconcileUndeclaredTaskColumns` then cleaned up after.
+
+    Both reasons the old fallback gave for preferring a wrong-but-legacy column are
+    now obsolete, and one of them was removed by an earlier slice of this same unit:
+
+      "triage only scans triage and todo" — no longer true. Discovery resolves the
+      task's own intake/hold roles (U7 PR4), so marketing's `backlog` IS scanned.
+
+      "the legacy move path throws on custom targets" — no longer true either; a
+      move out of a non-legacy source column resolves targets from the task's own
+      workflow adjacency (FN-7591).
+
+    Asserted as "a column this workflow declares" as well as by id, because the id
+    is incidental and the INVARIANT is what matters.
+    */
     const store = storeWithSelection("builtin:marketing");
-    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("triage");
+    const target = await resolveReplanTargetColumn(store, "FN-1");
+
+    expect(target).toBe("backlog");
+    const ir = await resolveWorkflowIrForTask(store as never, "FN-1");
+    expect((ir as unknown as { columns: Array<{ id: string }> }).columns.map((c) => c.id))
+      .toContain(target);
   });
 
   it("falls back to triage when workflow resolution throws", async () => {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -5164,6 +5164,26 @@ export class TaskExecutor {
       in an undeclared "triage" column, which the board rendered back in the intake lane.
       */
       const replanColumn = await resolveReplanTargetColumn(this.store, taskId);
+      /*
+      FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+      No declared replan column: park VISIBLY rather than log a move to `undefined`
+      and then not make it. `false` fails the graph's plan-replan node with
+      `remediation-not-scheduled`, which is the same shape as the zero-budget and
+      no-verdict branches above — a card left in place with an operator-readable
+      reason, not a silent no-op.
+      */
+      if (!replanColumn) {
+        executorLog.warn(
+          `${taskId}: plan-review replan NOT scheduled — the task's workflow declares no intake or hold column to replan in. Card left parked in ${liveTask.column}.`,
+        );
+        await this.store.logEntry(
+          taskId,
+          "Plan Review failed, but this task's workflow declares no planning column to replan in — left in place for a human.",
+          optionalStepRevisionLogOutcome(feedback, revisionKey),
+          this.getRunContextFor(taskId),
+        ).catch(() => undefined);
+        return false;
+      }
       await this.store.logEntry(
         taskId,
         `Plan Review failed — moved to ${replanColumn} for automatic replan (attempt ${nextCount}/${budgetLabel})`,
@@ -5293,6 +5313,25 @@ export class TaskExecutor {
     }
 
     const replanColumn = await resolveReplanTargetColumn(this.store, task.id);
+    /*
+    FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+    Same contract as the plan-review replan above: no declared column means no
+    move, said out loud. Returning here leaves the recovery-retry bookkeeping
+    unwritten on purpose — a retry that cannot relocate the card would just burn
+    the budget without changing anything.
+    */
+    if (!replanColumn) {
+      executorLog.warn(
+        `${task.id}: artifact-recovery replan NOT scheduled — the task's workflow declares no intake or hold column to replan in. Card left in place.`,
+      );
+      await this.store.logEntry(
+        task.id,
+        "Required workflow artifact missing, but this task's workflow declares no planning column to recover into — left in place for a human.",
+        `Missing artifact keys: ${artifactKeys.join(", ")}`,
+        context,
+      ).catch(() => undefined);
+      return;
+    }
     await this.store.logEntry(
       task.id,
       `Required workflow artifact missing — moved to ${replanColumn} for automatic planning recovery (attempt ${attempt}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)})`,

--- a/packages/engine/src/replan-target.ts
+++ b/packages/engine/src/replan-target.ts
@@ -1,5 +1,6 @@
 import type { Task, TaskStore } from "@fusion/core";
-import { resolveWorkflowIrForTask, workflowHasColumn } from "@fusion/core";
+import { resolveWorkflowIrForTask, resolveLifecycleColumns, workflowHasColumn } from "@fusion/core";
+import { schedulerLog } from "./logger.js";
 
 /*
 FNXC:WorkflowReplan 2026-07-12-23:15:
@@ -195,14 +196,59 @@ export function isTaskStillInPlanningStage(
   return !hasAdvancedPastPlanning(task);
 }
 
-export async function resolveReplanTargetColumn(store: TaskStore, taskId: string): Promise<string> {
+/**
+ * Where a Plan Review REVISE bounce sends the card to be re-specified.
+ *
+ * FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R3, R7):
+ * Resolved from the task's OWN workflow roles. This asked
+ * `workflowHasColumn(ir, "triage")` then `"todo"` and fell back to `"triage"` —
+ * twice by literal id, once by fiat. On a workflow that renames both, all three
+ * answers moved the card into a column the workflow does not declare: the R7
+ * violation reached by DESIGN rather than by drift, since the fallback returned the
+ * literal unconditionally including when the workflow could not be resolved at all.
+ * `reconcileUndeclaredTaskColumns` then had to clean up after a move the engine
+ * made on purpose.
+ *
+ * THE LEGACY IDS ARE PREFERRED FIRST, deliberately, and the trait resolution is the
+ * FALLBACK rather than the replacement. Both built-ins keep their existing target
+ * byte-for-byte: `builtin:coding` -> `triage`, Coding (Ideas) -> `todo`. Only a
+ * workflow that declares NEITHER legacy id — which previously got `"triage"` by
+ * fiat — reaches the resolved answer.
+ *
+ * WHY NOT SIMPLY "intake, else hold". I wrote that first and the existing suite
+ * caught it: Coding (Ideas) declares `ideas` as its intake, and `ideas` is MANUAL
+ * CAPTURE WITH NO AI (plan R10). Sending a rejected plan there stops it being
+ * replanned at all — it becomes an idea waiting for a human to press Start. The old
+ * code got Ideas right by ACCIDENT (it did not recognise `ideas` as intake at all
+ * and fell through to `todo`); a trait rule that "corrects" it would have shipped a
+ * regression dressed as a cleanup.
+ *
+ * So for a renamed workflow the fallback prefers HOLD over intake — the hold column
+ * is the planning lane and it has a releaser, whereas an intake column may be a
+ * manual-capture lane with nothing that auto-plans in it. That follows the Ideas
+ * precedent rather than contradicting it.
+ *
+ * `undefined` means "this workflow declares nowhere to replan" — the plan's U5
+ * contract is that such a task is skipped with a log rather than moved arbitrarily.
+ * Callers must park it visibly; inventing a column is what this change removes.
+ */
+export async function resolveReplanTargetColumn(
+  store: TaskStore,
+  taskId: string,
+): Promise<string | undefined> {
   try {
     const ir = await resolveWorkflowIrForTask(store, taskId);
     if (workflowHasColumn(ir, "triage")) return "triage";
     if (workflowHasColumn(ir, "todo")) return "todo";
-    return "triage";
+    const roles = resolveLifecycleColumns(ir);
+    return roles?.hold ?? roles?.intake;
   } catch {
-    return "triage";
+    /*
+    Unreachable in practice: `resolveWorkflowIrForTask` is TOTAL — every failure
+    path returns the default coding IR rather than throwing. Kept as belt-and-braces
+    and documented as such, so nobody writes a test for a state that cannot occur.
+    */
+    return undefined;
   }
 }
 
@@ -236,8 +282,20 @@ export async function moveTaskToReplanColumn(
   store: TaskStore,
   task: Pick<Task, "id" | "column">,
   target?: string,
-): Promise<string> {
+): Promise<string | undefined> {
   const replanColumn = target ?? await resolveReplanTargetColumn(store, task.id);
+  /*
+  FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+  No declared replan column: do NOT move. Every caller treats the return value as
+  "where the card now is", so a silent no-op would be a lie; returning `undefined`
+  makes the caller state the outcome instead of assuming one.
+  */
+  if (!replanColumn) {
+    schedulerLog.warn(
+      `${task.id}: replan rebound skipped — the task's workflow declares no intake or hold column to replan in; card left in ${task.column}`,
+    );
+    return undefined;
+  }
   if (task.column !== replanColumn) {
     await store.moveTask(task.id, replanColumn, { preserveWorktree: true });
   }

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -1792,8 +1792,23 @@ export class Scheduler {
             // status write is what makes triage rediscover a card whose replan column equals
             // its current column.
             const replanColumn = await moveTaskToReplanColumn(this.store, task);
+            /*
+            FNXC:ReplanTargetLifecycleColumns 2026-07-29-09:30 (U7 / R7):
+            The status write happens EITHER WAY, and deliberately: `needs-replan` is
+            what blocks dispatch and makes triage rediscover the card, and this
+            branch has already decided the card must not be released. A workflow with
+            nowhere to rebound still must not run a spec that failed validation.
+            Only the LOG is conditional, so it never claims a move that did not
+            happen — the whole point of `moveTaskToReplanColumn` returning the column.
+            */
             await this.store.updateTask(task.id, { status: "needs-replan" });
-            await this.store.logEntry(task.id, `Task rebounded to ${replanColumn} for re-specification — filesystem validation failed`, validation.reason);
+            await this.store.logEntry(
+              task.id,
+              replanColumn
+                ? `Task rebounded to ${replanColumn} for re-specification — filesystem validation failed`
+                : "Task held for re-specification (its workflow declares no planning column to rebound to) — filesystem validation failed",
+              validation.reason,
+            );
             return null;
           }
 


### PR DESCRIPTION
> **Stacked on #2517.** Base is `feature/u7-triage-resolved-columns`, which now carries the whole earlier chain (#2522, #2523, #2524, #2527). Merge #2517 first and this retargets cleanly.

## The bug

`resolveReplanTargetColumn` asked `workflowHasColumn(ir, "triage")`, then `"todo"`, then returned `"triage"` **unconditionally**.

For any workflow declaring neither — `builtin:marketing` (ideation/backlog/drafting/…), and every renamed set — a Plan Review REVISE moved the card into a column **the workflow does not declare**. That is the R7 violation this program exists to remove, reached by design rather than drift, with `reconcileUndeclaredTaskColumns` cleaning up after a move the engine made on purpose.

## The existing suite caught a regression I was about to ship

My first version was the obvious trait rule — *intake, else hold* — reasoning that a REVISE sends the card back to be re-specified, and specification starts at intake.

**That breaks Coding (Ideas).** Its intake is `ideas`, which is *manual capture with no AI* (plan R10). A rejected plan sent there stops being replanned at all and becomes an idea awaiting a human.

The old code got Ideas right **by accident** — it never recognised `ideas` as intake and fell through to `todo`. My "correction" would have shipped a regression dressed as a cleanup, and three existing Coding (Ideas) tests were the only thing between me and doing it.

So the legacy ids stay preferred **first**, and trait resolution is a **fallback, not a replacement**:

| Workflow | Target | Changed? |
|---|---|---|
| `builtin:coding` | `triage` | no |
| Coding (Ideas) | `todo` | no |
| `builtin:marketing` | `backlog` (its own hold) | **yes** — was `triage`, undeclared |
| renamed (backlog/drafting) | `drafting` | **yes** — was `triage`, undeclared |
| declares neither role | `undefined` → park | **yes** — was `triage` by fiat |

The fallback prefers **hold** over intake: the hold column is the planning lane and has a releaser, whereas an intake column may be manual-capture with nothing that auto-plans in it. That follows the Ideas precedent instead of contradicting it.

## The old fallback's own justification is obsolete — half of it removed by this unit

The deleted test explained itself: *"a custom entry column would strand the needs-replan card (triage only scans triage and todo) and the legacy move path throws on custom targets."*

Neither holds any more:

- **"triage only scans triage and todo"** — discovery resolves the task's own intake/hold roles since **U7 PR4 (#2517)**, so marketing's `backlog` *is* scanned.
- **"the move path throws on custom targets"** — a move out of a non-legacy source column resolves targets from the task's own workflow adjacency (FN-7591).

The workaround outlived its reason. Worth noting for other units: a literal fallback justified by a limitation elsewhere becomes a live bug the moment that limitation is fixed, and nothing links the two.

## Fail-closed callers

`undefined` means "this workflow declares nowhere to replan" (plan U5: *skipped with a log rather than moved arbitrarily*). All four call sites park **visibly** rather than log a move they did not make:

- executor's plan-review replan returns `false`, failing the graph's plan-replan node exactly as its zero-budget and no-verdict branches already do;
- executor's artifact-recovery replan returns without burning a retry that could not relocate the card;
- the scheduler's two rebounds **still write `needs-replan`** — deliberately, since that is what blocks dispatch and the branch has already decided the card must not be released — but only the *log* is conditional.

## One unreachable assertion removed from my own test before it landed

I wrote a case asserting `undefined` when the workflow "cannot be resolved". **It cannot occur:** `resolveWorkflowIrForTask` is total — every failure path returns the default coding IR rather than throwing. The assertion would have been a test for an impossible state, i.e. the exact guard-that-cannot-fire shape I keep flagging in others' work.

Replaced with the real and genuinely surprising behavior — an unreadable selection silently becomes the *default coding workflow*, so a renamed workflow whose selection fails to load replans to `triage` — and the `catch` is documented as unreachable so nobody re-adds the test.

## Revert proof

With the fiat fallback restored: **5 of 46 fail** across both suites.

**39 of the 40 pre-existing assertions pass unchanged.** The single expectation edit *is* the contract change, called out in the test with why both of its original reasons no longer hold.

## Verification

| Check | Result |
|---|---|
| 10 replan / planning / scheduler / executor suites | 130/130 |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (414 + 10 + 71) |
| `pnpm check:changesets` | clean |

## Ownership note

`replan-target.ts` is nominally U5's file; its B2 slice converted 12 sites and left this one. This is the planning lane's rebound seam — what decides where a rejected plan goes to be re-planned — so it sits inside U7's ownership question. Flagging rather than assuming: if U5 has this in flight, this is the conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
