### PR TITLE
P0 audit (U7, last site): a card in the merged Planning column was exempted from spec-staleness checks

### DIFF
--- a/.changeset/spec-staleness-post-u11.md
+++ b/.changeset/spec-staleness-post-u11.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A task waiting in Planning with leftover steps is checked for a stale spec again instead of being skipped.
+category: fix
+dev: U11 (#2515) audit of U7's assigned site. `shouldSkipSpecStalenessForPreservedProgress` exempted cards with leftover progress from staleness evaluation unless they were in `triage` or carried a planning-stage status. With `triage` gone from the default lineage that clause stopped matching, so a card in the merged Planning column with steps from a previous pass and a cleared status took the exemption and was never checked — the scheduler's stale-spec rebound never fired and the card could dispatch against a superseded spec. The lane is now injected (the function is pure and sync, called inside a scheduler filter) and defaults to the legacy id, so unwired callers are byte-identical; both real callers resolve and pass the task's own intake column.

--- a/packages/engine/src/__tests__/spec-staleness-post-u11.test.ts
+++ b/packages/engine/src/__tests__/spec-staleness-post-u11.test.ts
@@ -1,0 +1,93 @@
+/*
+FNXC:SpecStalenessPostU11 2026-07-29-18:10 (U11 #2515 audit — U7's assigned site):
+
+`shouldSkipSpecStalenessForPreservedProgress` decides whether a card's leftover
+progress EXEMPTS it from spec-staleness evaluation. It listed three "no, still
+evaluate" conditions: the card is in `triage`, or carries `needs-replan`, or
+carries `planning`.
+
+The audit answers, per the coordinator's three questions:
+
+  (a) Does `column === "triage"` still fire for a default-workflow card after
+      #2515?  NO. The default lineage no longer declares `triage` at all.
+
+  (b) What silently stops happening?  A card resting in the merged Planning column
+      with leftover steps and NO planning-stage status now takes the "preserved
+      progress" exemption, so its spec is never evaluated for staleness. The
+      scheduler's stale-spec rebound therefore never fires and the card can be
+      dispatched against a spec the reviewer already superseded.
+
+      That combination is not exotic: finalize clears `status` to null after the
+      handoff, and steps parsed from the previous planning pass remain on the row.
+      It is the FN-8596 shape exactly.
+
+  (c) Fix: resolve the planner lane instead of naming `triage`. The function is
+      pure and synchronous — one of its two callers invokes it inside a scheduler
+      filter — so the lane is INJECTED, defaulting to the legacy id. Callers that
+      know the workflow pass it; the rest are byte-identical.
+
+The status conditions are deliberately untouched: `needs-replan` and `planning` are
+statuses, not columns, and U11 did not move them.
+*/
+import { describe, expect, it } from "vitest";
+
+import { shouldSkipSpecStalenessForPreservedProgress } from "../spec-staleness.js";
+
+/** A card with leftover progress from a previous planning pass. */
+const withProgress = (over: Record<string, unknown> = {}) => ({
+  column: "todo",
+  status: null,
+  currentStep: 0,
+  steps: [{ name: "s1", status: "done" }],
+  ...over,
+} as never);
+
+describe("spec-staleness progress exemption resolves the planner lane", () => {
+  it("still evaluates a card in the DEFAULT planner column (no-regression half)", () => {
+    // Legacy vocabulary, legacy default lane: unchanged.
+    expect(shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "triage" }))).toBe(false);
+  });
+
+  it("still evaluates a card in the MERGED planning column when told the lane", () => {
+    /*
+    The #2515 gap. Without the lane this returns `true` — the card is exempted from
+    staleness evaluation entirely, so a superseded spec is never detected and the
+    scheduler's rebound never fires.
+    */
+    expect(
+      shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "todo" }), { intake: "todo" }),
+    ).toBe(false);
+  });
+
+  it("still evaluates a card in a RENAMED planner column when told the lane", () => {
+    expect(
+      shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "backlog" }), { intake: "backlog" }),
+    ).toBe(false);
+  });
+
+  it("EXEMPTS a card with progress that has genuinely left the planner lane", () => {
+    // The other side, so "always evaluate" cannot pass for "correctly in the lane":
+    // a card actually executing keeps its progress exemption.
+    expect(
+      shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "in-progress" }), { intake: "todo" }),
+    ).toBe(true);
+  });
+
+  it("keeps the legacy answer when no lane is supplied (strictly additive)", () => {
+    // A caller with no resolved roles behaves exactly as before — including the old
+    // WRONG answer for the merged column, which is what makes this safe to land
+    // ahead of the call-site wiring.
+    expect(shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "todo" }))).toBe(true);
+    expect(shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "triage" }))).toBe(false);
+  });
+
+  it("leaves the STATUS conditions untouched — they are not columns", () => {
+    // U11 moved a column, not a status; `needs-replan` and `planning` still force
+    // evaluation regardless of lane or progress.
+    for (const status of ["needs-replan", "planning"]) {
+      expect(
+        shouldSkipSpecStalenessForPreservedProgress(withProgress({ column: "in-progress", status }), { intake: "todo" }),
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -15,7 +15,7 @@ import { readFile, rm, writeFile } from "node:fs/promises";
 import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings, WorkflowStep, MissionStore, AsyncMissionStore, Slice, AgentState, AgentCapability, RunMutationContext, AgentHeartbeatConfig, Agent, AgentMemoryInclusionMode, ProjectSettings, MergeResult, WorkflowIrNode, WorkflowIrNodeKind, WorkflowStepResult as CoreWorkflowStepResult, ThinkingLevel } from "@fusion/core";
 import { getUnmetSchedulingDependencies } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
-import { emitWorkflowLifecycleEvent } from "@fusion/core";
+import { emitWorkflowLifecycleEvent, resolveTaskLifecycleColumns } from "@fusion/core";
 import { RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
@@ -11848,7 +11848,11 @@ export class TaskExecutor {
     if (!isActiveTask) {
       const tasksDir = join(this.store.getFusionDir(), "tasks");
       const promptPath = getPromptPath(tasksDir, task.id);
-      const staleness = await evaluateSpecStaleness({ settings, promptPath, task });
+      // FNXC:SpecStalenessPostU11 2026-07-29-18:25: pass the task's OWN planner lane so a
+      // card resting in the merged Planning column is still checked for a stale spec.
+      const stalenessLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.intake;
+      const staleness = await evaluateSpecStaleness({ settings, promptPath, task,
+        ...(stalenessLane ? { plannerLane: { intake: stalenessLane } } : {}) });
       if (staleness.isStale) {
         executorLog.warn(`Task ${task.id} specification is stale — ${staleness.reason}`);
         // Move to the workflow-aware replan column first, then set status so the task

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -11,6 +11,7 @@ import {
   type PrInfo,
   type AgentStore,
   type Settings,
+  resolveTaskLifecycleColumns,
 } from "@fusion/core";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -1779,7 +1780,11 @@ export class Scheduler {
 
           if (typeof this.store.getTasksDir === "function") {
             const promptPath = getPromptPath(this.store.getTasksDir(), task.id);
-            const staleness = await evaluateSpecStaleness({ settings, promptPath, task });
+            // FNXC:SpecStalenessPostU11 2026-07-29-18:25: pass the task's OWN planner lane so a
+            // card resting in the merged Planning column is still checked for a stale spec.
+            const stalenessLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.intake;
+            const staleness = await evaluateSpecStaleness({ settings, promptPath, task,
+              ...(stalenessLane ? { plannerLane: { intake: stalenessLane } } : {}) });
             if (staleness.isStale) {
               schedulerLog.warn(`Task ${task.id} specification is stale — ${staleness.reason}`);
               await moveTaskToReplanColumn(this.store, task);

--- a/packages/engine/src/spec-staleness.ts
+++ b/packages/engine/src/spec-staleness.ts
@@ -50,6 +50,13 @@ export interface EvaluateSpecStalenessOptions {
    */
   nowMs?: number;
   /**
+   * FNXC:SpecStalenessPostU11 2026-07-29-18:25 (U11 #2515 audit):
+   * The task's own planner lane. Callers that can resolve the workflow pass it so
+   * the preserved-progress exemption keys on the ROLE; omitting it keeps the legacy
+   * intake id and today's behavior exactly.
+   */
+  plannerLane?: SpecStalenessPlannerLane;
+  /**
    * Optional task metadata. When provided, evaluation skips already-started,
    * parked work so preserved progress is not sent back through triage solely
    * because the original PROMPT.md mtime exceeded the staleness threshold.
@@ -89,10 +96,40 @@ export interface EvaluateSpecStalenessOptions {
  * @param options - Evaluation options including settings and PROMPT.md path
  * @returns Spec staleness decision with staleness flag, metrics, and skip indicator
  */
+/**
+ * FNXC:SpecStalenessPostU11 2026-07-29-18:10 (U11 #2515 audit):
+ * The planner lane, injected. This function is PURE and SYNCHRONOUS — one caller
+ * invokes it inside a scheduler filter — so it cannot resolve an IR itself.
+ * Defaults to the legacy intake id, which keeps every existing caller
+ * byte-identical.
+ */
+export interface SpecStalenessPlannerLane {
+  intake: string;
+}
+
+const LEGACY_SPEC_STALENESS_LANE: SpecStalenessPlannerLane = { intake: "triage" };
+
 export function shouldSkipSpecStalenessForPreservedProgress(
   task: EvaluateSpecStalenessOptions["task"] | undefined,
+  plannerLane: SpecStalenessPlannerLane = LEGACY_SPEC_STALENESS_LANE,
 ): boolean {
-  if (!task || task.column === "triage" || task.status === "needs-replan" || task.status === "planning") {
+  /*
+  FNXC:SpecStalenessPostU11 2026-07-29-18:10 (U11 #2515 audit):
+  A card resting in the PLANNER LANE never earns the preserved-progress exemption —
+  its leftover steps belong to a previous planning pass, so its spec is exactly what
+  needs re-checking. Keyed on the literal `triage`, that clause stopped matching when
+  #2515 removed the column from the default lineage, and a card in the merged
+  Planning column with leftover steps and no planning-stage status was EXEMPTED from
+  staleness evaluation entirely: the scheduler's stale-spec rebound never fired and
+  the card could be dispatched against a superseded spec.
+
+  Not exotic — finalize clears `status` to null after the handoff while the previous
+  pass's steps remain on the row. That is the FN-8596 shape.
+
+  The two STATUS conditions are untouched on purpose: `needs-replan` and `planning`
+  are statuses, not columns, and U11 moved a column.
+  */
+  if (!task || task.column === plannerLane.intake || task.status === "needs-replan" || task.status === "planning") {
     return false;
   }
   if ((task.currentStep ?? 0) > 0) {
@@ -117,7 +154,7 @@ export async function evaluateSpecStaleness(
     };
   }
 
-  if (shouldSkipSpecStalenessForPreservedProgress(task)) {
+  if (shouldSkipSpecStalenessForPreservedProgress(task, options.plannerLane)) {
     return {
       isStale: false,
       ageMs: undefined,


### PR DESCRIPTION
> Based on `main`; independent of #2576. Completes my assigned P0 audit — `triage.ts`, `replan-target.ts` (#2576) and now `spec-staleness.ts:95`.

## The audit, in your three columns

| | |
|---|---|
| **(a) Still fires for a default card?** | **No.** `shouldSkipSpecStalenessForPreservedProgress` tests `task.column === "triage"`, and the default lineage no longer declares that column. |
| **(b) What silently stops happening** | The function exempts a card with leftover progress from staleness evaluation **unless** it is in the planner column or carries a planning-stage status. With the column clause dead, a card resting in the merged Planning column — steps from a previous pass, status already cleared — takes the exemption. Its spec is never evaluated, the scheduler's stale-spec rebound never fires, and it can be **dispatched against a spec the reviewer already superseded**. |
| **(c) Fix** | Resolve the planner lane instead of naming `triage`. |

The triggering combination is not exotic: **finalize clears `status` to null after the handoff while the previous pass's steps remain on the row.** That is the FN-8596 shape exactly.

## Injected, not resolved in place

The function is pure and synchronous, and one of its two callers invokes it **inside a scheduler filter** — it cannot read a store. So the lane is a parameter defaulting to the legacy intake id.

That default keeps every unwired caller byte-identical, and I assert it explicitly — **including that the merged column still gets the old wrong answer without a lane.** That assertion is the point: it is what makes this safe to land ahead of any call-site wiring, and it distinguishes a compatibility default from a second opinion.

Both real callers (`scheduler.ts`, `executor.ts`) then resolve and pass the task's own intake column.

## The status conditions are deliberately untouched

`needs-replan` and `planning` are **statuses, not columns**, and U11 moved a column. Pinned by a test so a later sweep does not "finish the job" by converting them too — that would be a different behavior change wearing this one's clothes.

## Revert proof

With the literal restored: **2 of 6 fail** — the merged-column and renamed-column cases.

The default-vocabulary case, the *left-the-lane* case, and the legacy-fallback case pass either way. That is the correct signature for a conversion that changes no existing behavior, and the left-the-lane case is there so *"always evaluate"* cannot pass for *"correctly in the lane"*.

## Verification

| Check | Result |
|---|---|
| new suite | 6/6 |
| pre-existing spec-staleness + scheduler-trait suites | 39/39, **no expectation edits** |
| `tsc --noEmit` (engine) | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (414 + 10 + 71) |
| `pnpm check:changesets` | clean |

## My audit is now closed

| Site | Verdict |
|---|---|
| `triage.ts` discovery — intake rule | correct as-is; `triage` is undeclared and reconcile re-homes |
| `triage.ts` discovery — hold rule | **product bug** — advancement guard absent → fixed in #2576 |
| `triage.ts` 613/651/741/1088 | already trait-resolved (#2517) |
| `replan-target.ts` | behavior already correct; expectations moved (#2576) |
| `spec-staleness.ts:95` | **silent exemption** — fixed here |

One cross-cutting note for the other auditors: in both bugs I found, the literal that stopped matching was **not** the harmful part. The harm came from the *fallthrough* — the hold rule that lacked a guard the intake rule had, and the exemption that applied once its exclusion went dead. Grepping for the literal finds the site; asking *"what does this branch fall through to now?"* is what finds the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
