### PR TITLE
U8: pin seam/primitive handler parity — the invariant that makes the dead seam harmless

### DIFF
--- a/packages/engine/src/__tests__/workflow-seam-primitive-parity.test.ts
+++ b/packages/engine/src/__tests__/workflow-seam-primitive-parity.test.ts
@@ -1,0 +1,74 @@
+/*
+FNXC:WorkflowExecutionOwnership 2026-07-29-17:20 (U8 / R4, R12):
+
+Two prompt-node handlers exist and only one runs. `createDefaultNodeHandlers` prefers
+`createPrimitivePromptLikeHandler` whenever `deps.primitives` is set, and `executeWorkflowGraph`
+always sets it — so `createPromptLikeHandler`, the legacy-seams variant, is unreachable for prompt
+nodes. That already cost one shipped behavior that never executed (the exit announcement).
+
+The invariant that makes the preference SAFE is parity: every seam name the seams handler can
+dispatch must also be handled by the primitives handler. If the primitives handler is missing one,
+a node declaring that seam does not fail loudly — it falls through to the custom-node runner and
+is treated as a custom node, or throws `No custom-node runner registered`. Either way the workflow
+author gets a nonsense result from a seam the IR is entitled to declare.
+
+`review-handoff` is called out separately because it is now load-bearing: the pending-review park
+node added to the built-in coding IRs declares it, so a parity gap there would mean a card that
+should be handed to review is not.
+*/
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const SOURCE = readFileSync(new URL("../workflow-node-handlers.ts", import.meta.url), "utf8")
+  .replace(/\/\*[\s\S]*?\*\//g, " ")
+  .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+
+/** The seam names `resolveSeamName` accepts — the whole surface an IR may declare. */
+const SEAM_NAMES = [
+  "planning",
+  "execute",
+  "review",
+  "review-handoff",
+  "merge",
+  "schedule",
+  "step-execute",
+] as const;
+
+function bodyOf(fnName: string): string {
+  const start = SOURCE.indexOf(`export function ${fnName}(`);
+  expect(start, `${fnName} not found`).toBeGreaterThan(-1);
+  const next = SOURCE.indexOf("\nexport function ", start + 1);
+  return SOURCE.slice(start, next === -1 ? undefined : next);
+}
+
+describe("prompt-node handler parity", () => {
+  it("resolveSeamName's accepted names are exactly the list under test", () => {
+    /* Guards the guard: a new seam name added to the resolver must be added here, or the parity
+       assertion below would silently stop covering it. */
+    const resolver = bodyOf("resolveSeamName");
+    for (const seam of SEAM_NAMES) {
+      expect(resolver, `resolveSeamName should accept ${seam}`).toContain(`seam === "${seam}"`);
+    }
+    const accepted = [...resolver.matchAll(/seam === "([a-z-]+)"/g)].map((m) => m[1]);
+    expect([...new Set(accepted)].sort()).toEqual([...SEAM_NAMES].sort());
+  });
+
+  it("the PRIMITIVES handler dispatches every seam name the seams handler can", () => {
+    const primitive = bodyOf("createPrimitivePromptLikeHandler");
+    const missing = SEAM_NAMES.filter((seam) => !primitive.includes(`seam === "${seam}"`));
+    expect(
+      missing,
+      "these seams would fall through to the custom-node runner on the LIVE handler",
+    ).toEqual([]);
+  });
+
+  it("review-handoff is handled on the live path — the pending-review park depends on it", () => {
+    expect(bodyOf("createPrimitivePromptLikeHandler")).toContain('seam === "review-handoff"');
+  });
+
+  it("dispatch prefers the primitives handler, which is why parity is required", () => {
+    expect(bodyOf("createDefaultNodeHandlers")).toMatch(
+      /deps\?\.primitives\s*\?\s*createPrimitivePromptLikeHandler/,
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #2578, which found that `createAuthoritativeWorkflowSeams`'s prompt entries never run. This pins the invariant that makes preferring the primitives handler *safe*, rather than merely current. **No production change.**

## Reachability, measured

| Seam | Reached how | Live? |
|---|---|---|
| `planning`, `execute`, `review`, `review-handoff`, `merge`, `schedule`, `step-execute` | only via `createPromptLikeHandler` | **No** — primitives handler wins for prompt nodes |
| `stepReview` | direct call, `executor.ts:7382` | Yes |
| `merge` | also passed to `createMergeAttemptHandler` | Yes, via that handler |

So the entire seams prompt path is dead, and every one of those seam names is served by `createPrimitivePromptLikeHandler` instead.

## Why parity is the thing worth asserting

Preferring one handler is only safe if it covers everything the other does. If the primitives handler is missing a seam name, the node **does not fail loudly** — it falls through to the custom-node runner and is treated as a custom node, or throws `No custom-node runner registered for node`. An IR is entitled to declare that seam, and gets nonsense either way.

`review-handoff` gets its own assertion because it is now **load-bearing**: the `review-pending-handoff` park node added to the built-in coding IRs in #2519/#2546 declares it. A parity gap there means a card that should be handed to review simply is not — with no error. I checked this before writing the test rather than after, and it is currently handled correctly on the live path; the test is what keeps it that way.

## Guard the guard

The seam list under test is asserted to equal the set `resolveSeamName` accepts. Without that, adding a seam to the resolver would silently narrow the parity check to the old list — a guard that stops covering the thing it was written for, which is the exact failure class this program keeps finding.

## Proven on injected defects

```
remove `review-handoff` from the primitives handler  ->  Tests  2 failed | 2 passed (4)
add a seam name to the resolver only                 ->  Tests  1 failed | 3 passed (4)
```

## Scope

Still **not** deleting `createPromptLikeHandler` or the dead seam entries. Deleting them is a delete-only change under this program's rule, it needs its own evidence that nothing outside `createDefaultNodeHandlers` constructs them (test helpers do), and this PR is the thing that makes such a deletion safe to reason about. Filed as the next slice.

## Verification

- New parity suite + graph-executor handlers + graph boundary — green
- `pnpm lint` clean; no production files touched, so no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)