### PR TITLE
fix(engine): a completed-blocked guard was inert on renamed boards — plus one owner for the terminal pair

### DIFF
--- a/packages/core/src/__tests__/resolve-terminal-columns.test.ts
+++ b/packages/core/src/__tests__/resolve-terminal-columns.test.ts
@@ -1,0 +1,66 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-13:40:
+Direct coverage for `resolveTerminalColumns`, the shared owner of the terminal pair.
+
+WHY THIS EXISTS SEPARATELY from the E2E that already exercises it through
+`runAiMerge`: the OTHER consumer — executor's `parkCompletedBlockedTask` guard — is a
+private method reached only from inside executor dispatch, so it cannot be driven end
+to end. Its correctness now rests entirely on this function, which therefore gets its
+own tests rather than inheriting confidence from a caller that happens to be reachable.
+
+THE PER-ROLE RULE IS THE POINT. A per-SET fallback collapses to one element for a
+workflow that declares `complete` but no `archived`, silently dropping half of every
+already-finished check — the P1 from PR #2471's review. Both partial shapes are tested
+in both directions here, because a per-set implementation passes for whichever role
+happens to be declared and fails for the other.
+*/
+import { describe, expect, it } from "vitest";
+import "../index.js"; // registers the built-in column traits
+import type { WorkflowIr } from "../workflow-ir-types.js";
+import { resolveTerminalColumns } from "../workflow-lifecycle-traits.js";
+
+function ir(columns: Array<{ id: string; trait: string }>): WorkflowIr {
+  return {
+    version: "v2",
+    id: "custom:terminal-test",
+    name: "terminal-test",
+    columns: columns.map((c) => ({ id: c.id, name: c.id, traits: [{ trait: c.trait }] })),
+    nodes: [
+      { id: "start", kind: "start", column: columns[0]?.id },
+      { id: "end", kind: "end", column: columns[columns.length - 1]?.id },
+    ],
+    edges: [{ from: "start", to: "end" }],
+  } as WorkflowIr;
+}
+
+describe("resolveTerminalColumns", () => {
+  it("returns both renamed roles when the workflow declares both", () => {
+    expect(
+      resolveTerminalColumns(ir([{ id: "shipped", trait: "complete" }, { id: "attic", trait: "archived" }])),
+    ).toEqual(["shipped", "attic"]);
+  });
+
+  it("keeps the legacy `archived` when only `complete` is declared", () => {
+    /* The P1 direction. A per-set fallback returns ["shipped"] here and the archived
+       short circuit silently stops existing. */
+    expect(resolveTerminalColumns(ir([{ id: "shipped", trait: "complete" }]))).toEqual(["shipped", "archived"]);
+  });
+
+  it("keeps the legacy `done` when only `archived` is declared", () => {
+    /* The mirror direction, which is what proves the rule is per-ROLE rather than
+       "whichever one we happened to find". */
+    expect(resolveTerminalColumns(ir([{ id: "attic", trait: "archived" }]))).toEqual(["done", "attic"]);
+  });
+
+  it("falls back to both legacy ids for a workflow declaring neither", () => {
+    expect(resolveTerminalColumns(ir([{ id: "backlog", trait: "hold" }]))).toEqual(["done", "archived"]);
+  });
+
+  it("resolves the built-in vocabulary to the legacy pair, byte-identically", () => {
+    /* The regression floor: the default workflow must keep behaving exactly as the raw
+       literal pair did, or this refactor changed the default board. */
+    expect(
+      resolveTerminalColumns(ir([{ id: "done", trait: "complete" }, { id: "archived", trait: "archived" }])),
+    ).toEqual(["done", "archived"]);
+  });
+});

--- a/packages/core/src/index.gate.ts
+++ b/packages/core/src/index.gate.ts
@@ -2240,7 +2240,7 @@ export { createWorkflowEventBus, getWorkflowEventBus, emitWorkflowLifecycleEvent
 export type { WorkflowEventBus, WorkflowEventSubscriber, WorkflowEventSubscription } from "./workflow-events.js";
 export { findWorkflowEventShapeViolations, isIdsOnlyWorkflowEvent, MAX_ID_VALUE_LENGTH, IMPLEMENTATION_EXITS } from "./types/workflow-events.js";
 export type { WorkflowLifecycleEvent, WorkflowLifecycleEventType, WorkflowLifecycleEventBase, TaskTransitionedEvent, NodeEnteredEvent, NodeCompletedEvent, RunSuspendedEvent, RunResumedEvent, WorkflowEventShapeViolation, ImplementationExit } from "./types/workflow-events.js";
-export { columnsWithFlag, columnHasFlag, resolveReboundTarget, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveLifecycleColumns, resolveTaskLifecycleColumns } from "./workflow-lifecycle-traits.js";
+export { columnsWithFlag, columnHasFlag, resolveReboundTarget, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveLifecycleColumns, resolveTaskLifecycleColumns, resolveTerminalColumns } from "./workflow-lifecycle-traits.js";
 export type { LifecycleColumns } from "./workflow-lifecycle-traits.js";
 export { resolveReviewLevelSteps, applyReviewLevelPreset } from "./review-level-preset.js";
 export { LEGACY_STATUS_ADOPTION, resolveLegacyStatusAdoption, resolveReviewLevelBackfill, planLegacyAdoption, resolveOrphanedPendingStepResults, type LegacyAdoptionPlan, type LegacyAdoptionCandidate, type LegacyAdoptionAction, type LegacyAdoptionKind } from "./legacy-adoption.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -454,7 +454,7 @@ export { createWorkflowEventBus, getWorkflowEventBus, emitWorkflowLifecycleEvent
 export type { WorkflowEventBus, WorkflowEventSubscriber, WorkflowEventSubscription } from "./workflow-events.js";
 export { findWorkflowEventShapeViolations, isIdsOnlyWorkflowEvent, MAX_ID_VALUE_LENGTH, IMPLEMENTATION_EXITS } from "./types/workflow-events.js";
 export type { WorkflowLifecycleEvent, WorkflowLifecycleEventType, WorkflowLifecycleEventBase, TaskTransitionedEvent, NodeEnteredEvent, NodeCompletedEvent, RunSuspendedEvent, RunResumedEvent, WorkflowEventShapeViolation, ImplementationExit } from "./types/workflow-events.js";
-export { columnsWithFlag, columnHasFlag, resolveReboundTarget, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveLifecycleColumns, resolveTaskLifecycleColumns } from "./workflow-lifecycle-traits.js";
+export { columnsWithFlag, columnHasFlag, resolveReboundTarget, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveLifecycleColumns, resolveTaskLifecycleColumns, resolveTerminalColumns } from "./workflow-lifecycle-traits.js";
 export type { LifecycleColumns } from "./workflow-lifecycle-traits.js";
 export { resolveReviewLevelSteps, applyReviewLevelPreset } from "./review-level-preset.js";
 export {

--- a/packages/core/src/workflow-lifecycle-traits.ts
+++ b/packages/core/src/workflow-lifecycle-traits.ts
@@ -70,6 +70,32 @@ export function resolveMergeOrchestrationColumn(ir: WorkflowIr): string | undefi
 }
 
 /**
+ * The workflow's TERMINAL column pair — where a card rests when there is nothing
+ * left to do. Returns `[complete, archived]`.
+ *
+ * FNXC:WorkflowLifecycleColumns 2026-07-29-13:10:
+ * THE FALLBACK IS PER-ROLE, NOT PER-SET, and that distinction is the whole reason
+ * this is a shared function instead of two inline expressions.
+ *
+ * A per-SET fallback — "if the workflow resolved any terminal role, use what it
+ * declared" — collapses to a one-element set for a workflow that declares
+ * `complete` but no `archived`, silently dropping the archived half of every
+ * already-finished check. That is a real P1 (PR #2471 review): an archived card
+ * then fell through a merge short circuit and threw "must be in 'in-review'" for
+ * a task whose actual state was "already done".
+ *
+ * Resolving each role against its OWN legacy id keeps both halves for a
+ * partially-declared workflow. `merger-ai` learned this the hard way and the
+ * logic lived only there; `executor`'s equivalent guard was still the raw
+ * `column === "done" || column === "archived"` literal pair and would have
+ * re-made the same mistake on conversion. One function, one lesson.
+ */
+export function resolveTerminalColumns(ir: WorkflowIr): readonly [string, string] {
+  const lifecycle = resolveLifecycleColumns(ir);
+  return [lifecycle?.complete ?? "done", lifecycle?.archived ?? "archived"] as const;
+}
+
+/**
  * KTD-10 rebound target: where a self-healing sweep requeues a recovered card.
  * Preference order — the workflow's `hold` column, else its `intake` column, else
  * its first column. Returns undefined only for a column-less (v1) IR, where the

--- a/packages/engine/src/__tests__/reliability-interactions/execute-requeue-loop-guard.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/execute-requeue-loop-guard.test.ts
@@ -423,6 +423,36 @@ describe("execute requeue loop guard", () => {
     expect(h.live.pausedReason).not.toBe(COMPLETED_BLOCKED_PAUSE_REASON);
   });
 
+  it("uses the LIVE column, not the stale snapshot, when deciding whether to move", async () => {
+    /*
+    The second half of the post-await re-read, and it needed its own case: the pause
+    test above passes even when the MOVE guard still reads the stale snapshot, so
+    without this one half of that fix was unproven.
+
+    Here the card has already reached the rebound column while the resolution was in
+    flight. Reading the stale snapshot issues a redundant move; reading the live row
+    correctly skips it.
+    */
+    const h = harness(
+      task({
+        id: "FN-2568-STALE-COLUMN",
+        column: "in-progress",
+        blockedBy: "FN-BLOCKER",
+        steps: [],
+      }),
+      [task({ id: "FN-BLOCKER", column: "todo" })],
+    );
+
+    const staleSnapshot = { ...(await h.store.getTask("FN-2568-STALE-COLUMN")) };
+    // Something else lands the card in the rebound column mid-await.
+    await h.store.moveTask("FN-2568-STALE-COLUMN", "todo" as never, { preservePause: true } as never);
+    h.store.moveTask.mockClear();
+
+    await (h.executor as any).parkCompletedBlockedTask(staleSnapshot, "dependency", "test", true);
+
+    expect(h.store.moveTask).not.toHaveBeenCalled();
+  });
+
   it("honours a pause that lands DURING the workflow resolution await", async () => {
     /*
     The conversion introduced the first `await` between this method's pause guard and

--- a/packages/engine/src/__tests__/reliability-interactions/execute-requeue-loop-guard.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/execute-requeue-loop-guard.test.ts
@@ -365,6 +365,95 @@ describe("execute requeue loop guard", () => {
     });
   });
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-12:50 (PR #2568 review — greptile):
+  Both fixes below were UNPROVEN when written: I mutated each and the existing 17
+  cases stayed green, which is the same "converted but untested" state this program
+  keeps finding in other people's work. These two pin them.
+  */
+  it("treats a LEGACY terminal column as terminal even on a renamed board", async () => {
+    /*
+    `resolveWorkflowIrForTask` does not throw when a definition is missing or corrupt —
+    it returns the BUILT-IN IR. So the catch alone left the common degraded case
+    resolving terminals that exclude the card's own column, and the guard went inert
+    exactly as it did before the conversion.
+
+    Union with the legacy pair closes it. Over-inclusion is the safe direction here:
+    skipping a park costs a cycle, while moving a FINISHED card out of its terminal
+    column is the failure the conversion exists to prevent.
+
+    The renamed workflow is driven through the store rather than assumed — the shared
+    mock resolves `builtin:coding` by default, whose terminals already contain `done`,
+    so without this override the assertion would pass whether or not the union exists.
+    */
+    const h = harness(
+      task({
+        id: "FN-2568-LEGACY-TERMINAL",
+        column: "done",
+        blockedBy: "FN-BLOCKER",
+        steps: [],
+      }),
+      [task({ id: "FN-BLOCKER", column: "todo" })],
+    );
+    const renamedIr = {
+      version: "v2",
+      id: "custom:renamed",
+      nodes: [],
+      edges: [],
+      columns: [
+        { id: "queued", name: "Q", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+        { id: "building", name: "B", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+        { id: "shipped", name: "S", traits: [{ trait: "complete" }] },
+      ],
+    };
+    h.store.getTaskWorkflowSelection.mockReturnValue({ workflowId: "custom:renamed", stepIds: [] });
+    h.store.getTaskWorkflowSelectionAsync.mockResolvedValue({ workflowId: "custom:renamed", stepIds: [] });
+    (h.store as unknown as { getWorkflowDefinition: unknown }).getWorkflowDefinition =
+      vi.fn().mockResolvedValue({ ir: renamedIr });
+
+    const parked = await (h.executor as any).parkCompletedBlockedTask(
+      await h.store.getTask("FN-2568-LEGACY-TERMINAL"),
+      "dependency",
+      "test",
+      true,
+    );
+
+    expect(parked).toBe(false);
+    expect(h.live).toMatchObject({ column: "done" });
+    expect(h.live.pausedReason).not.toBe(COMPLETED_BLOCKED_PAUSE_REASON);
+  });
+
+  it("honours a pause that lands DURING the workflow resolution await", async () => {
+    /*
+    The conversion introduced the first `await` between this method's pause guard and
+    its writes, so the caller's `task` snapshot can be stale by the time they run. A
+    user pause arriving in that window is the least forgivable case to steamroll.
+    */
+    const h = harness(
+      task({
+        id: "FN-2568-RACE",
+        column: "in-progress",
+        blockedBy: "FN-BLOCKER",
+        steps: [],
+      }),
+      [task({ id: "FN-BLOCKER", column: "todo" })],
+    );
+
+    const staleSnapshot = { ...(await h.store.getTask("FN-2568-RACE")) };
+    // The operator pauses while the IR resolution is in flight.
+    await h.store.updateTask("FN-2568-RACE", { paused: true, userPaused: true } as never);
+
+    const parked = await (h.executor as any).parkCompletedBlockedTask(
+      staleSnapshot,
+      "dependency",
+      "test",
+      true,
+    );
+
+    expect(parked).toBe(false);
+    expect(h.live).toMatchObject({ column: "in-progress", userPaused: true });
+  });
+
   it("parks the stale in-progress self-requeue marker path when completed work is blocked", async () => {
     const h = harness(
       task({

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1779,11 +1779,36 @@ not see it. Each site now resolves once and uses the same value for both.
  * `resolveReboundColumnFor` below: one IR resolution on a rare guard path, and a
  * resolution failure must keep today's behaviour rather than answer "not terminal".
  */
+/** The terminal ids from before workflows owned the vocabulary. */
+const LEGACY_TERMINAL_COLUMNS: readonly string[] = ["done", "archived"];
+
 async function resolveTerminalColumnsFor(store: TaskStore, taskId: string): Promise<readonly string[]> {
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-12:20 (PR #2568 review — greptile):
+  THE UNION IS DELIBERATE, and the `catch` alone was not enough.
+
+  `resolveWorkflowIrForTask` does NOT throw when a custom workflow definition is
+  missing, corrupt or unavailable — it returns the BUILT-IN IR. So the catch below
+  only covers hard failures, while the common degraded case hands back a
+  valid-looking default whose terminals are `done`/`archived`. A renamed board in
+  that state would resolve terminals that do not include its own terminal column,
+  and this guard would go inert exactly as it did before the conversion.
+
+  Unioning with the legacy pair closes that: a resolvable board contributes its real
+  terminals, and the legacy ids remain recognised whether they came from a genuine
+  default workflow or from a silent substitution.
+
+  Over-inclusion is the SAFE direction here, and that is why a union is acceptable
+  rather than sloppy. This guard answers "is the card already finished, so skip
+  parking?" — being too inclusive occasionally skips parking a card that was not
+  really terminal; being too exclusive MOVES a finished card out of its terminal
+  column, which is the failure the conversion exists to prevent.
+  */
   try {
-    return resolveTerminalColumns(await resolveWorkflowIrForTask(store, taskId));
+    const resolved = resolveTerminalColumns(await resolveWorkflowIrForTask(store, taskId));
+    return [...new Set([...resolved, ...LEGACY_TERMINAL_COLUMNS])];
   } catch {
-    return ["done", "archived"];
+    return LEGACY_TERMINAL_COLUMNS;
   }
 }
 
@@ -4482,7 +4507,23 @@ export class TaskExecutor {
     half it did not declare).
     */
     const terminalColumns = await resolveTerminalColumnsFor(this.store, task.id);
-    if (terminalColumns.includes(task.column)) return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-31-12:30 (PR #2568 review — greptile):
+    RE-READ AFTER THE AWAIT. The pause and column guards above ran against the `task`
+    snapshot the caller passed, and this conversion introduced the first `await`
+    between those guards and the writes below. Another dispatch or an operator action
+    can move or pause the card while the IR resolution is in flight, and the stale
+    snapshot would then let this method move a now-terminal task out of its terminal
+    column, or overwrite a pause an operator just applied.
+
+    Re-reading is cheap next to the resolution that precedes it, and it is the pause
+    check that matters most: a user pause landing during the await is precisely the
+    case where proceeding is least forgivable. Falling back to the passed snapshot on
+    a read failure keeps this no worse than before the await existed.
+    */
+    const liveTask = await this.store.getTask(task.id).catch(() => undefined) ?? task;
+    if (liveTask.paused === true || liveTask.userPaused === true) return false;
+    if (terminalColumns.includes(liveTask.column)) return false;
     if (!workComplete) return false;
 
     const message = `Completed work held — ${completionBlocker}; will advance to review when blocker clears`;
@@ -4490,8 +4531,14 @@ export class TaskExecutor {
     FNXC:WorkflowLifecycle 2026-07-12-23:13:
     FN-7926: completed work with a persistent `getTaskCompletionBlocker` result must not self-requeue through the execute node. Re-running implementation cannot clear dependency/blockedBy state, so it only feeds FN-7863's generic no-progress backstop and misclassifies good work as `EXECUTION_DISPATCH_LOOP_EXHAUSTED`. Park in a scheduler-skipped todo state, preserve worktree/branch/steps, and reset the FN-7863 signature so the backstop remains reserved for genuinely incomplete no-progress loops.
     */
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-31-17:10 (rebase merge, both sides kept):
+    main (#2644) resolved the literal `todo` into `reboundColumn`; this branch added the
+    post-await `liveTask` re-read. Taking either side alone loses the other — the
+    literal comes back, or the stale snapshot does.
+    */
     const reboundColumn = await resolveReboundColumnFor(this.store, task.id);
-    if (task.column !== reboundColumn) {
+    if (liveTask.column !== reboundColumn) {
       await this.store.moveTask(task.id, reboundColumn, {
         preserveProgress: true,
         preserveResumeState: true,

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -16,7 +16,7 @@ import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings,
 import { getUnmetSchedulingDependencies } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
-import { RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
+import { resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
@@ -1774,6 +1774,19 @@ clears. The move TARGET was converted here in U5b; the guards in front of it wer
 which is the half-conversion shape: the correct target reached through a check that could
 not see it. Each site now resolves once and uses the same value for both.
 */
+/**
+ * The task's terminal column pair, fail-soft to the legacy ids. Mirrors
+ * `resolveReboundColumnFor` below: one IR resolution on a rare guard path, and a
+ * resolution failure must keep today's behaviour rather than answer "not terminal".
+ */
+async function resolveTerminalColumnsFor(store: TaskStore, taskId: string): Promise<readonly string[]> {
+  try {
+    return resolveTerminalColumns(await resolveWorkflowIrForTask(store, taskId));
+  } catch {
+    return ["done", "archived"];
+  }
+}
+
 async function resolveReboundColumnFor(store: TaskStore, taskId: string): Promise<string> {
   try {
     return resolveReboundTarget(await resolveWorkflowIrForTask(store, taskId)) ?? "todo";
@@ -4458,7 +4471,18 @@ export class TaskExecutor {
 
   private async parkCompletedBlockedTask(task: Task, completionBlocker: string, source: string, workComplete = this.isTaskWorkComplete(task)): Promise<boolean> {
     if (task.paused === true || task.userPaused === true) return false;
-    if (task.column === "done" || task.column === "archived") return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-29-13:10:
+    Was the raw literal pair `column === "done" || column === "archived"`. On a renamed
+    board neither matched, so this "already finished, nothing to park" guard was INERT
+    and a completed card resting in the workflow's own terminal column fell through —
+    and the `column !== "todo"` branch below would then have MOVED it back out of that
+    terminal column. Resolved through core's shared `resolveTerminalColumns`, which owns
+    the per-role fallback (a partially-declared workflow keeps the legacy id for the
+    half it did not declare).
+    */
+    const terminalColumns = await resolveTerminalColumnsFor(this.store, task.id);
+    if (terminalColumns.includes(task.column)) return false;
     if (!workComplete) return false;
 
     const message = `Completed work held — ${completionBlocker}; will advance to review when blocker clears`;

--- a/packages/engine/src/merger-ai.ts
+++ b/packages/engine/src/merger-ai.ts
@@ -54,6 +54,7 @@ import {
   resolveMergerFallbackModel,
   resolveReboundTarget,
   resolveLifecycleColumns,
+  resolveTerminalColumns,
   resolveWorkflowIrForTask,
   type MergeDetails,
   type MergeResult,
@@ -1036,26 +1037,15 @@ export async function resolveFinalizeReboundColumn(store: TaskStore, taskId: str
 async function isAlreadyFinalizedColumn(store: TaskStore, task: Task): Promise<boolean> {
   let terminal: readonly string[] = LEGACY_TERMINAL_COLUMNS;
   try {
-    const lifecycle = resolveLifecycleColumns(await resolveWorkflowIrForTask(store, task.id));
-    if (lifecycle) {
-      /*
-      FNXC:WorkflowLifecycleColumns 2026-07-28-02:10 (PR #2471 review, P1):
-      The fallback is PER-ROLE, not per-set. The first cut replaced the whole
-      legacy pair whenever ANY terminal role resolved, so a workflow declaring
-      `complete` but no `archived` collapsed to a one-element set and silently
-      lost the archived short-circuit — an archived card then fell through to
-      `getTaskMergeBlocker` and threw "must be in 'in-review'".
-
-      Resolving each role against its OWN legacy id keeps both halves of the
-      guard for a partially-declared workflow. The two roles are independent:
-      a per-set rule passes for whichever role happens to be declared and fails
-      for the other, which is why both directions are tested.
-      */
-      terminal = [
-        lifecycle.complete ?? LEGACY_COMPLETE_COLUMN,
-        lifecycle.archived ?? LEGACY_ARCHIVED_COLUMN,
-      ];
-    }
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-29-13:10:
+    Delegated to core's `resolveTerminalColumns`. The per-role fallback below was
+    the ONLY copy of that rule, and executor's equivalent guard was still a raw
+    literal pair that would have re-made the same P1 on conversion. Same values,
+    one owner. Behaviour-preserving: proven by workflow-already-finalized-live-e2e,
+    whose per-set mutation still fails.
+    */
+    terminal = resolveTerminalColumns(await resolveWorkflowIrForTask(store, task.id));
   } catch {
     terminal = LEGACY_TERMINAL_COLUMNS;
   }

--- a/packages/engine/src/merger-ai.ts
+++ b/packages/engine/src/merger-ai.ts
@@ -53,7 +53,6 @@ import {
   resolveValidatorSettingsModel,
   resolveMergerFallbackModel,
   resolveReboundTarget,
-  resolveLifecycleColumns,
   resolveTerminalColumns,
   resolveWorkflowIrForTask,
   type MergeDetails,


### PR DESCRIPTION
Two commits: a behaviour-preserving extraction, then the behaviour change.

## ⚠️ Stack note worth acting on

**#2550 and #2554 both report MERGED, but their content is not on `main`.** They merged into their *base branches*, and the bottom of that stack (**#2544**) is still open. Nothing in this chain has reached `main` yet.

Nothing is lost — everything is in `origin/feature/workflow-e2e-merge-rebound`, which is why this PR targets it. But "merged" reads as "landed" and here it doesn't. **Merging #2544 flows the whole chain down.**

## The bug

`parkCompletedBlockedTask` opens with *"is this card already finished?"* and answered it with:

```ts
if (task.column === "done" || task.column === "archived") return false;
```

On a renamed board neither matches, so **the guard was inert** — and the very next branch (`if (task.column !== "todo")`) would then have **moved a completed card back out of its own terminal column**.

A guard that never fires does not fail a test. This one was found by tracing the last ledger site, not by anything going red.

## Why a shared owner, not a local fix

`merger-ai`'s `isAlreadyFinalizedColumn` held the **only** copy of the per-role terminal-pair rule — a P1 learned the hard way (PR #2471 review): a per-**set** fallback collapses to one element for a workflow declaring `complete` but no `archived`, silently dropping the archived half of every already-finished check.

Executor's guard was the raw literal pair, so **whoever converted it next would have re-made exactly that mistake** — the lesson lived in a comment in another file. Hence `resolveTerminalColumns(ir)` in core: one owner, one place for the rule.

## Evidence, and its limits

**Commit 1 (extraction) is proven behaviour-preserving**: `workflow-already-finalized-live-e2e` is unchanged and green through the delegation, and the per-set mutation **still fails** through the shared helper.

**Commit 2 (the fix) is unproven at the call site, and I'm labelling it rather than implying otherwise.** `parkCompletedBlockedTask` is private and reached only from inside executor dispatch — I could not drive it end to end. So the shared helper gets its **own** tests, in both partial-role directions, precisely because its other consumer can't vouch for it. The call site is a one-line delegation to a tested function.

Weaker evidence than the rest of this unit's work. Saying so, because quietly counting it as proven is the exact failure this unit exists to catch.

## Census

417 → 416. That ratchet (#2557) is a **ceiling**, so it stays green without coordination; lower the pin when convenient.

## Verification

- E2E suites 10/10; helper unit tests 5/5
- core + engine `tsc --noEmit` clean
- `pnpm test:gate` green (414 + 10 + 71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Note on the conflict status (2026-07-31)

GitHub reports this PR `CONFLICTING / DIRTY`. **It is not.** Three independent checks:

- `git rebase origin/main` on the pushed head reports *"up to date"* and leaves the SHA unchanged — the branch is already on top of main.
- `git merge-tree` against the merge base produces **zero** conflict markers.
- `origin/main` is unchanged at the commit this was rebased onto.

The remote SHA matches the local head, so the push landed. The `mergeable` field is a **stale computation** — it goes stale after a force-push and doesn't always recompute.

This branch has now been rebased and force-pushed four times against that cached value. Worth guarding at the source: the auto-retry treats `mergeable` as ground truth, so a stale value generates conflict notices indefinitely. Confirming with a trial rebase or `git merge-tree` before dispatching distinguishes "actually conflicting" from "GitHub hasn't recomputed" — one command, and it ends the loop.

Verification on the current head: merge gate green (487 + 158 + 10), engine + core tsc clean, lint clean, 20 tests in the affected suite, zero unresolved threads.
