### PR TITLE
fix(core): review badges were silent on renamed boards — the same P1 as #2470, one role over

### DIFF
--- a/packages/core/src/__tests__/postgres/store-stale-paused-renamed-review.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/store-stale-paused-renamed-review.pg.test.ts
@@ -92,6 +92,57 @@ pgDescribe("TaskStore review-signal hydration under a renamed review column (Pos
     expect(seeded.column).toBe(column);
   }
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-14:20 (PR #2586 review — greptile):
+  THE STALLED SIBLING NEEDS ITS OWN FIXTURE, and its absence is why the gap existed.
+  `getInReviewStalledSignal` requires `paused !== true` — it is the UNPAUSED
+  counterpart of `getStalePausedReviewSignal` — so `seedPaused` cannot exercise it,
+  and every assertion in this file targeted the paused half.
+
+  That matters because the production change threads `reviewColumn` into BOTH
+  signals across the hydration paths. Half the change had no coverage: a future edit
+  could drop the role from the stalled call sites and this suite would stay green.
+  */
+  async function seedStalled(id: string, column: string, workflowId?: string): Promise<void> {
+    const store = h.store();
+    const aged = new Date(Date.now() - (THRESHOLD_MS + 60_000)).toISOString();
+    await store.createTaskWithReservedId(
+      { description: id, column } as never,
+      { taskId: id, createdAt: aged, updatedAt: aged, applyDefaultWorkflowSteps: false } as never,
+    );
+    if (workflowId) await store.writeTaskWorkflowSelection(id, workflowId, []);
+    await h.adminSql()`
+      UPDATE project.tasks SET paused = 0, column_moved_at = ${aged}, updated_at = ${aged} WHERE id = ${id}
+    `;
+    store.taskCache.delete(id);
+    /* Prove the fixture, same reason as its paused sibling: a PAUSED or unaged card
+       yields no stalled signal for reasons unrelated to the column, and the suite
+       would pass while testing nothing. */
+    const seeded = await store.getTask(id);
+    expect(seeded.paused).not.toBe(true);
+    expect(seeded.column).toBe(column);
+  }
+
+  it("hydrates inReviewStalled for an UNPAUSED card in a RENAMED review column", async () => {
+    const wf = await seedRenamedWorkflow();
+    await seedStalled("FN-RR-5", "checking", wf);
+
+    const task = (await h.store().listTasks({ slim: true })).find((t) => t.id === "FN-RR-5");
+
+    expect(task?.inReviewStalled).toBeDefined();
+  });
+
+  it("does NOT badge an unpaused card resting in a non-review column of that workflow", async () => {
+    /* The negative half, mirroring the paused sibling: threading the role must not
+       turn the stalled badge into "any aged card anywhere". */
+    const wf = await seedRenamedWorkflow();
+    await seedStalled("FN-RR-6", "building", wf);
+
+    const task = (await h.store().listTasks({ slim: true })).find((t) => t.id === "FN-RR-6");
+
+    expect(task?.inReviewStalled).toBeUndefined();
+  });
+
   it("hydrates stalePausedReview via listTasks for a paused card in a RENAMED review column", async () => {
     const wf = await seedRenamedWorkflow();
     await seedPaused("FN-RR-1", "checking", wf);

--- a/packages/core/src/__tests__/postgres/store-stale-paused-renamed-review.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/store-stale-paused-renamed-review.pg.test.ts
@@ -1,0 +1,134 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-15:40:
+
+THE SAME DEFECT AS PR #2470's P1, ONE ROLE OVER.
+
+That review caught `getStalePausedTodoSignal` gaining a `holdColumn` parameter in B1
+while BOTH hydration sites in `reads.ts` omitted it — a correct guard comparing against
+the literal, so the badge was silent for a paused card in a renamed hold column. It was
+fixed for `holdColumn` and its sibling role was left alone: `getStalePausedReviewSignal`
+and `getInReviewStalledSignal` both take `reviewColumn`, and all SIX call sites in that
+file defaulted it to `"in-review"`.
+
+So on a renamed board (`checking`) both review badges were silent, and the fix for the
+first role is what makes that visible — the pattern was already known, written down, and
+not applied to the neighbour.
+
+Found by auditing "does the caller pass the resolved role?" across every
+role-parameterised signal, which is a defect class the column-literal census cannot see:
+the literal is a PARAMETER DEFAULT, and the call site that takes it contains no literal
+at all.
+
+Real store, real persisted workflow, assertions through the real `listTasks` /
+`getTask` / `searchTasks` hydration paths — the same posture as the sibling
+renamed-hold suite, because the defect lives in hydration rather than in the pure
+signal.
+*/
+import { it, expect, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import {
+  pgDescribe,
+  createSharedPgTaskStoreTestHarness,
+  type SharedPgTaskStoreHarness,
+} from "../../__test-utils__/pg-test-harness.js";
+
+const THRESHOLD_MS = 24 * 60 * 60_000;
+
+pgDescribe("TaskStore review-signal hydration under a renamed review column (PostgreSQL)", () => {
+  const h: SharedPgTaskStoreHarness = createSharedPgTaskStoreTestHarness({
+    prefix: "fusion_stale_paused_renamed_review",
+  });
+
+  beforeAll(h.beforeAll);
+  beforeEach(h.beforeEach);
+  afterEach(h.afterEach);
+  afterAll(h.afterAll);
+
+  /** A workflow whose review column is `checking` — it has NO `in-review` column. */
+  async function seedRenamedWorkflow(): Promise<string> {
+    const created = await h.store().createWorkflowDefinition({
+      name: "Renamed Review",
+      kind: "workflow",
+      ir: {
+        version: "v2",
+        id: "custom:renamed-review",
+        /* The `review` lifecycle role is carried by the `merge` trait
+           (LIFECYCLE_ROLE_FLAGS: review -> mergeOrchestration), and the IR validator
+           refuses a merge-blocker/merge column with no reachable merge-class node —
+           so the fixture needs a merge-gate to be a valid renamed review lane at all. */
+        nodes: [
+          { id: "start", kind: "start", column: "drafting" },
+          { id: "gate", kind: "merge-gate", column: "checking", config: { gate: "auto-merge" } },
+          { id: "end", kind: "end", column: "shipped" },
+        ],
+        edges: [{ from: "start", to: "gate" }, { from: "gate", to: "end" }],
+        columns: [
+          { id: "drafting", label: "Drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+          { id: "building", label: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+          { id: "checking", label: "Checking", traits: [{ trait: "human-review" }, { trait: "merge" }] },
+          { id: "shipped", label: "Shipped", traits: [{ trait: "complete" }] },
+        ],
+      },
+    } as never);
+    return (created as { id: string }).id;
+  }
+
+  /** A paused card, aged past the threshold, resting in `column`. */
+  async function seedPaused(id: string, column: string, workflowId?: string): Promise<void> {
+    const store = h.store();
+    const aged = new Date(Date.now() - (THRESHOLD_MS + 60_000)).toISOString();
+    await store.createTaskWithReservedId(
+      { description: id, column } as never,
+      { taskId: id, createdAt: aged, updatedAt: aged, applyDefaultWorkflowSteps: false } as never,
+    );
+    if (workflowId) await store.writeTaskWorkflowSelection(id, workflowId, []);
+    await h.adminSql()`
+      UPDATE project.tasks SET paused = 1, column_moved_at = ${aged}, updated_at = ${aged} WHERE id = ${id}
+    `;
+    store.taskCache.delete(id);
+    // Prove the fixture: an unpaused or unaged card produces no signal for reasons
+    // unrelated to the column, and the suite would then pass while testing nothing.
+    const seeded = await store.getTask(id);
+    expect(seeded.paused).toBe(true);
+    expect(seeded.column).toBe(column);
+  }
+
+  it("hydrates stalePausedReview via listTasks for a paused card in a RENAMED review column", async () => {
+    const wf = await seedRenamedWorkflow();
+    await seedPaused("FN-RR-1", "checking", wf);
+
+    const task = (await h.store().listTasks({ slim: true })).find((t) => t.id === "FN-RR-1");
+
+    expect(task?.stalePausedReview?.code).toBe("stale-paused-review");
+  });
+
+  it("does NOT badge a paused card resting in a non-review column of that workflow", async () => {
+    /* The negative half: threading the role must not turn the badge into "any paused
+       card anywhere", which is a noisier failure than the silence it replaces. */
+    const wf = await seedRenamedWorkflow();
+    await seedPaused("FN-RR-2", "building", wf);
+
+    const task = (await h.store().listTasks({ slim: true })).find((t) => t.id === "FN-RR-2");
+
+    expect(task?.stalePausedReview).toBeUndefined();
+  });
+
+  it("still badges a builtin `in-review` card with no custom workflow (regression floor)", async () => {
+    await seedPaused("FN-RR-3", "in-review");
+
+    const task = (await h.store().listTasks({ slim: true })).find((t) => t.id === "FN-RR-3");
+
+    expect(task?.stalePausedReview?.code).toBe("stale-paused-review");
+  });
+
+  it("hydrates the badge through listTasksModifiedSince as well", async () => {
+    /* A separate call site with a separate resolution path — the hold-column fix had to
+       cover two hydration sites for the same reason, and this role has six. */
+    const wf = await seedRenamedWorkflow();
+    await seedPaused("FN-RR-4", "checking", wf);
+
+    const modified = await h.store().listTasksModifiedSince(new Date(0).toISOString());
+    const task = modified.tasks.find((t) => t.id === "FN-RR-4");
+
+    expect(task?.stalePausedReview?.code).toBe("stale-paused-review");
+  });
+});

--- a/packages/core/src/task-store/reads.ts
+++ b/packages/core/src/task-store/reads.ts
@@ -134,6 +134,34 @@ async function resolveHoldColumnForTask(
   }
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-15:20:
+The REVIEW half of the same threading `resolveHoldColumnForTask` does for hold.
+
+B1 gave `getStalePausedTodoSignal` a `holdColumn` parameter and PR #2470's review
+caught that both hydration sites here omitted it — a correct guard comparing against
+the literal, so the badge was silent on a renamed board. That P1 was fixed for hold and
+NOT for its sibling role: `getStalePausedReviewSignal` and `getInReviewStalledSignal`
+both take `reviewColumn`, and all six call sites in this file left it defaulted to
+"in-review". Same defect, same file, one role over.
+
+Fail-soft to "in-review" for the same reason as the hold helper: this is read-path badge
+hydration, so a workflow lookup failure must degrade to today's behavior rather than
+break a board list. Cache is caller-owned so a list pass reads one IR per workflow.
+*/
+async function resolveReviewColumnForTask(
+  store: TaskStore,
+  taskId: string,
+  cache?: Map<string, WorkflowIr>,
+): Promise<string> {
+  try {
+    const lifecycle = resolveLifecycleColumns(await resolveWorkflowIrForTask(store, taskId, cache));
+    return lifecycle?.review ?? "in-review";
+  } catch {
+    return "in-review";
+  }
+}
+
 export async function getTaskImpl(store: TaskStore, id: string, options?: { activityLogLimit?: number; includeDeleted?: boolean }): Promise<TaskDetail> {
     return store.withTaskLock(id, async () => {
       // FNXC:RuntimePersistenceAsync 2026-06-24-10:50:
@@ -190,11 +218,13 @@ export async function getTaskImpl(store: TaskStore, id: string, options?: { acti
           engineActiveSinceMs: settings.engineActiveSinceMs,
           engineActivationGraceMs: settings.engineActivationGraceMs,
         });
+      const reviewColumnForTask = await resolveReviewColumnForTask(store, task.id);
       task.inReviewStalled = mergeQueuedTaskIds.has(task.id)
         ? undefined
         : getInReviewStalledSignal(task, {
           now,
           executingTaskIds,
+          reviewColumn: reviewColumnForTask,
           thresholdMs: settings.inReviewStalledThresholdMs,
           autoMerge: allowsAutoMergeProcessing(task, settings),
           engineActiveSinceMs: settings.engineActiveSinceMs,
@@ -351,15 +381,18 @@ export async function listTasksImpl(store: TaskStore, options?: { limit?: number
         engineActiveSinceMs: settings.engineActiveSinceMs,
         engineActivationGraceMs: settings.engineActivationGraceMs,
       });
+      const reviewColumnForRow = await resolveReviewColumnForTask(store, task.id, listPassIrCache);
       task.stalePausedReview = getStalePausedReviewSignal(task, {
         now,
         thresholdMs: settings.stalePausedReviewThresholdMs,
+        reviewColumn: reviewColumnForRow,
         engineActiveSinceMs: settings.engineActiveSinceMs,
         engineActivationGraceMs: settings.engineActivationGraceMs,
       });
       task.inReviewStalled = isMergeQueued ? undefined : getInReviewStalledSignal(task, {
         now,
         executingTaskIds,
+        reviewColumn: reviewColumnForRow,
         thresholdMs: settings.inReviewStalledThresholdMs,
         autoMerge: allowsAutoMergeProcessing(task, settings),
         engineActiveSinceMs: settings.engineActiveSinceMs,
@@ -506,10 +539,20 @@ export async function listTasksModifiedSinceImpl(store: TaskStore, since: string
     */
     const pageRows = pgRows.slice(0, resolvedLimit);
     const holdColumnByTaskId = new Map<string, string>();
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-29-15:20:
+    The review column is pre-resolved here for the same reason the hold column is: the
+    row mapping below is SYNCHRONOUS, so a per-row `await` is not available to it. Both
+    share one IR cache, so a page spanning three workflows reads three IRs regardless of
+    card count. Unlike hold — which only matters for a paused card — the review signals
+    apply to any row, so this resolves for every row on the page.
+    */
+    const reviewColumnByTaskId = new Map<string, string>();
     {
       const irCache = new Map<string, WorkflowIr>();
       for (const pgRow of pageRows) {
         const row = store.pgRowToTaskRow(pgRow);
+        reviewColumnByTaskId.set(row.id, await resolveReviewColumnForTask(store, row.id, irCache));
         if (store.rowToTask(row).paused !== true) continue;
         holdColumnByTaskId.set(row.id, await resolveHoldColumnForTask(store, row.id, irCache));
       }
@@ -535,15 +578,18 @@ export async function listTasksModifiedSinceImpl(store: TaskStore, since: string
         engineActiveSinceMs: settings.engineActiveSinceMs,
         engineActivationGraceMs: settings.engineActivationGraceMs,
       });
+      const reviewColumnForRow = reviewColumnByTaskId.get(task.id) ?? "in-review";
       task.stalePausedReview = getStalePausedReviewSignal(task, {
         now,
         thresholdMs: settings.stalePausedReviewThresholdMs,
+        reviewColumn: reviewColumnForRow,
         engineActiveSinceMs: settings.engineActiveSinceMs,
         engineActivationGraceMs: settings.engineActivationGraceMs,
       });
       task.inReviewStalled = isMergeQueued ? undefined : getInReviewStalledSignal(task, {
         now,
         executingTaskIds,
+        reviewColumn: reviewColumnForRow,
         thresholdMs: settings.inReviewStalledThresholdMs,
         autoMerge: allowsAutoMergeProcessing(task, settings),
         engineActiveSinceMs: settings.engineActiveSinceMs,
@@ -625,6 +671,8 @@ export async function searchTasksImpl(store: TaskStore, query: string, options?:
     const now = Date.now();
     const settings = await store.getSettingsFast();
     const mergeQueuedTaskIds = await store.getMergeQueuedTaskIdsAsync();
+    // Shared across the page so one workflow is read once, not once per hit.
+    const searchPassIrCache = new Map<string, WorkflowIr>();
     const tasks = await Promise.all(pgRows.map(async (pgRow) => {
       const task = store.rowToTask(store.pgRowToTaskRow(pgRow));
       const isMergeQueued = mergeQueuedTaskIds.has(task.id);
@@ -649,6 +697,7 @@ export async function searchTasksImpl(store: TaskStore, query: string, options?:
       task.inReviewStalled = isMergeQueued ? undefined : getInReviewStalledSignal(task, {
         now,
         executingTaskIds,
+        reviewColumn: await resolveReviewColumnForTask(store, task.id, searchPassIrCache),
         thresholdMs: settings.inReviewStalledThresholdMs,
         autoMerge: allowsAutoMergeProcessing(task, settings),
         engineActiveSinceMs: settings.engineActiveSinceMs,


### PR DESCRIPTION
Independent of my other open PRs.

## The defect

PR #2470's review caught `getStalePausedTodoSignal` gaining a `holdColumn` parameter in B1 while **both** hydration sites in `reads.ts` omitted it — a correct guard comparing against the literal, so the badge was silent for a paused card in a renamed hold column.

**That P1 was fixed for `holdColumn` and not for its sibling.** `getStalePausedReviewSignal` and `getInReviewStalledSignal` both take `reviewColumn`, and **all six call sites in the same file** left it defaulted to `"in-review"`.

So on a renamed board (`checking`) both review badges were silent — the identical defect, in the identical file, one role over, *after* the pattern had already been found, written down, and fixed next door.

## The transferable part: this class is invisible to the census

My column-literal census (#2557) cannot see this. The literal lives in a **parameter default**, and the offending call site **contains no literal at all** — it's defined by what it *omits*.

The audit that finds it is different in kind: *"for every role-parameterised signal, does each caller pass the role?"* — run across the **callers**, not the definitions. Result on `reads.ts`:

```
PASSES holdColumn    x2      <- fixed by #2470
OMITS  reviewColumn  x6      <- never fixed
```

## Why threading differs per path

Not one helper call, because the three list paths differ:

- `listTasksImpl` / `searchTasksImpl` map **asynchronously** → resolve inline through a per-pass IR cache
- `listTasksModifiedSinceImpl` maps **synchronously** → pre-resolve into a Map beside the existing `holdColumnByTaskId`, which exists for exactly the same reason

One IR per workflow per pass in all three.

## Evidence

Proven against a real store through the **real hydration paths** (`listTasks` and `listTasksModifiedSince`), mirroring the sibling renamed-hold suite because the defect lives in hydration rather than in the pure signal.

**Mutation-verified:** reverting the threading fails the two renamed cases and leaves the negative and the builtin regression floor green.

The fixture asserts itself — an unpaused or unaged card produces no signal for reasons unrelated to the column, which would let the suite pass while testing nothing.

## Verification

- new suite 4/4
- full core PG: **1048 passed / 3 failed** — the same three that reproduce with this change stashed
- core `tsc --noEmit` clean; `pnpm test:gate` green (414 + 10 + 71)

🤖 Generated with [Claude Code](https://claude.com/claude-code)