### PR TITLE
U8: delete-only audit says STOP — the seams path is not dead, and noop seams fail OPEN on merge

### DIFF
--- a/packages/engine/src/__tests__/workflow-noop-seams-fail-open.test.ts
+++ b/packages/engine/src/__tests__/workflow-noop-seams-fail-open.test.ts
@@ -1,0 +1,65 @@
+/*
+FNXC:WorkflowExecutionOwnership 2026-07-29-18:00 (U8 / R12 — characterization, no production change):
+
+DELETE-ONLY AUDIT RESULT: the legacy-seams prompt handler is NOT dead, so it was not deleted.
+
+`createDefaultNodeHandlers` prefers the primitives handler only when `deps.primitives` is set.
+`executeWorkflowGraph` always sets it, so the seams path is unreachable THERE — but
+`WorkflowTaskRuntime` passes `this.deps.primitives`, which is OPTIONAL, and `WorkflowTaskRuntime`
+is exported from the engine index. Construct it without primitives and the seams path is live.
+Under this program's delete-only rule ("any behavior change found while removing a branch means
+the branch was not dead — stop and treat it as a finding"), that is a stop.
+
+THE FINDING, which is why this file exists rather than a deletion: `createNoopLegacySeams()`
+returns SUCCESS for `execute`, `review`, `merge`, `planning`, `schedule` and `review-handoff`. So
+a handler set built from noop seams with no primitives runs a coding workflow to success having
+done no implementation, no review, and a merge seam that merely says yes.
+
+The asymmetry is the tell. `step-execute` deliberately fails CLOSED in the same file —
+"a step-execute node with no seam wired must NOT silently succeed — that would merge a task with
+no step work done". The hazard was recognised for exactly one seam and left fail-open for the
+rest, including `merge`.
+
+These tests PIN the current behavior rather than change it. Making the remaining seams fail closed
+is a behavior change across ~15 call sites that construct handlers from noop seams, and it belongs
+in its own PR with those call sites surveyed — not smuggled in beside an audit.
+*/
+import { describe, expect, it } from "vitest";
+import type { WorkflowIrNode } from "@fusion/core";
+import { createDefaultNodeHandlers, createNoopLegacySeams } from "../workflow-node-handlers.js";
+
+function promptNode(seam: string): WorkflowIrNode {
+  return { id: `${seam}-node`, kind: "prompt", column: "in-progress", config: { seam } } as WorkflowIrNode;
+}
+
+const ctx = { task: { id: "FN-NOOP" }, context: {} } as never;
+
+describe("noop legacy seams fail OPEN (characterization — not an endorsement)", () => {
+  const handlers = createDefaultNodeHandlers(createNoopLegacySeams());
+
+  it.each(["execute", "review", "merge", "planning", "schedule", "review-handoff"])(
+    "a %s node reports success having done nothing",
+    async (seam) => {
+      const result = await handlers.prompt!(promptNode(seam), ctx);
+      expect(result.outcome).toBe("success");
+    },
+  );
+
+  it("step-execute is the one seam that fails CLOSED", async () => {
+    /*
+    The asymmetry this file is really about. This node carries an active-instance requirement, so
+    reaching it without one throws rather than succeeding — either way it does not silently pass,
+    which is the property the other six lack.
+    */
+    await expect(handlers.prompt!(promptNode("step-execute"), ctx)).rejects.toThrow();
+  });
+
+  it("supplying primitives is what makes the fail-open path unreachable", () => {
+    /* The production wiring. If this preference is ever removed, the six seams above become
+       reachable from `executeWorkflowGraph` too. */
+    const withPrimitives = createDefaultNodeHandlers(createNoopLegacySeams(), undefined, {
+      primitives: {} as never,
+    });
+    expect(withPrimitives.prompt).not.toBe(handlers.prompt);
+  });
+});


### PR DESCRIPTION
I set out to delete `createPromptLikeHandler` and the seam entries #2578/#2580 showed are unreachable from `executeWorkflowGraph`. **The audit says stop, so nothing is deleted.** What it turned up instead is worth more than the cleanup.

## Why the branch is not dead

`createDefaultNodeHandlers` prefers the primitives handler **only when `deps.primitives` is set**:

- `executeWorkflowGraph` always sets it → seams path unreachable there.
- `WorkflowTaskRuntime` passes `this.deps.primitives`, which is **optional**, and `WorkflowTaskRuntime` is exported from the engine index. Construct it without primitives and the seams path is live.
- ~15 test call sites build handlers from seams with no primitives.

The program's delete-only rule is explicit: *any behavior change found while removing a branch means the branch was not dead — stop and treat it as a finding.* So this PR adds evidence, not deletions.

## The finding: noop seams fail OPEN, including `merge`

```ts
export function createNoopLegacySeams(): WorkflowLegacySeams {
  const success = async () => ({ outcome: "success" });
  return { planning: success, execute: success, review: success,
           "review-handoff": success, merge: success, schedule: success };
}
```

A handler set built from noop seams with no primitives runs a coding workflow **to success having done no implementation, no review, and a merge seam that merely says yes.**

**The asymmetry is the tell.** `step-execute` deliberately fails **closed** a few lines away, with a comment saying why:

> *"Fail closed: a step-execute node with no seam wired must NOT silently succeed — that would merge a task with no step work done."*

The hazard was recognised for exactly one seam and left fail-open for the other six — `merge` among them. That is not an argument that the others are safe; it is an argument that nobody revisited them.

## Severity, stated honestly

I could **not** find a production construction of `WorkflowTaskRuntime` without primitives, so I am not claiming a live exploit. What is proven is that the fail-open shape exists, is reachable through an exported class, and is guarded for one seam out of seven. Given that this program has now found the "silently does nothing" failure class seven times, I would rather it be pinned and visible than rediscovered.

## What this PR does

Characterization only — pins the six fail-open seams, pins `step-execute` as the one that fails closed, and pins that supplying primitives is what swaps the handler. **8 tests, no production change.**

Making the remaining seams fail closed is a real behavior change across ~15 call sites that construct handlers from noop seams. It belongs in its own PR with those surveyed — not smuggled in beside an audit, and not while I am also holding a routing move open.

## Verification

- New suite — 8 green; `pnpm lint` clean
- No production files touched, so no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)