### PR TITLE
live-agent-count.ts: 2 triage guards are NOT convertible — pin why (guards 2 → 2)

### DIFF
--- a/packages/core/src/__tests__/live-agent-count.test.ts
+++ b/packages/core/src/__tests__/live-agent-count.test.ts
@@ -88,3 +88,41 @@ describe("live agent count predicates", () => {
     });
   });
 });
+
+/*
+FNXC:WorkflowColumns 2026-07-29-20:30 (triage-guard census — anti-convergence guard):
+These pin the NO-ROLE-INFORMATION fallback across BOTH lifecycle vocabularies, so a
+future pass that drives the `column === "triage"` census to zero by deleting the
+legacy half fails here instead of silently breaking legacy boards.
+
+The fallback cannot resolve by trait — it runs precisely when no flags and no IR are
+available — so a literal is the only thing expressible, and it must cover the merged
+default column (`todo`, post-#2515) AND a legacy/custom workflow that still declares
+`triage` (a legal column id per KTD-8).
+
+It is reachable in production, contrary to the note that used to sit on it: the CLI
+counts unenriched rows, and both dashboard callers pass a possibly-undefined flag
+lookup, so a board mid-load lands here.
+*/
+describe("live-agent-count no-role-information fallback", () => {
+  const bare = (column: string) => ({ column, status: null } as unknown as Parameters<typeof isWaitingAgentTask>[0]);
+
+  it("counts a merged-column card as waiting with no flags supplied", () => {
+    expect(isWaitingAgentTask(bare("todo"))).toBe(true);
+  });
+
+  it("counts a LEGACY triage card as waiting with no flags supplied", () => {
+    // Deleting the `triage` half of the fallback to zero the census turns this red.
+    expect(isWaitingAgentTask(bare("triage"))).toBe(true);
+  });
+
+  it("does not count a wip or terminal column as waiting", () => {
+    expect(isWaitingAgentTask(bare("in-progress"))).toBe(false);
+    expect(isWaitingAgentTask(bare("done"))).toBe(false);
+  });
+
+  it("enrichment from ABSENT flags still resolves both vocabularies", () => {
+    expect(enrichRunningAgentTaskShapeFromFlags(bare("todo") as never, undefined).columnIsIntakeOrHold).toBe(true);
+    expect(enrichRunningAgentTaskShapeFromFlags(bare("triage") as never, undefined).columnIsIntakeOrHold).toBe(true);
+  });
+});

--- a/packages/core/src/live-agent-count.ts
+++ b/packages/core/src/live-agent-count.ts
@@ -84,15 +84,30 @@ export function enrichRunningAgentTaskShapeFromFlags<T extends RunningAgentTaskS
     columnIsIntakeOrHold: flags ? flags.intake === true || flags.hold === true : task.column === "triage" || task.column === "todo",
     columnCountsTowardWip: flags ? flags.countsTowardWip === true : task.column === "in-progress",
     /*
-    FNXC:WorkflowLifecycleColumns 2026-07-29-23:10:
-    These id fallbacks are REACHABLE, not fixture-only — callers may pass no flags for a column
-    absent from the board's flag map, which is the renamed or undeclared column case. A card in
-    such a column then matches no arm and is counted as neither running nor waiting, so the
-    footer's queued total under-reports it.
+    FNXC:WorkflowLifecycleColumns 2026-07-30-05:00 (triage-guard census — DO NOT converge these to zero):
+    THE LITERAL FALLBACKS ARE REACHABLE IN PRODUCTION. An earlier note claimed they were
+    "fixture-only; board/store callers always supply flags/IR". Measured, that is false on two counts:
+      - `cli/src/commands/project.ts` calls `countRunningAgentTasks(tasks)` on UNENRICHED rows — it
+        never calls an enrich helper at all;
+      - both dashboard callers pass a possibly-undefined lookup
+        (`columnFlagsByTaskId?.get(id) ?? columnFlagsById?.get(column)` in useExecutorStats,
+        `columnFlags` in Column.tsx), so a board mid-load, or a column id absent from the map, lands
+        here — the renamed or undeclared column case.
 
-    Converting them means deciding what an ABSENT flag set should mean, and "not intake" is as
-    much a guess as "todo is intake"; either choice moves an operator-visible count. Supply flags
-    rather than relying on these.
+    WHY `"triage"` STAYS despite the census. This branch runs precisely when NO role information is
+    available, so it cannot resolve by trait; a literal is the only thing expressible. It must
+    therefore cover BOTH vocabularies: the merged default column (`todo`, post-#2515) AND a legacy or
+    custom workflow that still declares `triage` (a legal column id per KTD-8). Deleting the `triage`
+    half to drive the census to zero would make every legacy-board card silently stop counting as
+    waiting — the exact silent-non-firing failure the census exists to eliminate, introduced in the
+    name of closing it.
+
+    Nor is narrowing it safe in the other direction: with an absent flag set, "not intake" is as much
+    a guess as "todo is intake", and either choice moves an operator-visible count (a card matching no
+    arm is counted as neither running nor waiting, so the footer under-reports it).
+
+    The right way to remove these is to make role information MANDATORY at the call sites — a
+    dashboard-loading change, not a vocabulary change. Supply flags rather than relying on these.
     */
     columnIsReviewOrMerge: flags ? flags.mergeOrchestration === true || flags.mergeBlocker === true : task.column === "in-review",
   };
@@ -112,7 +127,9 @@ function hasLiveWorkflowStepLease(task: RunningAgentTaskShape): boolean {
 }
 
 function terminalKind(task: RunningAgentTaskShape): ColumnTerminalKind {
-  // Legacy literals are intentionally fixture-only degradation when workflow IR is unavailable.
+  // FNXC:WorkflowColumns 2026-07-29-20:30: not fixture-only — see the note in
+  // enrichRunningAgentTaskShapeFromFlags. This is the no-role-information fallback and
+  // it is reached by the CLI's unenriched count and by dashboard boards mid-load.
   return task.columnTerminalKind ?? (task.column === "done" ? "complete" : task.column === "archived" ? "archived" : "none");
 }
 


### PR DESCRIPTION
Taking **`packages/core/src/live-agent-count.ts`** from the shared 48-guard backlog.

## Guard count

| file | before | after |
|---|---:|---:|
| `packages/core/src/live-agent-count.ts` | 2 | **2** |

Deliberately unchanged. This PR is the *evidence for why* rather than a conversion — and a test that makes the wrong conversion fail.

## Why these two cannot be converted

Both sites are the **no-role-information fallback**: they run precisely when neither trait flags nor an IR are available, so they cannot resolve by trait and a literal is the only thing expressible. The fallback must therefore cover **both** vocabularies — the merged default column (`todo`, post-#2515) **and** a legacy or custom workflow that still declares `triage`, which remains a legal column id per KTD-8.

Deleting the `triage` half to drive the census to zero would make every legacy-board card **silently stop counting as waiting** — the exact silent-non-firing failure the census exists to eliminate, introduced in the name of closing it. So this adds a test that fails on that edit.

## Measured finding — the file’s own note was wrong

It claimed these literals were *“fixture-only; board/store callers always supply flags/IR”*. False on two counts:

- **`cli/src/commands/project.ts:166`** calls `countRunningAgentTasks(tasks)` on **unenriched** rows — it never calls an enrich helper at all.
- **Both dashboard callers** pass a possibly-undefined lookup (`columnFlagsByTaskId?.get(id) ?? columnFlagsById?.get(column)` in `useExecutorStats`, `columnFlags` in `Column.tsx`), so a board mid-load, or a column id missing from the map, lands here.

A fallback documented as unreachable, that is reachable, is how a “harmless” literal becomes a live defect. Both notes are corrected in place.

## How these two *should* eventually go

Make role information **mandatory at the call sites** so the fallback ceases to exist. That is a dashboard-loading change (the flags maps are populated asynchronously), not a vocabulary change, and not one to make unilaterally from this seam.

**So for the completion bar: 2 of the 48 are not reachable by conversion alone.** Worth knowing before the count is expected to hit zero.

## Verification

**Revert-proof, measured:** narrowing the fallback to `todo` only — the wrong convergence — fails `counts a LEGACY triage card as waiting with no flags supplied` plus the enrichment case. `live-agent-count.ts` restored byte-identical.

`pnpm lint` clean · core `tsc` clean · `pnpm test:gate` green (482 + 10 + 71) · `live-agent-count` 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)