### PR TITLE
test: finish the 4 residual failures from the logger-mock sweep

### DIFF
--- a/packages/engine/src/__tests__/notification-service.test.ts
+++ b/packages/engine/src/__tests__/notification-service.test.ts
@@ -492,11 +492,21 @@ describe("NotificationService", () => {
       );
     });
 
+    /*
+    FNXC:NotificationLogging 2026-07-29-15:05:
+    This message is emitted at DEBUG level (notification-service.ts:580), not log.
+    The secrecy assertion is checked against BOTH channels on purpose: moving the
+    positive assertion to `debug` while leaving the negative on `log` alone would
+    let a token leak through the very channel the message now uses, and the test
+    would still pass.
+    */
     await vi.waitFor(() => {
-      expect(schedulerLog.log).toHaveBeenCalledWith("NotificationService ntfy access token updated");
+      expect(schedulerLog.debug).toHaveBeenCalledWith("NotificationService ntfy access token updated");
     });
-    expect(schedulerLog.log).not.toHaveBeenCalledWith(expect.stringContaining("new-token"));
-    expect(schedulerLog.log).not.toHaveBeenCalledWith(expect.stringContaining("old-token"));
+    for (const channel of [schedulerLog.log, schedulerLog.debug, schedulerLog.warn, schedulerLog.error]) {
+      expect(channel).not.toHaveBeenCalledWith(expect.stringContaining("new-token"));
+      expect(channel).not.toHaveBeenCalledWith(expect.stringContaining("old-token"));
+    }
     initSpy.mockRestore();
   });
 
@@ -784,7 +794,7 @@ describe("NotificationService", () => {
         expect.objectContaining({ event: "message:agent-to-user" }),
       );
     });
-    expect(schedulerLog.log).toHaveBeenCalledWith(
+    expect(schedulerLog.debug).toHaveBeenCalledWith(
       expect.stringContaining("NotificationService refreshed notification state reason=message:sent enabled=true"),
     );
   });
@@ -1097,7 +1107,7 @@ describe("NotificationService", () => {
           expect.objectContaining({ taskId: "FN-104", event: "merged" }),
         );
       });
-      expect(schedulerLog.log).toHaveBeenCalledWith(
+      expect(schedulerLog.debug).toHaveBeenCalledWith(
         expect.stringContaining("NotificationService refreshed notification state reason=task:moved:done enabled=true"),
       );
     });

--- a/packages/engine/src/__tests__/openclaw-runtime-integration.test.ts
+++ b/packages/engine/src/__tests__/openclaw-runtime-integration.test.ts
@@ -16,6 +16,16 @@ vi.mock("../logger.js", () => ({
 }));
 
 vi.mock("../pi.js", () => ({
+  /*
+  FNXC:TestInfrastructure 2026-07-29-15:30:
+  `wrapCustomToolsForPluginRuntime` (agent-session-helpers.ts:104) applies this as
+  the outermost tool wrapper on every NON-PI runtime path — which is exactly what
+  this suite exercises — so omitting it threw "No wrapToolsWithOutputBudget export
+  is defined on the ../pi.js mock" at session construction. Identity stub: the real
+  function returns tools byte-identical for a null budget, and this suite asserts
+  runtime selection/metadata, not output budgeting.
+  */
+  wrapToolsWithOutputBudget: vi.fn((tools: unknown[]) => tools),
   createFnAgent: mockCreateFnAgent,
   promptWithFallback: vi.fn().mockResolvedValue(undefined),
   describeModel: vi.fn().mockReturnValue("pi/default"),


### PR DESCRIPTION
**Stacked on #2573** (base is `feature/u9-regreen-completion-fanout`, not `main`) — merge that first. Test-only, 2 files.

#2573 left 4 failures it explicitly declined to fold in, so they wouldn't obscure what that sweep did. These are them.

## notification-service (3)

Three messages moved to **DEBUG** level in production (`notification-service.ts:580`, `:846`); the tests still asserted `schedulerLog.log`. Retargeted to `schedulerLog.debug`.

**The token case needed more than a relocation.** It asserted:

```js
expect(schedulerLog.log).not.toHaveBeenCalledWith(containing("new-token"))
```

Moving only the *positive* assertion to `debug` would leave the secrecy check watching a channel the message no longer uses — a token could leak through `debug` and the test would still pass. That's the trap in every "just point the assertion at the new channel" fix. The negative now runs across `log`, `debug`, `warn` and `error`.

**Verified the widening bites:** making the production line interpolate the token into the debug message fails the test (1 failed / 50 skipped). Before the widening, that exact leak went unnoticed.

## openclaw-runtime-integration (1)

`../pi.js` mock missing `wrapToolsWithOutputBudget` — same class as #2547. This suite exercises a **non-pi** runtime, which is precisely the path where `wrapCustomToolsForPluginRuntime` applies that wrapper.

## Why this was NOT swept repo-wide

37 `pi.js` mocks omit that export, so a sweep was the obvious move. I measured it instead:

| | Failed |
|---|---|
| before | 11 |
| after patching 30 files | **10** |

**Thirty files of churn for one test.** Reverted; only `openclaw` is patched.

The contrast with #2573 is the point: that sweep earned its 27-file diff by fixing **202** failures. This one earned nothing, and a no-op sweep across 30 test files is just future merge conflicts for the other workers on this program. Same instinct, opposite evidence — so the opposite decision.

(7 of the 37 had a factory shape my patcher didn't recognise and were skipped rather than hand-edited blind. Moot now that the sweep is reverted, but worth noting the number isn't 37/37.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)