### PR TITLE
triage census — engine/mission-feature-sync.ts: rollback resolves the planner lane by trait (1 site, literal retained with cause)

### DIFF
--- a/packages/engine/src/__tests__/mission-feature-sync.test.ts
+++ b/packages/engine/src/__tests__/mission-feature-sync.test.ts
@@ -26,3 +26,57 @@ describe("reconcileMissionFeatureState", () => {
     await expect(reconcileMissionFeatureState(taskStore, { id: "FN-1", column: "todo", status: "failed", error: "BLOCKED" } as never, { id: "F-1", status: "triaged" } as never)).resolves.toMatchObject({ kind: "failure" });
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-08:50 (triage-guard census):
+"The task went back to a pre-implementation lane" is a lifecycle ROLE. Naming `triage`/`todo`
+literally meant a workflow that renames either one stopped rolling its mission feature back — the
+feature stayed `in-progress` while the task was queued for re-planning, so the roadmap reported
+work in flight that nobody was doing. Silent, and only visible to whoever reads the mission board.
+*/
+describe("mission feature rollback resolves the planner lane from the task's workflow", () => {
+  const WF = "custom:renamed";
+  const renamedIr = {
+    version: "v2",
+    id: WF,
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "inbox", label: "Inbox", traits: [{ trait: "intake" }] },
+      { id: "drafting", label: "Drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "building", label: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "shipped", label: "Shipped", traits: [{ trait: "complete" }] },
+    ],
+  };
+  const renamedStore = {
+    getTask: async () => undefined,
+    getTaskWorkflowSelection: () => ({ workflowId: WF, stepIds: [] }),
+    getTaskWorkflowSelectionAsync: async () => ({ workflowId: WF, stepIds: [] }),
+    getWorkflowDefinition: async () => ({ id: WF, ir: renamedIr }),
+  } as never;
+
+  it("rolls back for a RENAMED hold column", async () => {
+    await expect(reconcileMissionFeatureState(
+      renamedStore,
+      { id: "FN-1", column: "drafting" } as never,
+      { id: "F-1", status: "in-progress" } as never,
+    )).resolves.toMatchObject({ kind: "update", status: "triaged" });
+  });
+
+  it("rolls back for a RENAMED intake column", async () => {
+    await expect(reconcileMissionFeatureState(
+      renamedStore,
+      { id: "FN-1", column: "inbox" } as never,
+      { id: "F-1", status: "in-progress" } as never,
+    )).resolves.toMatchObject({ kind: "update", status: "triaged" });
+  });
+
+  it("does NOT roll back from that workflow's implementation column", async () => {
+    /* The guard must stay narrow — rolling back mid-implementation would erase real progress. */
+    await expect(reconcileMissionFeatureState(
+      renamedStore,
+      { id: "FN-1", column: "building" } as never,
+      { id: "F-1", status: "in-progress" } as never,
+    )).resolves.toMatchObject({ kind: "noop" });
+  });
+});

--- a/packages/engine/src/__tests__/mission-feature-sync.test.ts
+++ b/packages/engine/src/__tests__/mission-feature-sync.test.ts
@@ -80,3 +80,49 @@ describe("mission feature rollback resolves the planner lane from the task's wor
     )).resolves.toMatchObject({ kind: "noop" });
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-11:25 (PR #2609 review — greptile):
+Both directions of over-inclusion erase roadmap state, so both are pinned.
+*/
+describe("mission feature rollback does not over-claim lanes", () => {
+  const WF = "custom:roles";
+  const store = (columns: unknown[]) => ({
+    getTask: async () => undefined,
+    getTaskWorkflowSelection: () => ({ workflowId: WF, stepIds: [] }),
+    getTaskWorkflowSelectionAsync: async () => ({ workflowId: WF, stepIds: [] }),
+    getWorkflowDefinition: async () => ({ id: WF, ir: { version: "v2", id: WF, nodes: [], edges: [], columns } }),
+  }) as never;
+
+  it("does NOT roll back from a MID-PIPELINE hold column", async () => {
+    /* `hold` is not a synonym for planning: this one is a manual wait AFTER implementation. */
+    const s = store([
+      { id: "inbox", traits: [{ trait: "intake" }] },
+      { id: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "awaiting-signoff", traits: [{ trait: "hold", config: { release: "manual" } }] },
+      { id: "shipped", traits: [{ trait: "complete" }] },
+    ]);
+    await expect(reconcileMissionFeatureState(s, { id: "FN-1", column: "awaiting-signoff" } as never, { id: "F-1", status: "in-progress" } as never))
+      .resolves.toMatchObject({ kind: "noop" });
+  });
+
+  it("does NOT treat a legacy id the workflow uses for IMPLEMENTATION as pre-implementation", async () => {
+    /* A workflow may legitimately name its wip column `todo`; the compat arm must yield to it. */
+    const s = store([
+      { id: "inbox", traits: [{ trait: "intake" }] },
+      { id: "todo", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "shipped", traits: [{ trait: "complete" }] },
+    ]);
+    await expect(reconcileMissionFeatureState(s, { id: "FN-1", column: "todo" } as never, { id: "F-1", status: "in-progress" } as never))
+      .resolves.toMatchObject({ kind: "noop" });
+  });
+
+  it("still rolls back from a legacy id the workflow does not claim", async () => {
+    const s = store([
+      { id: "inbox", traits: [{ trait: "intake" }] },
+      { id: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    ]);
+    await expect(reconcileMissionFeatureState(s, { id: "FN-1", column: "triage" } as never, { id: "F-1", status: "in-progress" } as never))
+      .resolves.toMatchObject({ kind: "update", status: "triaged" });
+  });
+});

--- a/packages/engine/src/mission-feature-sync.ts
+++ b/packages/engine/src/mission-feature-sync.ts
@@ -1,5 +1,5 @@
 import type { MissionFeature, Task, TaskStore } from "@fusion/core";
-import { resolveTaskLifecycleColumns } from "@fusion/core";
+import { resolveLifecycleColumns, resolveWorkflowIrForTask } from "@fusion/core";
 import { getTaskCompletionBlockerForStore } from "./task-completion.js";
 
 export type MissionFeatureSyncTargetStatus = "done" | "in-progress" | "triaged";
@@ -24,26 +24,46 @@ async function resolvePreImplementationColumns(
   task: Task,
 ): Promise<ReadonlySet<string>> {
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-30-08:45 (triage-guard census — why this entry stays open):
-  The legacy pair is UNIONED with the resolved lanes, not replaced by them, and that is a
-  deliberate stop short of the census goal rather than an oversight.
+  FNXC:WorkflowLifecycleColumns 2026-07-30-11:20 (triage-guard census; PR #2609 review — greptile):
+  INTAKE, plus the legacy ids ONLY where the workflow does not use them for something else.
 
-  A store that cannot name the task's workflow resolves to the default builtin, whose merged
-  Planning lane is `todo` alone — so replacing the pair would silently stop rolling back a card
-  sitting in `triage` under `builtin:legacy-coding`, which still declares that column. The failure
-  is invisible in the worst way: the mission feature stays `in-progress` while the task is queued
-  for re-planning, so the roadmap reports work in flight that nobody is doing.
+  Two corrections, both from review, both cases where a wider set silently erases roadmap state:
 
-  Union fixes the real defect — a RENAMED planner column now rolls the feature back where before
-  it did not — without regressing legacy. Closing the entry properly needs this function to know
-  whether a resolution is a real selection or a default guess, which is a resolver change, not a
-  call-site change.
+  - `hold` is NOT pre-implementation. A workflow may carry the trait on a mid-pipeline capacity or
+    manual-release wait; a card parked there is downstream of implementation, and rolling its
+    feature back to `triaged` erases work that really happened. (Same mistake I had already fixed
+    in the usage-limit lane — worth stating rather than quietly repeating.)
+  - The legacy union must not OVERRIDE a workflow's own roles. A custom workflow is free to name
+    its implementation or completion column `todo`, and unconditionally treating that id as
+    pre-implementation would reset an active feature mid-flight.
+
+  The legacy ids survive only as compat for a workflow that does not claim them, which is what a
+  `{ getTask }`-only store resolving to the default builtin needs: post-merge the default declares
+  `todo` as its Planning lane and no `triage` at all, so `builtin:legacy-coding` cards would
+  otherwise stop rolling back.
   */
-  const legacy = ["triage", "todo"];
-  const columns = await resolveTaskLifecycleColumns(taskStore as never, task.id).catch(() => undefined);
-  const lanes = new Set<string>(legacy);
+  const ir = await resolveWorkflowIrForTask(taskStore as never, task.id).catch(() => undefined);
+  const columns = ir ? resolveLifecycleColumns(ir) : undefined;
+  const order = (ir && "columns" in ir ? ir.columns ?? [] : []).map((column: { id: string }) => column.id);
+  const lanes = new Set<string>();
   if (columns?.intake) lanes.add(columns.intake);
-  if (columns?.hold) lanes.add(columns.hold);
+  /*
+  A hold column is pre-implementation only when it sits BEFORE the implementation column in the
+  workflow's declared order — `ir.columns` is ordered and that order IS the lifecycle order (see
+  the graph entry contract). That is what separates a planning queue from a mid-pipeline wait:
+  both carry `hold`, and the trait alone cannot tell them apart.
+  */
+  if (columns?.hold) {
+    const holdIndex = order.indexOf(columns.hold);
+    const wipIndex = columns.wip ? order.indexOf(columns.wip) : -1;
+    if (holdIndex !== -1 && (wipIndex === -1 || holdIndex < wipIndex)) lanes.add(columns.hold);
+  }
+  const claimedElsewhere = new Set(
+    [columns?.wip, columns?.review, columns?.complete, columns?.archived].filter((id): id is string => typeof id === "string"),
+  );
+  for (const legacyId of ["triage", "todo"]) {
+    if (!claimedElsewhere.has(legacyId)) lanes.add(legacyId);
+  }
   return lanes;
 }
 

--- a/packages/engine/src/mission-feature-sync.ts
+++ b/packages/engine/src/mission-feature-sync.ts
@@ -1,4 +1,5 @@
 import type { MissionFeature, Task, TaskStore } from "@fusion/core";
+import { resolveTaskLifecycleColumns } from "@fusion/core";
 import { getTaskCompletionBlockerForStore } from "./task-completion.js";
 
 export type MissionFeatureSyncTargetStatus = "done" | "in-progress" | "triaged";
@@ -13,8 +14,44 @@ export type MissionFeatureSyncDecision =
   | { kind: "update"; status: MissionFeatureSyncTargetStatus; reason: string }
   | { kind: "noop" };
 
+/**
+ * The columns a task can sit in BEFORE implementation, from its own workflow.
+ * Falls back to the legacy pair when the workflow cannot be resolved — conservative, because the
+ * cost of an empty set here is a mission feature frozen at `in-progress` forever.
+ */
+async function resolvePreImplementationColumns(
+  taskStore: MissionFeatureSyncStore,
+  task: Task,
+): Promise<ReadonlySet<string>> {
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-08:45 (triage-guard census — why this entry stays open):
+  The legacy pair is UNIONED with the resolved lanes, not replaced by them, and that is a
+  deliberate stop short of the census goal rather than an oversight.
+
+  A store that cannot name the task's workflow resolves to the default builtin, whose merged
+  Planning lane is `todo` alone — so replacing the pair would silently stop rolling back a card
+  sitting in `triage` under `builtin:legacy-coding`, which still declares that column. The failure
+  is invisible in the worst way: the mission feature stays `in-progress` while the task is queued
+  for re-planning, so the roadmap reports work in flight that nobody is doing.
+
+  Union fixes the real defect — a RENAMED planner column now rolls the feature back where before
+  it did not — without regressing legacy. Closing the entry properly needs this function to know
+  whether a resolution is a real selection or a default guess, which is a resolver change, not a
+  call-site change.
+  */
+  const legacy = ["triage", "todo"];
+  const columns = await resolveTaskLifecycleColumns(taskStore as never, task.id).catch(() => undefined);
+  const lanes = new Set<string>(legacy);
+  if (columns?.intake) lanes.add(columns.intake);
+  if (columns?.hold) lanes.add(columns.hold);
+  return lanes;
+}
+
+export type MissionFeatureSyncStore = Pick<TaskStore, "getTask">
+  & Partial<Pick<TaskStore, "getTaskWorkflowSelection" | "getTaskWorkflowSelectionAsync" | "getWorkflowDefinition">>;
+
 export async function reconcileMissionFeatureState(
-  taskStore: Pick<TaskStore, "getTask">,
+  taskStore: MissionFeatureSyncStore,
   task: Task,
   feature: Pick<MissionFeature, "id" | "status" | "lastValidatorStatus">,
   context: MissionFeatureSyncContext = {},
@@ -85,10 +122,21 @@ export async function reconcileMissionFeatureState(
     };
   }
 
-  if (
-    (task.column === "triage" || task.column === "todo")
-    && feature.status === "in-progress"
-  ) {
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-08:20 (triage-guard census):
+  "The task went BACK to a pre-implementation lane" is a lifecycle ROLE, not a pair of column
+  ids. Naming `triage`/`todo` literally means a workflow that renames either one stops rolling
+  its mission feature back — the feature stays `in-progress` while the task is queued for
+  re-planning, so the roadmap reports work in flight that nobody is doing. Silent, and only
+  visible to whoever reads the mission board.
+
+  Resolved by trait (intake or hold) from the task's OWN workflow. When the workflow cannot be
+  resolved the legacy pair is kept, so an unreadable workflow behaves exactly as before rather
+  than freezing the feature. Note the `triaged` STATUS below is a mission-feature status, not a
+  column id, and is deliberately untouched.
+  */
+  const preImplementationColumns = await resolvePreImplementationColumns(taskStore, task);
+  if (preImplementationColumns.has(task.column) && feature.status === "in-progress") {
     return {
       kind: "update",
       status: "triaged",


### PR DESCRIPTION
Taking `packages/engine/src/mission-feature-sync.ts` from the shared triage-guard backlog.

## Per-file guard count

| File | Before | After |
|---|---:|---:|
| `packages/engine/src/mission-feature-sync.ts` | 1 | **1** (behaviour fixed; literal retained — see below) |

## The defect

`(task.column === "triage" || task.column === "todo") && feature.status === "in-progress"` decides that a task has gone **back** to a pre-implementation lane and rolls its mission feature from `in-progress` to `triaged`.

That is a lifecycle **role**, not a pair of ids. Under a workflow that renames either column the guard stops matching, so the feature stays `in-progress` while the task sits queued for re-planning — **the roadmap reports work in flight that nobody is doing.** Silent, and only visible to whoever reads the mission board rather than the task board.

Fixed: the lane is resolved from the task's own workflow (intake or hold).

## Why the literal is still there, and why that is not laziness

The resolved set is **unioned** with the legacy pair rather than replacing it. A store that cannot name the task's workflow resolves to the default builtin, whose merged Planning lane is `todo` alone — so replacing the pair would silently stop rolling back a card in `triage` under `builtin:legacy-coding`, which still declares that column. That trades a guard that misses renamed workflows for one that misses legacy ones, which is not progress.

I found this the direct way: the existing test asserts `column: "triage"` rolls back with a `{ getTask }`-only store, and the replace-version turned it red. That test is correct, so the code changed rather than the assertion.

**Closing this entry needs a resolver-level change** — `resolveTaskLifecycleColumns` cannot currently tell a caller whether it resolved a real selection or fell back to the default guess. Every call site that must preserve legacy-column behaviour will hit the same wall, so it is worth fixing once in the resolver rather than five times at call sites. Flagging it as shared-backlog work rather than doing it inside a single-file conversion.

## Red-green

With the literal-only set restored, **both renamed cases fail** (`Tests 2 failed | 4 passed`): renamed hold (`drafting`) and renamed intake (`inbox`). The third new case is the regression floor — that workflow's implementation column (`building`) must **not** roll back, since doing so would erase real progress; "any non-wip column" would have been the easy wrong fix here too.

## Verification

- `mission-feature-sync` 6 tests green; scheduler cutover suite green
- `pnpm test:gate` green; `pnpm lint` clean; `tsc --noEmit` clean
- Engine-internal decision function, no user-facing behaviour change on the default workflow, so no changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)