### PR TITLE
Phase B — TAKING task-creation.ts: intake classification by trait (4 sites → 0)

### DIFF
--- a/packages/core/src/__tests__/store-create-intake-column.test.ts
+++ b/packages/core/src/__tests__/store-create-intake-column.test.ts
@@ -259,6 +259,40 @@ pgTest("createTask intake-column wiring (Coding (Ideas))", () => {
     expect(prompt).toBe(buildBootstrapPrompt(task.id, task.title, task.description));
   });
 
+  /*
+  FNXC:MergedPlanningColumn 2026-07-30-13:10 (PR #2613 review — greptile):
+  `isUnplannedStartCreate` must stay narrow. My conversion replaced `&& task.column === "todo"`
+  with "any column other than intake", which on a MANUAL-intake workflow classified a direct create
+  into `in-review` (or `done`) as an unplanned quick-add Start — handing it a bootstrap stub instead
+  of a specified prompt. Quick-add Start lands the card in the workflow's PLANNING column, so the
+  narrowing belongs on the hold column, resolved from the IR rather than named.
+  */
+  it("does not treat an Ideas create into a REVIEW column as an unplanned Start create", async () => {
+    const store = h.store();
+    const task = await store.createTask({
+      description: "direct ideas create past planning",
+      workflowId: "builtin:coding-ideas",
+      column: "in-review",
+    });
+    expect(task.column).toBe("in-review");
+    const prompt = await readFile(join(store.getTasksDir(), task.id, "PROMPT.md"), "utf-8");
+    expect(prompt).not.toBe(buildBootstrapPrompt(task.id, task.title, task.description));
+  });
+
+  it("still treats an Ideas quick-add Start create into the planning column as unplanned", async () => {
+    // The case `isUnplannedStartCreate` exists for (FN-8587): create+promote in one request, so the
+    // card never sat in the manual intake but has no spec.
+    const store = h.store();
+    const task = await store.createTask({
+      description: "ideas quick-add start",
+      workflowId: "builtin:coding-ideas",
+      column: "todo",
+    });
+    expect(task.column).toBe("todo");
+    const prompt = await readFile(join(store.getTasksDir(), task.id, "PROMPT.md"), "utf-8");
+    expect(prompt).toBe(buildBootstrapPrompt(task.id, task.title, task.description));
+  });
+
   it("keeps generateSpecifiedPrompt for a direct create into a NON-intake column", async () => {
     // The contract the old test was really protecting — an explicit column past intake is a
     // specified create, not an unplanned one.

--- a/packages/core/src/__tests__/store-create-intake-column.test.ts
+++ b/packages/core/src/__tests__/store-create-intake-column.test.ts
@@ -231,24 +231,44 @@ pgTest("createTask intake-column wiring (Coding (Ideas))", () => {
     expect(prompt).not.toContain("## Steps");
   });
 
-  it("keeps generateSpecifiedPrompt for a direct create into todo (not bootstrap)", async () => {
+  /*
+  FNXC:MergedPlanningColumn 2026-07-30-10:45 (Phase B — task-creation.ts conversion):
+  EXPECTATION INVERTED BY THE MERGE, deliberately.
+
+  This asserted "a direct create into `todo` is NOT an intake create, so it keeps
+  generateSpecifiedPrompt". That was true while the default workflow's intake was `triage`. U11
+  merged Todo into Planning, so `todo` IS the default's intake column — and a card created there
+  with no spec MUST get the bootstrap seed, because triage admits a card for planning only when its
+  PROMPT.md reads as a seed. Keeping the old expectation would pin the FN-8587 stall: a boilerplate
+  spec that reads as "already planned" and is never planned.
+
+  The old behavior survived only by accident of resolution failing: the harness has no persisted
+  default-workflow row, so `resolvedEntryColumn` was undefined and the sole remaining clause was the
+  literal `task.column === "triage"`. Removing that literal is what surfaced it — which is the point
+  of the conversion.
+
+  Renamed and re-pointed rather than deleted: the case it still guards is that an EXPLICIT column on
+  a create is honoured and classified against the workflow's own intake, not silently overridden.
+  */
+  it("treats a direct create into the default workflow's intake column as an intake create", async () => {
     const store = h.store();
-    const task = await store.createTask({ description: "direct todo create", column: "todo" });
+    const task = await store.createTask({ description: "direct intake create", column: "todo" });
     expect(task.column).toBe("todo");
-    const prompt = await readFile(
-      join(h.rootDir(), ".fusion", "tasks", task.id, "PROMPT.md"),
-      "utf-8",
-    );
-    // A direct todo create is NOT an intake column, so it must NOT get the bootstrap stub.
-    expect(prompt).not.toBe(`# ${task.id}\n\n${task.description}\n`);
-    // FNXC:OriginalDescriptionInPrompt 2026-07-14-23:35:
-    // Non-AI specified prompts must surface the operator description near the top.
+    const prompt = await readFile(join(store.getTasksDir(), task.id, "PROMPT.md"), "utf-8");
+    // `todo` is the merged Planning column and therefore the intake column: bootstrap seed.
+    expect(prompt).toBe(buildBootstrapPrompt(task.id, task.title, task.description));
+  });
+
+  it("keeps generateSpecifiedPrompt for a direct create into a NON-intake column", async () => {
+    // The contract the old test was really protecting — an explicit column past intake is a
+    // specified create, not an unplanned one.
+    const store = h.store();
+    const task = await store.createTask({ description: "direct wip create", column: "in-progress" });
+    expect(task.column).toBe("in-progress");
+    const prompt = await readFile(join(store.getTasksDir(), task.id, "PROMPT.md"), "utf-8");
+    expect(prompt).not.toBe(buildBootstrapPrompt(task.id, task.title, task.description));
     expect(prompt).toContain("## Original Description");
-    expect(prompt).toContain("direct todo create");
-    const originalIdx = prompt.indexOf("## Original Description");
-    const missionIdx = prompt.indexOf("## Mission");
-    expect(originalIdx).toBeGreaterThan(-1);
-    expect(missionIdx).toBeGreaterThan(originalIdx);
+    expect(prompt).toContain("direct wip create");
   });
 
   /*

--- a/packages/core/src/__tests__/store-reservation-atomicity.test.ts
+++ b/packages/core/src/__tests__/store-reservation-atomicity.test.ts
@@ -132,7 +132,19 @@ pgTest("FN-7074 task-create reservation atomicity", () => {
       "# Bad prompt\n\n## File Scope\n\n- `origin/fusion/fn-4280`\n";
 
     try {
-      await expect(store.createTask({ description: "bad scope", column: "todo" })).rejects.toBeInstanceOf(InvalidFileScopeError);
+      /*
+      FNXC:MergedPlanningColumn 2026-07-30-11:00 (Phase B — task-creation.ts conversion):
+      Column is now `in-progress`, not `todo`. This test stubs `generateSpecifiedPrompt` to inject a
+      bad `## File Scope`, so it needs a create that actually CALLS that generator. Post-U11 `todo`
+      is the default workflow's INTAKE column, so a create there gets the bootstrap seed instead —
+      and bootstrap intake prompts deliberately skip the file-scope hard-fail, because their body is
+      freeform operator prose where a stray `## File Scope` token is not a real declaration.
+
+      The invariant under test is RESERVATION ROLLBACK when validation throws, not which column the
+      card lands in — so the create is moved to a non-intake column where validation still runs. Using
+      an intake column here would have made the test vacuous: no throw, no rollback exercised.
+      */
+      await expect(store.createTask({ description: "bad scope", column: "in-progress" })).rejects.toBeInstanceOf(InvalidFileScopeError);
     } finally {
       store.generateSpecifiedPrompt = originalGenerate;
     }

--- a/packages/core/src/task-store/task-creation.ts
+++ b/packages/core/src/task-store/task-creation.ts
@@ -81,6 +81,40 @@ column carries `intake`. It must not call `materializeDefaultWorkflowSteps`, whi
 rows the caller explicitly opted out of by supplying its own `enabledWorkflowSteps`.
 Unresolvable workflow returns undefined and the caller keeps its existing legacy fallback.
 */
+/*
+FNXC:MergedPlanningColumn 2026-07-30-10:20 (Phase B — task-creation.ts to zero column literals):
+The two facts intake classification actually needs, resolved from the IR instead of compared against
+`"triage"`:
+
+  intake   — which column this workflow intakes into
+  manual   — whether that intake carries `autoTriage: false`, i.e. an operator must promote the card
+
+`manual` is what the `!== "triage"` comparison was really reaching for. It distinguished
+"manual-intake workflow" (Coding (Ideas)) from "the legacy default" by naming the default's column
+id — which stops meaning anything once the default's intake IS `todo`. The trait config states it
+directly and survives any rename or merge.
+
+Unresolvable workflow returns `{ manual: false }` with no intake, so callers keep their existing
+conservative behavior rather than acting on a guess.
+*/
+async function resolveWorkflowIntakeFacts(
+  store: TaskStore,
+  workflowIdOverride?: string,
+): Promise<{ intake?: string; manual: boolean }> {
+  try {
+    const workflowId = workflowIdOverride ?? (await store.getDefaultWorkflowId()) ?? DEFAULT_WORKFLOW_ID;
+    const ir = await resolveWorkflowIrById(store, workflowId);
+    const intake = columnsWithFlag(ir, "intake")[0];
+    if (!intake) return { manual: false };
+    const declared = (ir as { columns?: Array<{ id: string; traits?: Array<{ trait: string; config?: Record<string, unknown> }> }> })
+      .columns?.find((column) => column.id === intake);
+    const intakeTrait = declared?.traits?.find((trait) => trait.trait === "intake");
+    return { intake, manual: intakeTrait?.config?.autoTriage === false };
+  } catch {
+    return { manual: false };
+  }
+}
+
 async function resolveDefaultWorkflowIntakeColumn(store: TaskStore): Promise<string | undefined> {
   try {
     /*
@@ -378,6 +412,10 @@ export async function _createTaskInternalBackendImpl(store: TaskStore, input: Ta
     const fallbackIntakeColumn = (input.column || options?.resolvedEntryColumn || input.workflowId === null)
       ? undefined
       : await resolveDefaultWorkflowIntakeColumn(store);
+    /* Intake column + whether that intake is MANUAL (autoTriage:false), resolved from the IR. */
+    const intakeFacts = input.workflowId === null
+      ? { manual: false as boolean, intake: undefined as string | undefined }
+      : await resolveWorkflowIntakeFacts(store, input.workflowId ?? undefined);
     const declaredSymbols = resolveCreateDeclaredSymbols(input, options?.promptOverride);
     const task: Task = {
       id,
@@ -516,9 +554,22 @@ export async function _createTaskInternalBackendImpl(store: TaskStore, input: Ta
       plan-in-place `todo` column, so the pinned contract for a plain direct create into todo on the
       default workflow — which intentionally keeps generateSpecifiedPrompt — is untouched.
       */
-      const isUnplannedStartCreate = options?.resolvedEntryColumn !== undefined
-        && options.resolvedEntryColumn !== "triage"
-        && task.column === "todo";
+      /*
+      FNXC:MergedPlanningColumn 2026-07-30-10:25 (Phase B — task-creation.ts to zero column literals):
+      Was `resolvedEntryColumn !== "triage"` — naming the DEFAULT workflow's intake id to mean "this
+      workflow has a MANUAL intake". Post-U11 the default's intake IS `todo`, so that comparison
+      became vacuously true for the default workflow and the guard stopped distinguishing the two
+      shapes it exists to separate.
+
+      The real fact is the intake trait's `autoTriage: false`, and the real shape is "the card landed
+      PAST its workflow's manual intake" — which is what quick-add Start does by submitting the
+      workflow id and the post-intake column together. Both now come from the IR, so the pinned
+      contract for a plain direct create on a default (auto-triage) workflow is preserved by the
+      `manual` test rather than by an id coincidence.
+      */
+      const isUnplannedStartCreate = intakeFacts.manual
+        && intakeFacts.intake !== undefined
+        && task.column !== intakeFacts.intake;
       /*
       FNXC:MergedPlanningColumn 2026-07-29-14:50 (U11 post-merge audit):
       `fallbackIntakeColumn` must be honoured here too. Without it the card lands in the resolved
@@ -527,7 +578,15 @@ export async function _createTaskInternalBackendImpl(store: TaskStore, input: Ta
       reads as a seed, so it would sit in Planning already looking "planned". That is FN-8587's
       failure mode, reached by a different route.
       */
-      const isIntakeColumn = task.column === "triage"
+      /*
+      FNXC:MergedPlanningColumn 2026-07-30-10:25 (Phase B):
+      The leading `task.column === "triage"` was the last-resort clause for a card whose workflow
+      could not be resolved. `intakeFacts.intake` covers that properly — it falls back to
+      DEFAULT_WORKFLOW_ID rather than to a bare id — so the literal is gone and an explicit
+      `column: "triage"` create on a workflow that still declares `triage` is matched through the
+      resolved intake rather than a coincidence of naming.
+      */
+      const isIntakeColumn = (intakeFacts.intake !== undefined && task.column === intakeFacts.intake)
         || (options?.resolvedEntryColumn !== undefined && task.column === options.resolvedEntryColumn)
         || (fallbackIntakeColumn !== undefined && task.column === fallbackIntakeColumn)
         || isUnplannedStartCreate;
@@ -821,6 +880,10 @@ export async function _createTaskInternalImpl(store: TaskStore, input: TaskCreat
     const fallbackIntakeColumn = (input.column || options?.resolvedEntryColumn || input.workflowId === null)
       ? undefined
       : await resolveDefaultWorkflowIntakeColumn(store);
+    /* Intake column + whether that intake is MANUAL (autoTriage:false), resolved from the IR. */
+    const intakeFacts = input.workflowId === null
+      ? { manual: false as boolean, intake: undefined as string | undefined }
+      : await resolveWorkflowIntakeFacts(store, input.workflowId ?? undefined);
     const declaredSymbols = resolveCreateDeclaredSymbols(input, options?.promptOverride);
     const task: Task = {
       id,
@@ -917,9 +980,22 @@ export async function _createTaskInternalImpl(store: TaskStore, input: TaskCreat
     one request, so the card is unplanned despite not landing in the intake column. See the fuller
     rationale there; keeping both copies in step is the whole point (this pair has drifted before).
     */
-    const isUnplannedStartCreate = options?.resolvedEntryColumn !== undefined
-      && options.resolvedEntryColumn !== "triage"
-      && task.column === "todo";
+    /*
+      FNXC:MergedPlanningColumn 2026-07-30-10:25 (Phase B — task-creation.ts to zero column literals):
+      Was `resolvedEntryColumn !== "triage"` — naming the DEFAULT workflow's intake id to mean "this
+      workflow has a MANUAL intake". Post-U11 the default's intake IS `todo`, so that comparison
+      became vacuously true for the default workflow and the guard stopped distinguishing the two
+      shapes it exists to separate.
+
+      The real fact is the intake trait's `autoTriage: false`, and the real shape is "the card landed
+      PAST its workflow's manual intake" — which is what quick-add Start does by submitting the
+      workflow id and the post-intake column together. Both now come from the IR, so the pinned
+      contract for a plain direct create on a default (auto-triage) workflow is preserved by the
+      `manual` test rather than by an id coincidence.
+      */
+    const isUnplannedStartCreate = intakeFacts.manual
+      && intakeFacts.intake !== undefined
+      && task.column !== intakeFacts.intake;
     /*
     FNXC:MergedPlanningColumn 2026-07-29-17:15 (PR #2589 review — greptile):
     `fallbackIntakeColumn` must appear here, not only in the `column:` assignment above. Otherwise
@@ -935,7 +1011,15 @@ export async function _createTaskInternalImpl(store: TaskStore, input: TaskCreat
     one predicate that disagree, where the backend copy needed exactly this clause. A direct
     `_createTaskInternal` call — which the signature invites — would hit it.
     */
-    const isIntakeColumn = task.column === "triage"
+    /*
+    FNXC:MergedPlanningColumn 2026-07-30-10:25 (Phase B):
+    The leading `task.column === "triage"` was the last-resort clause for a card whose workflow
+    could not be resolved. `intakeFacts.intake` covers that properly — it falls back to
+    DEFAULT_WORKFLOW_ID rather than to a bare id — so the literal is gone and an explicit
+    `column: "triage"` create on a workflow that still declares `triage` is matched through the
+    resolved intake rather than a coincidence of naming.
+    */
+    const isIntakeColumn = (intakeFacts.intake !== undefined && task.column === intakeFacts.intake)
       || (options?.resolvedEntryColumn !== undefined && task.column === options.resolvedEntryColumn)
       || (fallbackIntakeColumn !== undefined && task.column === fallbackIntakeColumn)
       || isUnplannedStartCreate;

--- a/packages/core/src/task-store/task-creation.ts
+++ b/packages/core/src/task-store/task-creation.ts
@@ -100,16 +100,19 @@ conservative behavior rather than acting on a guess.
 async function resolveWorkflowIntakeFacts(
   store: TaskStore,
   workflowIdOverride?: string,
-): Promise<{ intake?: string; manual: boolean }> {
+): Promise<{ intake?: string; hold?: string; manual: boolean }> {
   try {
     const workflowId = workflowIdOverride ?? (await store.getDefaultWorkflowId()) ?? DEFAULT_WORKFLOW_ID;
     const ir = await resolveWorkflowIrById(store, workflowId);
     const intake = columnsWithFlag(ir, "intake")[0];
-    if (!intake) return { manual: false };
+    // The PLANNING column a quick-add Start create lands in — the workflow's hold column, which for
+    // a merged Planning lane is the same column as intake and is then excluded by the `!==` below.
+    const hold = columnsWithFlag(ir, "hold")[0];
+    if (!intake) return { hold, manual: false };
     const declared = (ir as { columns?: Array<{ id: string; traits?: Array<{ trait: string; config?: Record<string, unknown> }> }> })
       .columns?.find((column) => column.id === intake);
     const intakeTrait = declared?.traits?.find((trait) => trait.trait === "intake");
-    return { intake, manual: intakeTrait?.config?.autoTriage === false };
+    return { intake, hold, manual: intakeTrait?.config?.autoTriage === false };
   } catch {
     return { manual: false };
   }
@@ -414,7 +417,7 @@ export async function _createTaskInternalBackendImpl(store: TaskStore, input: Ta
       : await resolveDefaultWorkflowIntakeColumn(store);
     /* Intake column + whether that intake is MANUAL (autoTriage:false), resolved from the IR. */
     const intakeFacts = input.workflowId === null
-      ? { manual: false as boolean, intake: undefined as string | undefined }
+      ? { manual: false as boolean, intake: undefined as string | undefined, hold: undefined as string | undefined }
       : await resolveWorkflowIntakeFacts(store, input.workflowId ?? undefined);
     const declaredSymbols = resolveCreateDeclaredSymbols(input, options?.promptOverride);
     const task: Task = {
@@ -569,7 +572,9 @@ export async function _createTaskInternalBackendImpl(store: TaskStore, input: Ta
       */
       const isUnplannedStartCreate = intakeFacts.manual
         && intakeFacts.intake !== undefined
-        && task.column !== intakeFacts.intake;
+        && intakeFacts.hold !== undefined
+        && task.column !== intakeFacts.intake
+        && task.column === intakeFacts.hold;
       /*
       FNXC:MergedPlanningColumn 2026-07-29-14:50 (U11 post-merge audit):
       `fallbackIntakeColumn` must be honoured here too. Without it the card lands in the resolved
@@ -882,7 +887,7 @@ export async function _createTaskInternalImpl(store: TaskStore, input: TaskCreat
       : await resolveDefaultWorkflowIntakeColumn(store);
     /* Intake column + whether that intake is MANUAL (autoTriage:false), resolved from the IR. */
     const intakeFacts = input.workflowId === null
-      ? { manual: false as boolean, intake: undefined as string | undefined }
+      ? { manual: false as boolean, intake: undefined as string | undefined, hold: undefined as string | undefined }
       : await resolveWorkflowIntakeFacts(store, input.workflowId ?? undefined);
     const declaredSymbols = resolveCreateDeclaredSymbols(input, options?.promptOverride);
     const task: Task = {
@@ -995,7 +1000,9 @@ export async function _createTaskInternalImpl(store: TaskStore, input: TaskCreat
       */
     const isUnplannedStartCreate = intakeFacts.manual
       && intakeFacts.intake !== undefined
-      && task.column !== intakeFacts.intake;
+      && intakeFacts.hold !== undefined
+      && task.column !== intakeFacts.intake
+      && task.column === intakeFacts.hold;
     /*
     FNXC:MergedPlanningColumn 2026-07-29-17:15 (PR #2589 review — greptile):
     `fallbackIntakeColumn` must appear here, not only in the `column:` assignment above. Otherwise


### PR DESCRIPTION
**Taking:** `packages/core/src/task-store/task-creation.ts`

| file | guards before | after |
|---|---:|---:|
| `packages/core/src/task-store/task-creation.ts` | **4** | **0** |

(4 remaining pattern matches in that file are inside the new explanatory comments, not code.)

## What the literals meant, and why they had stopped meaning it

```
resolvedEntryColumn !== "triage"   ×2   "this workflow has a MANUAL intake"
task.column === "triage"           ×2   "created into the intake column"
```

The first named the **default workflow's intake id** to express *"not the default workflow"*. Post-U11 the default's intake **is** `todo`, so the comparison became vacuously true for the default workflow and the guard stopped separating the two shapes it exists to separate. The real fact is the intake trait's `autoTriage: false`, which `resolveWorkflowIntakeFacts` now reads from the IR alongside the intake column id.

The second was the last-resort clause for a card whose workflow could not be resolved. `intakeFacts.intake` covers that properly — it falls back to `DEFAULT_WORKFLOW_ID` rather than to a bare id — so an explicit `column: "triage"` create on a workflow that still declares `triage` (R11) is matched through the *resolved* intake instead of a coincidence of naming.

`isUnplannedStartCreate` is also restated in terms of what it actually detects — *"the card landed past its workflow's manual intake"*, which is what quick-add Start does by submitting the workflow id and the post-intake column together. That replaces `&& task.column === "todo"`, another id standing in for a relationship.

## Two expectations the conversion legitimately inverted

Both read before changing, neither retargeted blindly.

**1. *"keeps generateSpecifiedPrompt for a direct create into todo (not bootstrap)"***

`todo` **is** the default's intake now, so a card created there with no spec **must** get the bootstrap seed — triage admits a card for planning only when its `PROMPT.md` reads as a seed. Keeping the old expectation would have pinned the FN-8587 stall: a boilerplate spec that reads as "already planned" and is never planned.

The old behaviour survived only by **accident of resolution failing** in the harness, which left the `=== "triage"` literal as the sole deciding clause. Removing that literal is what surfaced it — which is the point of the conversion. Split into two tests so the contract it was really protecting (an explicit **non**-intake column stays a specified create) keeps its own case.

**2. `store-reservation-atomicity`'s file-scope rollback test**

It stubs `generateSpecifiedPrompt` to inject a bad `## File Scope`, so it needs a create that actually **calls** that generator. A `todo` create now gets the bootstrap seed instead, and bootstrap intake prompts deliberately skip the file-scope hard-fail because their body is freeform operator prose where a stray `## File Scope` token is not a real declaration.

Moved to a non-intake column so validation still runs. Left as-is the test would have been **vacuous** — no throw, no rollback exercised — while still reporting green.

## Verification

Core package vs the 47-failure post-merge main baseline: **47 failed — zero new.**

Two files reported failures in the wide run and pass in isolation (`create-task-reserved-id` 4/4, `schema-applier` 75/75) — the known contention pattern in this suite; re-run before attributing.

Gate **482 + 10 + 71** green. Lint and core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)