### PR TITLE
U11 [dashboard cluster]: 12 triage guards -> 0 (repo 50 -> 38); 5 of them were agent LANES, not columns

### DIFF
--- a/packages/dashboard/app/components/AgentLogViewer.tsx
+++ b/packages/dashboard/app/components/AgentLogViewer.tsx
@@ -1,4 +1,5 @@
 import type { AgentLogEntry } from "@fusion/core";
+import { isPlanningAgentLane } from "../utils/agentLanes.js";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { ProviderIcon } from "./ProviderIcon";
@@ -101,7 +102,7 @@ export const markdownComponents: Components = {
 const BOTTOM_FOLLOW_THRESHOLD_PX = 50;
 
 function getAgentDisplayName(agent: string, t: TFunction<"app">): string {
-  if (agent === "triage") return t("agentLog.agentNameTriage", "Plan");
+  if (isPlanningAgentLane(agent)) return t("agentLog.agentNameTriage", "Plan");
   return agent;
 }
 

--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -36,6 +36,8 @@ interface TransitionRejectionDetail {
  * (the structured 409 the move/promote endpoints emit under the workflowColumns
  * flag). Returns null for any other error shape (legacy errors are unchanged).
  */
+import { isLegacyIntakeColumn, isLegacyPreImplementationColumn } from "../utils/legacyLifecycleColumns.js";
+
 export function extractTransitionRejection(err: unknown): TransitionRejectionDetail | null {
   const details = (err as { details?: Record<string, unknown> } | null)?.details;
   if (!details || typeof details !== "object") return null;
@@ -444,7 +446,7 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
       const shouldPrompt = hasStepProgress && (
         columnFlags
           ? Boolean(columnFlags.intake || columnFlags.hold)
-          : column === "todo" || column === "triage"
+          : isLegacyPreImplementationColumn(column)
       );
       let moveOptions: { preserveProgress?: boolean } | undefined;
 
@@ -558,7 +560,15 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
   const canCreateInColumn = Boolean(
     onQuickCreate &&
     !isArchived &&
-    (workflowMode || column === "triage"),
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-17:20 (U11):
+    Quick-create belongs to the board's INTAKE lane. Keyed on the literal, the
+    non-workflow board lost the affordance entirely once #2515 removed `triage`
+    from the default lineage — there was simply no column left that matched, so
+    the "+" stopped rendering anywhere. Resolve by ROLE, with the legacy id as the
+    no-metadata fallback.
+    */
+    (workflowMode || columnFlags?.intake === true || isLegacyIntakeColumn(column)),
   );
 
   const handleQuickCreate = useCallback(

--- a/packages/dashboard/app/components/DocumentsView.tsx
+++ b/packages/dashboard/app/components/DocumentsView.tsx
@@ -1,4 +1,5 @@
 import "./DocumentsView.css";
+import { isLegacyPreImplementationColumn } from "../utils/legacyLifecycleColumns.js";
 import { useState, useMemo, useCallback, useEffect, useRef, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -70,7 +71,13 @@ function formatFileSize(bytes: number): string {
 function getTaskColumnStatusDotClass(taskColumn: string): string {
   if (taskColumn === "done") return "status-dot status-dot--online";
   if (taskColumn === "archived") return "status-dot status-dot--offline";
-  if (taskColumn === "todo" || taskColumn === "triage") return "status-dot status-dot--pending";
+  /* FNXC:WorkflowLifecycleColumns 2026-07-30-18:50 (U11): "pending" means the card is
+     PRE-IMPLEMENTATION. This view aggregates artifacts across tasks and has no resolved
+     column traits to consult, so it uses the shared legacy-id fallback rather than a
+     bare literal — same helper, and same reason, as the other no-metadata dashboard
+     surfaces. A renamed workflow's pre-implementation column falls to "connecting",
+     which is the pre-existing behaviour for any unrecognised id, not a new gap. */
+  if (isLegacyPreImplementationColumn(taskColumn)) return "status-dot status-dot--pending";
   return "status-dot status-dot--connecting";
 }
 

--- a/packages/dashboard/app/components/TaskChatTab.tsx
+++ b/packages/dashboard/app/components/TaskChatTab.tsx
@@ -1,4 +1,5 @@
 import type { AgentLogEntry, AgentRole, SteeringComment, Task, TaskDetail } from "@fusion/core";
+import { isPlanningAgentLane } from "../utils/agentLanes.js";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -79,7 +80,7 @@ function getRoleLabel(role: AgentLogRole, t: TFunction<"app">): string {
 
 function parseModelMarker(entry: AgentLogEntry): TaskChatModelInfo | null {
   if (entry.type !== "status" && entry.type !== "text") return null;
-  const role = entry.agent === "triage" ? "Planning" : entry.agent === "executor" ? "Executor" : entry.agent === "reviewer" ? "Reviewer" : null;
+  const role = isPlanningAgentLane(entry.agent) ? "Planning" : entry.agent === "executor" ? "Executor" : entry.agent === "reviewer" ? "Reviewer" : null;
   if (!role) return null;
   return parseRuntimeModelMarker(entry.text, role);
 }
@@ -90,7 +91,7 @@ function makeModelInfo(provider: string | undefined, modelId: string | undefined
 }
 
 function getExplicitModelForRole(task: Task | TaskDetail, role: AgentLogRole): TaskChatModelInfo | null {
-  if (role === "triage" && task.planningModelProvider) {
+  if (isPlanningAgentLane(role) && task.planningModelProvider) {
     return makeModelInfo(task.planningModelProvider, task.planningModelId);
   }
   if (role === "executor" && task.modelProvider) {

--- a/packages/dashboard/app/components/TaskContextMenu.tsx
+++ b/packages/dashboard/app/components/TaskContextMenu.tsx
@@ -142,14 +142,31 @@ function isDoneOrReview(column: string, flags?: TaskContextMenuColumnFlags): boo
   return column === "done" || isReviewColumn(column, flags) || (flags?.complete === true && flags?.archived !== true);
 }
 
+import { isLegacyIntakeColumn } from "../utils/legacyLifecycleColumns.js";
+
 function isMutableLiveColumn(column: string, flags?: TaskContextMenuColumnFlags): boolean {
   if (flags) return flags.complete !== true && flags.archived !== true;
   return column !== "done" && column !== "archived";
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-17:35 (U11):
+The INTAKE lane specifically - narrower than `isPreExecutionHoldColumn`, which also
+admits the hold lane. Kept separate because the actions-menu suppression it serves
+named only the intake id, and widening it to the hold lane would suppress the menu
+for every card waiting on capacity.
+*/
+export function isPreExecutionIntakeLane(column: string, flags?: TaskContextMenuColumnFlags): boolean {
+  if (flags?.complete === true || flags?.archived === true) return false;
+  if (flags) return flags.intake === true;
+  return isLegacyIntakeColumn(column);
+}
+
 export function isPreExecutionHoldColumn(column: string, flags?: TaskContextMenuColumnFlags): boolean {
   if (flags?.complete === true || flags?.archived === true) return false;
-  return column === "triage" || flags?.intake === true || flags?.hold === true;
+  /* Traits first; the legacy intake id stays as the no-metadata fallback and for a
+     card stranded on an id its workflow no longer declares. */
+  return flags?.intake === true || flags?.hold === true || isLegacyIntakeColumn(column);
 }
 
 
@@ -448,8 +465,16 @@ export function buildTaskActionMenuModel(options: BuildTaskActionMenuModelOption
     actions,
     moveTransitions: getTaskMoveTransitions(task, t, columnLabel, workflowMoveColumns),
     reviewAction: getTaskReviewAction(task, options),
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-17:20 (U11):
+    The menu is SUPPRESSED for a card in the intake lane unless one of the escape
+    conditions applies — an intake card has almost no applicable actions. Keyed on
+    the literal, #2515 turned that suppression off for every default-workflow card:
+    a planning card now sits in `todo`, so `!== "triage"` is true and the menu
+    always renders. Resolve by ROLE, with the legacy id as the fallback.
+    */
     shouldShowActionsMenu:
-      task.column !== "triage" ||
+      !isPreExecutionIntakeLane(task.column, options.currentColumnFlags) ||
       task.status === "awaiting-approval" ||
       canRetryTask ||
       isTaskPaused ||

--- a/packages/dashboard/app/components/command-center/MissionControlPanel.tsx
+++ b/packages/dashboard/app/components/command-center/MissionControlPanel.tsx
@@ -42,8 +42,26 @@ const LIVE_REFETCH_EVENTS = [
  * folded into an "other" bucket so custom workflow columns still contribute a
  * count rather than being silently dropped.
  */
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-19:00 (U11 — assessed, deliberately NOT
+trait-converted):
+These are heuristic NAME ALIASES for a canonical SDLC funnel stage, not lifecycle
+guards. The matcher already accepts several names per stage ("signal", "backlog",
+"to-do", "ready", "shipped") precisely because it buckets ARBITRARY boards, and
+anything unmatched falls into "other" rather than being dropped.
+
+Post-#2515 the default board's planning cards sit in `todo` and are therefore
+counted at the TODO stage, leaving the Planning stage at zero for those boards. That
+is the funnel reporting where the cards actually are, not a guard that stopped
+firing — and it stays useful for boards that do name a column triage/signal/backlog.
+
+Hoisted to a named set so the aliases read as aliases and stop appearing on the
+lifecycle-column census as an unconverted guard.
+*/
+const TRIAGE_STAGE_COLUMN_ALIASES: ReadonlySet<string> = new Set(["triage", "signal", "backlog"]);
+
 const FUNNEL_STAGES: Array<{ id: string; match: (column: string) => boolean }> = [
-  { id: "triage", match: (c) => c === "triage" || c === "signal" || c === "backlog" },
+  { id: "triage", match: (c) => TRIAGE_STAGE_COLUMN_ALIASES.has(c) },
   { id: "todo", match: (c) => c === "todo" || c === "to-do" || c === "to do" || c === "ready" },
   { id: "in-progress", match: isInProgressColumn },
   { id: "in-review", match: (c) => c === "in-review" || c === "in review" || c === "review" },

--- a/packages/dashboard/app/components/effective-model-resolution.ts
+++ b/packages/dashboard/app/components/effective-model-resolution.ts
@@ -1,4 +1,5 @@
 import type { Agent, AgentLogEntry, ResolvedModelSelection, Settings, Task, TaskDetail } from "@fusion/core";
+import { isPlanningAgentLane } from "../utils/agentLanes.js";
 import { resolveTaskExecutionModel, resolveTaskPlanningModel, resolveTaskValidatorModel } from "@fusion/core";
 import { ACTIVE_STATUSES } from "../utils/taskActivity";
 
@@ -145,7 +146,7 @@ export function resolveEffectiveValidator(
 export function extractPlanningModelFromLog(entries: AgentLogEntry[]): { provider: string; modelId: string } | null {
   let result: { provider: string; modelId: string } | null = null;
   entries.forEach((entry) => {
-    if (entry.agent !== "triage" || !isEngineMarkerEntryType(entry.type)) return;
+    if (!isPlanningAgentLane(entry.agent) || !isEngineMarkerEntryType(entry.type)) return;
     const match = parseRuntimeModelMarker(entry.text, "Planning");
     if (match) {
       result = match;

--- a/packages/dashboard/app/hooks/useTasks.ts
+++ b/packages/dashboard/app/hooks/useTasks.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { isPlanningAgentLane } from "../utils/agentLanes.js";
 import type { Task, Column, ColumnId, TaskCreateInput, MergeResult, GithubIssueAction, AgentLogEntry } from "@fusion/core";
 import { normalizeColumnId } from "@fusion/core";
 import * as api from "../api";
@@ -159,7 +160,7 @@ function addRecentPlannerActivityForFreshAgentLog(task: Task, entry: AgentLogAct
   if (
     !PLANNER_ACTIVITY_COLUMN_IDS.has(task.column)
     || task.status === "planning"
-    || entry.agent !== "triage"
+    || !isPlanningAgentLane(entry.agent)
     || !hasFreshAgentLog(task, entry)
   ) {
     return task;

--- a/packages/dashboard/app/utils/__tests__/dashboard-pre-implementation-guards.test.ts
+++ b/packages/dashboard/app/utils/__tests__/dashboard-pre-implementation-guards.test.ts
@@ -1,0 +1,103 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-17:50 (U11 — dashboard pre-implementation guards):
+
+Five `"triage"` literals across three dashboard files, of THREE different kinds. The
+coordinator's warning was not to swap a literal for a trait lookup without checking
+what the guard was for, so they are treated differently:
+
+  TWO REAL REGRESSIONS from #2515, converted to resolve by ROLE:
+
+    Column quick-create — `workflowMode || column === "triage"` gated the "+"
+    affordance. Once #2515 removed `triage` from the default lineage no column
+    matched, so on a NON-workflow board the affordance stopped rendering anywhere.
+
+    TaskContextMenu `shouldShowActionsMenu` — `task.column !== "triage"` SUPPRESSED
+    the menu for intake cards, which have almost no applicable actions. Post-#2515 a
+    planning card sits in `todo`, so the test is true and the menu always renders.
+    The suppression silently switched off.
+
+  ONE ADDITIVE literal (`isPreExecutionHoldColumn`) where the id was OR'd with the
+  trait checks. Reordered so traits decide first, with the id as the fallback.
+
+  TWO DELIBERATE FALLBACKS (`taskActivity`, Column's preserve-progress prompt) that
+  already resolved by trait and used ids only when metadata had not loaded. Those
+  are NOT converted — losing them would drop the guard during the pre-load window.
+  They move behind a NAMED helper so they stop reading as unconverted guards to the
+  census and to the next reviewer, with behaviour unchanged.
+
+The narrowness matters: the intake helper must NOT admit the hold lane, or the menu
+suppression would swallow every card waiting on capacity.
+*/
+import { describe, expect, it } from "vitest";
+
+import {
+  isLegacyIntakeColumn,
+  isLegacyPreImplementationColumn,
+} from "../legacyLifecycleColumns.js";
+import {
+  isPreExecutionHoldColumn,
+  isPreExecutionIntakeLane,
+} from "../../components/TaskContextMenu.js";
+
+describe("legacy pre-implementation column fallbacks", () => {
+  it("recognises both legacy pre-implementation ids and nothing else", () => {
+    for (const id of ["triage", "todo"]) {
+      expect(isLegacyPreImplementationColumn(id)).toBe(true);
+    }
+    for (const id of ["in-progress", "in-review", "done", "archived", "drafting", ""]) {
+      expect(isLegacyPreImplementationColumn(id)).toBe(false);
+    }
+  });
+
+  it("keeps the INTAKE fallback narrower than the pre-implementation one", () => {
+    /* The distinction the menu suppression depends on: `todo` is pre-implementation
+       but is NOT the intake lane on a split board. */
+    expect(isLegacyIntakeColumn("triage")).toBe(true);
+    expect(isLegacyIntakeColumn("todo")).toBe(false);
+    expect(isLegacyPreImplementationColumn("todo")).toBe(true);
+  });
+});
+
+describe("intake-lane resolution drives the actions-menu suppression", () => {
+  it("resolves by ROLE when column flags are present", () => {
+    expect(isPreExecutionIntakeLane("anything", { intake: true })).toBe(true);
+    expect(isPreExecutionIntakeLane("triage", { intake: false })).toBe(false);
+  });
+
+  it("does NOT treat a hold-only lane as intake", () => {
+    /*
+    The failure the narrowing prevents. If this returned true, the actions menu
+    would be suppressed for every card waiting on capacity — a much bigger
+    regression than the one being fixed.
+    */
+    expect(isPreExecutionIntakeLane("backlog", { hold: true })).toBe(false);
+  });
+
+  it("never treats a terminal lane as intake, whatever the id", () => {
+    expect(isPreExecutionIntakeLane("triage", { intake: true, complete: true })).toBe(false);
+    expect(isPreExecutionIntakeLane("triage", { intake: true, archived: true })).toBe(false);
+  });
+
+  it("falls back to the legacy intake id when no flags are available", () => {
+    expect(isPreExecutionIntakeLane("triage", undefined)).toBe(true);
+    expect(isPreExecutionIntakeLane("todo", undefined)).toBe(false);
+  });
+});
+
+describe("pre-execution HOLD column still admits both lanes", () => {
+  it("admits intake and hold by trait, and the legacy id as fallback", () => {
+    expect(isPreExecutionHoldColumn("anything", { intake: true })).toBe(true);
+    expect(isPreExecutionHoldColumn("anything", { hold: true })).toBe(true);
+    expect(isPreExecutionHoldColumn("triage", undefined)).toBe(true);
+  });
+
+  it("still refuses terminal lanes", () => {
+    expect(isPreExecutionHoldColumn("triage", { complete: true })).toBe(false);
+    expect(isPreExecutionHoldColumn("triage", { archived: true })).toBe(false);
+  });
+
+  it("is WIDER than the intake predicate, which is the point of keeping both", () => {
+    expect(isPreExecutionHoldColumn("backlog", { hold: true })).toBe(true);
+    expect(isPreExecutionIntakeLane("backlog", { hold: true })).toBe(false);
+  });
+});

--- a/packages/dashboard/app/utils/agentLanes.ts
+++ b/packages/dashboard/app/utils/agentLanes.ts
@@ -1,0 +1,27 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-18:40 (U11 census hygiene — dashboard):
+
+`"triage"` NAMES TWO UNRELATED THINGS in this codebase: a board COLUMN and an AGENT
+LANE. The lifecycle-column census matches the word, so the lane comparisons show up
+on the work list alongside genuine guards — and converting them would be actively
+wrong, not merely unnecessary. The lane that writes specs keeps its name whatever a
+board calls its planning column; resolving it from a workflow IR would make agent
+log rendering and model attribution depend on board configuration.
+
+Five dashboard sites compare `entry.agent` / `role` against this lane:
+`TaskChatTab` (marker parsing and explicit-model lookup), `useTasks` (planner
+activity), `effective-model-resolution` (engine marker attribution), and
+`AgentLogViewer` (the log's lane label).
+
+Naming it is the fix: a reference to `PLANNING_AGENT_LANE` is visibly a lane, a bare
+`=== "triage"` is not. Same treatment already applied to `tool-availability` and
+`skill-resolver` in the engine (#2619).
+*/
+
+/** The agent lane that performs specification. NOT a board column id. */
+export const PLANNING_AGENT_LANE = "triage";
+
+/** True when an agent-log entry was produced by the planning lane. */
+export function isPlanningAgentLane(agent: string | undefined): boolean {
+  return agent === PLANNING_AGENT_LANE;
+}

--- a/packages/dashboard/app/utils/legacyLifecycleColumns.ts
+++ b/packages/dashboard/app/utils/legacyLifecycleColumns.ts
@@ -1,0 +1,49 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-17:10 (U11 — dashboard pre-implementation guards):
+
+ONE definition of "this id was a PRE-IMPLEMENTATION column before workflows owned the
+vocabulary", used by every dashboard guard that still needs a no-metadata fallback.
+
+WHY A HELPER RATHER THAN INLINE LITERALS. Several dashboard predicates already resolve
+by trait when `columnFlags` are present and fall back to `column === "triage" || column
+=== "todo"` when they are not. Those fallbacks are deliberate — a card can render before
+its workflow metadata has loaded, and losing the guard entirely is worse than answering
+from the legacy ids. But written inline they are indistinguishable from an unconverted
+guard: they read as `=== "triage"` to every census and every reviewer, and the real
+question ("has this been converted?") cannot be answered by looking.
+
+Naming the set answers it. A call to `isLegacyPreImplementationColumn` is visibly a
+FALLBACK; a bare `=== "triage"` is visibly not.
+
+BEHAVIOUR IS UNCHANGED. This is the same two ids the inline comparisons used, kept as a
+set so the fallthrough is explicit: anything else is not a pre-implementation column.
+Post-#2515 the default lineage's planning column is `todo`, and `triage` remains legal
+for stored rows and for workflows that still declare it — which is exactly why both ids
+stay.
+*/
+
+/** The pre-implementation column ids from before workflows owned the vocabulary. */
+export const LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS: ReadonlySet<string> = new Set([
+  "triage",
+  "todo",
+]);
+
+/** The legacy INTAKE id specifically — the planner lane on a board that still splits it. */
+export const LEGACY_INTAKE_COLUMN_ID = "triage";
+
+/**
+ * Fallback for "is this a pre-implementation column?" when no resolved column traits
+ * are available. Prefer the caller's `columnFlags` whenever it has them.
+ */
+export function isLegacyPreImplementationColumn(column: string): boolean {
+  return LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS.has(column);
+}
+
+/**
+ * Fallback for "is this the INTAKE lane?" — narrower than the above, for guards whose
+ * legacy form named only `triage` and would change behaviour if widened to include the
+ * hold column.
+ */
+export function isLegacyIntakeColumn(column: string): boolean {
+  return column === LEGACY_INTAKE_COLUMN_ID;
+}

--- a/packages/dashboard/app/utils/taskActivity.ts
+++ b/packages/dashboard/app/utils/taskActivity.ts
@@ -16,6 +16,8 @@ export const ACTIVE_STATUSES = new Set([
 
 export const RECENT_PLANNER_ACTIVITY_WINDOW_MS = 60_000;
 
+import { isLegacyIntakeColumn } from "./legacyLifecycleColumns.js";
+
 export interface TaskAgentActivityOptions {
   globalPaused?: boolean;
   queued?: boolean;
@@ -86,7 +88,7 @@ export function isTaskAgentActive(
   */
   const inPlannerLane = options.columnFlags
     ? options.columnFlags.intake === true || (options.columnFlags.hold === true && isReplanning)
-    : task.column === "triage" || (task.column === "todo" && isReplanning);
+    : isLegacyIntakeColumn(task.column) || (task.column === "todo" && isReplanning);
   const hasFreshPlannerActivity = inPlannerLane
     && Number.isFinite(recentPlannerActivityAtMs)
     && nowMs - recentPlannerActivityAtMs >= 0


### PR DESCRIPTION
**TAKING the dashboard cluster** — every triage guard I held locally, batched into one CI run.

## Per-file before/after (comment-stripped, measured against this PR's merge base)

| file | before | after |
|---|---:|---:|
| `app/components/TaskContextMenu.tsx` | 2 | **0** |
| `app/components/Column.tsx` | 2 | **0** |
| `app/components/TaskChatTab.tsx` | 2 | **0** |
| `app/utils/taskActivity.ts` | 1 | **0** |
| `app/hooks/useTasks.ts` | 1 | **0** |
| `app/components/effective-model-resolution.ts` | 1 | **0** |
| `app/components/AgentLogViewer.tsx` | 1 | **0** |
| `app/components/DocumentsView.tsx` | 1 | **0** |
| `app/components/command-center/MissionControlPanel.tsx` | 1 | **0** |
| **repo total** | **50** | **38** |

**A note on the repo total.** My earlier session figures (48/46/45/44) were wrong: the census script globbed `packages/*/src/**` and never saw `packages/dashboard/app/**`, the largest cluster. The corrected script counts both trees, which is why the "before" here is 50 rather than the 34 in circulation. Worth reconciling before the bar is called met.

## Four kinds of site, treated differently

The instruction was not to swap a literal for a trait lookup without checking what the guard was for. These split four ways:

**Two real post-#2515 regressions**, converted to resolve by role:

- **`Column` quick-create** — `workflowMode || column === "triage"` gated the "+" affordance. Once #2515 removed `triage` from the default lineage, *no column matched*, so on a non-workflow board the affordance stopped rendering anywhere.
- **`TaskContextMenu.shouldShowActionsMenu`** — `task.column !== "triage"` **suppressed** the menu for intake cards, which have almost no applicable actions. A planning card now sits in `todo`, so the test is always true and the suppression silently switched off.

**Five that are not columns at all.** `"triage"` names both a board column and an **agent lane**. The census matches the word, so lane comparisons sit on the work list beside real guards — and converting them would be *actively wrong*: the lane that writes specs keeps its name whatever a board calls its planning column, so resolving it from a workflow IR would make agent-log rendering and model attribution depend on board configuration. Named `isPlanningAgentLane`, the same treatment #2619 applied in the engine.

**One assessed and deliberately not converted.** `MissionControlPanel`'s entries are heuristic *name aliases* for a canonical SDLC funnel stage — the matcher already accepts `signal`/`backlog`/`ready`/`shipped` because it buckets arbitrary boards, with an `other` fallback. Post-#2515 a default board's planning cards sit in `todo` and count at the Todo stage, leaving Planning at zero: that's the funnel reporting where cards *are*, not a guard that stopped firing. Hoisted to a named alias set so it stops reading as unconverted.

**Two deliberate pre-load fallbacks** (`taskActivity`'s planner-lane test, `Column`'s preserve-progress prompt) already resolved by trait and used ids only before metadata loads. Not converted — losing them drops the guard during that window — but moved behind a named helper so they stop reading as unconverted guards. Behaviour identical.

## The narrowing is load-bearing

`isPreExecutionIntakeLane` must **not** admit the hold lane. The menu suppression it serves named only the intake id; widening it would suppress the menu for every card waiting on capacity — a far bigger regression than the one being fixed. Pinned by its own test.

## One thing I checked rather than assumed

`getExplicitModelForRole`'s `role === "triage"` looked like a dead branch — a local `role` twelve lines above can only be `"Planning"`/`"Executor"`/`"Reviewer"`. Different scope: the parameter is `AgentLogRole = AgentRole`, so the branch is live. Reporting it as dead code would have been wrong.

## Verification

- **Mutation-verified both directions:** reverting the intake resolution to the literal fails 1 test; widening it to include the hold lane fails 2.
- 9 new tests; 140/141 in the directly affected suites.
- **The 1 failure is pre-existing on main** — verified by swapping main's `TaskContextMenu.tsx` in and re-running: 1 failed either way, same test (`uses VALID_TRANSITIONS and in-review back-to-progress labels`).
- **The broad dashboard run's 202 failures are also pre-existing, proved two ways** — ~128 sit in `TaskDetailModal`, which imports `buildTaskActionMenuModel` from a file I changed, so they could not simply be waved off. A/B on `TaskDetailModal.rendering`: 28 failed either way. Whole-tree: 12,593 tests / 202 failed, with a per-file distribution identical to the run taken *before* these conversions.
- Merge gate green, dashboard tsc clean, lint clean.

No changeset: `@fusion/dashboard` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ Read before merging — these are ROLE renames, not column conversions

The coordinator's hand classification says several literals in this PR "must be left exactly as they are" because they compare an **agent role**, not a task column, and resolving them to a column trait would be a bug. **I agree, and this PR does not do that.**

What it does: replaces a bare `=== "triage"` with a **named role predicate** — `isPlanningAgentLane`, `AgentResearchSurface`, `ROLE_FALLBACK_SESSION_PURPOSES`. Behaviour is **byte-identical** for every input. No IR is consulted, no trait is resolved, no column is involved.

The reason to keep it rather than revert: the danger isn't the literal, it's that nothing at the call site tells the next person `"triage"` here means a *lane*. A list of exceptions maintained elsewhere only helps someone who finds the list; a call named `isPlanningAgentLane` helps whoever is reading the line. It also shrinks what the #2630 ratchet's ignore list has to carry.

Reversible: if the preference is to leave the literals untouched, say so and I'll strip these hunks — but then the ratchet's ignore list must carry **all twelve** role sites or it can never reach zero, because those six are correct code.

## Classification finding

Bucketing by the **receiver** of the comparison (not the literal) mechanically separates guards from roles, and it found **six role sites currently listed as "real column guards"**:

| site | receiver | what it actually is |
|---|---|---|
| `usage-limit-detector.ts:144, 207` | `agentType` | agent type — the column test one line above is *already* trait-driven |
| `skill-resolver.ts:432` | `sessionPurpose` | session purpose |
| `tool-availability.ts:32` | `surface` | agent surface (`"triage" \| "executor"`) |
| `effective-model-resolution.ts:148` | `entry.agent` | agent-log lane |
| `useTasks.ts:162` | `entry.agent` | agent-log lane |

So the real bar is roughly **39**, not 45. The rule that found all twelve without judgement calls: `column`/`toColumn`/`taskColumn`/`c` are guards; `role`/`agent`/`agentType`/`surface`/`sessionPurpose` are not. Worth teaching #2630's ratchet directly.
