### PR TITLE
test(engine): prove the merge chokepoint's already-finalized short circuit — Lane 1 is now one function

### DIFF
--- a/packages/engine/src/__tests__/workflow-already-finalized-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-already-finalized-live-e2e.pg.test.ts
@@ -1,0 +1,134 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-11:30 (E2E — the already-finalized short circuit):
+
+`runAiMerge` is THE merge path (chokepoint U0), and the first thing it does after
+reading the task — explicitly "BEFORE any git work" — is ask whether the card is
+already in a terminal column of its OWN workflow. Its conversion note names the bug:
+
+    "Under a renamed workflow the literal `done`/`archived` pair stopped matching,
+     and the already-finalized card fell through to `getTaskMergeBlocker` — which
+     threw 'task is in shipped, must be in in-review' for a task whose real state
+     was 'already done, nothing to do'."
+
+So the failure is not a silent one for once — it THROWS, on a card that needed
+nothing done. That makes the observable difference unusually crisp: correct behaviour
+returns a clean no-op; the broken behaviour raises an error naming a column the
+operator never asked about.
+
+FOURTH TIME THE "NEEDS REAL GIT" INFERENCE WAS WRONG. The ledger had this behind the
+real-git lane because it lives in the merge family. The short circuit returns before
+any git work, so a real store and a real persisted workflow are the whole harness.
+
+THE PER-ROLE FALLBACK IS THE SUBTLE HALF (PR #2471 review, P1). The terminal pair is
+resolved per ROLE, not per set: a workflow that declares `complete` but no `archived`
+must keep the legacy `archived` id for the half it did not declare. The shared
+vocabulary fixture is exactly that shape — it declares a complete column and no
+archived one — so both directions are exercised here rather than assumed.
+*/
+import { beforeAll, beforeEach, afterEach, afterAll, describe, expect, it } from "vitest";
+import "@fusion/core"; // registers the built-in column traits
+
+import {
+  pgDescribe,
+  createSharedPgTaskStoreTestHarness,
+  type SharedPgTaskStoreHarness,
+} from "../../../core/src/__test-utils__/pg-test-harness.js";
+import { runAiMerge } from "../merger-ai.js";
+import { DEFAULT_VOCAB, RENAMED_VOCAB, lifecycleIr, type Vocabulary } from "./_workflow-vocabulary-fixture.js";
+
+pgDescribe("live already-finalized E2E: the merge chokepoint's terminal short circuit", () => {
+  const h: SharedPgTaskStoreHarness = createSharedPgTaskStoreTestHarness({
+    prefix: "fusion_already_finalized_e2e",
+  });
+
+  beforeAll(h.beforeAll);
+  beforeEach(h.beforeEach);
+  afterEach(h.afterEach);
+  afterAll(h.afterAll);
+
+  /** Seed a card and park it directly in `column`. Written through the admin client
+   *  because `archived` is not a lane the transition policy will walk a card into, and
+   *  the point here is the state a finished card is already in. The seed is asserted. */
+  async function seedAt(taskId: string, v: Vocabulary, key: string, column: string): Promise<void> {
+    const store = h.store();
+    const created = await store.createWorkflowDefinition({
+      name: `Already finalized ${key}`,
+      kind: "workflow",
+      ir: lifecycleIr(v, `custom:${key}`),
+    } as never);
+    await store.createTaskWithReservedId(
+      { description: `finalized ${taskId}`, column: v.hold } as never,
+      { taskId, applyDefaultWorkflowSteps: false } as never,
+    );
+    await store.writeTaskWorkflowSelection(taskId, (created as { id: string }).id, []);
+    await h.adminSql()`UPDATE project.tasks SET "column" = ${column} WHERE id = ${taskId}`;
+    store.taskCache.delete(taskId);
+    const seeded = await store.getTask(taskId);
+    expect(seeded.column).toBe(column);
+    expect((await store.getTaskWorkflowSelectionAsync(taskId))?.workflowId).toBe((created as { id: string }).id);
+  }
+
+  /** Run the real chokepoint. `projectRootDir` is the harness temp dir and is never
+   *  touched: the short circuit returns before any git work, which is the whole reason
+   *  this suite does not need a repository. */
+  async function merge(taskId: string) {
+    return runAiMerge(h.store(), h.rootDir(), taskId);
+  }
+
+  describe.each([
+    { label: "RENAMED vocabulary", vocab: RENAMED_VOCAB, key: "renamed" },
+    { label: "DEFAULT vocabulary (regression floor)", vocab: DEFAULT_VOCAB, key: "default" },
+  ])("$label", ({ vocab, key }) => {
+    it("short-circuits a card already in the workflow's COMPLETE column", async () => {
+      const taskId = `FN-AF-${key}-1`;
+      await seedAt(taskId, vocab, `${key}-1`, vocab.complete);
+
+      const result = await merge(taskId);
+
+      expect(result.noOp).toBe(true);
+      expect(result.reason).toBe("already-finalized");
+      expect(result.ok).toBe(true);
+    });
+
+    it("short-circuits a card in `archived` even though the workflow never declares it", async () => {
+      /* The per-role fallback. This fixture declares a complete column and NO archived
+         one, so `lifecycle.archived` is undefined and the guard must keep the legacy
+         `archived` id for that half alone. A per-SET fallback — replacing the whole
+         pair as soon as any role resolves — collapses to one element and silently
+         drops this short circuit, which is the P1 the review caught. */
+      const taskId = `FN-AF-${key}-2`;
+      await seedAt(taskId, vocab, `${key}-2`, "archived");
+
+      const result = await merge(taskId);
+
+      expect(result.noOp).toBe(true);
+      expect(result.reason).toBe("already-finalized");
+    });
+  });
+
+  it("does NOT short-circuit a card still in the review lane", async () => {
+    /* The negative half. "Treat anything that looks terminal as done" would make the
+       chokepoint silently skip real merges. A review-lane card must get past this
+       guard — it then fails for its own reasons (no branch/worktree here), which is a
+       DIFFERENT outcome from the clean no-op and is what this asserts. */
+    const taskId = "FN-AF-REVIEW";
+    await seedAt(taskId, RENAMED_VOCAB, "review", RENAMED_VOCAB.review);
+
+    const outcome = await merge(taskId).then(
+      (r) => ({ kind: "resolved" as const, reason: r.reason }),
+      (e: unknown) => ({ kind: "threw" as const, reason: e instanceof Error ? e.message : String(e) }),
+    );
+
+    expect(outcome.reason).not.toBe("already-finalized");
+  });
+
+  it("throws NOTHING for a finalized renamed card — the regression this guard exists for", async () => {
+    /* Stated as its own case because the pre-conversion symptom was an ERROR, not a
+       wrong column: "task is in 'shipped', must be in 'in-review'". Asserting the
+       absence of that throw is the clearest statement of what was fixed. */
+    const taskId = "FN-AF-NOTHROW";
+    await seedAt(taskId, RENAMED_VOCAB, "nothrow", RENAMED_VOCAB.complete);
+
+    await expect(merge(taskId)).resolves.toMatchObject({ noOp: true, reason: "already-finalized" });
+  });
+});

--- a/packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts
@@ -707,6 +707,13 @@ two self-healing sweeps verified PER SITE — reverting one fails exactly its ow
     so this proves the renamed board resolves correctly through a real store and a real
     persisted workflow, NOT that a card lands there. It was in the "needs real git"
     bucket by association; it is EXPORTED and takes (store, taskId) and touches no git.
+  - merger-ai.ts  isAlreadyFinalizedColumn — the merge chokepoint's already-finalized
+    short circuit, driven through the REAL `runAiMerge`
+    (workflow-already-finalized-live-e2e.pg.test.ts). It returns BEFORE any git work,
+    so no repository is needed. Both halves mutation-verified: the legacy-literal pair
+    fails the renamed complete cases, and a PER-SET fallback (instead of per-role)
+    fails the `archived` case on BOTH vocabularies — the exact P1 from PR #2471 review,
+    now regression-locked.
   - auto-merge-finalization.ts  completeColumn / mergeColumn / isCompleteColumn
     (workflow-merge-family-live-e2e.pg.test.ts; each of the three mutation-verified
     INDEPENDENTLY — the mergeColumn one needed its own case, see below)
@@ -727,8 +734,6 @@ NOT PROVEN end to end — real callers this suite does not reach:
     merge path is merger-ai's runAiMerge / landWorkspaceTask, which project-engine
     imports). Phase B converted a path production never executes. Not deleted here —
     it is production code owned by another slice — but proving it would prove nothing.
-  - merger-ai.ts:1039        isAlreadyFinalizedColumn — LIVE, but module-private and
-    reached only from runAiMerge, so it does need the real-git lane
   - executor.ts:1763,6339,6341        rebound target, merge-orchestration probe, complete column
   - mesh-lease-manager.ts:61 resolveReboundTarget
   - core/live-agent-count.ts    columnIsIntakeOrHold (the WAITING predicate) — the running
@@ -737,13 +742,18 @@ NOT PROVEN end to end — real callers this suite does not reach:
 
 WHY, and what each would take. Two lanes, and neither is another table row:
 
-  LANE 1 — REAL GIT (engine-slow), now SMALLER than it looked. Only two things
-  genuinely need it: merger-ai's `isAlreadyFinalizedColumn` and executor's
-  `resolveReboundColumnFor`, both module-private and reached only from inside
-  merge/session machinery. merger.ts's three sites do NOT need the lane because they
-  are dead (see above), and merger-ai's `resolveFinalizeReboundColumn` did not need it
-  at all — it is now covered. Third time the "this family needs git" inference has
-  been wrong; check what the FUNCTION touches before costing a lane for it.
+  LANE 1 — REAL GIT (engine-slow), now ONE FUNCTION. Only executor's private
+  `resolveReboundColumnFor` still needs it: its four callers all sit deep inside
+  executor session/recovery machinery.
+
+  Everything else that was filed under this lane turned out not to need it:
+  merger.ts's three sites are DEAD (aiMergeTask has no production caller),
+  merger-ai's `resolveFinalizeReboundColumn` is exported and store-only, and
+  `isAlreadyFinalizedColumn` returns before any git work. That is FOUR wrong
+  "this family needs git" inferences in a row, every one of them made by reasoning
+  from the family a function sits in rather than from what the function touches.
+  The rule, since it keeps being needed: trace the callers and read the function
+  before costing a lane for it.
 
   LANE 2 — DASHBOARD HTTP. register-task-workflow-routes' four sites live behind
   `registerTaskWorkflowRoutes(ctx, deps)`, which needs a full ApiRoutesContext plus


### PR DESCRIPTION
Stacked on #2550. Eighth E2E family.

## The bug, and why it's unusually crisp to assert

`runAiMerge` is **the** merge path, and the first thing it does after reading the task — explicitly *"BEFORE any git work"* — is ask whether the card is already terminal in its own workflow. The conversion note names it:

> Under a renamed workflow the literal `done`/`archived` pair stopped matching, and the already-finalized card fell through to `getTaskMergeBlocker` — which threw **"task is in 'shipped', must be in 'in-review'"** for a task whose real state was "already done, nothing to do".

For once the failure is **loud**, not silent. So the assertion is unusually crisp: correct behaviour returns a clean no-op; broken behaviour raises an error naming a column the operator never asked about.

## Fourth wrong "needs real git" inference

The ledger had this behind the real-git lane because it lives in the merge family. **It returns before any git work** — a real store and a real persisted workflow are the entire harness.

**Lane 1 is now one function**: executor's private `resolveReboundColumnFor`. Everything else filed under it turned out not to need it — `merger.ts`'s three sites are dead, `resolveFinalizeReboundColumn` is exported and store-only, and this one short-circuits early.

Four wrong inferences in a row, every one made by reasoning from *the family a function sits in* rather than *what the function touches*. The ledger now carries that rule explicitly, since it keeps being needed.

## The per-role fallback is the subtle half — now regression-locked

The terminal pair resolves **per role**, not per set: a workflow declaring `complete` but no `archived` must keep the legacy `archived` id for the half it did not declare.

The shared vocabulary fixture is exactly that shape, so mutating to a **per-set** fallback — the exact P1 from PR #2471's review — fails the `archived` case on **both** vocabularies: it collapses the pair to one element and silently drops the short circuit.

| mutation | result |
|---|---|
| legacy-literal pair | the renamed complete cases fail |
| per-set fallback | the `archived` case fails on **both** vocabularies |

## Negative half

A review-lane card must **not** be short-circuited — otherwise the chokepoint silently skips real merges.

## Verification

- lifecycle + merge-rebound + already-finalized: **30/30**
- engine `tsc --noEmit` clean
- `pnpm test:gate` green (414 + 10 + 71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)