### PR TITLE
fix(core): restore standalone central backend initialization

### DIFF
--- a/.changeset/central-core-cli-backend-init.md
+++ b/.changeset/central-core-cli-backend-init.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Node, mesh, and project CLI commands once again initialize the PostgreSQL central registry.
+category: fix
+dev: Restore the existing layer-less `CentralCore.init()` backend bootstrap that PostgreSQL dual-path cleanup accidentally left unreachable. Runtime attachment still adopts the project store layer through `attachBackendLayer()`, while standalone callers own and close their central backend lifecycle.

--- a/.changeset/central-core-cli-backend-init.md
+++ b/.changeset/central-core-cli-backend-init.md
@@ -2,6 +2,6 @@
 "@runfusion/fusion": patch
 ---
 
-summary: Node, mesh, and project CLI commands once again initialize the PostgreSQL central registry.
+summary: Node, mesh, and project CLI commands restore registry access without marking the host offline on exit.
 category: fix
-dev: Restore the existing layer-less `CentralCore.init()` backend bootstrap that PostgreSQL dual-path cleanup accidentally left unreachable. Runtime attachment still adopts the project store layer through `attachBackendLayer()`, while standalone callers own and close their central backend lifecycle.
+dev: Restore the existing layer-less `CentralCore.init()` backend bootstrap that PostgreSQL dual-path cleanup accidentally left unreachable. Generic `close()` only releases resources; daemon, engine-manager, and dashboard shutdown owners retain their explicitly ordered `markLocalNodeOffline()` writes.

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -45,14 +45,40 @@ describe("embedded backup runtime URL registry", () => {
     );
   });
 
-  it("keeps an owner URL live when only a joiner releases", () => {
+  it("keeps an owner URL live when only a joiner releases", async () => {
     const owner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: true });
     const joiner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false });
 
-    releaseEmbeddedRuntimeLease(joiner);
+    await releaseEmbeddedRuntimeLease(joiner);
     expect(getActiveEmbeddedRuntimeUrl()).toBe(embeddedUrl);
 
-    releaseEmbeddedRuntimeLease(owner);
+    await releaseEmbeddedRuntimeLease(owner);
+    expect(getActiveEmbeddedRuntimeUrl()).toBeUndefined();
+  });
+
+  it("defers owner shutdown until the final joined lease releases", async () => {
+    const stopOwner = vi.fn(async () => undefined);
+    const owner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: true });
+    const joiner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false });
+
+    await releaseEmbeddedRuntimeLease(owner, { stopOwner });
+    expect(stopOwner).not.toHaveBeenCalled();
+    expect(getActiveEmbeddedRuntimeUrl()).toBe(embeddedUrl);
+
+    await releaseEmbeddedRuntimeLease(joiner);
+    expect(stopOwner).toHaveBeenCalledOnce();
+    expect(getActiveEmbeddedRuntimeUrl()).toBeUndefined();
+  });
+
+  it("stops the owner immediately when joined leases already released", async () => {
+    const stopOwner = vi.fn(async () => undefined);
+    const owner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: true });
+    const joiner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false });
+
+    await releaseEmbeddedRuntimeLease(joiner);
+    await releaseEmbeddedRuntimeLease(owner, { stopOwner });
+
+    expect(stopOwner).toHaveBeenCalledOnce();
     expect(getActiveEmbeddedRuntimeUrl()).toBeUndefined();
   });
 

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -84,12 +84,26 @@ describe("embedded backup runtime URL registry", () => {
     const finalRelease = releaseEmbeddedRuntimeLease(joiner);
     await vi.waitFor(() => expect(stopOwner).toHaveBeenCalledOnce());
     expect(getActiveEmbeddedRuntimeUrl()).toBeUndefined();
-    expect(() => registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false })).toThrow(
-      EmbeddedRuntimeStoppingError,
-    );
+    let stoppingError: EmbeddedRuntimeStoppingError | undefined;
+    try {
+      registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false });
+    } catch (error) {
+      if (error instanceof EmbeddedRuntimeStoppingError) stoppingError = error;
+    }
+    expect(stoppingError).toBeInstanceOf(EmbeddedRuntimeStoppingError);
+    if (!stoppingError) throw new Error("Expected stopping registration to expose completion");
+    const stopCompletion = stoppingError.completion;
+    let stopCompletionSettled = false;
+    void stopCompletion.then(() => {
+      stopCompletionSettled = true;
+    });
+    await Promise.resolve();
+    expect(stopCompletionSettled).toBe(false);
 
     finishStop();
+    await stopCompletion;
     await finalRelease;
+    expect(stopCompletionSettled).toBe(true);
     expect(registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: true })).toBeDefined();
   });
 

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../backup.js";
 import {
   clearActiveEmbeddedRuntimeUrl,
+  EmbeddedRuntimeStoppingError,
   getActiveEmbeddedRuntimeUrl,
   invalidateEmbeddedRuntimeUrl,
   registerEmbeddedRuntimeUrl,
@@ -68,6 +69,28 @@ describe("embedded backup runtime URL registry", () => {
     await releaseEmbeddedRuntimeLease(joiner);
     expect(stopOwner).toHaveBeenCalledOnce();
     expect(getActiveEmbeddedRuntimeUrl()).toBeUndefined();
+  });
+
+  it("rejects registrations until a deferred owner stop completes", async () => {
+    const owner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: true });
+    const joiner = registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false });
+    let finishStop!: () => void;
+    const stopFinished = new Promise<void>((resolve) => {
+      finishStop = resolve;
+    });
+    const stopOwner = vi.fn(async () => stopFinished);
+    await releaseEmbeddedRuntimeLease(owner, { stopOwner });
+
+    const finalRelease = releaseEmbeddedRuntimeLease(joiner);
+    await vi.waitFor(() => expect(stopOwner).toHaveBeenCalledOnce());
+    expect(getActiveEmbeddedRuntimeUrl()).toBeUndefined();
+    expect(() => registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: false })).toThrow(
+      EmbeddedRuntimeStoppingError,
+    );
+
+    finishStop();
+    await finalRelease;
+    expect(registerEmbeddedRuntimeUrl(embeddedUrl, { ownsProcess: true })).toBeDefined();
   });
 
   it("stops the owner immediately when joined leases already released", async () => {

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createCentralBackendLayer: vi.fn(),
+  ensureBackendBootstrap: vi.fn(),
+  getLocalNode: vi.fn(),
+  releaseConnections: vi.fn(),
+  shutdown: vi.fn(),
+}));
+
+vi.mock("../postgres/startup-factory.js", () => ({
+  createCentralBackendLayer: mocks.createCentralBackendLayer,
+}));
+
+vi.mock("../async-central-core.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../async-central-core.js")>();
+  return {
+    ...actual,
+    ensureBackendBootstrap: mocks.ensureBackendBootstrap,
+    getLocalNode: mocks.getLocalNode,
+  };
+});
+
+import { CentralCore } from "../central-core.js";
+
+const cleanupDirs: string[] = [];
+
+describe("CentralCore layer-less initialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createCentralBackendLayer.mockResolvedValue({
+      asyncLayer: { db: {} },
+      releaseConnections: mocks.releaseConnections,
+      shutdown: mocks.shutdown,
+    });
+    mocks.getLocalNode.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    for (const dir of cleanupDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("boots and owns a PostgreSQL layer for standalone CLI callers", async () => {
+    const globalDir = mkdtempSync(join(tmpdir(), "fusion-central-cli-init-"));
+    cleanupDirs.push(globalDir);
+    const central = new CentralCore(globalDir);
+
+    await central.init();
+
+    expect(mocks.createCentralBackendLayer).toHaveBeenCalledWith({ globalSettingsDir: globalDir });
+    expect(mocks.ensureBackendBootstrap).toHaveBeenCalledOnce();
+    expect(central.backendMode).toBe(true);
+
+    await central.close();
+
+    expect(mocks.shutdown).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -58,6 +58,7 @@ describe("CentralCore layer-less initialization", () => {
 
     await central.close();
 
+    expect(mocks.getLocalNode).not.toHaveBeenCalled();
     expect(mocks.shutdown).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -152,13 +152,15 @@ describe("CentralCore layer-less initialization", () => {
     }));
 
     const closing = central.close();
-    await vi.waitFor(() => expect(mocks.shutdown).toHaveBeenCalledOnce());
     const sharedLayer = { db: { shared: true } };
-
-    await expect(central.init()).rejects.toThrow("CentralCore is closed");
-    await expect(central.attachBackendLayer(
+    const initializationAfterClose = central.init();
+    const attachmentAfterClose = central.attachBackendLayer(
       sharedLayer as unknown as Parameters<CentralCore["attachBackendLayer"]>[0],
-    )).rejects.toThrow("CentralCore is closed");
+    );
+
+    await expect(initializationAfterClose).rejects.toThrow("CentralCore is closed");
+    await expect(attachmentAfterClose).rejects.toThrow("CentralCore is closed");
+    await vi.waitFor(() => expect(mocks.shutdown).toHaveBeenCalledOnce());
 
     finishShutdown();
     await closing;

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -82,4 +82,32 @@ describe("CentralCore layer-less initialization", () => {
     await central.close();
     expect(mocks.shutdown).toHaveBeenCalledOnce();
   });
+
+  it("waits for in-flight initialization before closing its owned backend", async () => {
+    const globalDir = mkdtempSync(join(tmpdir(), "fusion-central-cli-close-race-"));
+    cleanupDirs.push(globalDir);
+    const central = new CentralCore(globalDir);
+    let finishBackend!: (value: {
+      asyncLayer: typeof ownedLayer;
+      releaseConnections: typeof mocks.releaseConnections;
+      shutdown: typeof mocks.shutdown;
+    }) => void;
+    mocks.createCentralBackendLayer.mockReturnValueOnce(new Promise((resolve) => {
+      finishBackend = resolve;
+    }));
+
+    const initialization = central.init();
+    await vi.waitFor(() => expect(mocks.createCentralBackendLayer).toHaveBeenCalledOnce());
+    const closing = central.close();
+    expect(mocks.shutdown).not.toHaveBeenCalled();
+    finishBackend({
+      asyncLayer: ownedLayer,
+      releaseConnections: mocks.releaseConnections,
+      shutdown: mocks.shutdown,
+    });
+
+    await Promise.all([initialization, closing]);
+    expect(mocks.shutdown).toHaveBeenCalledOnce();
+    expect(central.backendMode).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -110,4 +110,30 @@ describe("CentralCore layer-less initialization", () => {
     expect(mocks.shutdown).toHaveBeenCalledOnce();
     expect(central.backendMode).toBe(false);
   });
+
+  it("serializes close behind an in-flight layer attachment", async () => {
+    const globalDir = mkdtempSync(join(tmpdir(), "fusion-central-cli-attach-close-race-"));
+    cleanupDirs.push(globalDir);
+    const central = new CentralCore(globalDir);
+    await central.init();
+    const sharedLayer = { db: { shared: true } };
+    let finishAttachment!: () => void;
+    mocks.ensureBackendBootstrap.mockImplementationOnce(
+      () => new Promise<void>((resolve) => {
+        finishAttachment = resolve;
+      }),
+    );
+
+    const attachment = central.attachBackendLayer(
+      sharedLayer as unknown as Parameters<CentralCore["attachBackendLayer"]>[0],
+    );
+    await vi.waitFor(() => expect(mocks.ensureBackendBootstrap).toHaveBeenCalledTimes(2));
+    const closing = central.close();
+    expect(mocks.shutdown).not.toHaveBeenCalled();
+    finishAttachment();
+
+    await Promise.all([attachment, closing]);
+    expect(mocks.shutdown).toHaveBeenCalledOnce();
+    expect(central.backendMode).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -136,4 +136,34 @@ describe("CentralCore layer-less initialization", () => {
     expect(mocks.shutdown).toHaveBeenCalledOnce();
     expect(central.backendMode).toBe(false);
   });
+
+  /**
+   * FNXC:CentralPostgresCutover 2026-07-29-17:43:
+   * Closing CentralCore is terminal because cleanup removes listeners and releases owned resources. Later queued initialization or attachment must not revive a partially torn-down instance.
+   */
+  it("rejects initialization and layer attachment once close is requested", async () => {
+    const globalDir = mkdtempSync(join(tmpdir(), "fusion-central-cli-terminal-close-"));
+    cleanupDirs.push(globalDir);
+    const central = new CentralCore(globalDir);
+    await central.init();
+    let finishShutdown!: () => void;
+    mocks.shutdown.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      finishShutdown = resolve;
+    }));
+
+    const closing = central.close();
+    await vi.waitFor(() => expect(mocks.shutdown).toHaveBeenCalledOnce());
+    const sharedLayer = { db: { shared: true } };
+
+    await expect(central.init()).rejects.toThrow("CentralCore is closed");
+    await expect(central.attachBackendLayer(
+      sharedLayer as unknown as Parameters<CentralCore["attachBackendLayer"]>[0],
+    )).rejects.toThrow("CentralCore is closed");
+
+    finishShutdown();
+    await closing;
+
+    expect(mocks.createCentralBackendLayer).toHaveBeenCalledOnce();
+    expect(central.backendMode).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/central-core-layerless-init.test.ts
+++ b/packages/core/src/__tests__/central-core-layerless-init.test.ts
@@ -27,12 +27,13 @@ vi.mock("../async-central-core.js", async (importOriginal) => {
 import { CentralCore } from "../central-core.js";
 
 const cleanupDirs: string[] = [];
+const ownedLayer = { db: {} };
 
 describe("CentralCore layer-less initialization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.createCentralBackendLayer.mockResolvedValue({
-      asyncLayer: { db: {} },
+      asyncLayer: ownedLayer,
       releaseConnections: mocks.releaseConnections,
       shutdown: mocks.shutdown,
     });
@@ -45,6 +46,10 @@ describe("CentralCore layer-less initialization", () => {
     }
   });
 
+  /**
+   * FNXC:CentralCore 2026-07-29-16:10:
+   * Standalone callers must bootstrap the exact layer they own and release that lifecycle on close; concurrent init calls share the same allocation.
+   */
   it("boots and owns a PostgreSQL layer for standalone CLI callers", async () => {
     const globalDir = mkdtempSync(join(tmpdir(), "fusion-central-cli-init-"));
     cleanupDirs.push(globalDir);
@@ -53,12 +58,28 @@ describe("CentralCore layer-less initialization", () => {
     await central.init();
 
     expect(mocks.createCentralBackendLayer).toHaveBeenCalledWith({ globalSettingsDir: globalDir });
-    expect(mocks.ensureBackendBootstrap).toHaveBeenCalledOnce();
+    expect(mocks.ensureBackendBootstrap).toHaveBeenCalledWith(ownedLayer);
+    expect(central.asyncLayer).toBe(ownedLayer);
     expect(central.backendMode).toBe(true);
 
     await central.close();
 
     expect(mocks.getLocalNode).not.toHaveBeenCalled();
+    expect(mocks.shutdown).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces concurrent layer-less initialization into one owned backend", async () => {
+    const globalDir = mkdtempSync(join(tmpdir(), "fusion-central-cli-concurrent-init-"));
+    cleanupDirs.push(globalDir);
+    const central = new CentralCore(globalDir);
+
+    await Promise.all([central.init(), central.init()]);
+
+    expect(mocks.createCentralBackendLayer).toHaveBeenCalledOnce();
+    expect(mocks.ensureBackendBootstrap).toHaveBeenCalledOnce();
+    expect(mocks.ensureBackendBootstrap).toHaveBeenCalledWith(ownedLayer);
+
+    await central.close();
     expect(mocks.shutdown).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -320,17 +320,11 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   async init(): Promise<void> {
     if (this.initialized) return;
 
-    /*
-    FNXC:SqliteDualPathCleanup 2026-07-26-14:15:
-    CentralCore.init is PostgreSQL-only. When no asyncLayer is attached yet, mark initialized without opening SQLite; attachBackendLayer bootstraps PG later.
-    */
     if (this.asyncLayer) {
       await asyncCentralCore.ensureBackendBootstrap(this.asyncLayer);
       this.initialized = true;
       return;
     }
-    this.initialized = true;
-    return;
 
     /*
      * FNXC:CentralPostgresCutover 2026-07-14-17:14:

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -362,10 +362,6 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
       this.stopDiscovery();
     }
 
-    await this.markLocalNodeOffline().catch((error) => {
-      severityAuditLog.warn("[central-core] Failed to persist local node offline during close", error);
-    });
-
     // FNXC:CentralCore 2026-06-26-12:30: In backend mode there is no SQLite
     // CentralDatabase to close; the shared connection pool is owned by the
     // TaskStore/startup factory. CentralCore does not close the pool.

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -217,6 +217,8 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   private ownedBackendReleaseConnections: (() => Promise<void>) | null = null;
   private initializationPromise: Promise<void> | null = null;
   private lifecycleOperation: Promise<void> = Promise.resolve();
+  private closeRequested = false;
+  private closed = false;
 
   private runLifecycleOperation<T>(operation: () => Promise<T>): Promise<T> {
     const result = this.lifecycleOperation.then(operation, operation);
@@ -250,6 +252,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
    * call, backendMode is true and all methods delegate to PostgreSQL.
    */
   async attachBackendLayer(layer: AsyncDataLayer): Promise<void> {
+    this.assertAcceptingOperations();
     if (!layer) {
       throw new Error("attachBackendLayer requires a non-null AsyncDataLayer");
     }
@@ -257,6 +260,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   }
 
   private async attachBackendLayerOnce(layer: AsyncDataLayer): Promise<void> {
+    this.assertOpen();
     // Release a central-only pool before adopting the runtime's shared layer.
     if (this.ownedBackendReleaseConnections) {
       /*
@@ -330,6 +334,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
    * Idempotent — safe to call multiple times.
    */
   async init(): Promise<void> {
+    this.assertAcceptingOperations();
     if (this.initialized) return;
 
     /*
@@ -348,6 +353,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   }
 
   private async initializeOnce(): Promise<void> {
+    this.assertOpen();
     if (this.initialized) return;
 
     if (this.asyncLayer) {
@@ -388,6 +394,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
    * Closes database connections and releases resources.
    */
   async close(): Promise<void> {
+    this.closeRequested = true;
     return this.runLifecycleOperation(() => this.closeOnce());
   }
 
@@ -395,7 +402,11 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
     /*
     FNXC:CentralPostgresCutover 2026-07-29-16:26:
     Initialization, layer replacement, and close share one lifecycle queue. Cleanup must observe and release the backend the preceding operation publishes instead of returning early, leaking it, or letting attachment revive a core after shutdown.
+
+    FNXC:CentralPostgresCutover 2026-07-29-17:43:
+    Close is terminal. Operations queued after cleanup must fail instead of allocating or attaching a backend after listeners and owned resources have been released.
     */
+    this.closed = true;
     if (this.nodeDiscovery) {
       this.stopDiscovery();
     }
@@ -415,6 +426,14 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
     }
     this.initialized = false;
     this.removeAllListeners();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error("CentralCore is closed");
+  }
+
+  private assertAcceptingOperations(): void {
+    if (this.closeRequested) throw new Error("CentralCore is closed");
   }
 
   /** Persist the local mesh node's terminal state before its backend closes. */

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -215,6 +215,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   private readonly ensureGitRepositoryForProjectPath: typeof ensureGitRepositoryForProjectPath;
   private ownedBackendShutdown: (() => Promise<void>) | null = null;
   private ownedBackendReleaseConnections: (() => Promise<void>) | null = null;
+  private initializationPromise: Promise<void> | null = null;
 
   /**
    * FNXC:CentralCore 2026-06-26-12:30:
@@ -318,6 +319,23 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
    * Idempotent — safe to call multiple times.
    */
   async init(): Promise<void> {
+    if (this.initialized) return;
+
+    /*
+     * FNXC:CentralCore 2026-07-29-16:10:
+     * Layer-less initialization allocates an owned PostgreSQL lifecycle. Concurrent callers must share one in-flight attempt so a second backend cannot be orphaned when ownership fields are overwritten. Clear the promise after either outcome so a failed bootstrap remains retryable.
+     */
+    if (!this.initializationPromise) {
+      this.initializationPromise = this.initializeOnce();
+    }
+    try {
+      await this.initializationPromise;
+    } finally {
+      this.initializationPromise = null;
+    }
+  }
+
+  private async initializeOnce(): Promise<void> {
     if (this.initialized) return;
 
     if (this.asyncLayer) {

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -216,6 +216,13 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
   private ownedBackendShutdown: (() => Promise<void>) | null = null;
   private ownedBackendReleaseConnections: (() => Promise<void>) | null = null;
   private initializationPromise: Promise<void> | null = null;
+  private lifecycleOperation: Promise<void> = Promise.resolve();
+
+  private runLifecycleOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.lifecycleOperation.then(operation, operation);
+    this.lifecycleOperation = result.then(() => undefined, () => undefined);
+    return result;
+  }
 
   /**
    * FNXC:CentralCore 2026-06-26-12:30:
@@ -246,7 +253,10 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
     if (!layer) {
       throw new Error("attachBackendLayer requires a non-null AsyncDataLayer");
     }
-    await this.initializationPromise?.catch(() => undefined);
+    return this.runLifecycleOperation(() => this.attachBackendLayerOnce(layer));
+  }
+
+  private async attachBackendLayerOnce(layer: AsyncDataLayer): Promise<void> {
     // Release a central-only pool before adopting the runtime's shared layer.
     if (this.ownedBackendReleaseConnections) {
       /*
@@ -272,7 +282,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
     // post-construction injection point.
     (this as { asyncLayer: AsyncDataLayer | null }).asyncLayer = layer;
     this.initialized = false;
-    await this.init();
+    await this.initializeOnce();
   }
 
   private readonly onDiscoveryNodeDiscovered = (node: DiscoveredNode): void => {
@@ -327,12 +337,13 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
      * Layer-less initialization allocates an owned PostgreSQL lifecycle. Concurrent callers must share one in-flight attempt so a second backend cannot be orphaned when ownership fields are overwritten. Clear the promise after either outcome so a failed bootstrap remains retryable.
      */
     if (!this.initializationPromise) {
-      this.initializationPromise = this.initializeOnce();
+      this.initializationPromise = this.runLifecycleOperation(() => this.initializeOnce());
     }
+    const initialization = this.initializationPromise;
     try {
-      await this.initializationPromise;
+      await initialization;
     } finally {
-      this.initializationPromise = null;
+      if (this.initializationPromise === initialization) this.initializationPromise = null;
     }
   }
 
@@ -377,11 +388,14 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
    * Closes database connections and releases resources.
    */
   async close(): Promise<void> {
+    return this.runLifecycleOperation(() => this.closeOnce());
+  }
+
+  private async closeOnce(): Promise<void> {
     /*
     FNXC:CentralPostgresCutover 2026-07-29-16:26:
-    Close and layer replacement wait for in-flight layerless initialization. Cleanup must observe and release the backend init publishes instead of returning early and leaking its pool or embedded-runtime lease.
+    Initialization, layer replacement, and close share one lifecycle queue. Cleanup must observe and release the backend the preceding operation publishes instead of returning early, leaking it, or letting attachment revive a core after shutdown.
     */
-    await this.initializationPromise?.catch(() => undefined);
     if (this.nodeDiscovery) {
       this.stopDiscovery();
     }

--- a/packages/core/src/central-core.ts
+++ b/packages/core/src/central-core.ts
@@ -246,6 +246,7 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
     if (!layer) {
       throw new Error("attachBackendLayer requires a non-null AsyncDataLayer");
     }
+    await this.initializationPromise?.catch(() => undefined);
     // Release a central-only pool before adopting the runtime's shared layer.
     if (this.ownedBackendReleaseConnections) {
       /*
@@ -376,6 +377,11 @@ export class CentralCore extends EventEmitter<CentralCoreEvents> {
    * Closes database connections and releases resources.
    */
   async close(): Promise<void> {
+    /*
+    FNXC:CentralPostgresCutover 2026-07-29-16:26:
+    Close and layer replacement wait for in-flight layerless initialization. Cleanup must observe and release the backend init publishes instead of returning early and leaking its pool or embedded-runtime lease.
+    */
+    await this.initializationPromise?.catch(() => undefined);
     if (this.nodeDiscovery) {
       this.stopDiscovery();
     }

--- a/packages/core/src/postgres/active-backend-registry.ts
+++ b/packages/core/src/postgres/active-backend-registry.ts
@@ -21,6 +21,14 @@ interface Generation {
   readonly leases: Set<EmbeddedRuntimeLease>;
   latestRegistration: number;
   pendingOwnerStop: (() => Promise<void>) | null;
+  stopping: boolean;
+}
+
+export class EmbeddedRuntimeStoppingError extends Error {
+  constructor(readonly url: string) {
+    super(`Embedded PostgreSQL runtime is stopping: ${url}`);
+    this.name = "EmbeddedRuntimeStoppingError";
+  }
 }
 
 interface LeaseMetadata {
@@ -42,12 +50,13 @@ export function registerEmbeddedRuntimeUrl(
   options: { ownsProcess: boolean },
 ): EmbeddedRuntimeLease {
   let generation = generationsByUrl.get(url);
+  if (generation?.stopping) throw new EmbeddedRuntimeStoppingError(url);
   // FNXC:PostgresBackup 2026-07-16-12:40: An owner started a new postmaster,
   // so URL reuse must create a new generation rather than retain stale leases.
   if (!generation || options.ownsProcess) {
     const id = (nextGenerationByUrl.get(url) ?? 0) + 1;
     nextGenerationByUrl.set(url, id);
-    generation = { url, epoch: registryEpoch, id, leases: new Set(), latestRegistration: 0, pendingOwnerStop: null };
+    generation = { url, epoch: registryEpoch, id, leases: new Set(), latestRegistration: 0, pendingOwnerStop: null, stopping: false };
     generationsByUrl.set(url, generation);
   }
 
@@ -87,10 +96,24 @@ export async function releaseEmbeddedRuntimeLease(
     generation.pendingOwnerStop = options.stopOwner;
   }
   if (generation.leases.size === 0) {
-    generationsByUrl.delete(metadata.url);
     const stopOwner = generation.pendingOwnerStop;
     generation.pendingOwnerStop = null;
-    await stopOwner?.();
+    if (stopOwner) {
+      /*
+      FNXC:PostgresLifecycle 2026-07-29-16:26:
+      Keep the generation visible as stopping until the owner callback completes. A concurrent bootstrap must retry rather than join a postmaster that is already committed to termination.
+      */
+      generation.stopping = true;
+      try {
+        await stopOwner();
+      } finally {
+        if (generationsByUrl.get(metadata.url) === generation) {
+          generationsByUrl.delete(metadata.url);
+        }
+      }
+    } else {
+      generationsByUrl.delete(metadata.url);
+    }
   }
 }
 
@@ -118,7 +141,7 @@ export function invalidateEmbeddedRuntimeUrl(url: string, lease?: EmbeddedRuntim
 export function getActiveEmbeddedRuntimeUrl(): string | undefined {
   let latest: Generation | undefined;
   for (const generation of generationsByUrl.values()) {
-    if (generation.leases.size > 0 && (!latest || generation.latestRegistration > latest.latestRegistration)) {
+    if (!generation.stopping && generation.leases.size > 0 && (!latest || generation.latestRegistration > latest.latestRegistration)) {
       latest = generation;
     }
   }

--- a/packages/core/src/postgres/active-backend-registry.ts
+++ b/packages/core/src/postgres/active-backend-registry.ts
@@ -21,12 +21,16 @@ interface Generation {
   readonly leases: Set<EmbeddedRuntimeLease>;
   latestRegistration: number;
   pendingOwnerStop: (() => Promise<void>) | null;
+  stopCompletion: Promise<void> | null;
   stopping: boolean;
 }
 
 export class EmbeddedRuntimeStoppingError extends Error {
-  constructor(readonly url: string) {
-    super(`Embedded PostgreSQL runtime is stopping: ${url}`);
+  constructor(
+    readonly url: string,
+    readonly completion: Promise<void>,
+  ) {
+    super("Embedded PostgreSQL runtime is stopping");
     this.name = "EmbeddedRuntimeStoppingError";
   }
 }
@@ -50,13 +54,27 @@ export function registerEmbeddedRuntimeUrl(
   options: { ownsProcess: boolean },
 ): EmbeddedRuntimeLease {
   let generation = generationsByUrl.get(url);
-  if (generation?.stopping) throw new EmbeddedRuntimeStoppingError(url);
+  if (generation?.stopping) {
+    if (!generation.stopCompletion) {
+      throw new Error("Embedded PostgreSQL runtime stop completion is missing");
+    }
+    throw new EmbeddedRuntimeStoppingError(url, generation.stopCompletion);
+  }
   // FNXC:PostgresBackup 2026-07-16-12:40: An owner started a new postmaster,
   // so URL reuse must create a new generation rather than retain stale leases.
   if (!generation || options.ownsProcess) {
     const id = (nextGenerationByUrl.get(url) ?? 0) + 1;
     nextGenerationByUrl.set(url, id);
-    generation = { url, epoch: registryEpoch, id, leases: new Set(), latestRegistration: 0, pendingOwnerStop: null, stopping: false };
+    generation = {
+      url,
+      epoch: registryEpoch,
+      id,
+      leases: new Set(),
+      latestRegistration: 0,
+      pendingOwnerStop: null,
+      stopCompletion: null,
+      stopping: false,
+    };
     generationsByUrl.set(url, generation);
   }
 
@@ -102,10 +120,15 @@ export async function releaseEmbeddedRuntimeLease(
       /*
       FNXC:PostgresLifecycle 2026-07-29-16:26:
       Keep the generation visible as stopping until the owner callback completes. A concurrent bootstrap must retry rather than join a postmaster that is already committed to termination.
+
+      FNXC:PostgresLifecycle 2026-07-29-17:43:
+      Publish the actual stop completion to rejected registrants. Startup waits on lifecycle completion instead of exhausting a fixed retry window while an orderly shutdown is still in progress.
       */
       generation.stopping = true;
+      const stopCompletion = Promise.resolve().then(stopOwner);
+      generation.stopCompletion = stopCompletion;
       try {
-        await stopOwner();
+        await stopCompletion;
       } finally {
         if (generationsByUrl.get(metadata.url) === generation) {
           generationsByUrl.delete(metadata.url);

--- a/packages/core/src/postgres/active-backend-registry.ts
+++ b/packages/core/src/postgres/active-backend-registry.ts
@@ -4,8 +4,8 @@
  * while backup construction resolves synchronously. This process-local registry
  * bridges that gap without logging credentials. Leases represent individual
  * lifecycles within a physical cluster generation: a joiner's release cannot
- * clear a newer generation, and owner shutdown invalidates every lease because
- * it is the only lifecycle that actually stops the postmaster.
+ * clear a newer generation, and owner shutdown waits for every live lease
+ * because physical process ownership is not exclusive logical usage.
  */
 
 /** Opaque handle for one embedded-backend lifecycle registration. */
@@ -20,6 +20,7 @@ interface Generation {
   readonly id: number;
   readonly leases: Set<EmbeddedRuntimeLease>;
   latestRegistration: number;
+  pendingOwnerStop: (() => Promise<void>) | null;
 }
 
 interface LeaseMetadata {
@@ -46,7 +47,7 @@ export function registerEmbeddedRuntimeUrl(
   if (!generation || options.ownsProcess) {
     const id = (nextGenerationByUrl.get(url) ?? 0) + 1;
     nextGenerationByUrl.set(url, id);
-    generation = { url, epoch: registryEpoch, id, leases: new Set(), latestRegistration: 0 };
+    generation = { url, epoch: registryEpoch, id, leases: new Set(), latestRegistration: 0, pendingOwnerStop: null };
     generationsByUrl.set(url, generation);
   }
 
@@ -62,8 +63,16 @@ export function registerEmbeddedRuntimeUrl(
   return lease;
 }
 
-/** Release exactly one lifecycle lease; stale generation handles are inert. */
-export function releaseEmbeddedRuntimeLease(lease: EmbeddedRuntimeLease): void {
+/**
+ * Release exactly one lifecycle lease; stale generation handles are inert.
+ *
+ * FNXC:PostgresResourceLifecycle 2026-07-29-16:10:
+ * An embedded-process owner may close before joined consumers. Record its stop callback and run it only after the final lease releases so short-lived central/CLI cleanup cannot terminate PostgreSQL beneath another live store.
+ */
+export async function releaseEmbeddedRuntimeLease(
+  lease: EmbeddedRuntimeLease,
+  options: { stopOwner?: () => Promise<void> } = {},
+): Promise<void> {
   const metadata = leaseMetadata.get(lease);
   if (!metadata) return;
   const generation = generationsByUrl.get(metadata.url);
@@ -74,8 +83,14 @@ export function releaseEmbeddedRuntimeLease(lease: EmbeddedRuntimeLease): void {
   ) return;
 
   generation.leases.delete(lease);
+  if (metadata.ownsProcess && options.stopOwner) {
+    generation.pendingOwnerStop = options.stopOwner;
+  }
   if (generation.leases.size === 0) {
     generationsByUrl.delete(metadata.url);
+    const stopOwner = generation.pendingOwnerStop;
+    generation.pendingOwnerStop = null;
+    await stopOwner?.();
   }
 }
 

--- a/packages/core/src/postgres/startup-factory.ts
+++ b/packages/core/src/postgres/startup-factory.ts
@@ -58,7 +58,6 @@ import { applySchemaBaseline, MIGRATION_BOOKKEEPING_TABLE } from "./schema-appli
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { createAsyncDataLayer, type AsyncDataLayer } from "./data-layer.js";
 import {
-  invalidateEmbeddedRuntimeUrl,
   registerEmbeddedRuntimeUrl,
   releaseEmbeddedRuntimeLease,
   type EmbeddedRuntimeLease,
@@ -226,8 +225,8 @@ interface SchemaBackendBootResult {
 
 /**
  * FNXC:PostgresBackup 2026-07-16-12:40:
- * stop() only stops a postmaster owned by this lifecycle. Consequently owner
- * teardown burns the URL generation for every joiner, while joiner teardown
+ * stop() only stops a postmaster owned by this lifecycle. The runtime registry
+ * defers that owner stop until joined leases release, while joiner teardown
  * releases only its opaque lease. This keeps synchronous backup resolution
  * aligned with physical cluster liveness without logging the credential URL.
  */
@@ -237,16 +236,20 @@ async function stopEmbeddedRuntime(
   runtimeUrl: string | null,
   ownsProcess: boolean,
 ): Promise<void> {
+  if (!lease || !runtimeUrl) {
+    await lifecycle?.stop();
+    return;
+  }
+  if (ownsProcess) {
+    await releaseEmbeddedRuntimeLease(lease, {
+      stopOwner: async () => { await lifecycle?.stop(); },
+    });
+    return;
+  }
   try {
     await lifecycle?.stop();
   } finally {
-    if (lease && runtimeUrl) {
-      if (ownsProcess) {
-        invalidateEmbeddedRuntimeUrl(runtimeUrl, lease);
-      } else {
-        releaseEmbeddedRuntimeLease(lease);
-      }
-    }
+    await releaseEmbeddedRuntimeLease(lease);
   }
 }
 
@@ -1371,7 +1374,7 @@ export async function createTaskStoreForBackend(
       if (shutdownEmbedded) {
         try {
           (shutdownEmbedded as unknown as { detachWithoutStop?: () => void }).detachWithoutStop?.();
-          if (embeddedRuntimeLease) releaseEmbeddedRuntimeLease(embeddedRuntimeLease);
+          if (embeddedRuntimeLease) await releaseEmbeddedRuntimeLease(embeddedRuntimeLease);
         } catch (err) {
           log.warn(`startup-factory: embedded PostgreSQL detach failed: ${
             err instanceof Error ? err.message : String(err)

--- a/packages/core/src/postgres/startup-factory.ts
+++ b/packages/core/src/postgres/startup-factory.ts
@@ -58,6 +58,7 @@ import { applySchemaBaseline, MIGRATION_BOOKKEEPING_TABLE } from "./schema-appli
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { createAsyncDataLayer, type AsyncDataLayer } from "./data-layer.js";
 import {
+  EmbeddedRuntimeStoppingError,
   registerEmbeddedRuntimeUrl,
   releaseEmbeddedRuntimeLease,
   type EmbeddedRuntimeLease,
@@ -386,6 +387,15 @@ async function bootSchemaBackend(
       return await bootSchemaBackendOnce(options, bypassProjectIsolation);
     } catch (error) {
       if (
+        error instanceof EmbeddedRuntimeStoppingError &&
+        joinedRetryAttempt < JOINED_INSTANCE_RETRY_DELAYS_MS.length
+      ) {
+        const delayMs = JOINED_INSTANCE_RETRY_DELAYS_MS[joinedRetryAttempt];
+        joinedRetryAttempt += 1;
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+      if (
         error instanceof JoinedInstanceUnreachableError &&
         joinedRetryAttempt < JOINED_INSTANCE_RETRY_DELAYS_MS.length
       ) {
@@ -473,6 +483,7 @@ async function bootSchemaBackendOnce(
       }
     } catch (error) {
       await embeddedLifecycle.stop().catch(() => undefined);
+      if (error instanceof EmbeddedRuntimeStoppingError) throw error;
       throw new Error(
         `startup-factory: failed to start embedded PostgreSQL: ${error instanceof Error ? error.message : String(error)}`,
       );

--- a/packages/core/src/postgres/startup-factory.ts
+++ b/packages/core/src/postgres/startup-factory.ts
@@ -386,13 +386,12 @@ async function bootSchemaBackend(
     try {
       return await bootSchemaBackendOnce(options, bypassProjectIsolation);
     } catch (error) {
-      if (
-        error instanceof EmbeddedRuntimeStoppingError &&
-        joinedRetryAttempt < JOINED_INSTANCE_RETRY_DELAYS_MS.length
-      ) {
-        const delayMs = JOINED_INSTANCE_RETRY_DELAYS_MS[joinedRetryAttempt];
-        joinedRetryAttempt += 1;
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      if (error instanceof EmbeddedRuntimeStoppingError) {
+        /*
+        FNXC:PostgresLifecycle 2026-07-29-17:43:
+        A replacement backend waits for the shared registry's actual owner-stop completion. Fixed backoff budgets can expire during a valid slow shutdown and turn orderly handoff into startup failure.
+        */
+        await error.completion;
         continue;
       }
       if (


### PR DESCRIPTION
## Summary

- restore the owned PostgreSQL backend bootstrap for layer-less `CentralCore.init()` callers
- fix node, mesh, and project CLI commands returning empty state and logging `backendHandle is only available in backend mode` during cleanup
- add a hermetic regression test for standalone backend ownership and shutdown

PR #2454 accidentally added an unconditional early return immediately before the existing standalone bootstrap. Runtime pool sharing remains unchanged: `attachBackendLayer()` releases the central-only connections before adopting the project store layer.

## Verification

- RED: regression failed because `createCentralBackendLayer` had zero calls
- GREEN: focused regression passes
- `pnpm --filter @fusion/core typecheck`
- `pnpm --filter @fusion/core build`
- `pnpm test` with `FUSION_PG_TEST_SKIP=1`: 482 engine + 132 Core gate + 71 CLI shape + changed regression passed; isolation clean
- changeset format check passed

The local PostgreSQL merge-gate harness is unavailable without credentials (`empty password returned by client`), so its 10 tests were explicitly skipped rather than misreported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored PostgreSQL central registry access for standalone Node/mesh/project CLI commands without marking the host offline on shutdown.
  * Improved CentralCore lifecycle handling: concurrent `init()` coalesces, and operations are blocked once `close()` is requested/in progress.
  * Refined embedded PostgreSQL runtime shutdown: owner stop is coordinated with lease release, registrations are rejected while stopping, and shutdown/teardown uses lease lifecycle consistently. Embedded start failures now treat stopping as retryable.
* **Tests**
  * Expanded coverage for CentralCore close/init/attach races and embedded PostgreSQL lease/shutdown coordination scenarios.
* **Documentation**
  * Updated Changeset notes to clarify CLI and shutdown semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->