### PR TITLE
P0: main is RED after #2515 — and a card that already started work was being re-planned

### DIFF
--- a/.changeset/triage-merged-planning-column-fallout.md
+++ b/.changeset/triage-merged-planning-column-fallout.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A task that already started work is no longer sent back to be re-planned after the Planning column merge.
+category: fix
+dev: U11 (#2515) fallout. With Todo merged into Planning, one column carries both intake and hold traits and discovery makes the branches disjoint by testing hold first — but only the intake rule ever had the `isTaskStillInPlanningStage` advancement guard, because a card in the old `todo` could not be mid-planning. An advanced card (worktree + execution stamps) whose PROMPT.md is missing therefore hit the ENOENT "treat as unplanned" branch and was re-dispatched for planning, discarding its work: the FN-7977 / FN-8594 class, reintroduced by the column merge. The guard now applies to both rules and is passed the task's RESOLVED intake column, so a rebounded `needs-replan` card resting in the merged column is still correctly re-admitted.

--- a/packages/engine/src/__tests__/triage-planning-wake.test.ts
+++ b/packages/engine/src/__tests__/triage-planning-wake.test.ts
@@ -383,3 +383,80 @@ describe("TriageProcessor planning discovery: missing PROMPT.md", () => {
     expect(await discover(store, [task])).toEqual([]);
   });
 });
+
+/*
+FNXC:MergedPlanningPreFilter 2026-07-29-19:30 (PR #2576 review — greptile P1):
+The cheap pre-filter must never drop a card the real admission filters would keep.
+
+`couldBeCandidate` runs BEFORE lifecycle resolution — its whole purpose is to avoid
+a workflow-selection read per card — so it cannot know the task's lane. It called
+`isTaskStillInPlanningStage(t)` with the LEGACY lane, which reads a card resting in
+any renamed intake column as "advanced past planning".
+
+For a card carrying `status: "planning"` AND execution stamps that is fatal: the
+hold half (`status !== "planning"`) is false too, so the card is dropped before
+resolution and the lane-aware intake filter — which has no `status !== "planning"`
+condition and would have admitted it — never sees it.
+
+MY FIRST REPRO WAS WRONG and the failure said so: I used the MERGED column, where
+intake and hold are the same column, so the intake branch is disjointed away by
+`!isAtHoldColumn` and the hold branch excludes `status: "planning"` regardless. No
+loss there. The loss needs a workflow with SEPARATE renamed intake and hold columns
+— which is exactly the shape a pre-filter keyed on one hardcoded id cannot see.
+
+A pre-filter is an OVER-approximation by contract: it may only remove cards no real
+filter could want.
+*/
+const PREFILTER_WF = "custom:separate-lanes";
+
+function separateLanesIr() {
+  return {
+    version: "v2",
+    id: PREFILTER_WF,
+    name: PREFILTER_WF,
+    columns: [
+      { id: "backlog", name: "Intake", traits: [{ trait: "intake" }] },
+      { id: "drafting", name: "Hold", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "done", name: "Done", traits: [{ trait: "complete" }] },
+    ],
+    nodes: [],
+    edges: [],
+  };
+}
+
+describe("the discovery pre-filter never drops a card the real filters would admit", () => {
+  it("keeps a mid-planning card that already executed once, in a renamed INTAKE column", async () => {
+    const selection = { workflowId: PREFILTER_WF, stepIds: [] };
+    const task = createTask({
+      id: "FN-PREFILTER",
+      column: "backlog",
+      // Both halves of the pre-filter fail on this shape with the legacy lane:
+      // `status === "planning"` kills the hold half, and the execution stamps make
+      // the legacy advancement guard kill the intake half.
+      status: "planning",
+      firstExecutionAt: "2026-07-26T04:35:29.068Z",
+      executionStartedAt: "2026-07-26T04:35:29.068Z",
+      // Arrived in the planner column AFTER those stamps — the FN-8596
+      // discriminator. Without it the stamp branch reads "advanced" whatever the
+      // lane says, and the test would prove nothing about the lane.
+      columnMovedAt: "2026-07-27T00:00:00.000Z",
+      steps: [{ name: "step-1", status: "pending" }],
+    } as never);
+    const { store } = createEventedStore({
+      listTasks: vi.fn().mockResolvedValue([task]),
+      getTask: vi.fn().mockResolvedValue(task),
+      getTaskWorkflowSelection: vi.fn(() => selection),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+      getWorkflowDefinition: vi.fn(async () => ({ ir: separateLanesIr() })),
+    });
+    const processor = new TriageProcessor(store, "/tmp/root");
+    (processor as unknown as { running: boolean }).running = true;
+
+    const discovered = await (processor as unknown as {
+      discoverReadyPlanningTasks: (tasks: never[], now: number) => Promise<Array<{ id: string }>>;
+    }).discoverReadyPlanningTasks([task] as never, Date.now());
+
+    expect(discovered.some((t) => t.id === "FN-PREFILTER")).toBe(true);
+  });
+});

--- a/packages/engine/src/__tests__/triage-planning-wake.test.ts
+++ b/packages/engine/src/__tests__/triage-planning-wake.test.ts
@@ -308,7 +308,8 @@ describe("TriageProcessor planning discovery: missing PROMPT.md", () => {
       const { store } = createEventedStore();
       const task = createTask({
         id: "FN-REPLAN-EXECUTED",
-        column: "triage",
+        // U11 (#2515): the rebounded replan card now rests in the MERGED planning column.
+        column: "todo",
         status: "needs-replan",
         // A replan card carries the steps and spec of its previous (rejected) planning pass.
         steps: [{ name: "step-1", status: "pending" }],

--- a/packages/engine/src/__tests__/triage.test.ts
+++ b/packages/engine/src/__tests__/triage.test.ts
@@ -202,6 +202,28 @@ function createTriageTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+/*
+FNXC:TriageSuitePostU11 2026-07-29-16:40 (U11 #2515 fallout):
+The default lineage no longer declares a `triage` column — U11 merged Todo into
+Planning, keeping the id `todo`. `createTriageTask` still places cards in `triage`,
+which is correct for the fixtures that exercise the LEGACY column, and wrong for
+every fixture that means "a card awaiting specification": discovery resolves the
+task's own workflow, finds no `triage` in it, and admits nothing.
+
+Discovery fixtures use this helper instead, so they name the ROLE they mean rather
+than an id that moved out from under them. Left as a separate helper rather than
+changing `createTriageTask`'s default, because the finalize/move tests legitimately
+start a card upstream of the hold column and asserting on `triage` there is still
+the point.
+*/
+/** The default lineage's pre-implementation column after U11 (#2515). */
+const PLANNING_COLUMN = "todo";
+
+function createPlannableTask(overrides: Partial<Task> = {}): Task {
+  return createTriageTask({ column: PLANNING_COLUMN, ...overrides });
+}
+
+
 describe("buildSpecificationPrompt", () => {
   const baseTask: TaskDetail = {
     ...mockTaskDetail,
@@ -1725,22 +1747,22 @@ Planner rewrote mission without the raw request.
   describe("poll ordering", () => {
     it("dispatches eligible triage tasks by createdAt asc", async () => {
       const tasks: Task[] = [
-        createTriageTask({
+        createPlannableTask({
           id: "FN-100",
           priority: "normal",
           createdAt: "2026-01-01T00:01:00.000Z",
         }),
-        createTriageTask({
+        createPlannableTask({
           id: "FN-101",
           priority: "urgent",
           createdAt: "2026-01-01T00:10:00.000Z",
         }),
-        createTriageTask({
+        createPlannableTask({
           id: "FN-102",
           priority: "high",
           createdAt: "2026-01-01T00:03:00.000Z",
         }),
-        createTriageTask({
+        createPlannableTask({
           id: "FN-103",
           priority: "high",
           createdAt: "2026-01-01T00:02:00.000Z",
@@ -1776,12 +1798,12 @@ Planner rewrote mission without the raw request.
     it("excludes paused, awaiting-approval, failed, stuck-killed, and recovery-gated tasks from ordered candidates", async () => {
       const future = new Date(Date.now() + 60_000).toISOString();
       const tasks: Task[] = [
-        createTriageTask({ id: "FN-200", priority: "urgent" }),
-        createTriageTask({ id: "FN-201", priority: "urgent", paused: true }),
-        createTriageTask({ id: "FN-202", priority: "urgent", status: "awaiting-approval" }),
-        createTriageTask({ id: "FN-203", priority: "urgent", status: "failed" }),
-        createTriageTask({ id: "FN-204", priority: "urgent", status: "stuck-killed" }),
-        createTriageTask({ id: "FN-205", priority: "urgent", nextRecoveryAt: future }),
+        createPlannableTask({ id: "FN-200", priority: "urgent" }),
+        createPlannableTask({ id: "FN-201", priority: "urgent", paused: true }),
+        createPlannableTask({ id: "FN-202", priority: "urgent", status: "awaiting-approval" }),
+        createPlannableTask({ id: "FN-203", priority: "urgent", status: "failed" }),
+        createPlannableTask({ id: "FN-204", priority: "urgent", status: "stuck-killed" }),
+        createPlannableTask({ id: "FN-205", priority: "urgent", nextRecoveryAt: future }),
       ];
 
       const triageStore = createMockStore({
@@ -1814,12 +1836,12 @@ Planner rewrote mission without the raw request.
     */
     it("does not repeatedly dispatch a triage row that already has executor advancement evidence", async () => {
       const tasks: Task[] = [
-        createTriageTask({
+        createPlannableTask({
           id: "FN-ADVANCED",
           worktree: "/tmp/fusion-fn-advanced",
           firstExecutionAt: new Date().toISOString(),
         }),
-        createTriageTask({ id: "FN-UNPLANNED" }),
+        createPlannableTask({ id: "FN-UNPLANNED" }),
       ];
       const triageStore = createMockStore({
         listTasks: vi.fn().mockResolvedValue(tasks),
@@ -1848,12 +1870,12 @@ Planner rewrote mission without the raw request.
     */
     it("leaves global concurrency room for live in-progress agents when admitting planners", async () => {
       const tasks: Task[] = [
-        createTriageTask({ id: "FN-300", priority: "urgent" }),
-        createTriageTask({ id: "FN-301", priority: "urgent" }),
-        createTriageTask({ id: "FN-302", priority: "urgent" }),
-        createTriageTask({ id: "FN-303", priority: "urgent" }),
+        createPlannableTask({ id: "FN-300", priority: "urgent" }),
+        createPlannableTask({ id: "FN-301", priority: "urgent" }),
+        createPlannableTask({ id: "FN-302", priority: "urgent" }),
+        createPlannableTask({ id: "FN-303", priority: "urgent" }),
         {
-          ...createTriageTask({ id: "FN-EXEC", priority: "normal" }),
+          ...createPlannableTask({ id: "FN-EXEC", priority: "normal" }),
           column: "in-progress",
           status: null,
           sessionFile: "/tmp/fusion-fn-exec-session.json",
@@ -1893,9 +1915,9 @@ Planner rewrote mission without the raw request.
     */
     it("continues dispatching unplanned and explicit replan tasks to the planning agent", async () => {
       const tasks = [
-        createTriageTask({ id: "FN-PLANNER-UNDEFINED", status: undefined } as Partial<Task>),
-        createTriageTask({ id: "FN-PLANNER-NULL", status: null } as Partial<Task>),
-        createTriageTask({
+        createPlannableTask({ id: "FN-PLANNER-UNDEFINED", status: undefined } as Partial<Task>),
+        createPlannableTask({ id: "FN-PLANNER-NULL", status: null } as Partial<Task>),
+        createPlannableTask({
           id: "FN-PLANNER-REPLAN",
           status: "needs-replan",
           log: [{ action: "AI spec revision requested", outcome: "Add verification details." } as any],
@@ -5160,7 +5182,7 @@ describe("taskCreate tool model inheritance", () => {
       const task = {
         id: "FN-101",
         description: "Test triage task past",
-        column: "triage",
+        column: PLANNING_COLUMN,
         dependencies: [],
         steps: [],
         currentStep: 0,
@@ -5813,7 +5835,7 @@ describe("awaiting-approval poll exclusion", () => {
     const awaitingTask: Task = {
       id: "FN-AW1",
       description: "Awaiting approval task",
-      column: "triage",
+      column: PLANNING_COLUMN,
       status: "awaiting-approval",
       dependencies: [],
       steps: [],
@@ -5825,7 +5847,7 @@ describe("awaiting-approval poll exclusion", () => {
     const normalTask: Task = {
       id: "FN-NT1",
       description: "Normal triage task",
-      column: "triage",
+      column: PLANNING_COLUMN,
       dependencies: [],
       steps: [],
       currentStep: 0,
@@ -6788,7 +6810,7 @@ describe("evictStaleProcessing", () => {
         id,
         title: "Hung planner",
         description: "Test",
-        column: "triage",
+        column: PLANNING_COLUMN,
         dependencies: [],
         steps: [],
         currentStep: 0,

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -1517,7 +1517,24 @@ export class TriageProcessor {
       if (this.processing.has(t.id) || this.hasLivePlanningWork(t.id) || t.paused) return false;
       if (t.status === "awaiting-approval" || t.status === "failed" || t.status === "stuck-killed") return false;
       if (t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now) return false;
-      const couldBeIntake = isTaskStillInPlanningStage(t) && !this.advancedRecoveryReservations.has(t.id);
+      /*
+      FNXC:MergedPlanningPreFilter 2026-07-29-19:10 (PR #2576 review — greptile P1):
+      NO advancement guard here. This pre-filter runs BEFORE lifecycle resolution —
+      that is its whole purpose, to avoid a workflow-selection read per card — so it
+      cannot know the task's lane, and `isTaskStillInPlanningStage` with the legacy
+      lane reads a card in the MERGED Planning column as "advanced past planning".
+
+      For a card carrying `status: "planning"` AND execution stamps that was fatal:
+      the hold half below is false too, so the card was dropped before resolution
+      and the lane-aware filters — the ones this PR corrects — never saw it. The fix
+      admitted the card in theory while the pre-filter denied it in practice.
+
+      A pre-filter is an OVER-approximation by contract: it may only remove cards no
+      real filter could want. The advancement guard belongs to the real filters,
+      which have the lane; here it can only be wrong in the direction that loses
+      work. The reservation check stays because it is lane-independent.
+      */
+      const couldBeIntake = !this.advancedRecoveryReservations.has(t.id);
       const couldBeHold = t.status !== "planning";
       return couldBeIntake || couldBeHold;
     };
@@ -1538,11 +1555,24 @@ export class TriageProcessor {
     // An unresolved task id means the card was filtered out before resolution, so it is not a
     // candidate and both predicates are correctly false for it.
     const isAtHoldColumn = (t: Task): boolean => lifecycleByTaskId.get(t.id)?.hold === t.column;
+    /*
+    FNXC:MergedPlanningColumn 2026-07-29-16:55:
+    A lane is MERGED when intake and hold resolve to the same id — U11's shape.
+    Reported per task so `hasAdvancedPastPlanning` can apply the merged-column rule
+    only where it actually applies, rather than assuming the default lineage.
+    */
+    const mergedPlanningColumnFor = (t: Task): string | undefined => {
+      const lanes = lifecycleByTaskId.get(t.id);
+      return lanes?.intake !== undefined && lanes.intake === lanes.hold ? lanes.intake : undefined;
+    };
     const isAtIntakeColumn = (t: Task): boolean => lifecycleByTaskId.get(t.id)?.intake === t.column;
 
     const eligibleTriageTasks = candidates.filter(
       // `!isAtHoldColumn` keeps the two branches disjoint for a merged intake+hold column.
-      (t) => isAtIntakeColumn(t) && !isAtHoldColumn(t) && isTaskStillInPlanningStage(t, { intake: lifecycleByTaskId.get(t.id)?.intake ?? "triage" })
+      (t) => isAtIntakeColumn(t) && !isAtHoldColumn(t)
+        && isTaskStillInPlanningStage(t, lifecycleByTaskId.get(t.id)?.intake ?? "triage", {
+          mergedPlanningColumn: mergedPlanningColumnFor(t),
+        })
         && !this.advancedRecoveryReservations.has(t.id)
         && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
@@ -1567,7 +1597,32 @@ export class TriageProcessor {
     column has no worktree and no steps, so it is still admitted.
     */
     const eligibleTodoTasksRaw = candidates.filter(
-      (t) => isAtHoldColumn(t) && isTaskStillInPlanningStage(t, { intake: lifecycleByTaskId.get(t.id)?.intake ?? "triage" })
+      /*
+      FNXC:MergedPlanningColumn 2026-07-29-16:55 (U11 #2515 fallout — PRODUCT BUG):
+      The hold rule needs the ADVANCEMENT guard the intake rule already had.
+
+      Before #2515 the two pre-implementation columns were distinct, so an advanced
+      card (worktree + execution stamps) sat in `triage` and was excluded by the
+      intake rule's `isTaskStillInPlanningStage`. After the merge one column carries
+      BOTH traits, the branches are made disjoint by testing hold FIRST — and the
+      hold rule never had that guard, because a card in the old `todo` could not be
+      mid-planning.
+
+      Consequence: an advanced card whose PROMPT.md is missing hits the ENOENT
+      "treat as unplanned" branch below and is RE-DISPATCHED FOR PLANNING, discarding
+      the work it already has. That is the FN-7977 / FN-8594 class, reintroduced by
+      the column merge rather than by any change to the guard.
+
+      Passed the task's OWN planner column AND its merged-planning column, so the
+      distinction `hasAdvancedPastPlanning` draws between them is preserved: a merged
+      lane participates in the FN-8596 arrival-order rescue but not in the "planner
+      column is never advanced" shortcut, because on a merged lineage the same id
+      also means "released, awaiting capacity".
+      */
+      (t) => isAtHoldColumn(t)
+        && isTaskStillInPlanningStage(t, lifecycleByTaskId.get(t.id)?.intake ?? "triage", {
+          mergedPlanningColumn: mergedPlanningColumnFor(t),
+        })
         && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
         && t.status !== "planning"

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -1542,14 +1542,33 @@ export class TriageProcessor {
 
     const eligibleTriageTasks = candidates.filter(
       // `!isAtHoldColumn` keeps the two branches disjoint for a merged intake+hold column.
-      (t) => isAtIntakeColumn(t) && !isAtHoldColumn(t) && isTaskStillInPlanningStage(t)
+      (t) => isAtIntakeColumn(t) && !isAtHoldColumn(t) && isTaskStillInPlanningStage(t, { intake: lifecycleByTaskId.get(t.id)?.intake ?? "triage" })
         && !this.advancedRecoveryReservations.has(t.id)
         && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
         && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),
     );
+    /*
+    FNXC:MergedPlanningColumn 2026-07-29-16:55 (U11 #2515 fallout — PRODUCT BUG):
+    The hold rule needs the ADVANCEMENT guard the intake rule already had.
+
+    Before #2515 the two pre-implementation columns were distinct, so an advanced
+    card (worktree + execution stamps) sat in `triage` and was excluded by the intake
+    rule's `isTaskStillInPlanningStage`. After the merge one column carries BOTH
+    traits, the branches are made disjoint by testing hold FIRST — and the hold rule
+    never had that guard, because a card in the old `todo` could not be mid-planning.
+
+    Consequence: an advanced card whose PROMPT.md is missing hits the ENOENT
+    "treat as unplanned" branch below and is RE-DISPATCHED FOR PLANNING, discarding
+    the work it already has. That is the FN-7977 / FN-8594 class the guard exists to
+    prevent, reintroduced by the column merge rather than by any change to the guard.
+
+    Adding it here is safe for the ordinary case: an unplanned card in the hold
+    column has no worktree and no steps, so it is still admitted.
+    */
     const eligibleTodoTasksRaw = candidates.filter(
-      (t) => isAtHoldColumn(t) && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
+      (t) => isAtHoldColumn(t) && isTaskStillInPlanningStage(t, { intake: lifecycleByTaskId.get(t.id)?.intake ?? "triage" })
+        && !this.processing.has(t.id) && !this.hasLivePlanningWork(t.id) && !t.paused
         && t.status !== "awaiting-approval" && t.status !== "failed" && t.status !== "stuck-killed"
         && t.status !== "planning"
         && !(t.nextRecoveryAt && new Date(t.nextRecoveryAt).getTime() > now),


### PR DESCRIPTION
> **`origin/main` currently fails 8 tests in `triage.test.ts`.** This restores it to 228/228 and fixes the product bug those failures were pointing at. Based on `main`, no dependencies.

## The product bug (the reason this is not just a fixture PR)

U11 merged Todo into Planning, so **one column now carries both `intake` and `hold`**. Discovery keeps its two admission rules disjoint by testing hold **first** — so in the merged column, only the **hold** rule runs.

But only the **intake** rule ever had the `isTaskStillInPlanningStage` advancement guard, because a card in the old `todo` could not be mid-planning.

**Consequence:** an advanced card — worktree present, execution stamps set — whose `PROMPT.md` is missing falls into the documented ENOENT *"treat as unplanned"* branch and is **re-dispatched for planning, discarding the work it already has.**

That is the FN-7977 / FN-8594 class, reintroduced by the column merge rather than by any change to the guard. Blast radius: default-lineage cards that lost their spec file — precisely the population self-healing exists to rescue.

**Not a stall:** a legacy card sitting in `triage` is re-homed by `reconcileUndeclaredTaskColumns` (startup + periodic), so nothing is stranded without a rescue. The window is until the next reconcile pass. Flagging per your "tell me immediately" instruction — this is a *wrong-action* bug, not an unrescued stall.

## The fix, and the half the tests forced

The guard now applies to **both** rules, and is passed the task's **resolved** intake column.

That second half is load-bearing. With the legacy literal, a rebounded `needs-replan` card resting in the merged column reads as *"advanced"* and would never be re-admitted — trading a re-planning bug for a never-replanned one. Passing the resolved lane satisfies both:

| Card | Stamps vs arrival | Outcome |
|---|---|---|
| `FN-ADVANCED` (worktree + stamps, no status) | stamps **newer** than arrival | correctly excluded |
| rebounded `needs-replan` (executed once) | stamps **predate** arrival, in its own lane | correctly re-admitted |

`PlannerLaneColumns` / `LEGACY_PLANNER_LANE` are **brought forward from #2551** to do this. That PR now overlaps and should be rebased or closed — flagging rather than leaving two sources.

## Audit table for my assigned sites

| Site | (a) still fires for a default card? | (b) what silently stopped | (c) fix |
|---|---|---|---|
| `triage.ts` discovery — intake rule | **no** | nothing planned from `triage` | correct as-is: `triage` is undeclared; reconcile re-homes |
| `triage.ts` discovery — hold rule | yes, **too permissively** | advancement guard absent → advanced cards re-planned | guard added, resolved lane |
| `triage.ts` 613/651 (wake, evacuation) | already trait-resolved | — | covered by #2517 |
| `triage.ts` 741 / 1088 | already trait-resolved | — | covered by #2517 |
| `replan-target.ts` | yes, now returns `todo` | nothing — behavior already correct | expectations moved |
| `spec-staleness.ts:95` | not reached in this diff | — | **not audited yet**, see below |

## Fixtures: two kinds, told apart deliberately

Eight discovery fixtures placed cards in `column: "triage"` — a column the default lineage no longer declares — so discovery correctly ignored them and `specifyTask` ran **zero** times. Those now use a `PLANNING_COLUMN` helper that names the **role**.

I deliberately did **not** change `createTriageTask`'s default: the finalize/move tests legitimately start a card upstream of the hold column, and blanket-changing the helper **turned 8 failures into 13**. Measured, then reverted.

The `replan-target` expectations are a **contract move**, not a tidy-up: the default workflow no longer declares `triage`, so a rejected plan rebounds to `todo` — the same physical column operators now see as "Planning", so observable behavior is unchanged for them. Kept asserted with a note, because *"where does a rejected plan go back to"* is exactly what U11 changed.

## Revert proof

With the advancement guard removed from the hold rule, the *"does not repeatedly dispatch a triage row that already has executor advancement evidence"* case fails. The other 227 pass either way — the correct signature for a fix whose default behavior is otherwise unchanged.

## Verification

| Check | Result |
|---|---|
| triage + planning-wake + planning-evacuation + replan-target + self-healing-advanced-triage | **309/309** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (414 + 10 + 71) |
| `pnpm check:changesets` | clean |

## Still owed on my audit

`spec-staleness.ts:95` — not reached in this PR. Next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
