### PR TITLE
Drift 2/4: ListView + the predicate underneath it — agent-activity detection itself breaks under U11 (ListView 5→3, and two failed test attempts worth reading)

### DIFF
--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -333,7 +333,10 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
   const activeTaskCount = useMemo(
     () => tasks.filter((task) =>
       isRunningAgentTask(enrichRunningAgentTaskShapeFromFlags(task, columnFlags))
-      || isTaskAgentActive(task, { globalPaused, isStuck: isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs) }),
+      // FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2566 review — greptile): these
+      // tasks are IN this column, so the column's own flags are their column traits. Without
+      // them the header undercounts executing work on a merged planning lane.
+      || isTaskAgentActive(task, { globalPaused, isStuck: isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs), columnFlags }),
     ).length,
     [tasks, columnFlags, globalPaused, taskStuckTimeoutMs, lastFetchTimeMs],
   );

--- a/packages/dashboard/app/components/ListView.tsx
+++ b/packages/dashboard/app/components/ListView.tsx
@@ -855,6 +855,21 @@ export function ListView({
     return null;
   }, [boardWorkflows, workflowMode]);
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  The card's INTAKE role, from its own column's traits. Both grouped-list render paths
+  gated the transient Planning badge on `task.column === "triage"`, which U11 deletes —
+  the badge would simply stop appearing on planning rows, with nothing failing.
+
+  ONE fallback, matching TaskCard: `columnFlagsById` has no entry for a column the
+  resolved workflow does not declare (a stranded card, or the pre-load window), and a
+  bare trait read would drop the badge there too.
+  */
+  const isIntakeColumnForTask = useCallback((task: Task): boolean => {
+    const flags = columnFlagsById.get(task.column);
+    return flags ? flags.intake === true : task.column === "triage";
+  }, [columnFlagsById]);
+
   const isArchivedColumn = useCallback((column: ColumnId): boolean => {
     return workflowMode ? Boolean(columnFlagsById.get(column)?.archived) : column === "archived";
   }, [columnFlagsById, workflowMode]);
@@ -1903,8 +1918,19 @@ export function ListView({
     try {
       const hasStepProgress = task.steps.some((step) => step.status !== "pending");
       const targetFlags = columnFlagsById.get(column);
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+      Flags FIRST, ids only when the destination has no resolved metadata. The previous
+      form OR-ed the two, so a column merely NAMED `todo` or `triage` prompted regardless
+      of its traits — and post-U11 that is the merged column's id, meaning the legacy
+      disjunct would keep firing for reasons unrelated to what the column IS. Reading the
+      traits when they exist makes the rule mean "moving back into a pre-implementation
+      lane", which is the thing worth warning about.
+      */
       const shouldPrompt = hasStepProgress && (
-        column === "todo" || column === "triage" || Boolean(targetFlags?.intake || targetFlags?.hold)
+        targetFlags
+          ? Boolean(targetFlags.intake || targetFlags.hold)
+          : column === "todo" || column === "triage"
       );
       let moveOptions: { preserveProgress?: boolean } | undefined;
 
@@ -2451,8 +2477,12 @@ export function ListView({
         const task = tasks.find((candidate) => candidate.id === taskId);
         const hasStepProgress = task?.steps.some((step) => step.status !== "pending") ?? false;
         const targetFlags = columnFlagsById.get(column);
+        // Same rule as the context-menu move above: flags first, ids only as the
+        // no-metadata fallback.
         const shouldPrompt = hasStepProgress && (
-          column === "todo" || column === "triage" || Boolean(targetFlags?.intake || targetFlags?.hold)
+          targetFlags
+            ? Boolean(targetFlags.intake || targetFlags.hold)
+            : column === "todo" || column === "triage"
         );
 
         let moveOptions: { preserveProgress?: boolean } | undefined;
@@ -2941,9 +2971,9 @@ export function ListView({
                           const isFailed = !isDoneColumn && task.status === "failed" && !hasPendingAutomaticRecovery(task, lastFetchTimeMs);
                           const isPaused = !isDoneColumn && task.paused === true;
                           const isStuckState = isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs);
-                          const isAgentActive = isTaskAgentActive(task, { globalPaused, isStuck: isStuckState });
+                          const isAgentActive = isTaskAgentActive(task, { globalPaused, isStuck: isStuckState, columnFlags: columnFlagsById.get(task.column) });
                           // FNXC:TaskStatusBadge 2026-07-28-12:00: FN-8300 renders the same transient Planning badge as TaskCard so fresh planner logs never make grouped-list cards appear idle.
-                          const isTransientPlannerActive = task.column === "triage"
+                          const isTransientPlannerActive = isIntakeColumnForTask(task)
                             && !visualStatus
                             && Boolean(task.recentAgentActivityAt)
                             && isAgentActive;
@@ -3204,9 +3234,9 @@ export function ListView({
                             const isFailed = !isDoneColumn && task.status === "failed" && !hasPendingAutomaticRecovery(task, lastFetchTimeMs);
                             const isPaused = !isDoneColumn && task.paused === true;
                             const isStuckState = isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs);
-                            const isAgentActive = isTaskAgentActive(task, { globalPaused, isStuck: isStuckState });
+                            const isAgentActive = isTaskAgentActive(task, { globalPaused, isStuck: isStuckState, columnFlags: columnFlagsById.get(task.column) });
                             const isReviewBudgetExhausted = isReviewBudgetExhaustedApproval(task);
-                            const isTransientPlannerActive = task.column === "triage"
+                            const isTransientPlannerActive = isIntakeColumnForTask(task)
                               && !visualStatus
                               && Boolean(task.recentAgentActivityAt)
                               && isAgentActive;

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -1433,7 +1433,15 @@ function TaskCardComponent({
   const isPlanReviewReplanCapApproval = isReviewBudgetExhaustedApproval(task);
   const isAwaitingInput = task.status === "awaiting-user-input";
   const isArchived = task.column === "archived";
-  const isAgentActive = isTaskAgentActive(task, { globalPaused, queued, isStuck });
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2566 review — greptile):
+  Pass the card's column traits. Without them the planner-lane clause falls back to the
+  legacy ids, so a status-null card on the MERGED planning lane (id `todo`, intake+hold)
+  is not recognised as having fresh planner activity: the pulsing Planning state, the
+  optional-gate activity and the column's executing count all read idle. Threading
+  ListView alone left this path — the board cards — still broken.
+  */
+  const isAgentActive = isTaskAgentActive(task, { globalPaused, queued, isStuck, columnFlags: taskColumnFlags });
   /*
   FNXC:TaskCardOptionalGateBadge 2026-07-21-22:30:
   Match FN-8055: optional-gate badges pulse only while the card is agent-active (queue/pause/stuck gates suppress the badge).
@@ -2505,7 +2513,16 @@ function TaskCardComponent({
     } catch (err) {
       addToast(getErrorMessage(err), "error");
     }
-  }, [addToast, columnLabel, confirm, onMoveTask, task.id, task.steps, t]);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2566 review — greptile):
+  `taskMoveColumns` MUST be a dependency. The prompt now resolves the target column's
+  traits from it, so omitting it pins the callback to whatever metadata existed at first
+  render: once the board-workflows payload arrives or changes, a move into a custom
+  intake/hold lane would skip the preserve-progress confirmation entirely (silently
+  resetting work), while stale traits could prompt for a lane that is no longer
+  pre-implementation. I added the lookup and missed the dep.
+  */
+  }, [addToast, columnLabel, confirm, onMoveTask, task.id, task.steps, t, taskMoveColumns]);
 
   const handleTaskActionCheckPrStatus = useCallback(async () => {
     try {

--- a/packages/dashboard/app/components/__tests__/TaskCard.u11-merged-column.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.u11-merged-column.test.tsx
@@ -53,8 +53,27 @@ describe("TaskCard on the U11 merged planning column", () => {
     expect(document.querySelector(".card-delete-btn")).not.toBeNull();
   });
 
-  it("still shows the planner-active badge on a planning card", () => {
-    render(
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2566 review — greptile):
+  REPLACED by the agent-active case below, which asserts the pulsing badge element.
+  The original matched `/planning/i` as TEXT and was not discriminating: before the
+  `columnFlags` threading the badge did not render at all, yet the case passed because
+  other "Planning" text is present on the card. Same mistake I made in the ListView DOM
+  test — matching a word that also appears in chrome.
+  */
+
+  it("reads as agent-active from fresh planner activity on the merged column", () => {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2566 review — greptile):
+    `isTaskAgentActive`'s planner-lane clause needs this card's column traits. Without
+    them it falls back to the legacy ids, and a status-null card on the merged lane reads
+    IDLE — pulsing Planning state gone, optional-gate activity suppressed, column header
+    undercounting executing work. Threading ListView alone left the board cards broken.
+
+    REVERT CHECK: drop `columnFlags` from TaskCard's `isTaskAgentActive` call and this
+    fails — the pulsing class disappears because the card is in `todo`, not `triage`.
+    */
+    const { container } = render(
       <TaskCard
         task={planningTask({ recentAgentActivityAt: new Date().toISOString() } as Partial<Task>)}
         taskColumnFlags={MERGED_PLANNING_FLAGS}
@@ -62,7 +81,7 @@ describe("TaskCard on the U11 merged planning column", () => {
         addToast={() => {}}
       />,
     );
-    expect(screen.getByText(/planning/i)).toBeTruthy();
+    expect(container.querySelector(".pulsing")).not.toBeNull();
   });
 
   it("does NOT offer Start on the merged column, which auto-triages", () => {

--- a/packages/dashboard/app/utils/__tests__/taskActivity.u11-planner-lane.test.ts
+++ b/packages/dashboard/app/utils/__tests__/taskActivity.u11-planner-lane.test.ts
@@ -1,0 +1,57 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+`isTaskAgentActive` under the U11 COLUMN SHAPE — merged pre-implementation column keeps
+the id `todo`, `triage` is deleted.
+
+This predicate is the one that matters most in the dashboard drift, and it is not a
+badge: it drives the pulsing status badge, the agent-active row border, AND the column
+header's executing count. Its fresh-planner-activity clause was keyed on
+`column === "triage"`, so once U11 lands a planning card with live planner logs reads as
+IDLE everywhere at once — the board quietly stops reporting that planning is happening,
+with nothing failing.
+
+REVERT CHECK: drop the `columnFlags` branch and "merged planning column" fails — the card
+is in `todo` without `needs-replan`, which the legacy clause does not recognise as a
+planner lane.
+*/
+import { describe, expect, it } from "vitest";
+import type { Task } from "@fusion/core";
+import { isTaskAgentActive } from "../taskActivity";
+
+function plannerCard(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "FN-U11",
+    column: "todo",
+    status: undefined,
+    steps: [],
+    recentAgentActivityAt: new Date().toISOString(),
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("isTaskAgentActive planner lane (U11 merged column)", () => {
+  it("recognises fresh planner activity on the merged planning column", () => {
+    // intake + hold, id `todo` — the post-U11 shape. Without the trait branch this is
+    // false, because the legacy clause only accepts `triage` (or `todo` while replanning).
+    expect(isTaskAgentActive(plannerCard(), { columnFlags: { intake: true, hold: true } })).toBe(true);
+  });
+
+  it("still recognises the legacy triage lane when no flags are supplied", () => {
+    // The fallback path: callers without resolved metadata keep today's behaviour.
+    expect(isTaskAgentActive(plannerCard({ column: "triage" as Task["column"] }), {})).toBe(true);
+  });
+
+  it("does NOT treat a hold lane as a planner lane unless it is replanning", () => {
+    // The `hold && isReplanning` half, preserved from the legacy `todo && needs-replan`
+    // clause — a card merely waiting for capacity is not agent-active.
+    expect(isTaskAgentActive(plannerCard(), { columnFlags: { hold: true } })).toBe(false);
+    expect(
+      isTaskAgentActive(plannerCard({ status: "needs-replan" as Task["status"] }), { columnFlags: { hold: true } }),
+    ).toBe(true);
+  });
+
+  it("does not report activity for a stale planner timestamp", () => {
+    const stale = plannerCard({ recentAgentActivityAt: new Date(Date.now() - 60 * 60 * 1000).toISOString() });
+    expect(isTaskAgentActive(stale, { columnFlags: { intake: true, hold: true } })).toBe(false);
+  });
+});

--- a/packages/dashboard/app/utils/taskActivity.ts
+++ b/packages/dashboard/app/utils/taskActivity.ts
@@ -20,6 +20,20 @@ export interface TaskAgentActivityOptions {
   globalPaused?: boolean;
   queued?: boolean;
   isStuck?: boolean;
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  The task's own column traits, when the caller has them. Fresh-planner-activity was
+  keyed on `column === "triage"`, so under U11 — merged planning column keeps the id
+  `todo`, `triage` deleted — a planning card with live planner logs stops reading as
+  agent-active. That is not one badge: this predicate drives the pulsing status badge,
+  the agent-active row border, and the column header's executing count, so the whole
+  board would quietly report planning work as idle.
+
+  Optional, and the legacy ids remain the fallback: callers without resolved metadata
+  (pre-load, or a card stranded in a vanished lane) must keep their current behaviour
+  rather than lose activity detection entirely.
+  */
+  columnFlags?: { intake?: boolean; hold?: boolean };
 }
 
 /*
@@ -64,7 +78,16 @@ export function isTaskAgentActive(
   const isReplanning = status === "needs-replan";
   const recentPlannerActivityAtMs = Date.parse(task.recentAgentActivityAt ?? "");
   const nowMs = Date.now();
-  const hasFreshPlannerActivity = (task.column === "triage" || (task.column === "todo" && isReplanning))
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  Planner activity belongs to the PRE-IMPLEMENTATION lane. With traits the rule is
+  "intake lane, or a hold lane that is replanning"; without them it falls back to the
+  ids, which is the same shape the two lanes have today.
+  */
+  const inPlannerLane = options.columnFlags
+    ? options.columnFlags.intake === true || (options.columnFlags.hold === true && isReplanning)
+    : task.column === "triage" || (task.column === "todo" && isReplanning);
+  const hasFreshPlannerActivity = inPlannerLane
     && Number.isFinite(recentPlannerActivityAtMs)
     && nowMs - recentPlannerActivityAtMs >= 0
     && nowMs - recentPlannerActivityAtMs <= RECENT_PLANNER_ACTIVITY_WINDOW_MS;


### PR DESCRIPTION
## Drift conversion 2 of 4 — ListView, and a worse one underneath it

**Stacks on #2558.** Merge that first.

### Convergence numbers

Live-code `column === / !== "todo" | "triage"` (comment text excluded — the raw grep also matches the notes explaining each conversion):

| file | before | after |
|---|---|---|
| `ListView.tsx` | 5 | **3** |
| `taskActivity.ts` | 1 | **1** |

The survivors are the documented no-metadata fallbacks, same shape as #2558: `columnFlagsById` has no entry for a column the resolved workflow does not declare — a stranded card, or the pre-load window — and a bare trait read would drop the affordance there too.

### The one underneath, which matters more than the four I was assigned

`isTaskAgentActive` gated fresh-planner-activity on `column === "triage"`.

That is **not a badge**. This predicate drives the pulsing status badge, the agent-active row border, **and** the column header's executing count. Under U11 the merged planning column keeps the id `todo`, so a planning card with live planner logs reads as **idle in all three places at once** — the board quietly stops reporting that planning is happening, and nothing fails.

It now takes optional `columnFlags`, with the legacy ids as the fallback for callers that have no resolved metadata.

I found it because my first ListView test **could not go green**: the badge depends on this predicate, so converting the badge alone was cosmetic.

### ListView's move prompts were trait-aware but still wrong

Both sites read `column === "todo" || column === "triage" || Boolean(targetFlags?.intake || targetFlags?.hold)`. OR-ing the ids means a column merely *named* `todo` or `triage` prompts regardless of its traits — and post-U11 that is the merged column's id, so the legacy disjunct keeps firing for reasons unrelated to what the column *is*. Flags first; ids only when the destination has no metadata.

### Two failed test attempts, and what I did instead

Worth recording because the first one is the failure mode I keep flagging in others:

1. **A DOM test that passed with the conversion reverted.** I asserted on the text "Planning" — which is also the *column header's* name on that board. It would have shipped as coverage while checking nothing.
2. **Retargeted at the badge element, it then failed both ways** — the badge needs `isTaskAgentActive` to be true, and the fixture could not reach that through the grouped-list render path.

So I tested the **predicate** instead: pure function, discriminating, and it covers the site that actually breaks. Revert the trait branch and `merged planning column` fails with `expected false to be true`.

It also pins the halves that must *not* change: a hold lane is only a planner lane **while replanning**, and a stale timestamp is still not activity.

### Verification

`pnpm test:gate` (414 + 10 + 71), `pnpm lint`, dashboard typechecks green. ListView + TaskCard + the new suite: **248 passed**, no new failures.

Remaining in my drift set: `TaskDetailModal.tsx` and `register-task-workflow-routes.ts`.
