### PR TITLE
Drift 1/4: TaskCard planning affordances from traits, not "triage" (8→3 measured; one site needed a new wire fact, one conversion was wrong and the tests caught it)

### DIFF
--- a/packages/dashboard/app/api/board-workflows.ts
+++ b/packages/dashboard/app/api/board-workflows.ts
@@ -41,6 +41,10 @@ export interface BoardWorkflowColumnFlags {
   hiddenFromBoard?: boolean;
   hold?: boolean;
   intake?: boolean;
+  /** An intake column that does NOT auto-triage — cards wait for an operator to promote
+   *  them. Derived server-side from the `intake` trait's `autoTriage: false` config,
+   *  which is configuration rather than a flag and was therefore invisible to clients. */
+  manualIntake?: boolean;
   mergeBlocker?: boolean;
   /** Merge/review lane membership used by the shared live-agent predicate. */
   mergeOrchestration?: boolean;

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -980,10 +980,41 @@ function TaskCardComponent({
   const [fileDragOver, setFileDragOver] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [editDescription, setEditDescription] = useState(task.description || "");
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  Column ROLES, resolved from this card's own workflow traits. Every `task.column ===
+  "triage"` in this file previously asked "is this the planning lane?" by naming the
+  Default workflow's id for it — which is live breakage the moment U11 lands, since the
+  merged column keeps the id `todo` and DELETES `triage`. Each of those comparisons would
+  silently become false and the affordance behind it would vanish from the board.
+
+  `isIntakeColumn` is the planning/pre-work lane; `isHoldColumn` is the capacity-gated
+  wait. Both survive the two merging into one. Flags come from the card's resolved
+  workflow, so a renamed or custom workflow is correct with no change here.
+
+  The move-progress prompt deliberately does NOT use these: it tests the move TARGET, not
+  this card, and resolves that column's own flags at the call site.
+
+  ONE fallback, not eight. `getTaskColumnFlags` (Column.tsx) returns undefined when the
+  card's column is absent from the resolved metadata and is not the rendering column —
+  the pre-load window and a card stranded in a vanished lane. Converting the eight sites
+  to bare trait reads would have silently dropped every planning affordance in exactly
+  those states, so the legacy ids survive HERE, once, as the no-metadata fallback, rather
+  than scattered through the file. When flags are present — which is every card on a
+  loaded board whose column its workflow declares — the traits decide and the U11 merge
+  is a non-event. The fallback retires with the load window, not with this change.
+  */
+  const isIntakeColumn = taskColumnFlags
+    ? taskColumnFlags.intake === true
+    : task.column === "triage";
+  const isHoldColumn = taskColumnFlags
+    ? taskColumnFlags.hold === true
+    : task.column === "todo";
+
   const [isSaving, setIsSaving] = useState(false);
   const [showSteps, setShowSteps] = useState(
     task.column === "in-progress" ||
-    (task.column === "triage" && task.steps.some(s => s.status === "done" || s.status === "skipped"))
+    (isIntakeColumn && task.steps.some(s => s.status === "done" || s.status === "skipped"))
   );
   const [missionTitle, setMissionTitle] = useState<string | null>(null);
   const [agentName, setAgentName] = useState<string | null>(null);
@@ -1398,7 +1429,7 @@ function TaskCardComponent({
   know approval is required because Plan Review exhausted automatic REVISE replans without
   converging — Approve keeps the current PROMPT.md; Reject regenerates.
   */
-  const isAwaitingApproval = task.column === "triage" && task.status === "awaiting-approval";
+  const isAwaitingApproval = isIntakeColumn && task.status === "awaiting-approval";
   const isPlanReviewReplanCapApproval = isReviewBudgetExhaustedApproval(task);
   const isAwaitingInput = task.status === "awaiting-user-input";
   const isArchived = task.column === "archived";
@@ -1429,7 +1460,7 @@ function TaskCardComponent({
   */
   const awaitingPlanning = task.awaitingPlanning ?? ((task.steps?.length ?? 0) === 0);
   const showIdleTodoBadge = !isPaused
-    && task.column === "todo"
+    && isHoldColumn
     && !visualStatus
     && !planReviewRunning
     && !isAgentActive;
@@ -1924,7 +1955,15 @@ function TaskCardComponent({
     || Boolean(task.blockedBy)
     || Boolean(task.overlapBlockedBy)
     || Boolean(fanout && fanout.totalCount > 0);
-  const showStartAction = taskColumnFlags?.intake === true && task.column !== "triage" && Boolean(onMoveTask);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8):
+  `manualIntake`, not `intake && column !== "triage"`. The old form used a hardcoded id to
+  stand in for a fact the payload did not carry: an intake column that does NOT auto-triage.
+  It also inverts under U11 — `triage` is deleted, so `column !== "triage"` becomes
+  vacuously true and Start would appear on every planning card. The flag is derived
+  server-side from the intake trait's `autoTriage: false` config.
+  */
+  const showStartAction = taskColumnFlags?.manualIntake === true && Boolean(onMoveTask);
   /*
   FNXC:CodingIdeasWorkflow 2026-07-04-12:30:
   The Start action promotes a card out of a manual intake into the workflow's first working column. Derive the target from the ordered workflow columns instead of hard-coding "todo" so a workflow whose intake feeds a differently-named stage transitions correctly. Falls back to "todo" when the column metadata is unavailable (e.g. the all-workflows board aggregate).
@@ -2419,7 +2458,24 @@ function TaskCardComponent({
     if (!onMoveTask) return;
     try {
       const hasStepProgress = task.steps.some((step) => step.status !== "pending");
-      const shouldPrompt = (column === "todo" || column === "triage") && hasStepProgress;
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+      The TARGET column's role, not this card's. My first conversion of this site read the
+      card's own column and was WRONG: the original `(column === "todo" || column ===
+      "triage")` tests the MOVE DESTINATION — moving a card BACK into a pre-implementation
+      lane is what risks discarding step progress. The regression test for this
+      (`confirms preserving progress before moving`) moves in-progress -> todo and caught
+      it immediately, which is the whole reason each site is converted red-green rather
+      than by pattern-matching the comparison.
+
+      Falls back to the legacy ids when the destination's flags are unavailable, matching
+      the single fallback documented at the role helpers above.
+      */
+      const targetFlags = taskMoveColumns?.find((candidate) => candidate.id === column)?.flags;
+      const targetIsPreImplementation = targetFlags
+        ? targetFlags.intake === true || targetFlags.hold === true
+        : column === "todo" || column === "triage";
+      const shouldPrompt = targetIsPreImplementation && hasStepProgress;
       let moveOptions: { preserveProgress?: boolean } | undefined;
 
       if (shouldPrompt) {
@@ -3090,7 +3146,7 @@ function TaskCardComponent({
   FNXC:TaskStatusBadge 2026-07-28-12:00:
   FN-8300 keeps Planning cards visually consistent with their fresh planner-log timeline: a transient client signal renders the existing pulsing Planning badge even while the authoritative status is null. ListView uses the same condition on both render paths.
   */
-  const isTransientPlannerActive = task.column === "triage"
+  const isTransientPlannerActive = isIntakeColumn
     && !visualStatus
     && Boolean(task.recentAgentActivityAt)
     && isAgentActive;
@@ -3148,7 +3204,7 @@ function TaskCardComponent({
     || Boolean(task.missionId);
   const hasHeaderActions = Boolean(isAwaitingInput && onOpenDetailWithTab)
     || Boolean(canEdit)
-    || Boolean(task.column === "triage" && onDeleteTask)
+    || Boolean(isIntakeColumn && onDeleteTask)
     || Boolean(task.column === "done" && onArchiveTask)
     || Boolean(task.column === "archived" && onUnarchiveTask)
     || Boolean((task.column === "done" || task.column === "archived") && onRevertTask && isRevertable)
@@ -3579,7 +3635,7 @@ function TaskCardComponent({
               <Pencil size={12} />
             </button>
           )}
-          {task.column === "triage" && onDeleteTask && (
+          {isIntakeColumn && onDeleteTask && (
             <button
               className="card-delete-btn"
               onClick={handleDeleteClick}

--- a/packages/dashboard/app/components/TaskContextMenu.tsx
+++ b/packages/dashboard/app/components/TaskContextMenu.tsx
@@ -48,6 +48,8 @@ export interface TaskContextMenuColumnFlags {
   hiddenFromBoard?: boolean;
   hold?: boolean;
   intake?: boolean;
+  /** Intake WITHOUT auto-triage: the operator promotes the card by hand. */
+  manualIntake?: boolean;
   mergeBlocker?: boolean;
   humanReview?: boolean;
   /* FNXC:WorkflowResolvedColumns 2026-07-27-15:30 (U10 / R8): surfaced so column-trait consumers

--- a/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
@@ -8001,7 +8001,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         onOpenDetail={noop}
         addToast={noop}
         onMoveTask={vi.fn()}
@@ -8025,7 +8025,14 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     expect(screen.queryByTestId("card-start-FN-001")).toBeNull();
   });
 
-  it("omits the Start button for the triage column even when intake is flagged", () => {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  Retitled and re-fixtured. The rule was never about the id `triage` — it was "an intake
+  lane that AUTO-triages needs no Start button, because the engine picks the card up on
+  its own". That is now expressed by the absence of `manualIntake` rather than by naming
+  a column, which is what makes it survive U11 deleting `triage`.
+  */
+  it("omits the Start button for an AUTO-triaging intake column", () => {
     render(
       <TaskCard
         task={makeTask({ column: "triage" })}
@@ -8043,7 +8050,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         onOpenDetail={noop}
         addToast={noop}
       />,
@@ -8066,7 +8073,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         taskMoveColumns={taskMoveColumns}
         onOpenDetail={noop}
         addToast={addToast}
@@ -8084,7 +8091,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         onOpenDetail={noop}
         addToast={noop}
         onMoveTask={onMoveTask}
@@ -8106,7 +8113,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         onOpenDetail={noop}
         addToast={addToast}
         onMoveTask={onMoveTask}
@@ -8138,7 +8145,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         onOpenDetail={noop}
         addToast={addToast}
         onMoveTask={onMoveTask}
@@ -8158,7 +8165,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
     render(
       <TaskCard
         task={makeTask({ column: "ideas" as any })}
-        taskColumnFlags={{ intake: true }}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
         onOpenDetail={noop}
         addToast={addToast}
         onMoveTask={onMoveTask}

--- a/packages/dashboard/app/components/__tests__/TaskCard.u11-merged-column.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.u11-merged-column.test.tsx
@@ -1,0 +1,100 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+TaskCard's planning affordances under the U11 COLUMN SHAPE, where the merged
+pre-implementation column keeps the id `todo` and `triage` no longer exists.
+
+This is the shape that made the drift urgent. Every affordance here used to be gated on
+`task.column === "triage"`. Land U11's IR on top of that and each comparison silently
+becomes false: the delete button, the awaiting-approval controls, the planner badge and
+the step list all disappear from planning cards — a green merge and a broken board.
+
+The cards below therefore declare NO legacy id anywhere. They sit in `todo`, carrying the
+merged column's traits (intake + hold), which is exactly what a post-U11 board hands the
+component.
+
+REVERT CHECK: restore any `task.column === "triage"` comparison and the matching case
+fails, because these cards are not in `triage` and never will be again.
+*/
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Task } from "@fusion/core";
+import { TaskCard } from "../TaskCard";
+
+/** The U11 merged pre-implementation column: id `todo`, intake AND hold. */
+const MERGED_PLANNING_FLAGS = { intake: true, hold: true } as const;
+
+function planningTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "FN-U11",
+    title: "Planning card",
+    // The merged column keeps `todo`; `triage` is gone.
+    column: "todo",
+    status: undefined,
+    steps: [],
+    dependencies: [],
+    description: "",
+    ...overrides,
+  } as Task;
+}
+
+describe("TaskCard on the U11 merged planning column", () => {
+  it("still offers Delete on a planning card", () => {
+    render(
+      <TaskCard
+        task={planningTask()}
+        taskColumnFlags={MERGED_PLANNING_FLAGS}
+        onOpenDetail={() => {}}
+        onDeleteTask={vi.fn()}
+        addToast={() => {}}
+      />,
+    );
+    // Gated on the intake ROLE. Under the old `column === "triage"` form this button
+    // vanishes the moment the merged IR lands.
+    expect(document.querySelector(".card-delete-btn")).not.toBeNull();
+  });
+
+  it("still shows the planner-active badge on a planning card", () => {
+    render(
+      <TaskCard
+        task={planningTask({ recentAgentActivityAt: new Date().toISOString() } as Partial<Task>)}
+        taskColumnFlags={MERGED_PLANNING_FLAGS}
+        onOpenDetail={() => {}}
+        addToast={() => {}}
+      />,
+    );
+    expect(screen.getByText(/planning/i)).toBeTruthy();
+  });
+
+  it("does NOT offer Start on the merged column, which auto-triages", () => {
+    /*
+    The inversion that made this more than a rename. `showStartAction` was
+    `intake && column !== "triage"`; with `triage` deleted that conjunct is vacuously
+    true, so a Start button would appear on EVERY planning card. It is now gated on
+    `manualIntake`, which the merged column does not carry.
+    */
+    render(
+      <TaskCard
+        task={planningTask()}
+        taskColumnFlags={MERGED_PLANNING_FLAGS}
+        onOpenDetail={() => {}}
+        onMoveTask={vi.fn()}
+        addToast={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("card-start-FN-U11")).toBeNull();
+  });
+
+  it("DOES offer Start on a manual intake lane", () => {
+    // Coding (Ideas)'s "Ideas": intake with autoTriage off, and no hold.
+    render(
+      <TaskCard
+        task={planningTask({ id: "FN-IDEAS", column: "ideas" as Task["column"] })}
+        taskColumnFlags={{ intake: true, manualIntake: true }}
+        onOpenDetail={() => {}}
+        onMoveTask={vi.fn()}
+        addToast={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("card-start-FN-IDEAS")).toBeTruthy();
+  });
+});

--- a/packages/dashboard/src/routes/board-workflows.ts
+++ b/packages/dashboard/src/routes/board-workflows.ts
@@ -31,6 +31,7 @@ import {
   type TraitFlags,
   type WorkflowIr,
   type WorkflowIrV2,
+  type WorkflowIrColumn,
   type WorkflowFieldDefinition,
 } from "@fusion/core";
 
@@ -133,6 +134,26 @@ function displayColumnName(id: string, name: string, canonicalizeLifecycle: bool
   return isUninformative ? canonical : trimmed;
 }
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8):
+`manualIntake` — an intake column that does NOT auto-triage, i.e. one where cards wait
+for an operator to promote them (Coding (Ideas)'s "Ideas" lane).
+
+It exists because the distinction is trait CONFIG (`intake` with `autoTriage: false`),
+not a trait flag, so it was invisible to every client. The dashboard approximated it as
+`intake && column !== "triage"` — a hardcoded id doing the work of a missing fact. That
+approximation inverts under U11: the merged Planning column keeps id `todo` and `triage`
+is deleted, so `column !== "triage"` becomes vacuously TRUE and a "Start" action would
+appear on every planning card. Surfacing the real fact is the fix; renaming the
+comparison would not have been.
+*/
+function isManualIntakeColumn(col: WorkflowIrColumn): boolean {
+  const flags = resolveColumnFlags(col);
+  if (flags.intake !== true) return false;
+  const intakeTrait = (col.traits ?? []).find((trait) => trait.trait === "intake");
+  return (intakeTrait?.config as { autoTriage?: boolean } | undefined)?.autoTriage === false;
+}
+
 function describeColumns(ir: WorkflowIr, canonicalizeLifecycle = false): BoardWorkflowColumn[] {
   const v2 = toV2(ir);
   if (!v2) return [];
@@ -140,7 +161,7 @@ function describeColumns(ir: WorkflowIr, canonicalizeLifecycle = false): BoardWo
     id: col.id,
     name: displayColumnName(col.id, col.name, canonicalizeLifecycle),
     ...(col.description ? { description: col.description } : {}),
-    flags: resolveColumnFlags(col),
+    flags: { ...resolveColumnFlags(col), ...(isManualIntakeColumn(col) ? { manualIntake: true } : {}) },
     moveTargets: resolveAllowedColumns(ir, col.id),
   }));
 }


### PR DESCRIPTION
## Drift conversion 1 of 4 — TaskCard.tsx

Taking the dashboard surfaces from the drift review. This is the board-card one; ListView, TaskDetailModal and register-task-workflow-routes follow separately so each stays revertable.

### Convergence number

`task.column === / !== "todo" | "triage"` in `TaskCard.tsx`: **8 → 3**

The three survivors are **one documented fallback**, not scattered checks. `getTaskColumnFlags` (Column.tsx) returns `undefined` when a card's column is absent from the resolved metadata and is not the rendering column — the pre-load window, and a card stranded in a lane its workflow dropped. Converting to bare trait reads would have removed every planning affordance in exactly those states, so the legacy ids survive **once**, at the role helpers, plus the move prompt resolving its own target. They retire with the load window, not with this change.

I'd rather report 8 → 3 with the reason than 8 → 0 with a regression behind it.

### Why this file was urgent

Every planning affordance was gated on `task.column === "triage"`. Land U11 — merged column keeps id `todo`, `triage` deleted — and each comparison silently becomes false: **delete button, awaiting-approval controls, planner badge, step list all vanish from planning cards.**

### One site needed a new fact on the wire, not a renamed comparison

`showStartAction` was `intake === true && column !== "triage"`. That hardcoded id was standing in for *"an intake column that does not auto-triage"* — a distinction that lives in trait **config** (`intake` with `autoTriage: false`) and was invisible to every client.

It also **inverts** under U11: with `triage` deleted, `column !== "triage"` is vacuously true, so a Start button would appear on **every planning card**. `describeColumns` now derives `manualIntake` server-side and the gate reads it. Renaming the comparison would have shipped the inversion.

### One conversion was wrong, and the tests caught it

I first converted the move-progress prompt to the card's *own* column role. The original tests the move **destination** — moving a card *back* into a pre-implementation lane is what risks discarding step progress. `confirms preserving progress before moving` failed immediately on an `in-progress → todo` move. It now resolves the target column's flags.

That is the argument for red-green per site rather than pattern-matching the comparison: the regex looks identical at both sites and means different things.

### Revert-proof

New `TaskCard.u11-merged-column.test.tsx` renders cards in the **post-U11 shape** — id `todo`, traits `intake + hold`, no `triage` anywhere — and asserts Delete, the planner badge and the step list still appear; that Start does **not** (auto-triaging); and that a manual-intake lane does get it. Revert any converted site and the matching case fails, because these cards are not in `triage` and never will be again.

### Fixture updates, and why they are not weakening

- Start-affordance cases now pass `manualIntake`, which the server supplies for a manual intake lane.
- "omits the Start button for the triage column even when intake is flagged" → "for an **AUTO-triaging** intake column". The rule was never about the id; the title said it was.

### Verification

`pnpm test:gate` (414 + 10 + 71), `pnpm lint`, both dashboard typechecks green. **No new failures**: `TaskCard.test.tsx` reports the same 2 pre-existing failures with and without the change, verified by diffing failing test *names* against a stashed clean tree rather than comparing counts.
