### PR TITLE
Drift (unowned): the planner-activity signal was never written after #2515 — the three badge conversions were reading an empty field

### DIFF
--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -434,7 +434,18 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
     try {
       const sourceTask = allTasks?.find((t) => t.id === taskId) ?? task;
       const hasStepProgress = sourceTask?.steps.some((step) => step.status !== "pending") ?? false;
-      const shouldPrompt = (column === "todo" || column === "triage") && hasStepProgress;
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+      This component's `column` IS the drop target, so its own `columnFlags` are the
+      target's traits — no lookup needed, unlike the same prompt in TaskCard/ListView
+      where the card and the destination differ. Ids remain the fallback for the
+      no-metadata window.
+      */
+      const shouldPrompt = hasStepProgress && (
+        columnFlags
+          ? Boolean(columnFlags.intake || columnFlags.hold)
+          : column === "todo" || column === "triage"
+      );
       let moveOptions: { preserveProgress?: boolean } | undefined;
 
       if (shouldPrompt) {

--- a/packages/dashboard/app/hooks/__tests__/useTasks.test.ts
+++ b/packages/dashboard/app/hooks/__tests__/useTasks.test.ts
@@ -3840,6 +3840,61 @@ describe("useTasks", () => {
       expect(result.current.tasks[0]?.recentAgentActivityAt).toBeUndefined();
     });
 
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+    The SOURCE of the planner-activity signal. It only stamped `recentAgentActivityAt`
+    for cards literally in `triage`, and #2515 removed that column from the default
+    lineage — so after that merge the stamp never happened for a default-workflow card
+    and every consumer (pulsing Planning badge, agent-active border, column executing
+    count) had no data to act on, however correctly they resolved their own traits.
+
+    REVERT CHECK: restore `task.column !== "triage"` and this fails — the card is in the
+    merged planning column `todo`, so nothing is stamped and the badge has nothing to
+    render.
+    */
+    it("stamps planner activity for a card in the MERGED planning column", async () => {
+      const initialTask = createMockTask({
+        column: "todo",
+        status: null,
+        updatedAt: "2026-07-28T12:00:00.000Z",
+      });
+      mockFetchTasks.mockResolvedValueOnce([initialTask]);
+      const { result } = renderHook(() => useTasks());
+
+      await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+      act(() => {
+        MockEventSource.instances[0]._emit("agent:log", {
+          taskId: initialTask.id,
+          timestamp: "2026-07-28T12:00:01.000Z",
+          type: "tool",
+          agent: "triage",
+        });
+      });
+      expect(result.current.tasks[0]?.recentAgentActivityAt).toBe("2026-07-28T12:00:01.000Z");
+    });
+
+    it("does not stamp planner activity for a card outside any planning lane", async () => {
+      // The stamp must still NARROW: an executing card is not planner activity.
+      const initialTask = createMockTask({
+        column: "in-progress",
+        status: null,
+        updatedAt: "2026-07-28T12:00:00.000Z",
+      });
+      mockFetchTasks.mockResolvedValueOnce([initialTask]);
+      const { result } = renderHook(() => useTasks());
+
+      await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+      act(() => {
+        MockEventSource.instances[0]._emit("agent:log", {
+          taskId: initialTask.id,
+          timestamp: "2026-07-28T12:00:01.000Z",
+          type: "tool",
+          agent: "triage",
+        });
+      });
+      expect(result.current.tasks[0]?.recentAgentActivityAt).toBeUndefined();
+    });
+
     it("keeps clearing in-review stalls when a fresh agent log arrives", async () => {
       const initialTask = createMockTask({
         column: "in-review",

--- a/packages/dashboard/app/hooks/useTasks.ts
+++ b/packages/dashboard/app/hooks/useTasks.ts
@@ -136,9 +136,28 @@ function clearInReviewStallForFreshAgentLog(task: Task, entry: AgentLogActivityE
   };
 }
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+This is the SOURCE of the planner-activity signal, and it was the narrowest gate of all:
+it only stamped `recentAgentActivityAt` for cards literally in `triage`. #2515 removed
+that column from the default lineage, so after that merge the stamp never happened for a
+default-workflow card — and every consumer downstream (the pulsing Planning badge, the
+agent-active row border, the column's executing count) had NO DATA to act on, however
+correctly they resolved their own column traits.
+
+Converting the consumers without this would have been cosmetic: they would ask the right
+question of a field nothing ever set.
+
+This hook processes SSE and has no resolved column metadata, so the lane is matched by id
+against BOTH shapes — pre-merge `triage` and post-merge `todo`. Over-stamping a legacy
+hold-lane card is harmless: every consumer additionally requires the column to be an
+INTAKE lane before showing anything, so the extra timestamps are filtered downstream.
+*/
+const PLANNER_ACTIVITY_COLUMN_IDS = new Set(["triage", "todo"]);
+
 function addRecentPlannerActivityForFreshAgentLog(task: Task, entry: AgentLogActivityEvent): Task {
   if (
-    task.column !== "triage"
+    !PLANNER_ACTIVITY_COLUMN_IDS.has(task.column)
     || task.status === "planning"
     || entry.agent !== "triage"
     || !hasFreshAgentLog(task, entry)


### PR DESCRIPTION
## Drift, unowned: the planner-activity signal was never being written

**Stacks on #2577.** Merge order: #2566 → #2577 → this.

### This is what made the other three PRs cosmetic

`addRecentPlannerActivityForFreshAgentLog` in `useTasks.ts` stamped `recentAgentActivityAt` **only for cards literally in `triage`**. #2515 removed that column from the default lineage, so after that merge the stamp never happened for a default-workflow card.

Every consumer downstream then had **no data to act on**, however correctly it resolved its own column traits:

- the pulsing Planning badge (TaskCard, ListView)
- the agent-active row border
- the column header's executing count

So #2558 / #2566 / #2577 convert the *readers* of a field that nothing was *writing*. They ask the right question of an empty value. This is the fix that gives them something to read — and it was on nobody's drift list. I found it chasing why a badge test would not go green.

### The decision, and why I did not thread metadata here

The hook processes SSE and has no resolved column metadata. The lane is matched by id against **both** shapes — pre-merge `triage`, post-merge `todo`.

Over-stamping a legacy hold-lane card is harmless: every consumer additionally requires the column to be an **intake** lane before rendering anything, so the extra timestamps are filtered downstream. Threading board context into this hook to avoid a harmless over-stamp would be a much larger change for no behavioural gain, so I widened instead and wrote the reasoning at the site.

### Also converted

`Column.tsx`'s move-progress prompt. Unlike the same prompt in TaskCard/ListView/TaskDetailModal, this component's `column` **is** the drop target, so its own `columnFlags` are the target's traits — no lookup needed. Worth noting because the same-looking regex meant three different things across four files, which is exactly why these were converted one at a time.

### Revert-proof

Restore `task.column !== "triage"` and the merged-column case fails: `expected undefined to be '2026-07-28T12:00:01.000Z'` — nothing stamped, badge has nothing to render. A companion case pins that the stamp still **narrows**: an `in-progress` card is not planner activity.

### Verification

`pnpm test:gate` (482 + 10 + 71), `pnpm lint`, dashboard typecheck green. `useTasks.test.ts` + `Board.test.tsx`: 210 passed.

### Audited and deliberately left

| site | verdict |
|---|---|
| `Column.tsx:550` `workflowMode \|\| column === "triage"` | Dead in practice — `workflowMode` is true whenever lanes resolve, so the disjunct only matters with no metadata at all. Not worth a change. |
| `taskSorting.ts:73` `column === "todo"` | Still correct for the default (the merged column keeps that id); wrong only for a renamed workflow's hold lane. Needs the sort to take flags — a wider signature change than this PR's scope, and cosmetic (ordering) rather than a lost affordance. |
| `worktreeGrouping.ts:77` | Same shape as above; grouping only, no lost control. |
