### PR TITLE
U7 PR11: the five triage under-the-lock planning guards resolve the intake column (stacked on #2551)

### DIFF
--- a/.changeset/planner-lane-callsites.md
+++ b/.changeset/planner-lane-callsites.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: On a workflow with renamed columns, planning writes are no longer refused after a stale-status sweep clears the card.
+category: fix
+dev: U7 / R3. The five triage call sites of `isTaskStillInPlanningStage` — the under-the-lock guards for `updateTaskAtomic`, `withTaskLock`, `deleteTaskIf`, and discovery — used the legacy `triage` default, so a renamed-workflow card whose planning status had been cleared read as "advanced past planning" and every guarded write was refused. They now read the task's intake column synchronously from the snapshot the discovery pass publishes (these run under the task lock, where nothing may await). A task no pass has published falls back to the legacy id, so the pre-first-poll window is byte-identical. self-healing.ts's three call sites are left to that file's owner per the drift-review split.

--- a/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
+++ b/packages/engine/src/__tests__/triage-resolved-lifecycle-columns.test.ts
@@ -691,3 +691,102 @@ describe("stuck-abort recognises a completed handoff in the workflow's own hold 
     });
   }
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. The under-the-lock planning guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+/*
+FNXC:PlannerLanePredicate 2026-07-29-12:10 (U7 / R3):
+`isTaskStillInPlanningStage` is the predicate handed to `moveTaskIf`,
+`deleteTaskIf` and `updateTaskAtomic` as their UNDER-THE-LOCK guard. It asked
+`column === "triage"` literally, so on a renamed workflow a card resting in its own
+intake column read as "advanced past planning" and every guarded write was REFUSED —
+the planning claim, the finalize handoff, the duplicate delete.
+
+That is the same class as the discovery and release literals, but strictly worse in
+consequence: those made planning not START, this makes planning unable to FINISH,
+and it fails as a refusal rather than as an absence, so the card sits with a
+half-written state and a warning nobody reads.
+
+These guards run under the task lock, where nothing may await, so the lane is read
+SYNCHRONOUSLY from the snapshot the discovery pass publishes. A task no pass has
+seen falls back to the legacy intake id, so the pre-first-poll window is unchanged —
+asserted below, because that fallback is the reason this cannot regress a workflow
+that never renamed anything.
+*/
+describe("the under-the-lock planning guards resolve the task's intake column", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    resetExecutorMocks();
+    vi.clearAllMocks();
+    rootDir = await mkdtemp(join(tmpdir(), "fusion-triage-guard-"));
+    vi.spyOn(planLog, "log").mockImplementation(() => {});
+    vi.spyOn(planLog, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  /**
+   * A card resting in its own intake column, holding steps from a previous planning
+   * pass, with its status ALREADY CLEARED.
+   *
+   * The cleared status is load-bearing and it corrected my first fixture: with
+   * `status: "planning"` the predicate returns "still planning" from the
+   * planning-stage-status branch BEFORE it ever reaches the column check, so the
+   * literal could not have mattered and the test proved nothing. The column branch
+   * only bites once the status is gone — which is exactly the FN-8596 second strand
+   * the production comment describes: the stale-status sweep clears `planning` to
+   * null, and the card is then judged purely on its column and its leftover steps.
+   */
+  const replannedCard = (column: string): Task => createTask({
+    id: "FN-001",
+    column,
+    status: null,
+    steps: [{ id: "s0", title: "Implement", status: "pending" }],
+  } as Partial<Task>);
+
+  /** Did the guarded planning-state write land? */
+  async function guardedWriteLanded(
+    names: { intake: string; hold: string; wip: string },
+    opts: { publishRoles?: boolean } = { publishRoles: true },
+  ): Promise<boolean> {
+    const task = replannedCard(names.intake);
+    const store = createStore({ tasks: [task], workflowIr: ir(names) });
+    const processor = new TriageProcessor(store, rootDir);
+    if (opts.publishRoles) {
+      vi.spyOn(processor as unknown as { specifyTask: (t: Task) => Promise<void> }, "specifyTask")
+        .mockResolvedValue(undefined);
+      (processor as unknown as { running: boolean }).running = true;
+      await (processor as unknown as { poll: () => Promise<void> }).poll();
+      vi.mocked(store.updateTaskAtomic!).mockClear();
+    }
+
+    return (processor as unknown as {
+      updatePlanningStateIfStillCurrent: (t: Task, p: Partial<Task>) => Promise<boolean>;
+    }).updatePlanningStateIfStillCurrent(task, { status: "planning" });
+  }
+
+  it("permits the guarded write for a card in the DEFAULT intake column (no-regression half)", async () => {
+    expect(await guardedWriteLanded(DEFAULT_NAMES)).toBe(true);
+  });
+
+  it("permits the guarded write for a card in a RENAMED intake column", async () => {
+    // Pre-conversion this was refused: the card read as "advanced past planning"
+    // while resting exactly where planning puts it, so the planning claim, the
+    // finalize handoff and the duplicate delete were all rejected.
+    expect(await guardedWriteLanded(RENAMED)).toBe(true);
+  });
+
+  it("keeps the legacy answer for a card no discovery pass has published", async () => {
+    // The compatibility window, asserted rather than assumed: with no published
+    // roles the lane is the legacy `triage`, so a renamed intake column still reads
+    // as advanced — byte-identical to the behavior before this conversion.
+    expect(await guardedWriteLanded(RENAMED, { publishRoles: false })).toBe(false);
+    expect(await guardedWriteLanded(DEFAULT_NAMES, { publishRoles: false })).toBe(true);
+  });
+});

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -329,6 +329,26 @@ export class TriageProcessor {
   */
   private static readonly LEGACY_PLANNING_LANE = { intake: "triage", hold: "todo" } as const;
 
+  /**
+   * FNXC:PlannerLanePredicate 2026-07-29-12:10 (U7 / R3):
+   * The planner lane to hand `isTaskStillInPlanningStage`, read SYNCHRONOUSLY from
+   * the snapshot the discovery pass publishes.
+   *
+   * Every consumer of that predicate is an under-the-lock guard — `moveTaskIf`,
+   * `deleteTaskIf`, `updateTaskAtomic` — where nothing may await, so this cannot
+   * become a lookup. The snapshot exists precisely because these paths are
+   * synchronous.
+   *
+   * Falls back to the legacy intake id for a task no pass has published yet, so the
+   * answer in that window is byte-identical to before this conversion. Named
+   * separately from `LEGACY_PLANNING_LANE` only because the predicate wants the
+   * intake column alone.
+   */
+  private plannerLaneFor(taskId: string): { intake: string } {
+    const intake = this.lifecycleRolesByTask.get(taskId)?.intake;
+    return { intake: intake ?? TriageProcessor.LEGACY_PLANNING_LANE.intake };
+  }
+
   private running = false;
   private polling = false;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -1589,7 +1609,7 @@ export class TriageProcessor {
     };
 
     const eligibleTriageTasks = allTasks.filter(
-      (t) => isAt(t, "intake") && isTaskStillInPlanningStage(t)
+      (t) => isAt(t, "intake") && isTaskStillInPlanningStage(t, { intake: rolesById.get(t.id)!.intake! })
         && !this.advancedRecoveryReservations.has(t.id)
         && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
@@ -3301,7 +3321,7 @@ export class TriageProcessor {
       // Compatibility adapters used by older embedded hosts do not expose the
       // core task lock; current TaskStore implementations always take the atomic path.
       const liveTask = await Promise.resolve(this.store.getTask(task.id)).catch(() => task) ?? task;
-      if (!isTaskStillInPlanningStage(liveTask)) {
+      if (!isTaskStillInPlanningStage(liveTask, this.plannerLaneFor(task.id))) {
         return false;
       }
       await this.store.updateTask(task.id, typeof patch === "function" ? patch(liveTask) : patch);
@@ -3310,7 +3330,7 @@ export class TriageProcessor {
 
     let persisted = false;
     await this.store.updateTaskAtomic(task.id, (liveTask) => {
-      if (!isTaskStillInPlanningStage(liveTask)) {
+      if (!isTaskStillInPlanningStage(liveTask, this.plannerLaneFor(task.id))) {
         /*
          * FNXC:Triage 2026-07-15-16:35:
          * FN-7977: a provider or validation failure must never overwrite an
@@ -3353,7 +3373,7 @@ export class TriageProcessor {
     }
     return store.withTaskLock(task.id, async () => {
       const live = await store.readTaskForMove(task.id);
-      if (!isTaskStillInPlanningStage(live)) {
+      if (!isTaskStillInPlanningStage(live, this.plannerLaneFor(task.id))) {
         planLog.warn(
           `${task.id}: planning-guarded write skipped — no longer in the planning stage `
           + `(column=${live?.column ?? "unknown"}, status=${live?.status ?? "null"}, `
@@ -3631,7 +3651,8 @@ export class TriageProcessor {
       if (resolution === "delete") {
         const deleteTaskIf = (this.store as unknown as { deleteTaskIf?: TaskStore["deleteTaskIf"] }).deleteTaskIf;
         if (typeof deleteTaskIf !== "function") return;
-        const result = await deleteTaskIf.call(this.store, task.id, isTaskStillInPlanningStage, {
+        const plannerLane = this.plannerLaneFor(task.id);
+        const result = await deleteTaskIf.call(this.store, task.id, (live) => isTaskStillInPlanningStage(live, plannerLane), {
           removeLineageReferences: true,
           // FNXC:TaskDeleteAttribution 2026-07-26-14:30: duplicate-resolution delete is engine-driven.
           auditContext: { agentId: task.assignedAgentId ?? "triage", runId: generateSyntheticRunId("triage-delete", task.id), callerKind: "engine" },


### PR DESCRIPTION
> **Stack: #2517 → #2551 → this.** Follows #2551, which made the planner lane injectable; this wires triage's own call sites.

## What was broken

`isTaskStillInPlanningStage` is the predicate handed to `updateTaskAtomic`, `withTaskLock`, `deleteTaskIf` and discovery as their **under-the-lock guard**. All five triage sites used the legacy `triage` default — so on a renamed workflow, a card resting in its own intake column read as *"advanced past planning"* and **every guarded write was refused**: the planning claim, the finalize handoff, the duplicate delete.

This is worse in consequence than the discovery and release literals already fixed in this unit. Those made planning fail to **start**; this makes it unable to **finish** — and it fails as a *refusal* rather than an absence, so the card sits half-written behind a warning nobody reads.

## A snapshot read, not a lookup

These guards run **under the task lock, where nothing may await**; an in-transaction guard that yields is not a guard. `plannerLaneFor` reads the roles the discovery pass already publishes (#2523's snapshot) — which is exactly what that snapshot exists for. Unpublished tasks fall back to the legacy intake id, so the pre-first-poll window is byte-identical. **Asserted, not assumed.**

## My first fixture proved nothing, and the failure said so

I built the card with `status: "planning"`. But the predicate returns *"still planning"* from the planning-stage-**status** branch before it ever reaches the column check — so the literal could not have mattered and all three cases would have passed either way.

The column branch only bites once the status is **cleared** — which is precisely the FN-8596 second strand the production comment describes: the stale-status sweep clears `planning` to null, and the card is then judged purely on its column and its leftover steps. Fixture corrected to that shape, with the reason recorded in it.

That is the **seventh** fixture defect in this unit, and the first where the defect was my *test premise* rather than a store fake. The tell was the one `docs/solutions/store-fake-defects-that-masquerade-as-production-bugs.md` (#2534) names — failing for the wrong reason. Here it was **passing** for the wrong reason, which the "both halves failed" heuristic would not have caught; only the unpublished-roles control did, by passing when it should have failed. Worth adding to that doc: a control that passes when you expected red is the same signal as a test that fails for the wrong reason.

## Revert proof

With all five guards back on the legacy default: **1 of 36 fails** — the renamed-intake case. The default-vocabulary case *and the legacy-fallback case* pass either way, the correct signature for a conversion that changes no existing behavior.

## Convergence

| File | `column === / !== "todo" \| "triage"` |
|---|---|
| `triage.ts` | **0** (was 11 across the chain; unchanged by this PR — it converts *call sites*, not comparisons) |
| `replan-target.ts` | **0** (#2551) |

`self-healing.ts`'s three `isTaskStillInPlanningStage` call sites are **deliberately not touched** — that file is the capacity worker's under the drift-review split, and they carry the same latent breakage. Split on file boundaries so we do not collide.

## Verification

| Check | Result |
|---|---|
| suite | 36/36 |
| 15 triage / planning / replan / self-healing / restart suites | 461/461, clean exit, **no expectation edits** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (414 + 10 + 71) |
| `pnpm check:changesets` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
