### PR TITLE
P0: default Planning cards read as ADVANCED after #2515 (FN-8596 stranding re-opened) + 6 red tests repaired

### DIFF
--- a/packages/engine/src/__tests__/replan-target-merged-planning-column.test.ts
+++ b/packages/engine/src/__tests__/replan-target-merged-planning-column.test.ts
@@ -1,0 +1,116 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-15:05 (U11 — post-#2515 P0 audit):
+
+#2515 merged Todo into Planning on the DEFAULT lineage: one pre-implementation
+column, id `todo`, display "Planning". `triage` stayed a legal id, so nothing
+throws — but every bare `column === "triage"` guard simply stopped matching for
+default-workflow cards.
+
+`hasAdvancedPastPlanning` carried two such guards, and they are NOT the same rule:
+
+  1. The FN-8596 "second strand" rescue: a card holding execution stamps that
+     PREDATE its arrival in the planner lane is replanning, not advanced. Its own
+     comment records what happens when nobody owns that card — "Nobody owned the
+     card and it sat indefinitely."
+
+  2. "The planner column itself is never advanced."
+
+Rule 1 must recognise the merged Planning column. Rule 2 must NOT: on the merged
+lineage `todo` is ALSO the released/hold lane, so treating it as blanket
+"not advanced" would make a released card with steps read as still-planning and
+break `hasAdvancedPastPlanning(t) || releasedToTodo`.
+
+That asymmetry is the whole fix, and these tests pin both halves.
+*/
+import { describe, expect, it } from "vitest";
+
+import { hasAdvancedPastPlanning, isTaskStillInPlanningStage } from "../replan-target.js";
+
+const ARRIVED = "2026-07-29T12:00:00.000Z";
+const BEFORE_ARRIVAL = "2026-07-29T11:00:00.000Z";
+const AFTER_ARRIVAL = "2026-07-29T13:00:00.000Z";
+
+function card(over: Record<string, unknown> = {}) {
+  return {
+    column: "todo",
+    status: null,
+    steps: [],
+    worktree: null,
+    columnMovedAt: ARRIVED,
+    ...over,
+  } as never;
+}
+
+describe("hasAdvancedPastPlanning on the merged Planning column (post-#2515 default lineage)", () => {
+  it("rescues a merged-Planning card whose execution stamps predate its arrival", () => {
+    /*
+    The stall. Pre-#2515 this card sat in `triage` and the FN-8596 rescue caught it.
+    Post-merge it sits in `todo` with status cleared to null by the stale-status
+    sweep, so the rescue stopped firing and every guarded planning write no-ops.
+    */
+    const replanning = card({
+      column: "todo",
+      firstExecutionAt: BEFORE_ARRIVAL,
+      executionStartedAt: BEFORE_ARRIVAL,
+      steps: [{ id: "s1" }],
+    });
+    expect(hasAdvancedPastPlanning(replanning)).toBe(false);
+    expect(isTaskStillInPlanningStage(replanning)).toBe(true);
+  });
+
+  it("still reads a merged-Planning card claimed AFTER arrival as advanced", () => {
+    /* The FN-8361 race must keep its answer: a stamp NEWER than arrival is a live
+       claim, and recovery must not clear the status out from under execution. */
+    expect(
+      hasAdvancedPastPlanning(
+        card({ column: "todo", executionStartedAt: AFTER_ARRIVAL, steps: [{ id: "s1" }] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a RELEASED merged-Planning card with steps reading as advanced", () => {
+    /*
+    The direction the fix must NOT break. On the merged lineage `todo` is also the
+    hold lane, so rule 2 stays keyed to a DEDICATED planner column. A released card
+    carries steps and no stamps; treating the column as blanket "not advanced" here
+    would strand the release path instead.
+    */
+    expect(hasAdvancedPastPlanning(card({ column: "todo", steps: [{ id: "s1" }] }))).toBe(true);
+  });
+
+  it("keeps an actively-planning merged card not-advanced via its status", () => {
+    expect(hasAdvancedPastPlanning(card({ column: "todo", status: "planning", steps: [{ id: "s1" }] }))).toBe(false);
+  });
+
+  it("leaves the dedicated-planner lineage byte-identical", () => {
+    /* Coding (Ideas) and every workflow that still declares `triage`. */
+    expect(hasAdvancedPastPlanning(card({ column: "triage", steps: [{ id: "s1" }] }))).toBe(false);
+    expect(
+      hasAdvancedPastPlanning(
+        card({ column: "triage", firstExecutionAt: BEFORE_ARRIVAL, steps: [{ id: "s1" }] }),
+      ),
+    ).toBe(false);
+    expect(
+      hasAdvancedPastPlanning(
+        card({ column: "triage", firstExecutionAt: AFTER_ARRIVAL, steps: [{ id: "s1" }] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps every implementation column advanced", () => {
+    for (const column of ["in-progress", "in-review", "done", "archived"]) {
+      expect(hasAdvancedPastPlanning(card({ column, steps: [{ id: "s1" }] }))).toBe(true);
+    }
+  });
+
+  it("honours an explicitly supplied merged planning column", () => {
+    /* A renamed workflow that also merges planning into its hold lane. */
+    const renamed = card({
+      column: "drafting",
+      firstExecutionAt: BEFORE_ARRIVAL,
+      steps: [{ id: "s1" }],
+    });
+    expect(hasAdvancedPastPlanning(renamed)).toBe(true);
+    expect(hasAdvancedPastPlanning(renamed, "triage", { mergedPlanningColumn: "drafting" })).toBe(false);
+  });
+});

--- a/packages/engine/src/__tests__/replan-target-renamed-planner.test.ts
+++ b/packages/engine/src/__tests__/replan-target-renamed-planner.test.ts
@@ -1,0 +1,72 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-10:05 (U11 conversion — replan-target):
+
+`replan-target.ts` decides two things by literal column id:
+
+  1. `hasAdvancedPastPlanning` — "is this card resting in the planner column?"
+     Two comparisons against `"triage"`. A card in a renamed planner column reads
+     as ADVANCED, which is the dangerous direction: the replan guards then treat a
+     card that is still being planned as one that has moved on, so recovery paths
+     stop protecting it and planning writes get skipped.
+
+  2. `resolveReplanTargetColumn` — where a rejected plan is sent back to. It asks
+     `workflowHasColumn(ir, "triage")` then `("todo")`. For a workflow using
+     neither name BOTH lookups miss and it falls through to `"triage"` — a column
+     that workflow does not declare. Today that strands the card; after U11
+     deletes `todo` it also removes the second chance.
+
+The final fallback stays a DELIBERATE LITERAL and is not converted — see the
+existing FNXC note in the source. Its value is precisely that it is NOT
+trait-resolved: it fires only when a workflow declares no planner lane at all, and
+resolving it against that workflow (to its own entry column) is the stranded-card
+bug it was written to fix.
+
+Written against the literal implementation and observed FAILING first.
+*/
+import { describe, expect, it } from "vitest";
+import type { Task } from "@fusion/core";
+
+import { hasAdvancedPastPlanning, isTaskStillInPlanningStage } from "../replan-target.js";
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "FN-1",
+    column: "drafting",
+    status: null,
+    steps: [],
+    worktree: undefined,
+    columnMovedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  } as unknown as Task;
+}
+
+describe("hasAdvancedPastPlanning under a renamed planner column", () => {
+  it("does NOT treat a card resting in the renamed planner column as advanced", () => {
+    /*
+    The dangerous direction. Reading "still planning" as "advanced" makes the
+    replan guards stop protecting a card that is mid-plan, so planning writes are
+    silently skipped and the card is never re-specified.
+    */
+    /* STEPS ARE LOAD-BEARING HERE. With an empty step list the final branch
+       returns false anyway, so the assertion would pass without the planner-lane
+       check ever running. A card carrying steps from its previous planning pass is
+       the case that actually distinguishes the two. */
+    const planned = task({ column: "drafting", steps: [{ name: "s", status: "done" }] } as Partial<Task>);
+    expect(hasAdvancedPastPlanning(planned, "drafting")).toBe(false);
+    expect(isTaskStillInPlanningStage(planned, "drafting")).toBe(true);
+  });
+
+  it("still treats a card in a NON-planner column as advanced", () => {
+    /* The negative half: the parameter must narrow, not blanket-answer. */
+    expect(hasAdvancedPastPlanning(task({ column: "building", steps: [{ name: "s", status: "done" }] } as Partial<Task>), "drafting")).toBe(true);
+  });
+
+  it("defaults to the legacy planner column when no column is supplied", () => {
+    /* Byte-identical for every caller that cannot resolve a workflow — including
+       the three in self-healing.ts, which are another worker's slice. */
+    const planned = task({ column: "triage", steps: [{ name: "s", status: "done" }] } as Partial<Task>);
+    expect(hasAdvancedPastPlanning(planned)).toBe(false);
+    expect(isTaskStillInPlanningStage(planned)).toBe(true);
+  });
+});

--- a/packages/engine/src/__tests__/replan-target.test.ts
+++ b/packages/engine/src/__tests__/replan-target.test.ts
@@ -253,14 +253,22 @@ describe("planning-stage guard", () => {
 });
 
 describe("resolveReplanTargetColumn", () => {
-  it("targets triage for the default Coding workflow", async () => {
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-15:25 (U11 — post-#2515 audit):
+#2515 removed `triage` from the DEFAULT lineage, so the default workflow's replan
+column is now its merged Planning column, `todo`. `resolveReplanTargetColumn`
+already reads the IR rather than a literal, so it self-healed to the right answer
+and these expectations were the stale half — they were left RED on main by #2515.
+Updated to the post-merge truth, not loosened: each still pins one exact column.
+*/
+  it("targets the merged Planning column for the default Coding workflow", async () => {
     const store = storeWithSelection("builtin:coding");
-    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("triage");
+    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("todo");
   });
 
-  it("targets triage when the task has no workflow selection", async () => {
+  it("targets the merged Planning column when the task has no workflow selection", async () => {
     const store = storeWithSelection(undefined);
-    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("triage");
+    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("todo");
   });
 
   it("targets todo for Coding (Ideas), which declares no triage column", async () => {
@@ -276,14 +284,20 @@ describe("resolveReplanTargetColumn", () => {
     await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("triage");
   });
 
-  it("falls back to triage when workflow resolution throws", async () => {
+  /* Resolution failure no longer reaches the `triage` catch: the resolver swallows
+     the error and hands back the default IR, whose planner lane is now `todo`. The
+     two literal `return "triage"` fallbacks survive only for workflows that declare
+     neither column (see the marketing case above) — a pre-existing wart, since that
+     names a column the default lineage no longer has. Left for the owner of the
+     replan-target column policy rather than widened here. */
+  it("falls back to the default lineage planner when workflow resolution throws", async () => {
     const store = {
       getTaskWorkflowSelection: vi.fn(() => {
         throw new Error("boom");
       }),
       getWorkflowDefinition: vi.fn().mockRejectedValue(new Error("boom")),
     } as unknown as TaskStore;
-    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("triage");
+    await expect(resolveReplanTargetColumn(store, "FN-1")).resolves.toBe("todo");
   });
 });
 
@@ -325,7 +339,7 @@ moves.
 describe("replan bounces preserve the task worktree (FN-8603)", () => {
   const REPLAN_BOUNCE_ORIGINS = ["in-progress", "in-review", "done"] as const;
   const REPLAN_COLUMN_SHAPES = [
-    { workflowId: undefined, expected: "triage", label: "default Coding (triage replan column)" },
+    { workflowId: undefined, expected: "todo", label: "default Coding (merged Planning replan column, post-#2515)" },
     { workflowId: "builtin:coding-ideas", expected: "todo", label: "Coding (Ideas) (plan-in-place todo)" },
   ] as const;
 

--- a/packages/engine/src/replan-target.ts
+++ b/packages/engine/src/replan-target.ts
@@ -82,6 +82,18 @@ export function hasAdvancedPastPlanning(
     // the execution-stamp branch). Optional so existing narrowed callers still compile; absent, the
     // branch keeps its prior "stamps mean advanced" answer.
     & Partial<Pick<Task, "firstExecutionAt" | "executionStartedAt" | "columnMovedAt">>,
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-29-10:20 (U11):
+  The workflow's PLANNER column. `triage` is only what the builtin coding workflow
+  calls it, and reading a renamed planner column as "advanced" is the dangerous
+  direction: the replan guards stop protecting a card that is still mid-plan, so
+  planning writes are skipped and it is never re-specified.
+
+  Defaults to the legacy id so every unconverted caller is byte-identical — which
+  includes the three call sites in self-healing.ts, deliberately left alone
+  because that file belongs to another worker's slice.
+  */
+  plannerColumn: string = "triage",
 ): boolean {
   if (
     task.column === "in-progress"
@@ -162,7 +174,7 @@ export function hasAdvancedPastPlanning(
     AFTER landing here has a stamp NEWER than its arrival, so it still reads advanced and stays with
     the advanced-recovery sweep.
     */
-    const inPlannerLane = task.column === "triage";
+    const inPlannerLane = task.column === plannerColumn;
     if (!(stampPredatesArrival && inPlannerLane)) {
       return true;
     }
@@ -170,7 +182,7 @@ export function hasAdvancedPastPlanning(
   }
   // The planner column itself is never "advanced" — nothing executes out of triage, and the steps
   // below belong to the card's previous planning pass.
-  if (task.column === "triage") {
+  if (task.column === plannerColumn) {
     return false;
   }
   // Plan-in-place planner lane ("todo"): a card explicitly parked for planning has not advanced.
@@ -191,13 +203,33 @@ the "not advanced" answer, and TypeScript could not flag it.
 export function isTaskStillInPlanningStage(
   task: Pick<Task, "column" | "worktree" | "steps" | "status">
     & Partial<Pick<Task, "firstExecutionAt" | "executionStartedAt" | "columnMovedAt">>,
+  plannerColumn: string = "triage",
 ): boolean {
-  return !hasAdvancedPastPlanning(task);
+  return !hasAdvancedPastPlanning(task, plannerColumn);
 }
 
 export async function resolveReplanTargetColumn(store: TaskStore, taskId: string): Promise<string> {
   try {
     const ir = await resolveWorkflowIrForTask(store, taskId);
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-29-10:40 (U11 — NOT CONVERTED, and why):
+    These two lookups look like `intake ?? hold` but they are not, and swapping
+    them for roles is WRONG. Coding (Ideas) declares `ideas` as its intake column
+    with `autoTriage: false` and does its planning in `todo` (the hold column,
+    plan-in-place). A role swap therefore sends its replans to the raw-ideas
+    column instead of the planning lane — caught here by the pre-existing
+    "targets todo for Coding (Ideas)" test rather than in production.
+
+    The real discriminator is which lane the triage service SCANS, which depends
+    on the intake column's `autoTriage` config, not on the intake/hold roles
+    alone. Resolving that correctly is its own change with its own evidence; it is
+    deliberately not smuggled into a conversion PR.
+
+    U11 IMPACT, flagged rather than assumed: the second lookup asks for `"todo"`,
+    which U11 deletes. For builtin coding the first lookup still matches `triage`
+    (which U11 keeps), so the builtins stay correct — but a workflow relying on the
+    `todo` branch loses it. That is a real follow-up, not a blocker for this PR.
+    */
     if (workflowHasColumn(ir, "triage")) return "triage";
     if (workflowHasColumn(ir, "todo")) return "todo";
     return "triage";

--- a/packages/engine/src/replan-target.ts
+++ b/packages/engine/src/replan-target.ts
@@ -94,6 +94,22 @@ export function hasAdvancedPastPlanning(
   because that file belongs to another worker's slice.
   */
   plannerColumn: string = "triage",
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-29-15:10 (U11 — post-#2515 P0 audit):
+  The workflow's MERGED planning column: a lane that is the planner AND the hold
+  column at once. #2515 made that the default lineage's shape (one
+  pre-implementation column, id `todo`, display "Planning"), so this defaults to
+  `todo` rather than being absent — that default is what closes the stall for
+  every caller at once, with no call-site change.
+
+  Deliberately SEPARATE from `plannerColumn`, because the two rules below are not
+  the same rule. A merged column participates in the FN-8596 arrival-order rescue
+  but NOT in the "planner column is never advanced" shortcut: on a merged lineage
+  the same id also means "released, awaiting capacity", and a released card with
+  steps must keep reading as advanced or `hasAdvancedPastPlanning(t) ||
+  releasedToTodo` stops distinguishing anything.
+  */
+  roles: { mergedPlanningColumn?: string } = { mergedPlanningColumn: "todo" },
 ): boolean {
   if (
     task.column === "in-progress"
@@ -174,7 +190,11 @@ export function hasAdvancedPastPlanning(
     AFTER landing here has a stamp NEWER than its arrival, so it still reads advanced and stays with
     the advanced-recovery sweep.
     */
-    const inPlannerLane = task.column === plannerColumn;
+    /* Merged lanes participate HERE — the rescue is already gated on the stamp
+       predating arrival, so a released card later claimed by execution (newer
+       stamp) still reads as advanced and stays with the advanced-recovery sweep. */
+    const inPlannerLane = task.column === plannerColumn
+      || (roles.mergedPlanningColumn != null && task.column === roles.mergedPlanningColumn);
     if (!(stampPredatesArrival && inPlannerLane)) {
       return true;
     }
@@ -204,8 +224,9 @@ export function isTaskStillInPlanningStage(
   task: Pick<Task, "column" | "worktree" | "steps" | "status">
     & Partial<Pick<Task, "firstExecutionAt" | "executionStartedAt" | "columnMovedAt">>,
   plannerColumn: string = "triage",
+  roles: { mergedPlanningColumn?: string } = { mergedPlanningColumn: "todo" },
 ): boolean {
-  return !hasAdvancedPastPlanning(task, plannerColumn);
+  return !hasAdvancedPastPlanning(task, plannerColumn, roles);
 }
 
 export async function resolveReplanTargetColumn(store: TaskStore, taskId: string): Promise<string> {


### PR DESCRIPTION
Rebased onto `main` (post-#2515) and **upgraded from a conversion to a P0 stall fix**.

## What changed since review

Greptile's P1 on this PR said the `plannerColumn` seam was unused — *"every current production caller omits `plannerColumn`, so this default still compares against `triage`."* That was correct, and **#2515 turned it from an unused seam into a live stall.**

## The stall

#2515 merged Todo into Planning on the default lineage (one pre-implementation column, id `todo`, display "Planning"). `triage` stayed a legal id, so nothing throws — the bare `column === "triage"` guards in `hasAdvancedPastPlanning` just **stopped matching for default-workflow cards**.

A default card in `todo`, status cleared to null by the stale-status sweep, carrying execution stamps from a previous pass, now returns **ADVANCED**. So `isTaskStillInPlanningStage` is false and nine guarded call sites refuse planning updates, finalize, delete and handoff:

`triage.ts` 3108 / 3117 / 3160 / 3438 / 3937 — `self-healing.ts` 12126 / 12448 / 12454

The file's own FNXC note at `:150` already records what that costs:

> Nobody owned the card and it sat indefinitely.

This is that same FN-8596 stranding, re-opened by the column merge. Confirmed empirically — the rescue test fails on pre-fix code.

## The fix is an asymmetry, and that's the point

The two guards are **not the same rule**:

1. the FN-8596 **arrival-order rescue** — a stamp predating arrival in the planner lane means replanning, not advancement
2. **"the planner column itself is never advanced"**

Rule 1 must recognise the merged Planning column. **Rule 2 must not** — on the merged lineage `todo` is *also* the released/hold lane, so making it blanket "not advanced" would strand the release path instead: a released card with steps would read as still-planning and `hasAdvancedPastPlanning(t) || releasedToTodo` would stop distinguishing anything.

Rule 1 is already gated on the stamp predating arrival, so a released card later claimed by execution keeps its newer stamp and still reads as advanced.

**Closed via the default** (`mergedPlanningColumn = "todo"`) rather than by wiring call sites — the stall closes everywhere at once, with no call-site change and nothing to collide with another worker's slice. Dedicated-planner workflows (Coding (Ideas), and every workflow still declaring `triage`) are byte-identical.

## Second commit: 6 tests left RED on main by #2515

Verified pre-existing by stashing every local change and re-running — same 6 failures on a clean branch. `resolveReplanTargetColumn` reads the IR rather than a literal, so it **self-healed** to the correct post-merge answer (`todo`); the expectations were the stale half. Updated to the post-merge truth, not loosened — each still pins one exact column.

## Audit table for this file (P0 sweep)

| site | still fires for a default card? | what silently stopped | disposition |
|---|---|---|---|
| `replan-target.ts:177` `inPlannerLane` | **NO** | FN-8596 rescue — planning writes no-op, card strands | **fixed** (rule 1) |
| `replan-target.ts:185` never-advanced | NO | nothing — must stay dedicated-planner-only | **deliberately unchanged** (rule 2) |
| `resolveReplanTargetColumn` | yes (IR-driven) | — self-healed to `todo` | tests repaired |
| its two `return "triage"` fallbacks | n/a | reachable only for workflows declaring neither column | **recorded, not fixed** — column-policy decision, has its own covering test |

## Verification

- **Mutation-verified both directions:** dropping the merged lane from rule 1 fails **2** tests; wrongly extending rule 2 to the merged lane fails **1**
- 50 replan-target tests green (7 new)
- merge gate green (414 + 10 + 71), tsc clean, lint clean

## Separate finding — affects every worker

`resolveTaskWorkflowIrSync` **cannot resolve a task's selection in production.** `getTaskWorkflowSelectionImpl` is `return undefined` unconditionally and `getTaskWorkflowSelectionAsyncImpl` is *"always PostgreSQL path"*, so the sync resolver **always** returns the DEFAULT workflow IR. `moves.ts` already hit this and fixed it by going async. Any conversion built on the sync resolver is inert for **custom** workflows — harmless for default cards, since the default IR is exactly what comes back. Reported to the coordinator for the other workers; not actionable in this PR, which uses no sync resolution.

No changeset: `@fusion/engine` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
