### PR TITLE
U11: resolve auto-claim's candidate gate and dependency set by role (3 -> 0)

### DIFF
--- a/packages/engine/src/__tests__/auto-claim-snapshot-renamed-columns.test.ts
+++ b/packages/engine/src/__tests__/auto-claim-snapshot-renamed-columns.test.ts
@@ -1,0 +1,117 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-12:10 (U11 conversion — auto-claim):
+
+`isRunnableAutoClaimCandidate` is the single source of truth for "may an idle
+agent claim this card?", and it decided two things by literal column id:
+
+  the CANDIDATE GATE     `task.column === "todo"` — the hold column.
+  DEPENDENCY SATISFACTION `dep.column === "done" || "archived"` — the terminal set.
+
+The two fail in OPPOSITE directions, which is why both are covered here:
+
+  a renamed HOLD column makes every card fail the gate, so auto-claim silently
+  surfaces nothing and idle agents sit with an empty candidate list — a stall with
+  no error anywhere;
+
+  a renamed TERMINAL column makes finished dependencies read as UNMET, so a card
+  whose blockers are all done is never offered — the same stall, arrived at from
+  the other side.
+
+FN-6873 pinned the literal gate after an archived card leaked into a heartbeat
+prompt from a stale cache. That intent is preserved exactly: the gate still admits
+ONLY the hold column, and archived/done/intake/wip/review rows are still excluded.
+This changes which id means "hold", not which roles may be claimed.
+
+Written against the literal implementation and observed FAILING first.
+*/
+import { describe, expect, it } from "vitest";
+import type { Task } from "@fusion/core";
+
+import { isRunnableAutoClaimCandidate } from "../auto-claim-snapshot.js";
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "FN-1",
+    title: "t",
+    column: "drafting",
+    paused: false,
+    assignedAgentId: undefined,
+    checkedOutBy: undefined,
+    deletedAt: undefined,
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    columnMovedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  } as unknown as Task;
+}
+
+const RENAMED = { hold: "drafting", terminal: ["shipped", "retired"] };
+
+describe("auto-claim candidacy under a renamed column vocabulary", () => {
+  describe("the candidate gate (renamed hold)", () => {
+    it("admits a card resting in the RENAMED hold column", () => {
+      const t = task();
+      expect(isRunnableAutoClaimCandidate(t, new Map([[t.id, t]]), RENAMED)).toBe(true);
+    });
+
+    it("still EXCLUDES every non-hold column, preserving the FN-6873 intent", () => {
+      /*
+      The gate exists because an archived card leaked into a heartbeat prompt.
+      Converting must change which id means "hold", never which roles may be
+      claimed — so each of these stays excluded.
+      */
+      for (const column of ["inbox", "building", "reviewing", "shipped", "retired"]) {
+        const t = task({ column });
+        expect(isRunnableAutoClaimCandidate(t, new Map([[t.id, t]]), RENAMED)).toBe(false);
+      }
+    });
+
+    it("defaults to the legacy todo gate when no roles are supplied", () => {
+      const legacy = task({ column: "todo" });
+      expect(isRunnableAutoClaimCandidate(legacy, new Map([[legacy.id, legacy]]))).toBe(true);
+      const renamed = task({ column: "drafting" });
+      expect(isRunnableAutoClaimCandidate(renamed, new Map([[renamed.id, renamed]]))).toBe(false);
+    });
+  });
+
+  describe("dependency satisfaction (renamed terminal)", () => {
+    it("treats a dependency in a RENAMED terminal column as satisfied", () => {
+      const dep = task({ id: "FN-DEP", column: "shipped" });
+      const t = task({ dependencies: ["FN-DEP"] });
+      const byId = new Map([[t.id, t], [dep.id, dep]]);
+      expect(isRunnableAutoClaimCandidate(t, byId, RENAMED)).toBe(true);
+    });
+
+    it("honors the SECOND declared terminal column, not just the first", () => {
+      /* Terminal is a set. A fix handling only the primary complete column would
+         pass the case above and fail here. */
+      const dep = task({ id: "FN-DEP", column: "retired" });
+      const t = task({ dependencies: ["FN-DEP"] });
+      expect(isRunnableAutoClaimCandidate(t, new Map([[t.id, t], [dep.id, dep]]), RENAMED)).toBe(true);
+    });
+
+    it("still blocks on a dependency that has NOT reached a terminal column", () => {
+      /* The negative half: without it, "always satisfied" would pass both cases
+         above and prove nothing. */
+      const dep = task({ id: "FN-DEP", column: "building" });
+      const t = task({ dependencies: ["FN-DEP"] });
+      expect(isRunnableAutoClaimCandidate(t, new Map([[t.id, t], [dep.id, dep]]), RENAMED)).toBe(false);
+    });
+  });
+
+  describe("non-column guards are untouched", () => {
+    it.each([
+      ["paused", { paused: true }],
+      ["assigned", { assignedAgentId: "a1" }],
+      ["checked out", { checkedOutBy: "a1" }],
+      ["soft-deleted", { deletedAt: "2026-01-01T00:00:00.000Z" }],
+    ])("still excludes a %s card in the renamed hold column", (_label, over) => {
+      const t = task(over as Partial<Task>);
+      expect(isRunnableAutoClaimCandidate(t, new Map([[t.id, t]]), RENAMED)).toBe(false);
+    });
+  });
+});

--- a/packages/engine/src/auto-claim-snapshot.ts
+++ b/packages/engine/src/auto-claim-snapshot.ts
@@ -37,15 +37,47 @@ Auto-claim runnability must have one source of truth so the snapshot rebuild and
 FNXC:AutoClaim 2026-06-21-16:09:
 FN-6873 pins `column === "todo"` as the candidate gate after FN-6872 appeared in a heartbeat prompt while archived from a stale cache. Archived, done, triage, in-progress, in-review, soft-deleted, paused, assigned, checked-out, and dependency-blocked rows can satisfy dependencies where allowed, but must never be surfaced or claimed as auto-claim candidates.
 */
-export function isRunnableAutoClaimCandidate(task: Task, tasksById: ReadonlyMap<string, Task>): boolean {
-  return task.column === "todo"
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-12:25 (U11):
+The two lifecycle ROLES this predicate decides by. `todo`/`done`/`archived` are
+only what the builtin coding workflow calls them, and the two failures point in
+OPPOSITE directions:
+
+  a renamed HOLD column makes every card fail the gate, so auto-claim surfaces
+  nothing and idle agents sit with an empty candidate list;
+
+  a renamed TERMINAL column makes finished dependencies read as UNMET, so a card
+  whose blockers are all done is never offered.
+
+Either way the symptom is a silent stall with no error. Both default to the legacy
+ids, so an unconverted caller is byte-identical.
+
+FN-6873's intent is UNCHANGED: the gate still admits ONLY the hold column, and
+archived/done/intake/wip/review rows remain excluded. This changes which id means
+"hold", not which roles may be claimed.
+*/
+export interface AutoClaimColumnRoles {
+  /** The capacity-wait column whose residents may be claimed. */
+  hold: string;
+  /** Columns that end a task's life, satisfying a dependency. */
+  terminal: readonly string[];
+}
+
+const LEGACY_AUTO_CLAIM_ROLES: AutoClaimColumnRoles = { hold: "todo", terminal: ["done", "archived"] };
+
+export function isRunnableAutoClaimCandidate(
+  task: Task,
+  tasksById: ReadonlyMap<string, Task>,
+  roles: AutoClaimColumnRoles = LEGACY_AUTO_CLAIM_ROLES,
+): boolean {
+  return task.column === roles.hold
     && task.paused !== true
     && !task.assignedAgentId
     && !task.checkedOutBy
     && !task.deletedAt
     && task.dependencies.every((dependencyId) => {
       const dependency = tasksById.get(dependencyId);
-      return dependency?.column === "done" || dependency?.column === "archived";
+      return dependency !== undefined && roles.terminal.includes(dependency.column);
     });
 }
 


### PR DESCRIPTION
Based on `main`. Nearest **unassigned** work in my area after the drift review reassigned `self-healing.ts` — auto-claim is scheduler-adjacent and was on no worker's list.

## Measured (drift-review tracking)

| file | comparisons before | after |
|---|---:|---:|
| `packages/engine/src/auto-claim-snapshot.ts` | **3** | **0** |

## Two decisions, failing in opposite directions

`isRunnableAutoClaimCandidate` is the single source of truth for *"may an idle agent claim this card?"*:

- **candidate gate** — `column === "todo"` (the hold role)
- **dependency satisfaction** — `dep.column === "done" || "archived"` (the terminal set)

They fail **opposite** ways, which is why both are covered rather than just the gate:

- a renamed **hold** column makes every card fail the gate → auto-claim surfaces nothing, idle agents get an empty candidate list;
- a renamed **terminal** column makes finished dependencies read as **unmet** → a card whose blockers are all done is never offered.

Either way the symptom is identical and silent: no error, no log, just an agent that never claims anything. Converting one and not the other leaves that stall fully intact while looking done.

## FN-6873's intent is preserved exactly

That guard was added after an archived card leaked into a heartbeat prompt from a stale cache. A test asserts every non-hold column (intake, wip, review, complete, archived) is **still excluded**. This changes *which id means "hold"*, never *which roles may be claimed*. The paused / assigned / checked-out / soft-deleted guards are pinned unchanged too.

The dependency check also moved from two `===` comparisons to a **set**, so a workflow declaring a second terminal column is honored — covered by a test a primary-column-only fix would fail.

## Verification

- **Mutation-verified:** ignoring the roles parameter fails **3 of 10** new tests
- 26 tests green (10 new + the pre-existing auto-claim invalidation suite)
- merge gate green (414 + 10 + 71), tsc clean, lint clean

No changeset: `@fusion/engine` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
