### PR TITLE
test(engine): prove the LIVE merge path's rebound column — and merger.ts's three sites are a dead path

### DIFF
--- a/packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts
@@ -701,6 +701,12 @@ two self-healing sweeps verified PER SITE — reverting one fails exactly its ow
     by reading: forcing the hydration back to the `todo` literal fails exactly that
     file's renamed case. It was listed here as unproven because I had assumed a
     separate E2E was needed; it was not.
+  - merger-ai.ts  resolveFinalizeReboundColumn — the LIVE merge path's rebound column
+    (workflow-merge-rebound-live-e2e.pg.test.ts; mutation-verified). Weaker,
+    returned-decision evidence: the resolver returns a column and does not move a card,
+    so this proves the renamed board resolves correctly through a real store and a real
+    persisted workflow, NOT that a card lands there. It was in the "needs real git"
+    bucket by association; it is EXPORTED and takes (store, taskId) and touches no git.
   - auto-merge-finalization.ts  completeColumn / mergeColumn / isCompleteColumn
     (workflow-merge-family-live-e2e.pg.test.ts; each of the three mutation-verified
     INDEPENDENTLY — the mergeColumn one needed its own case, see below)
@@ -714,8 +720,15 @@ consumer is still to land, or it should be deleted. Not resolved here: it is pro
 by the U4 slice, and guessing which is a decision for its author.
 
 NOT PROVEN end to end — real callers this suite does not reach:
-  - merger.ts:324-326        resolveCompleteColumn / resolveMergeOrchestrationColumn / resolveReboundTarget
-  - merger-ai.ts:1022,1039   resolveReboundTarget, resolveLifecycleColumns
+  - merger.ts:324-326        resolveCompleteColumn / resolveMergeOrchestrationColumn /
+    resolveReboundTarget — DEAD PATH, do not build a lane for these. Every call sits
+    inside `aiMergeTask`, which is soft-deprecated, exported only with an @deprecated
+    tag, and has NO production caller (verified by grep across all packages; the live
+    merge path is merger-ai's runAiMerge / landWorkspaceTask, which project-engine
+    imports). Phase B converted a path production never executes. Not deleted here —
+    it is production code owned by another slice — but proving it would prove nothing.
+  - merger-ai.ts:1039        isAlreadyFinalizedColumn — LIVE, but module-private and
+    reached only from runAiMerge, so it does need the real-git lane
   - executor.ts:1763,6339,6341        rebound target, merge-orchestration probe, complete column
   - mesh-lease-manager.ts:61 resolveReboundTarget
   - core/live-agent-count.ts    columnIsIntakeOrHold (the WAITING predicate) — the running
@@ -724,12 +737,13 @@ NOT PROVEN end to end — real callers this suite does not reach:
 
 WHY, and what each would take. Two lanes, and neither is another table row:
 
-  LANE 1 — REAL GIT (engine-slow). merger.ts's `resolveMergerLifecycleColumn` and
-  executor.ts's `resolveReboundColumnFor` are module-private helpers whose only
-  callers sit inside merge/session machinery that needs a real worktree, branch and
-  squash. merger-ai.ts is the same. Re-checked with the lens that freed
-  auto-merge-finalization and both self-healing rebounds — these genuinely do need
-  the lane; the earlier over-broad claim does not apply to them.
+  LANE 1 — REAL GIT (engine-slow), now SMALLER than it looked. Only two things
+  genuinely need it: merger-ai's `isAlreadyFinalizedColumn` and executor's
+  `resolveReboundColumnFor`, both module-private and reached only from inside
+  merge/session machinery. merger.ts's three sites do NOT need the lane because they
+  are dead (see above), and merger-ai's `resolveFinalizeReboundColumn` did not need it
+  at all — it is now covered. Third time the "this family needs git" inference has
+  been wrong; check what the FUNCTION touches before costing a lane for it.
 
   LANE 2 — DASHBOARD HTTP. register-task-workflow-routes' four sites live behind
   `registerTaskWorkflowRoutes(ctx, deps)`, which needs a full ApiRoutesContext plus

--- a/packages/engine/src/__tests__/workflow-merge-rebound-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-merge-rebound-live-e2e.pg.test.ts
@@ -1,0 +1,95 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-10:40 (E2E — the LIVE merge-rebound resolver):
+
+`merger-ai.ts` is the live merge path (`runAiMerge` / `landWorkspaceTask` are what
+project-engine imports). `resolveFinalizeReboundColumn` decides where a card goes
+when finalization has to put it back — the failure branch of a merge, reached four
+times in `runAiMerge` and once in `landWorkspaceTask`.
+
+WHY THIS IS HERE AND NOT BEHIND THE REAL-GIT LANE. The ledger listed the whole merge
+family as needing a real worktree, branch and squash. Re-checked with the lens that
+already freed auto-merge-finalization and both self-healing rebounds:
+`resolveFinalizeReboundColumn` is EXPORTED and takes `(store, taskId)`. It touches no
+git at all. Its callers need git; it does not — and it is the part that carries the
+column vocabulary.
+
+OBSERVABILITY, labelled honestly: this resolver RETURNS a column, it does not move a
+card, so this is returned-decision evidence rather than persisted-row evidence. It
+proves the renamed board's rebound column is resolved correctly through a real store
+and a real persisted workflow; it does NOT prove a card lands there, because reaching
+that requires the merge failure branch and therefore the lane. Recorded that way in
+the ledger rather than counted as a full close.
+*/
+import { beforeAll, beforeEach, afterEach, afterAll, describe, expect, it } from "vitest";
+import "@fusion/core"; // registers the built-in column traits
+
+import {
+  pgDescribe,
+  createSharedPgTaskStoreTestHarness,
+  type SharedPgTaskStoreHarness,
+} from "../../../core/src/__test-utils__/pg-test-harness.js";
+import { resolveFinalizeReboundColumn } from "../merger-ai.js";
+import { DEFAULT_VOCAB, RENAMED_VOCAB, lifecycleIr, type Vocabulary } from "./_workflow-vocabulary-fixture.js";
+
+pgDescribe("live merge-rebound E2E: where the LIVE merge path puts a card back", () => {
+  const h: SharedPgTaskStoreHarness = createSharedPgTaskStoreTestHarness({
+    prefix: "fusion_merge_rebound_e2e",
+  });
+
+  beforeAll(h.beforeAll);
+  beforeEach(h.beforeEach);
+  afterEach(h.afterEach);
+  afterAll(h.afterAll);
+
+  async function seedBoundTask(taskId: string, v: Vocabulary, key: string): Promise<void> {
+    const store = h.store();
+    const created = await store.createWorkflowDefinition({
+      name: `Merge rebound ${key}`,
+      kind: "workflow",
+      ir: lifecycleIr(v, `custom:${key}`),
+    } as never);
+    await store.createTaskWithReservedId(
+      { description: `merge rebound ${taskId}`, column: v.review } as never,
+      { taskId, applyDefaultWorkflowSteps: false } as never,
+    );
+    await store.writeTaskWorkflowSelection(taskId, (created as { id: string }).id, []);
+    store.taskCache.delete(taskId);
+    // Prove the binding took: an unbound task resolves to the DEFAULT builtin IR and
+    // this suite would then pass for a reason unrelated to the renamed workflow.
+    const selection = await store.getTaskWorkflowSelectionAsync(taskId);
+    expect(selection?.workflowId).toBe((created as { id: string }).id);
+  }
+
+  describe.each([
+    { label: "RENAMED vocabulary", vocab: RENAMED_VOCAB, key: "renamed" },
+    { label: "DEFAULT vocabulary (regression floor)", vocab: DEFAULT_VOCAB, key: "default" },
+  ])("$label", ({ vocab, key }) => {
+    it("resolves the finalize-rebound column from the card's own workflow", async () => {
+      const taskId = `FN-MR-${key}-1`;
+      await seedBoundTask(taskId, vocab, `${key}-1`);
+
+      expect(await resolveFinalizeReboundColumn(h.store(), taskId)).toBe(vocab.hold);
+    });
+  });
+
+  it("falls back to the legacy column for a task with no resolvable workflow", async () => {
+    /* The fail-soft half, and it must stay: a merge finalization must never be
+       abandoned because a workflow lookup failed. An unknown task id is the cleanest
+       way to force the catch without corrupting a row. */
+    expect(await resolveFinalizeReboundColumn(h.store(), "FN-DOES-NOT-EXIST")).toBe("todo");
+  });
+
+  it("resolves a RENAMED board to a column that board actually declares", async () => {
+    /* The differential stated as the invariant that matters: whatever this returns
+       must be a column the workflow declares, or the card is rebounded into a lane the
+       board does not draw — the strand this program keeps finding. */
+    const taskId = "FN-MR-DIFF";
+    await seedBoundTask(taskId, RENAMED_VOCAB, "diff");
+
+    const resolved = await resolveFinalizeReboundColumn(h.store(), taskId);
+
+    const declared = new Set(Object.values(RENAMED_VOCAB));
+    expect(declared.has(resolved)).toBe(true);
+    expect(new Set(Object.values(DEFAULT_VOCAB)).has(resolved)).toBe(false);
+  });
+});


### PR DESCRIPTION
Stacked on #2544. Seventh E2E family, plus a reclassification that shrinks the remaining work.

## Two findings, both from tracing callers rather than trusting the family

### 1. `merger.ts`'s three census sites are a DEAD PATH

Every call to `resolveMergerLifecycleColumn` sits inside **`aiMergeTask`** — which is soft-deprecated, exported only with an `@deprecated` tag, and has **no production caller anywhere in the repo** (verified by grep across all packages). The live merge path is `merger-ai`'s `runAiMerge` / `landWorkspaceTask`, which is what `project-engine` actually imports.

**Phase B converted a path production never executes.** Not deleted here — it's production code owned by another slice — but building a real-git lane to prove it would prove nothing, and the ledger now says so instead of costing someone a week.

### 2. `merger-ai`'s `resolveFinalizeReboundColumn` never needed the lane either

It's **exported**, takes `(store, taskId)`, and touches no git — only its callers do. It is the live merge path's answer to *"where does this card go back to?"*, reached four times in `runAiMerge` and once in `landWorkspaceTask`.

Now covered against a real store and a real persisted renamed workflow. **Mutation-verified:** forcing the legacy literal fails exactly the two renamed cases.

## Labelled honestly as weaker evidence

This resolver **returns** a column and does not move a card — returned-decision, not persisted-row. It proves the renamed board resolves correctly; it does **not** prove a card lands there, which needs the merge failure branch and therefore the lane. Recorded that way in the ledger rather than counted as a full close.

## Lane 1 is smaller than advertised

Only two things genuinely need real git now: `merger-ai`'s private `isAlreadyFinalizedColumn` and `executor`'s private `resolveReboundColumnFor`.

**This is the third time the "this family needs git" inference has been wrong** (after `auto-merge-finalization` and both self-healing rebounds). The ledger now carries the rule explicitly: check what the *function* touches before costing a lane for it.

## Fixture guard

The seed asserts the workflow binding took effect — an unbound task resolves to the **default builtin IR**, and the suite would then pass for a reason unrelated to the renamed workflow. That exact trap has bitten this program more than once.

## Verification

- lifecycle + merge-rebound suites 24/24
- engine `tsc --noEmit` clean
- `pnpm test:gate` green (414 + 10 + 71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)