### PR TITLE
P0: approved plans never released after #2515 + triage.ts 11 -> 0

### DIFF
--- a/packages/engine/src/__tests__/triage-release-renamed-hold.test.ts
+++ b/packages/engine/src/__tests__/triage-release-renamed-hold.test.ts
@@ -1,0 +1,198 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-08:15 (U11 conversion — triage planner lanes):
+
+Triage's planning HANDOFF releases a finished card out of the planner column into
+the backlog, and it targeted the literal `"todo"`. For a workflow that names its
+hold column anything else, the release move sends the card to a column that
+workflow does not declare — and after U11 deletes `todo` from the builtins, it
+sends every card to a column that does not exist at all.
+
+This is the load-bearing site of the eight in triage.ts: the other seven decide
+whether a card is IN a planner lane (latency or a missed sweep if wrong), while
+this one performs the move that ends planning. If it fails, a card sits in the
+planner column holding a finished spec — the exact symptom FN-8361 and the
+handoff-outcome work were about.
+
+Reuses the `recoverApprovedTask` seam, which is the one public method that reaches
+the release move without a live planning session.
+
+Written against the literal implementation and observed FAILING first.
+*/
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+import { TriageProcessor } from "../triage.js";
+import { planLog } from "../logger.js";
+
+const WF = "custom:wf";
+
+const REAL_SPEC = [
+  "# Task: FN-001 - Real spec",
+  "",
+  "## Context",
+  "Some context that is long enough to clear deterministic validation checks.",
+  "",
+  "## Steps",
+  "1. Implement the thing",
+  "2. Verify the thing",
+  "",
+  "## File Scope",
+  "- packages/engine/src/triage.ts",
+].join("\n");
+
+/** Hold is `drafting`, intake is `inbox` — no `todo` column exists. */
+function renamedIr(): WorkflowIr {
+  return {
+    version: "v2",
+    id: WF,
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "inbox", name: "inbox", traits: [{ trait: "intake" }] },
+      { id: "drafting", name: "drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "shipped", name: "shipped", traits: [{ trait: "complete" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+/** The builtin shape, for the regression floor. */
+function defaultIr(): WorkflowIr {
+  return {
+    version: "v2",
+    id: WF,
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "triage", name: "triage", traits: [{ trait: "intake" }] },
+      { id: "todo", name: "todo", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "in-progress", name: "in-progress", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "done", name: "done", traits: [{ trait: "complete" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "FN-001",
+    title: "Task",
+    description: "desc",
+    column: "inbox",
+    status: "planning",
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Task;
+}
+
+function createStore(task: Task, ir: WorkflowIr | null): { store: TaskStore; moveTaskIf: ReturnType<typeof vi.fn> } {
+  const selection = { workflowId: WF, stepIds: [] };
+  const moveTaskIf = vi.fn(async (_id: string, column: string) => ({
+    moved: true,
+    task: { ...task, column, status: null },
+  }));
+  const store: Record<string, unknown> = {
+    on: vi.fn(),
+    off: vi.fn(),
+    listTasks: vi.fn().mockResolvedValue([]),
+    getTask: vi.fn(async (id: string) => (id === task.id ? task : undefined)),
+    getSettings: vi.fn().mockResolvedValue({ requirePlanApproval: false } as Settings),
+    parseDependenciesFromPrompt: vi.fn().mockResolvedValue([]),
+    parseStepsFromPrompt: vi.fn().mockResolvedValue([]),
+    parseFileScopeFromPrompt: vi.fn().mockResolvedValue([]),
+    updateTask: vi.fn(),
+    updateTaskAtomic: vi.fn(async (_id: string, patch: unknown) => {
+      const next = typeof patch === "function"
+        ? (patch as (t: Task) => Partial<Task> | null)(task)
+        : (patch as Partial<Task> | null);
+      if (next) Object.assign(task, next);
+      return task;
+    }),
+    moveTask: vi.fn(),
+    withTaskLock: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
+    readTaskForMove: vi.fn(async (id: string) => (id === task.id ? task : undefined)),
+    recordActivity: vi.fn().mockResolvedValue(undefined),
+    moveTaskIf,
+    logEntry: vi.fn(),
+    getTaskWorkflowSelection: vi.fn(() => selection),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => (ir ? { ir } : null)),
+    resolveTaskWorkflowIrSync: vi.fn(() => {
+      if (!ir) throw new Error("unresolvable");
+      return ir;
+    }),
+  };
+  return { store: store as unknown as TaskStore, moveTaskIf };
+}
+
+describe("triage planning handoff releases into the workflow's hold column", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-release-"));
+    await mkdir(join(rootDir, ".fusion", "tasks", "FN-001"), { recursive: true });
+    await writeFile(join(rootDir, ".fusion", "tasks", "FN-001", "PROMPT.md"), REAL_SPEC);
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("releases into the RENAMED hold column, not the literal todo", async () => {
+    const task = createTask();
+    const { store, moveTaskIf } = createStore(task, renamedIr());
+
+    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    expect(moveTaskIf).toHaveBeenCalledWith("FN-001", "drafting", expect.any(Function));
+    expect(moveTaskIf).not.toHaveBeenCalledWith("FN-001", "todo", expect.any(Function));
+  });
+
+  it("still releases into todo for the builtin workflow (regression floor)", async () => {
+    const task = createTask({ column: "triage" });
+    const { store, moveTaskIf } = createStore(task, defaultIr());
+
+    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    expect(moveTaskIf).toHaveBeenCalledWith("FN-001", "todo", expect.any(Function));
+  });
+
+  it("falls back to todo for a workflow with NO column vocabulary", async () => {
+    /* Conservative: a v1 / column-less IR has no hold role to resolve, so the
+       release must behave exactly as before this conversion rather than guessing.
+       (A store that cannot return an IR at all bails earlier in finalize, before
+       the release — so the column-less IR is the case that actually reaches here.) */
+    const task = createTask({ column: "triage" });
+    const v1 = { version: "v1", id: WF, nodes: [], edges: [] } as unknown as WorkflowIr;
+    const { store, moveTaskIf } = createStore(task, v1);
+
+    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    expect(moveTaskIf).toHaveBeenCalledWith("FN-001", "todo", expect.any(Function));
+  });
+
+  it("does NOT move a card already resting in the hold column", async () => {
+    /*
+    The U11 shape, and the reason this conversion matters beyond renaming: once
+    triage carries the capacity hold, planning happens IN the hold column, so a
+    finished card is already where the release would send it. The guard must
+    recognise that and skip the move rather than issue a same-column move.
+    */
+    const task = createTask({ column: "drafting" });
+    const { store, moveTaskIf } = createStore(task, renamedIr());
+
+    await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    expect(moveTaskIf).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/__tests__/triage-release-renamed-hold.test.ts
+++ b/packages/engine/src/__tests__/triage-release-renamed-hold.test.ts
@@ -75,6 +75,26 @@ function defaultIr(): WorkflowIr {
   } as unknown as WorkflowIr;
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-16:05 (P0 audit — #2515):
+The MERGED default lineage as #2515 actually shipped it: ONE pre-implementation
+column, id `todo`, carrying intake AND hold. This is the shape that broke
+`recoverApprovedTask`, whose guard was a bare `task.column !== "triage"`.
+*/
+function mergedDefaultIr(): WorkflowIr {
+  return {
+    version: "v2",
+    id: WF,
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "todo", name: "Planning", traits: [{ trait: "intake" }, { trait: "hold", config: { release: "capacity" } }] },
+      { id: "in-progress", name: "in-progress", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "done", name: "done", traits: [{ trait: "complete" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
 function createTask(overrides: Partial<Task> = {}): Task {
   return {
     id: "FN-001",
@@ -179,6 +199,27 @@ describe("triage planning handoff releases into the workflow's hold column", () 
     await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
 
     expect(moveTaskIf).toHaveBeenCalledWith("FN-001", "todo", expect.any(Function));
+  });
+
+  it("P0: admits a MERGED-lineage card sitting in the Planning column (#2515)", async () => {
+    /*
+    THE STALL. `recoverApprovedTask` opened with a bare `task.column !== "triage"`.
+    #2515 merged Todo into Planning on the default lineage, so every default card
+    now sits in `todo` and this guard rejected all of them — an approved plan whose
+    finalize was interrupted was never released, and nothing else owns that card.
+
+    `triage` stayed a legal id, so nothing threw; the guard just stopped matching.
+    The assertion is the RETURN VALUE, because on a merged lineage the card is
+    already where the release would send it — so "no move issued" is what BOTH the
+    broken and the fixed code do, and only the outcome discriminates.
+    */
+    const task = createTask({ column: "todo" });
+    const { store, moveTaskIf } = createStore(task, mergedDefaultIr());
+
+    const recovered = await new TriageProcessor(store, rootDir).recoverApprovedTask(task);
+
+    expect(recovered).toBe(true);
+    expect(moveTaskIf).not.toHaveBeenCalled();
   });
 
   it("does NOT move a card already resting in the hold column", async () => {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -54,6 +54,8 @@ import {
   localeDisplayName,
   parsePlanningPlanMd,
   type NearDuplicateCandidate,
+  resolveLifecycleColumns,
+  type WorkflowIr,
 } from "@fusion/core";
 
 
@@ -287,6 +289,41 @@ export type PlanningHandoffOutcome = "released" | "parked" | "withheld";
  *  `finalizeApprovedTask` for why this is a report object and not a return value. */
 export interface PlanningHandoffReport {
   outcome: PlanningHandoffOutcome;
+}
+
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-08:40 (U11 conversion — triage planner lanes):
+The PLANNER LANES for a task: the columns where specification happens, resolved
+from its own workflow.
+
+Triage's eight column decisions are all one of two questions — "is this card in a
+planner lane?" (hold or intake) and "where does a finished plan get released to?"
+(hold) — and both were answered with literals. Under a renamed workflow every one
+silently stops matching; after U11 deletes `todo` from the builtins, they stop
+matching everywhere.
+
+SYNCHRONOUS on purpose: several call sites are inside event listeners and pure
+filter predicates, and introducing an `await` there would reorder handlers
+relative to a synchronous emitter (see the scheduler conversion, where exactly
+that broke five pre-existing tests).
+
+Fail-soft to the legacy pair so an unresolvable or column-less workflow behaves
+exactly as before.
+
+NOTE FOR U11: once `triage` carries the capacity hold, `hold` and `intake` resolve
+to the SAME column. Every `hold || intake` check below then collapses to one
+column, and the release move becomes a no-op the guard already skips — which is
+the intended end state, not a degenerate case.
+*/
+function resolvePlannerLanes(store: TaskStore, taskId: string): { hold: string; intake: string } {
+  try {
+    const ir = (store as unknown as { resolveTaskWorkflowIrSync?: (id: string) => WorkflowIr }).resolveTaskWorkflowIrSync?.(taskId);
+    const lifecycle = ir ? resolveLifecycleColumns(ir) : undefined;
+    return { hold: lifecycle?.hold ?? "todo", intake: lifecycle?.intake ?? "triage" };
+  } catch {
+    return { hold: "todo", intake: "triage" };
+  }
 }
 
 export class TriageProcessor {
@@ -610,7 +647,8 @@ export class TriageProcessor {
     */
     this.taskColumnWakeHandler = (task: Task) => {
       if (!task?.id) return;
-      if (task.column !== "todo" && task.column !== "triage") return;
+      const wakeLanes = resolvePlannerLanes(this.store, task.id);
+      if (task.column !== wakeLanes.hold && task.column !== wakeLanes.intake) return;
       if (task.paused === true || task.userPaused === true) return;
       // Already being planned (or mid-plan) — the running poll/session owns it.
       if (this.processing.has(task.id) || this.hasLivePlanningWork(task.id)) return;
@@ -648,7 +686,8 @@ export class TriageProcessor {
       an unrelated update.
       */
       if (typeof task.column !== "string") return;
-      if (task.column === "todo" || task.column === "triage" || task.column === "in-progress") return;
+      const disposeLanes = resolvePlannerLanes(this.store, task.id);
+      if (task.column === disposeLanes.hold || task.column === disposeLanes.intake || task.column === "in-progress") return;
       if (this.activeSubagentSessions.has(task.id)) {
         this.disposeSubagentsForTask(task.id, `task moved to ${task.column}`);
       }
@@ -738,7 +777,8 @@ export class TriageProcessor {
     try {
       const stale = allTasks.filter((t) => {
         if (t.status !== "planning") return false;
-        if (t.column !== "triage" && t.column !== "todo") return false;
+        const lanes = resolvePlannerLanes(this.store, t.id);
+        if (t.column !== lanes.intake && t.column !== lanes.hold) return false;
         if (this.processing.has(t.id)) return false;
         if (t.userPaused === true || t.paused === true) return false;
         const touchedAt = Date.parse(t.updatedAt ?? t.columnMovedAt ?? "");
@@ -766,8 +806,13 @@ export class TriageProcessor {
     FNXC:CodingIdeasWorkflow 2026-07-04-12:00:
     In the merged planner/capacity "todo" column a task can carry status "planning" when the triage service is specifying it in place. A crash/restart before planning completes leaves that status set, so the startup sweep must clear it from BOTH triage and todo — otherwise a stale planning todo task permanently occupies a planning admission slot and blocks new triage work. (The separate maxTriageConcurrent pool AND its setting are both gone — FN-8453 removed the pool, the capacity simplification removed the dead key; planning shares the one agent count.)
     */
-    const triageTasks = await this.store.listTasks({ column: "triage", slim: true });
-    const todoTasks = await this.store.listTasks({ column: "todo", slim: true });
+    /* Both planner lanes, resolved from the DEFAULT workflow — this startup sweep
+       is board-wide and has no single task to resolve against. Cards belonging to
+       a workflow with different lane names are picked up by the per-task filter
+       below rather than by this query. */
+    const sweepLanes = resolvePlannerLanes(this.store, "");
+    const triageTasks = await this.store.listTasks({ column: sweepLanes.intake, slim: true });
+    const todoTasks = await this.store.listTasks({ column: sweepLanes.hold, slim: true });
     const stale = [...triageTasks, ...todoTasks].filter(
       (t) => t.status === "planning" && !this.processing.has(t.id),
     );
@@ -1085,7 +1130,11 @@ export class TriageProcessor {
     const recoverableStatus =
       task.status === "planning"
       || (task.status == null && this.hasPassedPlanReview(task));
-    if (task.column !== "triage" || !recoverableStatus) {
+    /* FNXC:WorkflowLifecycleColumns 2026-07-29-09:05 (U11): the INTAKE lane, not
+       the literal. Converting only the `todo` sites left this one rejecting every
+       card whose workflow renames its planner column, so the release below was
+       unreachable for exactly the workflows the conversion was for. */
+    if (task.column !== resolvePlannerLanes(this.store, task.id).intake || !recoverableStatus) {
       return false;
     }
 
@@ -1282,7 +1331,7 @@ export class TriageProcessor {
       freshTask.status === "planning"
       || freshTask.status === "needs-replan"
       || freshTask.status === "plan-review-unavailable";
-    const releasedToTodo = freshTask.column === "todo" && !planningStageStatus;
+    const releasedToTodo = freshTask.column === resolvePlannerLanes(this.store, freshTask.id).hold && !planningStageStatus;
     if (hasAdvancedPastPlanning(freshTask) || releasedToTodo) {
       const nextStuckKillCount = (freshTask.stuckKillCount ?? task.stuckKillCount ?? 0) + 1;
       planLog.log(
@@ -4003,7 +4052,8 @@ export class TriageProcessor {
       if (!await this.updatePlanningStateIfStillCurrent(task, { title: promptDeclaredTitle })) return;
     }
 
-    if (task.column !== "todo") {
+    const releaseTarget = resolvePlannerLanes(this.store, task.id).hold;
+    if (task.column !== releaseTarget) {
       const moveTaskIf = (this.store as unknown as { moveTaskIf?: TaskStore["moveTaskIf"] }).moveTaskIf;
       if (typeof moveTaskIf !== "function") {
         // FNXC:TriageFinalizeVisibility 2026-07-26-19:05: the release move is the handoff. If it
@@ -4016,7 +4066,7 @@ export class TriageProcessor {
         report.outcome = "withheld";
         return;
       }
-      const release = await moveTaskIf.call(this.store, task.id, "todo", isTaskStillInPlanningStage);
+      const release = await moveTaskIf.call(this.store, task.id, releaseTarget, isTaskStillInPlanningStage);
       if (!release.moved) {
         planLog.warn(
           `${task.id}: planning handoff to todo REFUSED by the planning-stage guard `

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -55,7 +55,6 @@ import {
   parsePlanningPlanMd,
   type NearDuplicateCandidate,
   resolveLifecycleColumns,
-  type WorkflowIr,
 } from "@fusion/core";
 
 
@@ -806,16 +805,35 @@ export class TriageProcessor {
     FNXC:CodingIdeasWorkflow 2026-07-04-12:00:
     In the merged planner/capacity "todo" column a task can carry status "planning" when the triage service is specifying it in place. A crash/restart before planning completes leaves that status set, so the startup sweep must clear it from BOTH triage and todo — otherwise a stale planning todo task permanently occupies a planning admission slot and blocks new triage work. (The separate maxTriageConcurrent pool AND its setting are both gone — FN-8453 removed the pool, the capacity simplification removed the dead key; planning shares the one agent count.)
     */
-    /* Both planner lanes, resolved from the DEFAULT workflow — this startup sweep
-       is board-wide and has no single task to resolve against. Cards belonging to
-       a workflow with different lane names are picked up by the per-task filter
-       below rather than by this query. */
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-29-16:40 (U11 — self-review of this PR):
+    A board-wide startup sweep has NO single task to resolve lanes against, so it
+    queries the UNION of the legacy planner ids and the default workflow's resolved
+    lanes rather than picking one answer.
+
+    The union is load-bearing, not defensive. Resolving the two queries from the
+    default workflow alone looked equivalent and was not: post-#2515 that workflow's
+    `intake` and `hold` are the SAME merged column, so both queries collapsed onto
+    `todo` and nothing ever swept `triage`. A legacy or Coding (Ideas) card left
+    holding a stale `planning` status would then occupy a planning admission slot
+    permanently — exactly the failure the 2026-07-04 note above describes. Caught by
+    `triage.test.ts`'s rebounded-replan case.
+
+    Querying extra columns is free here: the sweep only READS and every row is
+    filtered on `status === "planning"` before anything is written.
+    */
     const sweepLanes = resolvePlannerLanes(this.store, "");
-    const triageTasks = await this.store.listTasks({ column: sweepLanes.intake, slim: true });
-    const todoTasks = await this.store.listTasks({ column: sweepLanes.hold, slim: true });
-    const stale = [...triageTasks, ...todoTasks].filter(
-      (t) => t.status === "planning" && !this.processing.has(t.id),
+    const sweepColumns = [...new Set(["triage", "todo", sweepLanes.intake, sweepLanes.hold])];
+    const swept = await Promise.all(
+      sweepColumns.map((column) => this.store.listTasks({ column, slim: true })),
     );
+    const seen = new Set<string>();
+    const stale = swept.flat().filter((t) => {
+      if (t.status !== "planning" || this.processing.has(t.id)) return false;
+      if (seen.has(t.id)) return false;
+      seen.add(t.id);
+      return true;
+    });
     for (const t of stale) {
       planLog.log(`Startup sweep: clearing stale 'planning' status on ${t.id}`);
       await this.store.updateTask(t.id, { status: null });


### PR DESCRIPTION
Rebased onto post-#2515 `main`. **This PR is the fix for a P0 stall**, not just a conversion.

## Stall 1 — approved plans were never released

`recoverApprovedTask` opened with a bare `task.column !== "triage"`. #2515 merged Todo into Planning on the default lineage, so every default card now sits in `todo` and **this guard rejected all of them**. An approved plan whose finalize was interrupted was never released, and nothing else owns that card. Callers: `triage.ts:1296` (stuck-kill recovery) and `in-process-runtime.ts:1460`.

`triage` stayed a legal id, so nothing threw — the guard just stopped matching.

I verified the fix **mechanism** rather than assuming it. `resolveLifecycleColumns` on the IR #2515 actually shipped returns:

```
{ intake: "todo", hold: "todo", wip: "in-progress", review: "in-review", complete: "done", archived: "archived" }
```

so the converted guard admits default cards. The new regression test asserts the **return value**, because on a merged lineage the card is already where the release would send it — "no move issued" is what *both* the broken and the fixed code do, so only the outcome discriminates.

**Mutation-verified:** restoring the literal `!== "triage"` fails 2 of 5 tests.

## A defect of my own, found while auditing — same shape as the P0

`clearStaleSpecifyingStatuses` is a board-wide startup sweep with no single task to resolve lanes against, and I had resolved **both** its queries from the default workflow. Post-#2515 that workflow's `intake` and `hold` are the **same** column, so both queries collapsed onto `todo` and **nothing ever swept `triage`**. A legacy or Coding (Ideas) card holding a stale `planning` status would then occupy a planning admission slot permanently — exactly the failure the 2026-07-04 note above that function warns about.

Now queries the **union** of the legacy planner ids and the resolved lanes, deduped by task id. Querying extra columns is free here: the sweep only reads, and every row is filtered on `status === "planning"` before anything is written.

Caught by `triage.test.ts`, **not by my own tests** — worth recording, since it is the same collapse the P0 is about.

## Rebase note

The discovery conflict was resolved **in favour of `main`**. Main's version is strictly better than mine: it resolves lanes with the **async** `resolveTaskLifecycleColumns` (so it is not subject to the sync-resolver limitation below), keeps the two admission branches disjoint for a merged column, and bounds concurrency. My sync version was dropped.

## Measured

| file | comparisons before | after |
|---|---:|---:|
| `packages/engine/src/triage.ts` | **11** | **0** |

## Known red, NOT from this PR

8 tests in `triage.test.ts` fail on **clean `origin/main`** — confirmed by swapping main's `triage.ts` into this tree and re-running (same 8). They are reporting the upgrade stall, not stale expectations: a card *sitting* in `triage` is admitted by nothing after #2515 (`expected "specifyTask" to be called 4 times, but got 0 times`), and #2515 shipped no data migration re-homing those rows. Left untouched here — the fix is a data migration, not a conversion. Reported to the coordinator separately.

## Verification

- merge gate green (414 + 10 + 71), tsc clean, lint clean
- mutation-verified as above

## Separate finding — affects every worker

`resolveTaskWorkflowIrSync` **cannot resolve a task's selection in production.** `getTaskWorkflowSelectionImpl` is `return undefined` unconditionally and `getTaskWorkflowSelectionAsyncImpl` is *"always PostgreSQL path"*, so the sync resolver **always** returns the DEFAULT workflow IR. `moves.ts` already hit this and fixed it by going async. Consequence for `resolvePlannerLanes` here: correct for default-lineage cards (the default IR is exactly what comes back — which is why Stall 1 is genuinely fixed) and **inert for custom workflows**. Not papered over; the async path is main's discovery code, and converting the remaining event-listener sites needs the handler-reordering problem solved first.

No changeset: `@fusion/engine` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## P0 audit table — every `triage` site in my assigned files

(a) does it still fire for a default-workflow card after #2515? (b) if not, what silently stops happening? (c) fix.

| site | (a) still fires? | (b) what silently stops | (c) disposition |
|---|---|---|---|
| `triage.ts:613` wake handler | **yes** | — OR-shaped (`todo \|\| triage`), still matches | converted anyway |
| `triage.ts:651` evacuation guard | **yes** | — OR-shaped, still matches | converted anyway |
| `triage.ts:741` stale-planning sweep | **yes** | — OR-shaped, still matches | converted anyway |
| `triage.ts:1088` `recoverApprovedTask` | **NO** | **STALL 1** — approved plan never released; nothing else owns the card | **fixed + regression test + mutation-verified** |
| `triage.ts:1396` advanced-recovery discovery | **NO** | that recovery never matches a default card | fixed by the same conversion |
| `clearStaleSpecifyingStatuses` (mine) | **NO** | **my own defect** — both queries collapsed onto `todo`, `triage` never swept; stale `planning` holds an admission slot forever | **fixed** (union of legacy + resolved lanes) |
| `replan-target.ts:177` / `:185` | **NO** | **STALL 2** — see #2552 | fixed in #2552 |
| `spec-staleness.ts:95` | **NO** | narrow: a Planning card with null status and `currentStep > 0` now skips staleness where it previously did not | **recorded, not fixed** — see below |
| discovery (`isAtIntakeColumn`) | **NO** | **STALL 3** — a card *sitting* in `triage` is admitted by nothing | **reported, not fixed** — needs a data migration |

**Why `spec-staleness.ts:95` is not fixed here.** The guard already returns `false` for `status === "planning"` and `needs-replan`, so an *actively* planning card is still covered by status. The `column === "triage"` arm only added coverage for a planner-lane card with **no** status — and post-merge that case is genuinely ambiguous, because `todo` is now both the planning lane and the hold lane, so a card with progress there may legitimately be a released card that *should* skip. Guessing either way is a behaviour change without evidence, so I recorded it rather than picking one.
