### PR TITLE
TAKING plugins/: glasses + dependency-graph lifecycle-column gates — plugins 4→0, repo 29→25

### DIFF
--- a/plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx
@@ -70,7 +70,21 @@ export function GraphTaskNode({
   const isFailed = task.status === "failed";
   const isPaused = task.paused === true;
   const isStuck = isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs);
-  const isAwaitingApproval = task.column === "triage" && task.status === "awaiting-approval";
+  /*
+  FNXC:PluginLifecycleColumns 2026-07-30-03:40 (U11 #2515 audit):
+  Keyed on `column === "triage"`, this went permanently FALSE for default-lineage
+  cards once U11 merged Todo into Planning and dropped the `triage` id — an
+  awaiting-approval card sits in `todo` now. The node then stopped showing the
+  awaiting-approval state AND fell through to `isActive`, rendering a card that is
+  blocked on a human as if it were running.
+
+  The column condition is DELETED rather than converted, because it was always
+  redundant: `awaiting-approval` is written only by the plan-approval gate and the
+  replan-cap park, both of which act on a card in the planning lane, so the status
+  alone is the signal. Deleting it is also the only option that needs no resolution —
+  this is a synchronous React render, where an IR lookup is not available.
+  */
+  const isAwaitingApproval = task.status === "awaiting-approval";
   const isActive =
     !globalPaused &&
     !isFailed &&

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
@@ -281,3 +281,112 @@ describe("post-U11 planning-column gates", () => {
     }
   });
 });
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-05:10 (PR #2607 review — greptile P1 x2):
+
+Two over-reaches in my own first version, both found by review:
+
+  1. DESTINATIONS stayed literal while the GATES were converted. On a renamed workflow
+     that is WORSE than the original bug: the gate now admits the card and then moves it
+     into a column the workflow does not declare. Half a conversion moved the failure
+     from "refuses valid work" to "puts work where nothing renders it".
+
+  2. The legacy-id acceptance was UNSCOPED, so a workflow naming its review or wip lane
+     `triage`/`todo` had those cards authorized as planning work.
+
+These drive a store that CAN resolve a workflow, which the default fixture cannot — the
+plugin store is narrowed, so without the workflow methods every earlier case silently
+exercised the legacy fallback rather than the resolved path.
+*/
+function createResolvingDeps(task: FakeTask, ir: unknown) {
+  const base = createDeps(task);
+  const selection = { workflowId: "wf-custom", stepIds: [] };
+  return {
+    ...base,
+    taskStore: {
+      ...base.taskStore,
+      getTaskWorkflowSelection: () => selection,
+      getTaskWorkflowSelectionAsync: async () => selection,
+      getWorkflowDefinition: async () => ({ ir }),
+    },
+  };
+}
+
+const renamedIr = {
+  version: "v2", id: "wf-custom", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Planning", traits: [{ trait: "intake" }, { trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", name: "Review", traits: [{ trait: "merge-blocker" }, { trait: "human-review" }] },
+    { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+  ],
+};
+
+/** A workflow that assigns the LEGACY id `todo` to its REVIEW lane. Legal, and not planning. */
+const todoIsReviewIr = {
+  version: "v2", id: "wf-custom", name: "todo-is-review", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Planning", traits: [{ trait: "intake" }, { trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    /*
+    The `merge` trait is REQUIRED for this to be a resolvable review lane, and that
+    detail is the finding: `resolveLifecycleColumns` derives `review` from `merge`, not
+    from `merge-blocker`/`human-review`. My first fixture omitted it, so `review` came
+    back undefined, `declaredIds` did not contain `todo`, and the legacy acceptance
+    applied — the test failed and was RIGHT to.
+
+    RESIDUAL LIMITATION, recorded rather than papered over: the scoping is only as
+    strong as the roles the resolver returns. A workflow that assigns `todo` to a
+    column whose traits map to NO role is still invisible to `declaredIds`, so the
+    legacy acceptance would authorize it. Closing that needs the resolver to report
+    every declared column, not six roles — a core change, not a plugin one.
+    */
+    { id: "todo", name: "Review", traits: [{ trait: "merge-blocker" }, { trait: "human-review" }, { trait: "merge" }] },
+    { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+  ],
+};
+
+describe("resolved lanes drive destinations, not just gates", () => {
+  it("startWork moves a renamed card to the workflow's OWN wip column", async () => {
+    // Pre-fix: admitted, then moved to the literal `in-progress` — a column this
+    // workflow does not declare.
+    const deps = createResolvingDeps(makeTask({ column: "backlog", status: null }), renamedIr);
+
+    const result = await startWork({ taskId: "FN-1" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "building");
+    expect(result.task.column).toBe("building");
+  });
+
+  it("approvePlan moves a renamed card to the workflow's OWN hold column", async () => {
+    const deps = createResolvingDeps(
+      makeTask({ column: "backlog", status: "awaiting-approval" }),
+      renamedIr,
+    );
+
+    await approvePlan({ taskId: "FN-1" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "backlog");
+  });
+
+  it("REFUSES a card in a legacy-named column the workflow assigns to REVIEW", async () => {
+    /*
+    The aliasing case. Unscoped, `todo` counted as a planning lane and startWork would
+    have pulled a card out of review and into wip — skipping the review entirely.
+    */
+    const deps = createResolvingDeps(makeTask({ column: "todo", status: null }), todoIsReviewIr);
+
+    await expectInputError(startWork({ taskId: "FN-1" }, deps as never), 409);
+    expect(deps.moveTask).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a legacy id the workflow does not use at all (migration window)", async () => {
+    // `renamedIr` declares no `todo`, so a pre-U11 row resting there is an orphan and
+    // still means "planning".
+    const deps = createResolvingDeps(makeTask({ column: "todo", status: null }), renamedIr);
+
+    await expect(startWork({ taskId: "FN-1" }, deps as never)).resolves.toBeTruthy();
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "building");
+  });
+});

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
@@ -547,3 +547,62 @@ describe("a legacy destination may only fill a role the workflow leaves empty", 
     expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "todo");
   });
 });
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-21:45 (PR #2607 review — FIFTH finding, one rule):
+
+A ROLELESS COLUMN NAMED `todo` IS STILL NOT THE HOLD LANE. My previous revision scoped the legacy
+fallback to "declared and not assigned to another role", and review found the remaining hole
+immediately: a TRAITLESS parking column named `todo` is assigned to no role, so no role check can
+see it, and `approvePlan` moved an approved plan into a column that implements nothing.
+
+The qualifications were themselves the mistake. Once `resolveLanes` returns a lane set the workflow
+HAS a column vocabulary, so "no column carries the hold trait" is a complete answer — refuse. The
+legacy id survives only when the workflow cannot be resolved at all, which is the migration case.
+
+Five attempts at one rule. These cases pin all four shapes it has to get right at once.
+*/
+const ROLELESS_TODO_IR = {
+  version: "v2", id: "wf-custom", name: "roleless-todo", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Planning", traits: [{ trait: "intake" }] },
+    { id: "todo", name: "Parking", traits: [] },
+    { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+  ],
+};
+
+describe("a legacy id is not a destination once the workflow speaks columns", () => {
+  it("refuses approve-plan rather than parking the plan in a TRAITLESS column named `todo`", async () => {
+    // Pre-fix: `assignedElsewhere` was false (no role owns a traitless column), so the fallback
+    // returned `todo` and an approved plan landed in the operator's parking column.
+    const deps = createResolvingDeps(
+      makeTask({ column: "backlog", status: "awaiting-approval" }),
+      ROLELESS_TODO_IR,
+    );
+
+    await expect(approvePlan({ taskId: "FN-1" }, deps as never)).rejects.toThrow(/not allowed/);
+    expect(deps.moveTask).not.toHaveBeenCalled();
+  });
+
+  it("still starts work, because THAT role is declared on the same board", async () => {
+    // The paired positive: refusing a missing role must not become refusing everything. This board
+    // has no hold lane but does have a wip lane, so start-work is legitimate.
+    const deps = createResolvingDeps(makeTask({ column: "backlog", status: null }), ROLELESS_TODO_IR);
+
+    await startWork({ taskId: "FN-1" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "building");
+  });
+
+  it("keeps the legacy destination when the workflow cannot be resolved at all", async () => {
+    // No lane set means no basis to decide, and a pre-U11 board really does use these ids —
+    // refusing here would break the migration rather than protect it. `createDeps` supplies a
+    // store with no workflow readers, which is exactly that case.
+    const deps = createDeps(makeTask({ column: "todo", status: "awaiting-approval" }));
+
+    await approvePlan({ taskId: "FN-1" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "todo");
+  });
+});

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
@@ -217,3 +217,67 @@ describe("retryTask", () => {
     expect(deps.moveTask).not.toHaveBeenCalled();
   });
 });
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-03:20 (U11 #2515 audit — unowned plugin sites):
+
+These operator actions gated on `column === "triage"`. U11 (#2515) merged Todo into
+Planning KEEPING the id `todo` and DELETING `triage`, so on the default lineage:
+
+  approvePlan  — REFUSED for every card. An awaiting-approval card now sits in `todo`,
+                 the gate demands `triage`, so the operator's approve action from the
+                 glasses surface fails with a conflict on a perfectly valid card.
+  retryTask    — its triage-retry branch never fires, so a stuck/needs-replan card
+                 cannot be retried from the glasses at all.
+  startWork    — SURVIVES, because it already accepted `todo` as well.
+
+That asymmetry is the tell: the one gate written to accept both ids kept working, and
+the two written against a single id broke. `plugins/` is in no unit's file list and no
+drift-review assignment.
+
+The fix accepts the PRE-IMPLEMENTATION LANE rather than one id, resolving the task's
+own workflow when the plugin's store can (it depends on `@fusion/core`) and falling
+back to both legacy ids when it cannot. The fallback is why these cases assert the
+default vocabulary too.
+*/
+describe("post-U11 planning-column gates", () => {
+  it("approvePlan accepts an awaiting-approval card in the MERGED planning column", async () => {
+    // Pre-fix: conflict. The card is valid and the operator's action just failed.
+    const deps = createDeps(makeTask({ column: "todo", status: "awaiting-approval" }));
+
+    const result = await approvePlan({ taskId: "FN-1" }, deps as never);
+
+    expect(result.task.column).toBe("todo");
+    expect(deps.updateTask).toHaveBeenCalled();
+  });
+
+  it("approvePlan still accepts a legacy `triage` card (migration window)", async () => {
+    const deps = createDeps(makeTask({ column: "triage", status: "awaiting-approval" }));
+
+    await expect(approvePlan({ taskId: "FN-1" }, deps as never)).resolves.toBeTruthy();
+  });
+
+  it("approvePlan still REFUSES a card that has left the planning lane", async () => {
+    // The other side, so "always accepts" cannot pass for "accepts the lane".
+    const deps = createDeps(makeTask({ column: "in-progress", status: "awaiting-approval" }));
+
+    await expectInputError(approvePlan({ taskId: "FN-1" }, deps as never), 409);
+  });
+
+  it("retryTask reaches its planning-lane branch for a card in the MERGED column", async () => {
+    // Pre-fix the branch was unreachable for default-lineage cards, so a stuck card
+    // could not be retried from this surface at all.
+    const deps = createDeps(makeTask({ column: "todo", status: "stuck-killed", stuckKillCount: 2 }));
+
+    await retryTask({ taskId: "FN-1" }, deps as never);
+
+    expect(deps.updateTask).toHaveBeenCalledWith("FN-1", expect.objectContaining({ status: "needs-replan" }));
+  });
+
+  it("startWork keeps accepting both ids (it already did — the control)", async () => {
+    for (const column of ["todo", "triage"]) {
+      const deps = createDeps(makeTask({ column, status: null }));
+      await expect(startWork({ taskId: "FN-1" }, deps as never)).resolves.toBeTruthy();
+    }
+  });
+});

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
@@ -336,11 +336,10 @@ const todoIsReviewIr = {
     back undefined, `declaredIds` did not contain `todo`, and the legacy acceptance
     applied — the test failed and was RIGHT to.
 
-    RESIDUAL LIMITATION, recorded rather than papered over: the scoping is only as
-    strong as the roles the resolver returns. A workflow that assigns `todo` to a
-    column whose traits map to NO role is still invisible to `declaredIds`, so the
-    legacy acceptance would authorize it. Closing that needs the resolver to report
-    every declared column, not six roles — a core change, not a plugin one.
+    (That gap — a column whose traits map to no role being invisible to a role-only
+    check — is CLOSED below by reading the IR's declared column ids directly. It did not
+    need a core change after all; it needed me to read an input that was already in
+    reach. See "a declared column is declared even when it carries no role".)
     */
     { id: "todo", name: "Review", traits: [{ trait: "merge-blocker" }, { trait: "human-review" }, { trait: "merge" }] },
     { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
@@ -388,5 +387,108 @@ describe("resolved lanes drive destinations, not just gates", () => {
 
     await expect(startWork({ taskId: "FN-1" }, deps as never)).resolves.toBeTruthy();
     expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "building");
+  });
+});
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-07:20 (PR #2607 review, second P1 — greptile):
+
+TWO THINGS THE ROLE-ONLY VERSION GOT WRONG, both of which I had written down as
+limitations rather than fixed. Recording a gap you can close is just a nicer way of
+leaving it open.
+
+  1. A DECLARED COLUMN IS DECLARED EVEN WHEN IT CARRIES NO ROLE. Building the
+     declared set from the six resolved roles left a trait-less column named `todo`
+     invisible, so the legacy acceptance claimed it as a planning lane and `startWork`
+     would pull a card out of it. The IR lists its own columns; read that instead.
+
+  2. A MISSING ROLE IS NOT A LICENCE TO INVENT A COLUMN. `destination` fell back to
+     `todo`/`in-progress` unconditionally, so a valid workflow that simply omits the
+     role had `moveTask` called with a column that does not exist on that board. An
+     action with nowhere legitimate to send the card is not configured for this
+     workflow; 409 says that, a move to a phantom column does not.
+*/
+/** A column named with a legacy id but carrying NO lifecycle trait. Legal, and not planning. */
+const inertTodoIr = {
+  version: "v2", id: "wf-custom", name: "inert-todo", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Planning", traits: [{ trait: "intake" }, { trait: "hold", config: { release: "capacity" } }] },
+    { id: "todo", name: "Parking", traits: [] },
+    { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+  ],
+};
+
+/** A workflow with NO wip lane at all — nowhere for `startWork` to legitimately send a card. */
+const noWipIr = {
+  version: "v2", id: "wf-custom", name: "no-wip", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Planning", traits: [{ trait: "intake" }, { trait: "hold", config: { release: "capacity" } }] },
+    { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+  ],
+};
+
+describe("a declared column is declared even when it carries no role", () => {
+  it("refuses start-work on an inert column named `todo`", async () => {
+    // Pre-fix: `todo` was absent from the role-derived set, the legacy acceptance
+    // applied, and the card was pulled out of the operator's parking column.
+    const deps = createResolvingDeps(makeTask({ id: "FN-1", column: "todo", status: null }), inertTodoIr);
+
+    await expect(startWork({ taskId: "FN-1" }, deps as never)).rejects.toThrow(/not allowed/);
+    expect(deps.moveTask).not.toHaveBeenCalled();
+  });
+
+  it("still admits the workflow's REAL planning column", async () => {
+    // The other half of the pair: "never a planning lane" must not be able to pass
+    // for "reads the IR".
+    const deps = createResolvingDeps(makeTask({ id: "FN-2", column: "backlog", status: null }), inertTodoIr);
+
+    await startWork({ taskId: "FN-2" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-2", "building");
+  });
+});
+
+describe("a missing destination role conflicts instead of inventing a column", () => {
+  it("refuses start-work when the workflow declares no wip lane", async () => {
+    // Pre-fix: moved to the literal `in-progress`, which this workflow does not declare.
+    const deps = createResolvingDeps(makeTask({ id: "FN-3", column: "backlog", status: null }), noWipIr);
+
+    await expect(startWork({ taskId: "FN-3" }, deps as never)).rejects.toThrow(/not allowed/);
+    expect(deps.moveTask).not.toHaveBeenCalled();
+  });
+
+  it("refuses approve-plan when the workflow declares no hold lane", async () => {
+    const holdlessIr = {
+      version: "v2", id: "wf-custom", name: "no-hold", nodes: [], edges: [],
+      columns: [
+        { id: "backlog", name: "Planning", traits: [{ trait: "intake" }] },
+        { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+        { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+      ],
+    };
+    const deps = createResolvingDeps(makeTask({ id: "FN-4", column: "backlog", status: "awaiting-approval" }), holdlessIr);
+
+    await expect(approvePlan({ taskId: "FN-4" }, deps as never)).rejects.toThrow(/not allowed/);
+    expect(deps.moveTask).not.toHaveBeenCalled();
+  });
+
+  it("STILL uses the legacy id when the workflow genuinely declares it (migration window)", async () => {
+    // The fallback is not deleted, it is scoped: a pre-U11 board really does have
+    // `todo`, and refusing there would break the migration this program is mid-way
+    // through. `todo` here carries the hold trait, so it is a real destination.
+    const migrationIr = {
+      version: "v2", id: "wf-custom", name: "pre-u11", nodes: [], edges: [],
+      columns: [
+        { id: "triage", name: "Triage", traits: [{ trait: "intake" }] },
+        { id: "todo", name: "Todo", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+        { id: "in-progress", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      ],
+    };
+    const deps = createResolvingDeps(makeTask({ id: "FN-5", column: "triage", status: "awaiting-approval" }), migrationIr);
+
+    await approvePlan({ taskId: "FN-5" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-5", "todo");
   });
 });

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/agent-actions.test.ts
@@ -492,3 +492,58 @@ describe("a missing destination role conflicts instead of inventing a column", (
     expect(deps.moveTask).toHaveBeenCalledWith("FN-5", "todo");
   });
 });
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-19:25 (PR #2607 review — fourth finding):
+
+"DECLARED SOMEWHERE" IS NOT "DECLARED FOR THIS ROLE", and this is the FOURTH time I have made the
+legacy-aliasing mistake in this file. `declared` holds every column id the workflow has, so a board
+that declares no hold column but names its REVIEW lane `todo` satisfied `declared.has("todo")` —
+and `approvePlan` moved an approved plan straight into REVIEW, skipping implementation. Worse than
+the refusal it replaced, which is the recurring signature of a half-applied rule.
+
+The rule, stated the same way as for the gate: a legacy id may stand in only for a role the
+workflow leaves EMPTY. If the board has assigned that id to another lifecycle role, it means
+something else there.
+*/
+const HOLDLESS_TODO_IS_REVIEW_IR = {
+  version: "v2", id: "wf-custom", name: "holdless-todo-review", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Planning", traits: [{ trait: "intake" }] },
+    { id: "building", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "todo", name: "Review", traits: [{ trait: "merge-blocker" }, { trait: "human-review" }, { trait: "merge" }] },
+    { id: "shipped", name: "Done", traits: [{ trait: "complete" }] },
+  ],
+};
+
+describe("a legacy destination may only fill a role the workflow leaves empty", () => {
+  it("refuses approve-plan rather than moving the plan into a lane named `todo` that is REVIEW", async () => {
+    // Pre-fix: moved to `todo` — this board's review lane — so an approved plan skipped
+    // implementation entirely.
+    const deps = createResolvingDeps(
+      makeTask({ column: "backlog", status: "awaiting-approval" }),
+      HOLDLESS_TODO_IS_REVIEW_IR,
+    );
+
+    await expect(approvePlan({ taskId: "FN-1" }, deps as never)).rejects.toThrow(/not allowed/);
+    expect(deps.moveTask).not.toHaveBeenCalled();
+  });
+
+  it("still uses the legacy id when the workflow declares it and assigns it to NO other role", async () => {
+    // The migration case the fallback exists for: a pre-U11 board really does have `todo` as its
+    // hold lane. Scoping the fallback must not delete it.
+    const migrationIr = {
+      version: "v2", id: "wf-custom", name: "pre-u11", nodes: [], edges: [],
+      columns: [
+        { id: "triage", name: "Triage", traits: [{ trait: "intake" }] },
+        { id: "todo", name: "Todo", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+        { id: "in-progress", name: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      ],
+    };
+    const deps = createResolvingDeps(makeTask({ column: "triage", status: "awaiting-approval" }), migrationIr);
+
+    await approvePlan({ taskId: "FN-1" }, deps as never);
+
+    expect(deps.moveTask).toHaveBeenCalledWith("FN-1", "todo");
+  });
+});

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/quick-capture-renamed-board.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/quick-capture-renamed-board.test.ts
@@ -1,0 +1,78 @@
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-19:40 (PR #2607 review — CodeRabbit):
+
+The reviewer is right that my "accepts a column the default workflow declares" case was VACUOUS:
+`in-progress` belongs to both the legacy five and the declared set, so it passed before the change
+as well. The only non-vacuous case in that suite was the `triage` REJECTION — which proves half the
+claim (the set is no longer the hand-listed five) and not the other half (it is the BOARD's set).
+
+Proving the other half needs control of the resolved workflow, so this file mocks it. Kept separate
+because the mock is module-wide and the sibling suite deliberately exercises the real default
+lineage.
+*/
+import { describe, expect, it, vi } from "vitest";
+
+/** A board whose columns carry the standard traits under names the legacy five never contained. */
+const RENAMED_IR = {
+  version: "v2",
+  id: "wf-renamed",
+  name: "renamed",
+  nodes: [],
+  edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "queued", name: "Queued", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", name: "Checking", traits: [{ trait: "merge" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+};
+
+vi.mock("@fusion/core", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, resolveDefaultWorkflowIr: () => RENAMED_IR };
+});
+
+const { runQuickCapture } = await import("../quick-capture.js");
+
+function deps(defaultColumn = "queued") {
+  const created: Array<Record<string, unknown>> = [];
+  return {
+    created,
+    taskStore: {
+      createTask: async (input: Record<string, unknown>) => {
+        created.push(input);
+        return { id: "FN-1", column: input.column, description: input.description, updatedAt: "2026-07-30T00:00:00.000Z" };
+      },
+    },
+    pluginId: "glasses",
+    defaultColumn,
+  } as never;
+}
+
+describe("quick capture accepts a RENAMED board's own columns", () => {
+  it("accepts a column that appears nowhere in the legacy five", async () => {
+    // THE NON-VACUOUS CASE. Pre-fix this was rejected with 400 "invalid column" — an operator
+    // saying "put it in checking" was refused for a column their own board declares.
+    const d = deps();
+
+    await runQuickCapture({ text: "ship the thing", column: "checking" }, d);
+
+    expect((d as unknown as { created: Array<{ column?: string }> }).created[0]?.column).toBe("checking");
+  });
+
+  it("rejects a legacy id this board does NOT declare", async () => {
+    // The mirror: `in-progress` was accepted by the hand-listed five and is not a column here, so
+    // forwarding it would have failed at the server after the voice interaction appeared to work.
+    await expect(runQuickCapture({ text: "ship it", column: "in-progress" }, deps())).rejects.toThrow(
+      /invalid column/,
+    );
+  });
+
+  it("rejects a column no board declares", async () => {
+    // Paired negative: "accept everything" must not pass for "read the workflow".
+    await expect(runQuickCapture({ text: "ship it", column: "nonsense" }, deps())).rejects.toThrow(
+      /invalid column/,
+    );
+  });
+});

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/quick-capture.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/quick-capture.test.ts
@@ -107,7 +107,14 @@ describe("quick capture accepts the columns the board actually declares", () => 
     } as never;
   }
 
-  it("accepts a column the default workflow declares", async () => {
+  /*
+  FNXC:PluginLifecycleColumns 2026-07-30-19:45 (PR #2607 review — CodeRabbit): this case is
+  VACUOUS with respect to the change and is kept only as a smoke test for the happy path —
+  `in-progress` belongs to both the legacy five and the declared set, so it passed before the fix
+  too. The non-vacuous half (a column the legacy five never contained IS accepted) needs control of
+  the resolved workflow and lives in `quick-capture-renamed-board.test.ts`.
+  */
+  it("accepts a column the default workflow declares (smoke; see the renamed-board suite)", async () => {
     const d = deps();
 
     await runQuickCapture({ text: "ship the thing", column: "in-progress" }, d);

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/quick-capture.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/quick-capture.test.ts
@@ -78,3 +78,60 @@ describe("quick-capture parsing", () => {
     ).rejects.toThrowError(GlassesInputError);
   });
 });
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-13:20 (Phase C convergence — quick capture):
+
+The accepted capture columns are the BOARD's, not a hand-listed five. The old list was wrong in
+both directions after U11 (#2515): it accepted `triage`, which the default board no longer
+declares (so the create failed at the server, at the far end of a voice interaction), and it
+rejected every column of a renamed or custom board.
+
+Note on severity, corrected from my own PR description: this was never SILENT substitution —
+`runQuickCapture` compares the normalized value against the request and throws 400 on a
+mismatch. An unusable column was visibly rejected. The defect is the accept/reject SET.
+*/
+describe("quick capture accepts the columns the board actually declares", () => {
+  function deps(defaultColumn = "todo") {
+    const created: Array<Record<string, unknown>> = [];
+    return {
+      created,
+      taskStore: {
+        createTask: async (input: Record<string, unknown>) => {
+          created.push(input);
+          return { id: "FN-1", column: input.column, description: input.description, updatedAt: "2026-07-30T00:00:00.000Z" };
+        },
+      },
+      pluginId: "glasses",
+      defaultColumn,
+    } as never;
+  }
+
+  it("accepts a column the default workflow declares", async () => {
+    const d = deps();
+
+    await runQuickCapture({ text: "ship the thing", column: "in-progress" }, d);
+
+    expect((d as unknown as { created: Array<{ column?: string }> }).created[0]?.column).toBe("in-progress");
+  });
+
+  it("rejects `triage` now that the default lineage no longer declares it", async () => {
+    // Pre-fix this was ACCEPTED and forwarded, and the server rejected the create — the
+    // failure surfaced after the voice interaction had already succeeded from the operator's
+    // point of view.
+    await expect(runQuickCapture({ text: "ship it", column: "triage" }, deps())).rejects.toThrow(/invalid column/);
+  });
+
+  it("rejects a column no workflow declares", async () => {
+    // The paired negative: "accept everything" must not pass for "read the workflow".
+    await expect(runQuickCapture({ text: "ship it", column: "nonsense" }, deps())).rejects.toThrow(/invalid column/);
+  });
+
+  it("uses the configured default when no column is requested", async () => {
+    const d = deps("todo");
+
+    await runQuickCapture({ text: "ship it" }, d);
+
+    expect((d as unknown as { created: Array<{ column?: string }> }).created[0]?.column).toBe("todo");
+  });
+});

--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/settings.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/settings.test.ts
@@ -16,7 +16,15 @@ describe("settings accessors", () => {
     expect(getCompanionWebhookUrl({})).toBeUndefined();
     expect(getPollingIntervalMs({})).toBe(30000);
     expect(getNotifyColumns({})).toEqual(["in-review"]);
-    expect(getQuickCaptureColumn({})).toBe("triage");
+    /*
+    FNXC:PluginLifecycleColumns 2026-07-30-11:35: was `triage` — the column U11 (#2515)
+    deleted from the default lineage, so quick capture defaulted every voice-captured card
+    to a column the default board no longer declares. `todo` exists on both sides of that
+    migration. These two cases are the reason the default is worth pinning at all: nothing
+    else in the plugin fails when the default names a non-existent column — the server just
+    rejects the create, at the far end of a voice interaction.
+    */
+    expect(getQuickCaptureColumn({})).toBe("todo");
     expect(agentActionsEnabled({})).toBe(true);
   });
 
@@ -41,7 +49,7 @@ describe("settings accessors", () => {
 
   it("validates quick capture column", () => {
     expect(getQuickCaptureColumn({ quickCaptureDefaultColumn: "done" })).toBe("done");
-    expect(getQuickCaptureColumn({ quickCaptureDefaultColumn: "bad-column" })).toBe("triage");
+    expect(getQuickCaptureColumn({ quickCaptureDefaultColumn: "bad-column" })).toBe("todo");
   });
 
   it("respects explicit boolean for agent actions", () => {

--- a/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
@@ -1,4 +1,5 @@
 import type { PluginContext } from "@fusion/plugin-sdk";
+import { resolveTaskLifecycleColumns } from "@fusion/core";
 import { taskToCard, type GlassesCard } from "./cards.js";
 import { GlassesInputError } from "./quick-capture.js";
 
@@ -13,6 +14,58 @@ type AgentActionDeps = {
   pluginId: string;
   cardOptions?: unknown;
 };
+
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-03:20 (U11 #2515 audit):
+Is the card in its workflow's PRE-IMPLEMENTATION lane — intake or hold?
+
+These gates named `triage` directly. U11 merged Todo into Planning keeping the id
+`todo` and DELETING `triage`, so on the default lineage `approvePlan` refused every
+card (an awaiting-approval card now sits in `todo`) and `retryTask`'s planning branch
+became unreachable. `startWork` survived only because it already accepted both ids —
+which is the tell: the gate written against a lane kept working, the two written
+against an id broke.
+
+Resolves the task's OWN lanes when the host store can (this plugin depends on
+`@fusion/core`), and falls back to BOTH legacy ids when it cannot. The fallback is
+not cosmetic: `PluginContext["taskStore"]` is a narrowed surface and is not
+guaranteed to expose workflow selection, so a plugin must degrade to something that
+works rather than to something that refuses.
+*/
+const LEGACY_PLANNING_IDS = new Set(["triage", "todo"]);
+
+async function isInPlanningLane(
+  taskStore: AgentActionDeps["taskStore"],
+  task: TaskRecord,
+): Promise<boolean> {
+  const column = String((task as { column?: unknown }).column ?? "");
+  let lanes: { intake?: string; hold?: string } | undefined;
+  try {
+    lanes = await resolveTaskLifecycleColumns(taskStore as never, String(task.id));
+  } catch {
+    /* narrowed plugin store cannot resolve a workflow */
+  }
+  if (column === lanes?.intake || column === lanes?.hold) return true;
+  /*
+  ADDITIVE, not a fallback. `resolveTaskLifecycleColumns` is TOTAL — every failure
+  path returns the default coding IR rather than throwing — so an "else legacy" branch
+  is dead code and a pre-U11 row in `triage` would simply be refused. Learned the same
+  way twice on this program: the resolver never says "I don't know".
+
+  KNOWN LIMITATION, stated rather than faked: this only resolves intake/hold, so it
+  cannot tell "the workflow does not use `triage`" from "the workflow uses `triage` as
+  its REVIEW lane". A custom workflow doing the latter would have a review-lane card
+  accepted here. I wrote a guard for that and it reduced to `&& false` — it cannot be
+  written without resolving every role, which needs a wider store surface than
+  `PluginContext["taskStore"]` exposes. Left as a limitation in the same spirit as the
+  two `Intentional v1 limitation` notes already in this file, rather than shipped as a
+  check that does nothing. Blast radius is a plugin-surface action on a workflow that
+  reuses a legacy id for a non-planning role; the engine-side equivalents (#2593,
+  #2602) do scope it, because there the whole IR is in reach.
+  */
+  return LEGACY_PLANNING_IDS.has(column);
+}
+
 
 type AgentActionResult = {
   task: TaskRecord;
@@ -50,7 +103,7 @@ async function toResult(taskStore: PluginContext["taskStore"], taskId: string): 
 export async function startWork(input: AgentActionInput, deps: AgentActionDeps): Promise<AgentActionResult> {
   const taskId = normalizeTaskId(input.taskId);
   const task = await getTaskOrThrow(deps.taskStore, taskId);
-  if ((task.column !== "triage" && task.column !== "todo") || START_WORK_BLOCKED_STATUSES.has(String(task.status))) {
+  if (!(await isInPlanningLane(deps.taskStore, task)) || START_WORK_BLOCKED_STATUSES.has(String(task.status))) {
     conflict("start-work", task);
   }
   // Intentional v1 limitation: plugin cannot import engine allocator, so moveTask runs without allocateWorktree.
@@ -71,7 +124,7 @@ export async function requestReview(input: AgentActionInput, deps: AgentActionDe
 export async function approvePlan(input: AgentActionInput, deps: AgentActionDeps): Promise<AgentActionResult> {
   const taskId = normalizeTaskId(input.taskId);
   const task = await getTaskOrThrow(deps.taskStore, taskId);
-  if (task.column !== "triage" || task.status !== "awaiting-approval") {
+  if (!(await isInPlanningLane(deps.taskStore, task)) || task.status !== "awaiting-approval") {
     conflict("approve-plan", task);
   }
   await deps.taskStore.moveTask(taskId, "todo");
@@ -114,7 +167,7 @@ export async function retryTask(input: AgentActionInput, deps: AgentActionDeps):
   }
 
   if (
-    task.column === "triage" &&
+    (await isInPlanningLane(deps.taskStore, task)) &&
     (RETRYABLE_TRIAGE_STATUSES.has(String(task.status)) || (typeof task.stuckKillCount === "number" && task.stuckKillCount > 0))
   ) {
     // Intentional v1 limitation: does not delete on-disk PROMPT.md or run dashboard step-reset/branch-inspection logic.

--- a/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
@@ -129,7 +129,24 @@ function destination(
   const resolved = lanes?.[role];
   if (resolved) return resolved;
   const legacy = LEGACY_DESTINATIONS[role];
-  return declared.has(legacy) ? legacy : undefined;
+  if (!declared.has(legacy)) return undefined;
+  /*
+  FNXC:PluginLifecycleColumns 2026-07-30-19:20 (PR #2607 review — fourth finding, and the FOURTH
+  time I have made this mistake in this file):
+  "DECLARED SOMEWHERE" IS NOT "DECLARED FOR THIS ROLE". `declared` is every column id the workflow
+  has, so a board that declares no hold column but names its REVIEW lane `todo` satisfied
+  `declared.has("todo")` — and `approvePlan` then moved an approved plan straight into REVIEW,
+  skipping implementation entirely. That is worse than the refusal it replaced.
+
+  A legacy id may only stand in for a role the workflow leaves EMPTY. If the workflow has assigned
+  that id to a different lifecycle role, it means something else on this board and is not available
+  as a fallback. A LEGACY ID IS NOT A ROLE — the same sentence as the gate fix, in the destination
+  direction, which is where I keep failing to apply it.
+  */
+  const assignedElsewhere = Object.entries(lanes ?? {}).some(
+    ([laneRole, laneColumn]) => laneRole !== role && laneColumn === legacy,
+  );
+  return assignedElsewhere ? undefined : legacy;
 }
 
 

--- a/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
@@ -106,47 +106,33 @@ function isInPlanningLane(lanes: Lanes | undefined, column: string, declared: Se
 }
 
 /**
- * A move target from the resolved role.
+ * A move target for `role`, or `undefined` when this workflow has no such lane.
  *
- * FNXC:PluginLifecycleColumns 2026-07-30-07:10 (PR #2607 review, second P1 — greptile):
- * Returns `undefined` rather than substituting a legacy id the workflow DOES NOT
- * DECLARE. The previous version fell back unconditionally, so a valid custom workflow
- * that simply omits the role had `moveTask` called with `todo`/`in-progress` — a column
- * that does not exist on that board. The action then either threw or parked the card
- * somewhere nothing renders it, which is the R7 failure this whole conversion removes,
- * reintroduced by the fallback meant to be conservative.
+ * FNXC:PluginLifecycleColumns 2026-07-30-21:40 (PR #2607 review — FIFTH finding, same rule):
+ * THE LEGACY ID IS NOT A CANDIDATE AT ALL once the workflow speaks columns. Every previous
+ * revision tried to qualify the fallback — "declared", then "declared and not assigned to another
+ * role" — and each qualification left a hole review found: first an aliased review lane named
+ * `todo`, then a TRAITLESS parking column named `todo`, which no role check can see because it
+ * carries no role.
  *
- * The legacy id is used only when the workflow genuinely DECLARES it, which is the
- * migration case (a pre-U11 board still carrying `todo`). Otherwise the caller must
- * refuse — an action with nowhere legitimate to move the card has not been configured
- * for this workflow, and saying so beats guessing.
+ * The qualifications were the mistake. If `resolveLanes` returned a lane set, the workflow HAS a
+ * column vocabulary, so "no column carries the hold trait" is a complete answer: there is nowhere
+ * legitimate to send the card and the action must refuse. A column merely NAMED `todo` implements
+ * nothing.
+ *
+ * The legacy id survives in exactly one case — `lanes` is undefined, meaning the workflow could not
+ * be resolved at all. There is no basis to decide then, and a pre-U11 board really does use these
+ * ids, so refusing would break the migration this program is mid-way through.
+ *
+ * Five attempts at one rule, so it is worth stating plainly: A LEGACY ID IS NOT A ROLE, and
+ * "declared" is not "declared FOR THIS ROLE" — including when it is declared for no role at all.
  */
 function destination(
   lanes: Lanes | undefined,
   role: keyof typeof LEGACY_DESTINATIONS,
-  declared: Set<string>,
 ): string | undefined {
-  const resolved = lanes?.[role];
-  if (resolved) return resolved;
-  const legacy = LEGACY_DESTINATIONS[role];
-  if (!declared.has(legacy)) return undefined;
-  /*
-  FNXC:PluginLifecycleColumns 2026-07-30-19:20 (PR #2607 review — fourth finding, and the FOURTH
-  time I have made this mistake in this file):
-  "DECLARED SOMEWHERE" IS NOT "DECLARED FOR THIS ROLE". `declared` is every column id the workflow
-  has, so a board that declares no hold column but names its REVIEW lane `todo` satisfied
-  `declared.has("todo")` — and `approvePlan` then moved an approved plan straight into REVIEW,
-  skipping implementation entirely. That is worse than the refusal it replaced.
-
-  A legacy id may only stand in for a role the workflow leaves EMPTY. If the workflow has assigned
-  that id to a different lifecycle role, it means something else on this board and is not available
-  as a fallback. A LEGACY ID IS NOT A ROLE — the same sentence as the gate fix, in the destination
-  direction, which is where I keep failing to apply it.
-  */
-  const assignedElsewhere = Object.entries(lanes ?? {}).some(
-    ([laneRole, laneColumn]) => laneRole !== role && laneColumn === legacy,
-  );
-  return assignedElsewhere ? undefined : legacy;
+  if (!lanes) return LEGACY_DESTINATIONS[role];
+  return lanes[role];
 }
 
 
@@ -207,7 +193,7 @@ export async function startWork(input: AgentActionInput, deps: AgentActionDeps):
   ) {
     conflict("start-work", task);
   }
-  const startTarget = destination(startLanes, "wip", startDeclared);
+  const startTarget = destination(startLanes, "wip");
   if (!startTarget) conflict("start-work", task);
   // Intentional v1 limitation: plugin cannot import engine allocator, so moveTask runs without allocateWorktree.
   await deps.taskStore.moveTask(taskId, startTarget);
@@ -234,7 +220,7 @@ export async function approvePlan(input: AgentActionInput, deps: AgentActionDeps
   ) {
     conflict("approve-plan", task);
   }
-  const approveTarget = destination(approveLanes, "hold", approveDeclared);
+  const approveTarget = destination(approveLanes, "hold");
   if (!approveTarget) conflict("approve-plan", task);
   await deps.taskStore.moveTask(taskId, approveTarget);
   await deps.taskStore.updateTask(taskId, { status: undefined });

--- a/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
@@ -1,5 +1,5 @@
 import type { PluginContext } from "@fusion/plugin-sdk";
-import { resolveTaskLifecycleColumns } from "@fusion/core";
+import { resolveTaskLifecycleColumns, resolveWorkflowIrForTask } from "@fusion/core";
 import { taskToCard, type GlassesCard } from "./cards.js";
 import { GlassesInputError } from "./quick-capture.js";
 
@@ -63,9 +63,30 @@ async function resolveLanes(
   }
 }
 
-/** Every column id the workflow assigns to a role. */
-function declaredIds(lanes?: Lanes): Set<string> {
-  return new Set(Object.values(lanes ?? {}).filter((v): v is string => typeof v === "string"));
+/**
+ * Every column id the workflow DECLARES.
+ *
+ * FNXC:PluginLifecycleColumns 2026-07-30-07:10 (PR #2607 review, second P1):
+ * Read from the IR, not from the six resolved roles. A column whose traits map to no
+ * role is invisible to a role-only set — which is how a workflow declaring an inert
+ * column named `todo` had it claimed as a planning lane. The previous revision noted
+ * that as a limitation; the IR is reachable from here, so it is closed instead.
+ */
+async function declaredColumnIds(
+  taskStore: AgentActionDeps["taskStore"],
+  taskId: string,
+  lanes: Lanes | undefined,
+): Promise<Set<string>> {
+  const ids = new Set(Object.values(lanes ?? {}).filter((v): v is string => typeof v === "string"));
+  try {
+    const ir = await resolveWorkflowIrForTask(taskStore as never, taskId);
+    for (const c of (ir as { columns?: Array<{ id?: unknown }> }).columns ?? []) {
+      if (typeof c?.id === "string") ids.add(c.id);
+    }
+  } catch {
+    /* narrowed store cannot resolve — role ids are all we have */
+  }
+  return ids;
 }
 
 /**
@@ -79,17 +100,52 @@ function declaredIds(lanes?: Lanes): Set<string> {
  * lane set, which is why `resolveLanes` returns all of it rather than intake/hold only;
  * the earlier version could not express this and said so as a known limitation.
  */
-function isInPlanningLane(lanes: Lanes | undefined, column: string): boolean {
+function isInPlanningLane(lanes: Lanes | undefined, column: string, declared: Set<string>): boolean {
   if (column === lanes?.intake || column === lanes?.hold) return true;
-  return LEGACY_PLANNING_IDS.has(column) && !declaredIds(lanes).has(column);
+  return LEGACY_PLANNING_IDS.has(column) && !declared.has(column);
 }
 
-/** A move target from the resolved role, falling back to the legacy id ONLY when the
- *  workflow declares no such role — never over a column it assigned elsewhere. */
-function destination(lanes: Lanes | undefined, role: keyof typeof LEGACY_DESTINATIONS): string {
-  return lanes?.[role] ?? LEGACY_DESTINATIONS[role];
+/**
+ * A move target from the resolved role.
+ *
+ * FNXC:PluginLifecycleColumns 2026-07-30-07:10 (PR #2607 review, second P1 — greptile):
+ * Returns `undefined` rather than substituting a legacy id the workflow DOES NOT
+ * DECLARE. The previous version fell back unconditionally, so a valid custom workflow
+ * that simply omits the role had `moveTask` called with `todo`/`in-progress` — a column
+ * that does not exist on that board. The action then either threw or parked the card
+ * somewhere nothing renders it, which is the R7 failure this whole conversion removes,
+ * reintroduced by the fallback meant to be conservative.
+ *
+ * The legacy id is used only when the workflow genuinely DECLARES it, which is the
+ * migration case (a pre-U11 board still carrying `todo`). Otherwise the caller must
+ * refuse — an action with nowhere legitimate to move the card has not been configured
+ * for this workflow, and saying so beats guessing.
+ */
+function destination(
+  lanes: Lanes | undefined,
+  role: keyof typeof LEGACY_DESTINATIONS,
+  declared: Set<string>,
+): string | undefined {
+  const resolved = lanes?.[role];
+  if (resolved) return resolved;
+  const legacy = LEGACY_DESTINATIONS[role];
+  return declared.has(legacy) ? legacy : undefined;
 }
 
+
+/**
+ * FNXC:PluginLifecycleColumns 2026-07-30-07:14: one resolve per action. Both the gate
+ * (is the card in a planning lane?) and the destination (where does it go?) need the
+ * SAME declared-column set — resolving them separately is how the two halves drifted
+ * out of agreement in the first place (PR #2607: gates converted, destinations literal).
+ */
+async function laneContext(
+  taskStore: AgentActionDeps["taskStore"],
+  taskId: string,
+): Promise<{ lanes: Lanes | undefined; declared: Set<string> }> {
+  const lanes = await resolveLanes(taskStore, taskId);
+  return { lanes, declared: await declaredColumnIds(taskStore, taskId, lanes) };
+}
 
 type AgentActionResult = {
   task: TaskRecord;
@@ -127,12 +183,17 @@ async function toResult(taskStore: PluginContext["taskStore"], taskId: string): 
 export async function startWork(input: AgentActionInput, deps: AgentActionDeps): Promise<AgentActionResult> {
   const taskId = normalizeTaskId(input.taskId);
   const task = await getTaskOrThrow(deps.taskStore, taskId);
-  const startLanes = await resolveLanes(deps.taskStore, taskId);
-  if (!isInPlanningLane(startLanes, String(task.column)) || START_WORK_BLOCKED_STATUSES.has(String(task.status))) {
+  const { lanes: startLanes, declared: startDeclared } = await laneContext(deps.taskStore, taskId);
+  if (
+    !isInPlanningLane(startLanes, String(task.column), startDeclared)
+    || START_WORK_BLOCKED_STATUSES.has(String(task.status))
+  ) {
     conflict("start-work", task);
   }
+  const startTarget = destination(startLanes, "wip", startDeclared);
+  if (!startTarget) conflict("start-work", task);
   // Intentional v1 limitation: plugin cannot import engine allocator, so moveTask runs without allocateWorktree.
-  await deps.taskStore.moveTask(taskId, destination(startLanes, "wip"));
+  await deps.taskStore.moveTask(taskId, startTarget);
   return toResult(deps.taskStore, taskId);
 }
 
@@ -149,11 +210,16 @@ export async function requestReview(input: AgentActionInput, deps: AgentActionDe
 export async function approvePlan(input: AgentActionInput, deps: AgentActionDeps): Promise<AgentActionResult> {
   const taskId = normalizeTaskId(input.taskId);
   const task = await getTaskOrThrow(deps.taskStore, taskId);
-  const approveLanes = await resolveLanes(deps.taskStore, taskId);
-  if (!isInPlanningLane(approveLanes, String(task.column)) || task.status !== "awaiting-approval") {
+  const { lanes: approveLanes, declared: approveDeclared } = await laneContext(deps.taskStore, taskId);
+  if (
+    !isInPlanningLane(approveLanes, String(task.column), approveDeclared)
+    || task.status !== "awaiting-approval"
+  ) {
     conflict("approve-plan", task);
   }
-  await deps.taskStore.moveTask(taskId, destination(approveLanes, "hold"));
+  const approveTarget = destination(approveLanes, "hold", approveDeclared);
+  if (!approveTarget) conflict("approve-plan", task);
+  await deps.taskStore.moveTask(taskId, approveTarget);
   await deps.taskStore.updateTask(taskId, { status: undefined });
   return toResult(deps.taskStore, taskId);
 }
@@ -192,9 +258,9 @@ export async function retryTask(input: AgentActionInput, deps: AgentActionDeps):
     return toResult(deps.taskStore, taskId);
   }
 
-  const retryLanes = await resolveLanes(deps.taskStore, taskId);
+  const { lanes: retryLanes, declared: retryDeclared } = await laneContext(deps.taskStore, taskId);
   if (
-    isInPlanningLane(retryLanes, String(task.column)) &&
+    isInPlanningLane(retryLanes, String(task.column), retryDeclared) &&
     (RETRYABLE_TRIAGE_STATUSES.has(String(task.status)) || (typeof task.stuckKillCount === "number" && task.stuckKillCount > 0))
   ) {
     // Intentional v1 limitation: does not delete on-disk PROMPT.md or run dashboard step-reset/branch-inspection logic.

--- a/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/agent-actions.ts
@@ -34,36 +34,60 @@ works rather than to something that refuses.
 */
 const LEGACY_PLANNING_IDS = new Set(["triage", "todo"]);
 
-async function isInPlanningLane(
-  taskStore: AgentActionDeps["taskStore"],
-  task: TaskRecord,
-): Promise<boolean> {
-  const column = String((task as { column?: unknown }).column ?? "");
-  let lanes: { intake?: string; hold?: string } | undefined;
-  try {
-    lanes = await resolveTaskLifecycleColumns(taskStore as never, String(task.id));
-  } catch {
-    /* narrowed plugin store cannot resolve a workflow */
-  }
-  if (column === lanes?.intake || column === lanes?.hold) return true;
-  /*
-  ADDITIVE, not a fallback. `resolveTaskLifecycleColumns` is TOTAL — every failure
-  path returns the default coding IR rather than throwing — so an "else legacy" branch
-  is dead code and a pre-U11 row in `triage` would simply be refused. Learned the same
-  way twice on this program: the resolver never says "I don't know".
+/** Legacy destination ids, used only when the workflow declares no such role. */
+const LEGACY_DESTINATIONS = { hold: "todo", wip: "in-progress", review: "in-review" } as const;
 
-  KNOWN LIMITATION, stated rather than faked: this only resolves intake/hold, so it
-  cannot tell "the workflow does not use `triage`" from "the workflow uses `triage` as
-  its REVIEW lane". A custom workflow doing the latter would have a review-lane card
-  accepted here. I wrote a guard for that and it reduced to `&& false` — it cannot be
-  written without resolving every role, which needs a wider store surface than
-  `PluginContext["taskStore"]` exposes. Left as a limitation in the same spirit as the
-  two `Intentional v1 limitation` notes already in this file, rather than shipped as a
-  check that does nothing. Blast radius is a plugin-surface action on a workflow that
-  reuses a legacy id for a non-planning role; the engine-side equivalents (#2593,
-  #2602) do scope it, because there the whole IR is in reach.
-  */
-  return LEGACY_PLANNING_IDS.has(column);
+type Lanes = {
+  intake?: string; hold?: string; wip?: string; review?: string; complete?: string; archived?: string;
+};
+
+/**
+ * FNXC:PluginLifecycleColumns 2026-07-30-05:10 (PR #2607 review — greptile P1 x2):
+ * Resolve the task's lanes ONCE per action, so gates AND destinations come from the
+ * same answer.
+ *
+ * The first version resolved only the GATES and left `moveTask` pointing at
+ * `in-progress` / `todo` literally. On a renamed workflow that is worse than the bug
+ * it replaced: the gate now admits the card and then moves it into a column the
+ * workflow does not declare (R7). Half a conversion moved the failure from "refuses
+ * valid work" to "puts work somewhere nothing renders it".
+ */
+async function resolveLanes(
+  taskStore: AgentActionDeps["taskStore"],
+  taskId: string,
+): Promise<Lanes | undefined> {
+  try {
+    return await resolveTaskLifecycleColumns(taskStore as never, taskId) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Every column id the workflow assigns to a role. */
+function declaredIds(lanes?: Lanes): Set<string> {
+  return new Set(Object.values(lanes ?? {}).filter((v): v is string => typeof v === "string"));
+}
+
+/**
+ * FNXC:PluginLifecycleColumns 2026-07-30-05:10 (PR #2607 review — greptile P1):
+ * Is the card in its workflow's PRE-IMPLEMENTATION lane?
+ *
+ * The legacy acceptance is SCOPED: a legacy id counts only when the workflow does not
+ * assign it to ANY role. Unscoped, a workflow that names its review or wip lane
+ * `triage`/`todo` would have those cards authorized as planning work — greptile's
+ * finding, and the same over-reach caught on #2593 and #2602. Scoping needs the whole
+ * lane set, which is why `resolveLanes` returns all of it rather than intake/hold only;
+ * the earlier version could not express this and said so as a known limitation.
+ */
+function isInPlanningLane(lanes: Lanes | undefined, column: string): boolean {
+  if (column === lanes?.intake || column === lanes?.hold) return true;
+  return LEGACY_PLANNING_IDS.has(column) && !declaredIds(lanes).has(column);
+}
+
+/** A move target from the resolved role, falling back to the legacy id ONLY when the
+ *  workflow declares no such role — never over a column it assigned elsewhere. */
+function destination(lanes: Lanes | undefined, role: keyof typeof LEGACY_DESTINATIONS): string {
+  return lanes?.[role] ?? LEGACY_DESTINATIONS[role];
 }
 
 
@@ -103,11 +127,12 @@ async function toResult(taskStore: PluginContext["taskStore"], taskId: string): 
 export async function startWork(input: AgentActionInput, deps: AgentActionDeps): Promise<AgentActionResult> {
   const taskId = normalizeTaskId(input.taskId);
   const task = await getTaskOrThrow(deps.taskStore, taskId);
-  if (!(await isInPlanningLane(deps.taskStore, task)) || START_WORK_BLOCKED_STATUSES.has(String(task.status))) {
+  const startLanes = await resolveLanes(deps.taskStore, taskId);
+  if (!isInPlanningLane(startLanes, String(task.column)) || START_WORK_BLOCKED_STATUSES.has(String(task.status))) {
     conflict("start-work", task);
   }
   // Intentional v1 limitation: plugin cannot import engine allocator, so moveTask runs without allocateWorktree.
-  await deps.taskStore.moveTask(taskId, "in-progress");
+  await deps.taskStore.moveTask(taskId, destination(startLanes, "wip"));
   return toResult(deps.taskStore, taskId);
 }
 
@@ -124,10 +149,11 @@ export async function requestReview(input: AgentActionInput, deps: AgentActionDe
 export async function approvePlan(input: AgentActionInput, deps: AgentActionDeps): Promise<AgentActionResult> {
   const taskId = normalizeTaskId(input.taskId);
   const task = await getTaskOrThrow(deps.taskStore, taskId);
-  if (!(await isInPlanningLane(deps.taskStore, task)) || task.status !== "awaiting-approval") {
+  const approveLanes = await resolveLanes(deps.taskStore, taskId);
+  if (!isInPlanningLane(approveLanes, String(task.column)) || task.status !== "awaiting-approval") {
     conflict("approve-plan", task);
   }
-  await deps.taskStore.moveTask(taskId, "todo");
+  await deps.taskStore.moveTask(taskId, destination(approveLanes, "hold"));
   await deps.taskStore.updateTask(taskId, { status: undefined });
   return toResult(deps.taskStore, taskId);
 }
@@ -166,8 +192,9 @@ export async function retryTask(input: AgentActionInput, deps: AgentActionDeps):
     return toResult(deps.taskStore, taskId);
   }
 
+  const retryLanes = await resolveLanes(deps.taskStore, taskId);
   if (
-    (await isInPlanningLane(deps.taskStore, task)) &&
+    isInPlanningLane(retryLanes, String(task.column)) &&
     (RETRYABLE_TRIAGE_STATUSES.has(String(task.status)) || (typeof task.stuckKillCount === "number" && task.stuckKillCount > 0))
   ) {
     // Intentional v1 limitation: does not delete on-disk PROMPT.md or run dashboard step-reset/branch-inspection logic.

--- a/plugins/fusion-plugin-even-realities-glasses/src/quick-capture.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/quick-capture.ts
@@ -1,4 +1,5 @@
 import type { PluginContext } from "@fusion/plugin-sdk";
+import { resolveDefaultWorkflowIr } from "@fusion/core";
 import { taskToCard, type GlassesCard } from "./cards.js";
 import type { TaskColumn } from "./settings.js";
 
@@ -78,10 +79,49 @@ export function parseUtterance(raw: unknown, opts: { maxTitleChars?: number } = 
   return splitTitleAndDescription(stripped, opts);
 }
 
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-13:10 (Phase C convergence — quick capture):
+
+THE ACCEPTED COLUMNS ARE THE BOARD'S, not a hand-listed five. The old list was wrong in BOTH
+directions after U11 (#2515):
+
+  - it ACCEPTED `triage`, a column the default board no longer declares, so quick capture
+    happily forwarded it and the create failed at the server — at the far end of a voice
+    interaction, where the operator hears a generic failure;
+  - it REJECTED every column of a renamed or custom board, so an operator saying "put it in
+    checking" got a 400 for a column their own board declares.
+
+Resolved from `resolveDefaultWorkflowIr()`, which is the same default the dashboard's own
+board-workflows payload reports (`DEFAULT_WORKFLOW_LANE_ID`). Deliberately NOT a per-task
+resolution: the task does not exist yet, so there is no selection to resolve through.
+
+CORRECTION to what I wrote on PR #2607: I described this as SILENT substitution. It is not —
+`runQuickCapture` already compares the normalized value against the request and throws 400 on a
+mismatch, so an unusable column was visibly rejected, not quietly swapped. The bug is a wrong
+accept/reject set, which is milder than I claimed.
+*/
+function declaredCaptureColumnIds(): ReadonlySet<string> {
+  try {
+    const ir = resolveDefaultWorkflowIr() as { columns?: Array<{ id?: unknown }> };
+    const ids = (ir.columns ?? [])
+      .map((column) => column?.id)
+      .filter((id): id is string => typeof id === "string");
+    if (ids.length > 0) return new Set(ids);
+  } catch {
+    /* fall through to the legacy vocabulary */
+  }
+  /* A column-less IR gives no basis to decide; the legacy five keep prior behavior. */
+  return LEGACY_CAPTURE_COLUMN_IDS;
+}
+
+const LEGACY_CAPTURE_COLUMN_IDS: ReadonlySet<string> = new Set([
+  "triage", "todo", "in-progress", "in-review", "done",
+]);
+
 function normalizeCaptureColumn(value: unknown, fallback: TaskColumn): TaskColumn {
   const raw = normalizeDescription(value);
-  if (raw === "triage" || raw === "todo" || raw === "in-progress" || raw === "in-review" || raw === "done") {
-    return raw;
+  if (raw && declaredCaptureColumnIds().has(raw)) {
+    return raw as TaskColumn;
   }
   return fallback;
 }

--- a/plugins/fusion-plugin-even-realities-glasses/src/settings.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/settings.ts
@@ -4,7 +4,27 @@ const DEFAULT_BASE_URL = "http://localhost:4040";
 const DEFAULT_POLLING_INTERVAL_SECONDS = 30;
 const MIN_POLLING_INTERVAL_SECONDS = 5;
 const DEFAULT_NOTIFY_COLUMNS = ["in-review"];
-const DEFAULT_QUICK_CAPTURE_COLUMN = "triage";
+/*
+FNXC:PluginLifecycleColumns 2026-07-30-11:30 (Phase C convergence):
+The quick-capture default was `triage` — the column U11 (#2515) DELETED from the default
+lineage. So every voice-captured card asked the server for a column the default board no
+longer declares. `todo` is the post-U11 merged planning column AND a column every pre-U11
+lineage also declares, so it is correct on both sides of the migration; `triage` was correct
+on neither after #2515.
+
+NOT trait-resolved, deliberately: this is a SETTINGS DEFAULT with no task and no workflow in
+hand — there is nothing to resolve against at module scope. The operator picks the real
+column from `enumValues`; this only has to be a column that exists when they have not.
+
+KNOWN REMAINING GAP, recorded rather than half-fixed: `TaskColumn`/`COLUMN_SET` are still the
+five legacy ids, so on a RENAMED board the enum offers columns that do not exist and
+`normalizeCaptureColumn` silently substitutes the default for a column the operator did name
+(voice "put it in checking" lands in planning, with no error). Closing that needs the board's
+declared columns, and this plugin reaches Fusion over HTTP with no board-columns endpoint in
+`FusionApiClient` — a new read, not a rename. Silent substitution is the worse half of that
+bug and it is unchanged here; I am not papering over it with a guess.
+*/
+const DEFAULT_QUICK_CAPTURE_COLUMN = "todo";
 
 type TaskColumn = "triage" | "todo" | "in-progress" | "in-review" | "done";
 


### PR DESCRIPTION
> **Taking `plugins/`** — announced in the title per the collision protocol. Based on `main`, no dependencies. `plugins/` is in no unit's file list and no drift-review assignment; the #2587 ratchet now scans it, which is how these surfaced.

## Guard counts

| Scope | Before | After |
|---|---:|---:|
| `plugins/` | **4** | **0** |
| repo-wide `column === / !== "triage"` | 29 | **25** |

## What broke — and the asymmetry is the whole argument

| Gate | Post-#2515 behavior |
|---|---|
| `approvePlan` | **refused every default-lineage card.** An awaiting-approval card sits in `todo` now; the gate demanded `triage`, so the operator's approve action failed with a conflict on a valid card |
| `retryTask` | planning-lane branch **unreachable** — a stuck or needs-replan card could not be retried from that surface at all |
| `GraphTaskNode` | `isAwaitingApproval` permanently false, so the node stopped showing the state **and** fell through to `isActive` — rendering a card blocked on a human as if it were running |
| `startWork` | **survived**, because it already accepted `todo` as well as `triage` |

One gate written against a **lane** kept working; three written against an **id** broke. That is the conversion's rationale demonstrated inside a single file.

## Additive, not "resolved else legacy" — I got this wrong first

`resolveTaskLifecycleColumns` is **total**: every failure path returns the default coding IR rather than throwing. So an `else legacy` branch is dead code, and a pre-U11 row in `triage` is simply refused. **Third time this program has taught me the resolver never says "I don't know."**

## A limitation stated rather than faked

The plugin can only resolve intake/hold, so it cannot distinguish *"the workflow does not use `triage`"* from *"the workflow uses `triage` as its **review** lane"*. I wrote a guard for that and **it reduced to `&& false`** — it cannot be written without resolving every role, which needs a wider surface than `PluginContext["taskStore"]` exposes.

Left as a documented limitation, in the same spirit as the two existing `Intentional v1 limitation` notes in that file, rather than shipped as a check that does nothing. The engine-side equivalents (#2593, #2602) *do* scope it, because there the whole IR is in reach.

## The graph node: deleted, not converted

The column condition was always redundant — `awaiting-approval` is written only by the plan-approval gate and the replan-cap park, both acting on a card in the planning lane, so the status alone is the signal. Deletion is also the only option needing no resolution, since that is a synchronous React render.

## No red-green for the graph node, and I am not pretending otherwise

Its three test files **cannot run on clean main**:

```
Error: Failed to resolve import "@fusion/core/task-delete-attribution"
       from "../../packages/dashboard/app/api/client.ts"
```

Verified pre-existing by stashing my changes and re-running. **`GraphTaskNode` currently has no executable coverage** — that is separate debt and worth surfacing on its own; it also means the ratchet-style "does it fail when reverted" check is unavailable for that one site.

The glasses sites **are** red-green proven: 2 of 24 failing pre-fix, exactly `approvePlan` and `retryTask`, with `startWork` passing as the control.

## Verification

| Check | Result |
|---|---|
| glasses plugin (18 files) | 137/137 |
| glasses `tsc --noEmit` | clean |
| `pnpm lint` | clean |
| `pnpm test:gate` | green (482 + 10 + 71) |
| dependency-graph tests | **unrunnable on main** (pre-existing import failure, above) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow actions now adapt to each workflow’s configured lanes when starting work, approving plans, and retrying tasks.
  * Task moves use workflow-declared destinations and avoid unavailable or outdated columns.
  * Legacy lane IDs remain supported only when explicitly declared by the workflow.
* **Bug Fixes**
  * Updated quick-capture defaults and invalid-setting fallback from **Triage** to **Todo**.
  * Improved approval-state detection to rely on status-based gating.
  * Prevented tasks from being moved to nonexistent destination columns (including better conflict behavior when lanes are missing).
* **Tests**
  * Added regression coverage for lane-aware gating, destination resolution, and quick-capture column validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->