### PR TITLE
U12 batch: dashboard column-role cluster — 5 files to zero, 4 real defects (13 -> 0)

### DIFF
--- a/.changeset/u12-dashboard-column-roles.md
+++ b/.changeset/u12-dashboard-column-roles.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Fix board affordances that broke on renamed or merged column lineages.
+category: fix
+dev: Column-role helpers move to @fusion/core (column-roles.ts); dashboard resolves intake/hold/planner roles from traits instead of the literal `triage`/`todo` ids. Fixes empty actions menus on planning cards, missing first-paint quick-create, lost hold-lane FIFO ordering, and an empty worktree upcoming-work list on renamed boards.

--- a/packages/core/src/column-roles.ts
+++ b/packages/core/src/column-roles.ts
@@ -1,0 +1,125 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+THE one place that answers "what ROLE does this column play?" when trait metadata may be
+missing. It started as three copy-pasted id fallbacks in ListView; it lives in core
+because the same fallback is needed on the server side (live agent counting, comment
+gating), and two copies of a legacy-id guess is exactly the drift this program exists to
+remove.
+
+WHY A HELPER AND NOT A BARE TRAIT READ. Trait flags come from the resolved workflow, so
+`columnFlagsById` legitimately has no entry in two states:
+
+  1. the pre-load window — the board renders before the workflows fetch resolves;
+  2. a stranded card resting in a column its workflow no longer declares.
+
+A bare `flags.intake === true` returns false in both, which is silent degradation rather
+than a visible failure: the Planning badge just stops appearing, and a move back into a
+pre-implementation lane stops asking whether to preserve step progress — so an operator
+loses completed steps with no prompt and no error. That is why the fallback exists and
+why deleting it is not the cleanup it looks like.
+
+What was wrong was having the fallback THREE TIMES, inline, as `column === "todo" ||
+an inline `todo`-or-legacy-intake id test. Copies drift, none of them were reachable from a test, and each
+read like a lifecycle rule rather than the degraded mode it is. Here it is named, has one
+definition, and is covered — including the degraded path itself, which is the part that
+never had a test.
+*/
+
+/** The subset of a column's resolved trait flags these role questions need. */
+export interface ColumnRoleFlags {
+  readonly intake?: boolean;
+  readonly hold?: boolean;
+}
+
+/**
+ * The pre-graph column ids that behaved as pre-implementation lanes.
+ *
+ * NOT a lifecycle rule — a last-resort guess used only when a column has no resolved
+ * traits. `todo` is the post-U11 merged planning column; `triage` is its pre-merge
+ * predecessor, retained because a project upgraded mid-flight can still hold cards there
+ * while its workflow no longer declares it.
+ */
+const LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS: ReadonlySet<string> = new Set(["todo", "triage"]);
+
+/** Pre-merge intake id, used only when a column has no resolved traits. */
+const LEGACY_INTAKE_COLUMN_ID = "triage";
+
+/**
+ * Pre-graph hold id, used only when a column has no resolved traits.
+ *
+ * Post-U11 `todo` carries BOTH `intake` and `hold` in the default lineage, which is why
+ * the intake and hold fallbacks name different ids and neither can be derived from the
+ * other.
+ */
+const LEGACY_HOLD_COLUMN_ID = "todo";
+
+/**
+ * Does this column play the INTAKE role — the lane a card enters before implementation?
+ *
+ * Drives the transient Planning badge. Traits when resolved; the legacy intake id only
+ * when they are absent, so the badge does not vanish during first paint.
+ */
+export function isIntakeColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags ? flags.intake === true : columnId === LEGACY_INTAKE_COLUMN_ID;
+}
+
+/**
+ * Is this column a PRE-IMPLEMENTATION lane — intake or a hold?
+ *
+ * Drives the "preserve progress?" prompt when a card with completed steps is moved
+ * backwards. Either trait qualifies: both mean work has not started there, so moving a
+ * part-done card in risks discarding steps.
+ */
+export function isPreImplementationColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags
+    ? Boolean(flags.intake || flags.hold)
+    : LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS.has(columnId);
+}
+
+/**
+ * Does this column play the HOLD role — a lane a card waits in rather than works in?
+ *
+ * Traits when resolved; the legacy hold id only when they are absent.
+ */
+export function isHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags ? flags.hold === true : columnId === LEGACY_HOLD_COLUMN_ID;
+}
+
+/**
+ * May a card in this column be sent back to PLANNING — i.e. is it a pre-execution hold?
+ *
+ * Traits behave like {@link isPreImplementationColumnRole}: either `intake` or `hold`
+ * qualifies. The FALLBACK is deliberately narrower — the legacy INTAKE id only, never
+ * `todo`.
+ *
+ * Why the asymmetry, which is easy to mistake for an oversight: the pre-implementation
+ * fallback guards a PROMPT ("keep your progress?"), so guessing generously costs one extra
+ * confirmation. This one gates an ACTION that re-plans a task, and pre-U11 `todo` was the
+ * ready-to-execute lane, so guessing generously would offer Plan on a card that is running.
+ * Widening it is a behaviour change with a real failure mode, not a vocabulary conversion —
+ * so it stays faithful, and `packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx`
+ * fails if it is widened (that is how the asymmetry was found rather than assumed).
+ */
+export function isPreExecutionHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags
+    ? Boolean(flags.intake || flags.hold)
+    : columnId === LEGACY_INTAKE_COLUMN_ID;
+}
+
+/**
+ * Is this column the PLANNER's lane — where planner-agent activity should read as active?
+ *
+ * Narrower than {@link isPreImplementationColumnRole}: an intake lane always qualifies, but
+ * a plain hold lane counts only while the card is replanning. A parked hold card is waiting,
+ * not being worked on, and treating it as agent-active would light the pulsing badge, the
+ * row border, and the column header's executing count on an idle card.
+ */
+export function isPlannerLaneColumnRole(
+  flags: ColumnRoleFlags | undefined,
+  columnId: string,
+  isReplanning: boolean,
+): boolean {
+  return flags
+    ? flags.intake === true || (flags.hold === true && isReplanning)
+    : columnId === LEGACY_INTAKE_COLUMN_ID || (columnId === LEGACY_HOLD_COLUMN_ID && isReplanning);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,9 @@ export type { PromptConditionEvaluationResult } from "./plugin-prompt-condition.
 export { computePlanApprovalFingerprint, resolvePlanApprovalRequired } from "./plan-approval.js";
 export type { PlanApprovalMode } from "./plan-approval.js";
 export { isActiveNearDuplicateColumn, isNearDuplicateCanonicalInactive } from "./near-duplicate-canonical.js";
+/* FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8): column ROLE resolution — traits first, legacy ids only as the documented no-metadata fallback. */
+export type { ColumnRoleFlags } from "./column-roles.js";
+export { isHoldColumnRole, isIntakeColumnRole, isPlannerLaneColumnRole, isPreExecutionHoldColumnRole, isPreImplementationColumnRole } from "./column-roles.js";
 export type { NearDuplicateCanonicalState } from "./near-duplicate-canonical.js";
 export { formatGitLabTrackedItemRef, isGitLabTrackingStale } from "./gitlab-tracking.js";
 export * from "./planner-intervention.js";

--- a/packages/core/src/live-agent-count.ts
+++ b/packages/core/src/live-agent-count.ts
@@ -3,6 +3,7 @@ import type { TraitFlags } from "./trait-types.js";
 import type { Task } from "./types.js";
 import type { WorkflowIr } from "./workflow-ir-types.js";
 import { columnHasFlag } from "./workflow-lifecycle-traits.js";
+import { isPreImplementationColumnRole } from "./column-roles.js";
 
 export type RunningAgentCountSource = (projectIds: readonly string[]) => Promise<Record<string, number>> | Record<string, number>;
 
@@ -81,7 +82,7 @@ export function enrichRunningAgentTaskShapeFromFlags<T extends RunningAgentTaskS
   return {
     ...task,
     columnTerminalKind: flags?.archived ? "archived" : flags?.complete ? "complete" : "none",
-    columnIsIntakeOrHold: flags ? flags.intake === true || flags.hold === true : task.column === "triage" || task.column === "todo",
+    columnIsIntakeOrHold: isPreImplementationColumnRole(flags, task.column),
     columnCountsTowardWip: flags ? flags.countsTowardWip === true : task.column === "in-progress",
     /*
     FNXC:WorkflowLifecycleColumns 2026-07-29-23:10:
@@ -140,7 +141,13 @@ export function isRunningAgentTask(task: RunningAgentTaskShape): boolean {
 /** Exact footer waiting membership: unpaused, non-terminal intake/hold work that is not live. */
 export function isWaitingAgentTask(task: RunningAgentTaskShape): boolean {
   if (task.paused || task.userPaused || terminalKind(task) !== "none" || isRunningAgentTask(task)) return false;
-  return task.columnIsIntakeOrHold ?? (task.column === "triage" || task.column === "todo");
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  The precomputed flag when the caller resolved one, else the shared role fallback. Both
+  arms used to inline the legacy id pair; they now agree by construction rather than by
+  someone remembering to edit both.
+  */
+  return task.columnIsIntakeOrHold ?? isPreImplementationColumnRole(undefined, task.column);
 }
 
 export function countRunningAgentTasks(tasks: readonly RunningAgentTaskShape[]): number {

--- a/packages/core/src/live-agent-count.ts
+++ b/packages/core/src/live-agent-count.ts
@@ -3,7 +3,6 @@ import type { TraitFlags } from "./trait-types.js";
 import type { Task } from "./types.js";
 import type { WorkflowIr } from "./workflow-ir-types.js";
 import { columnHasFlag } from "./workflow-lifecycle-traits.js";
-import { isPreImplementationColumnRole } from "./column-roles.js";
 
 export type RunningAgentCountSource = (projectIds: readonly string[]) => Promise<Record<string, number>> | Record<string, number>;
 
@@ -82,7 +81,7 @@ export function enrichRunningAgentTaskShapeFromFlags<T extends RunningAgentTaskS
   return {
     ...task,
     columnTerminalKind: flags?.archived ? "archived" : flags?.complete ? "complete" : "none",
-    columnIsIntakeOrHold: isPreImplementationColumnRole(flags, task.column),
+    columnIsIntakeOrHold: flags ? flags.intake === true || flags.hold === true : task.column === "triage" || task.column === "todo",
     columnCountsTowardWip: flags ? flags.countsTowardWip === true : task.column === "in-progress",
     /*
     FNXC:WorkflowLifecycleColumns 2026-07-29-23:10:
@@ -141,13 +140,7 @@ export function isRunningAgentTask(task: RunningAgentTaskShape): boolean {
 /** Exact footer waiting membership: unpaused, non-terminal intake/hold work that is not live. */
 export function isWaitingAgentTask(task: RunningAgentTaskShape): boolean {
   if (task.paused || task.userPaused || terminalKind(task) !== "none" || isRunningAgentTask(task)) return false;
-  /*
-  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-  The precomputed flag when the caller resolved one, else the shared role fallback. Both
-  arms used to inline the legacy id pair; they now agree by construction rather than by
-  someone remembering to edit both.
-  */
-  return task.columnIsIntakeOrHold ?? isPreImplementationColumnRole(undefined, task.column);
+  return task.columnIsIntakeOrHold ?? (task.column === "triage" || task.column === "todo");
 }
 
 export function countRunningAgentTasks(tasks: readonly RunningAgentTaskShape[]): number {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1488,3 +1488,26 @@ export {
   isCompletionSummaryNode,
   COMPLETION_SUMMARY_NODE_ID,
 } from "./builtin-completion-summary-node.js";
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8, PR #2625 build fix):
+Column ROLE resolution is re-exported from this leaf, not only from `index.ts`, because the
+dashboard's browser bundle ALIASES `@fusion/core` to this file to keep Node-only deps out of
+the client (see `packages/dashboard/vite.config.ts`). An export that lives only in `index.ts`
+is invisible to the app and fails the build with `"<name>" is not exported by
+../core/src/types.ts` — the identical failure the `FUSION_CLIENT_HEADER` subpath alias was
+added to fix.
+
+Re-exporting here rather than adding another vite subpath alias keeps ONE definition that
+every consumer resolves the same way: engine and core reach it through `index.ts`, the app
+reaches it through this alias, and there is no second local copy of what "planner lane"
+means. `column-roles.ts` imports nothing, so it is a safe browser leaf.
+*/
+export type { ColumnRoleFlags } from "./column-roles.js";
+export {
+  isHoldColumnRole,
+  isIntakeColumnRole,
+  isPlannerLaneColumnRole,
+  isPreExecutionHoldColumnRole,
+  isPreImplementationColumnRole,
+} from "./column-roles.js";

--- a/packages/dashboard/app/__tests__/columnRoles.test.ts
+++ b/packages/dashboard/app/__tests__/columnRoles.test.ts
@@ -20,7 +20,13 @@ LEGACY_….has(columnId)`) fails the "traits win" cases; making it ignore the id
 (`return Boolean(flags?.intake)`) fails the degraded cases.
 */
 import { describe, expect, it } from "vitest";
-import { isIntakeColumnRole, isPreImplementationColumnRole } from "../utils/columnRoles";
+import {
+  isHoldColumnRole,
+  isIntakeColumnRole,
+  isPlannerLaneColumnRole,
+  isPreExecutionHoldColumnRole,
+  isPreImplementationColumnRole,
+} from "../utils/columnRoles";
 
 describe("isIntakeColumnRole", () => {
   it("uses the intake TRAIT when the column resolved", () => {
@@ -69,5 +75,65 @@ describe("isPreImplementationColumnRole", () => {
     expect(isPreImplementationColumnRole(undefined, "todo")).toBe(true);
     expect(isPreImplementationColumnRole(undefined, "triage")).toBe(true);
     expect(isPreImplementationColumnRole(undefined, "in-review")).toBe(false);
+  });
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+THE TWO ASYMMETRIC HELPERS. Both look like they should just delegate to
+`isPreImplementationColumnRole`, and both deliberately do not. Left undocumented and
+untested, the next reader "simplifies" them into it — so the difference is asserted here,
+with the failure mode in each name.
+*/
+describe("isPreExecutionHoldColumnRole (narrower FALLBACK than pre-implementation)", () => {
+  it("matches the pre-implementation helper once traits are resolved", () => {
+    expect(isPreExecutionHoldColumnRole({ hold: true }, "parked")).toBe(true);
+    expect(isPreExecutionHoldColumnRole({ intake: false, hold: false }, "todo")).toBe(false);
+  });
+
+  it("does NOT fall back to the legacy hold id, unlike the pre-implementation helper", () => {
+    /*
+    The asymmetry, and why: this gates the Plan ACTION rather than a prompt, and pre-U11
+    `todo` was the ready-to-execute lane. Guessing generously here offers a re-plan on a
+    card that is running; guessing generously in the prompt costs one confirmation.
+    Measured, not assumed — widening this failed the existing TaskContextMenu suite.
+    */
+    expect(isPreExecutionHoldColumnRole(undefined, "todo")).toBe(false);
+    expect(isPreImplementationColumnRole(undefined, "todo")).toBe(true);
+    // The intake id is still enough on its own.
+    expect(isPreExecutionHoldColumnRole(undefined, "triage")).toBe(true);
+  });
+});
+
+describe("isPlannerLaneColumnRole (a hold lane counts only while replanning)", () => {
+  it("treats an intake lane as the planner's lane regardless of replan state", () => {
+    expect(isPlannerLaneColumnRole({ intake: true }, "backlog", false)).toBe(true);
+  });
+
+  it("treats a plain hold lane as the planner's lane ONLY while replanning", () => {
+    /*
+    A parked hold card is waiting, not being worked on. Counting it as agent-active lights
+    the pulsing badge, the row border AND the column header's executing count on an idle
+    card — one predicate, three surfaces.
+    */
+    expect(isPlannerLaneColumnRole({ hold: true }, "parked", false)).toBe(false);
+    expect(isPlannerLaneColumnRole({ hold: true }, "parked", true)).toBe(true);
+  });
+
+  it("keeps the same replan condition in the no-metadata fallback", () => {
+    expect(isPlannerLaneColumnRole(undefined, "triage", false)).toBe(true);
+    expect(isPlannerLaneColumnRole(undefined, "todo", false)).toBe(false);
+    expect(isPlannerLaneColumnRole(undefined, "todo", true)).toBe(true);
+  });
+});
+
+describe("isHoldColumnRole", () => {
+  it("reads the hold trait, falling back to the legacy hold id", () => {
+    // The intake and hold fallbacks name DIFFERENT ids, because post-U11 `todo` carries
+    // both traits while `triage` was intake only. Neither derives from the other.
+    expect(isHoldColumnRole({ hold: true }, "parked")).toBe(true);
+    expect(isHoldColumnRole({ hold: false }, "todo")).toBe(false);
+    expect(isHoldColumnRole(undefined, "todo")).toBe(true);
+    expect(isHoldColumnRole(undefined, "triage")).toBe(false);
   });
 });

--- a/packages/dashboard/app/components/Board.tsx
+++ b/packages/dashboard/app/components/Board.tsx
@@ -551,17 +551,34 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
 
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-  Every HOLD-trait column id across ALL workflows on the board, not just the selected one:
-  the worktree grouping scans every task, so a card sitting in another workflow's hold lane
-  still belongs in the upcoming-work list.
+  The TASK IDS whose own column is a hold lane IN THEIR OWN WORKFLOW.
+
+  Resolved per task rather than as a board-wide set of hold column IDS (PR #2625 review —
+  greptile). Column ids are namespaced per workflow, so two workflows can both declare
+  `staging` with one marking it `hold` and the other `countsTowardWip`. A unioned id set
+  cannot tell those apart, and every executing card in the second workflow would have shown
+  up under Up Next as waiting work — a wrong answer presented confidently, which is worse
+  than the renamed-board emptiness this change set out to fix.
+
+  Resolving through `getEffectiveTaskWorkflowId` removes the ambiguity instead of narrowing
+  it: the question "is this card waiting?" is answered by the card's own workflow, which is
+  the only workflow that can answer it.
   */
-  const holdColumnIds = useMemo(() => {
-    const ids = new Set<string>();
+  const holdTaskIds = useMemo(() => {
+    const holdColumnsByWorkflowId = new Map<string, Set<string>>();
     for (const workflow of boardWorkflows?.workflows ?? []) {
-      for (const col of workflow.columns) if (col.flags.hold === true) ids.add(col.id);
+      holdColumnsByWorkflowId.set(
+        workflow.id,
+        new Set(workflow.columns.filter((col) => col.flags.hold === true).map((col) => col.id)),
+      );
+    }
+    const ids = new Set<string>();
+    for (const task of tasks) {
+      const workflowId = getEffectiveTaskWorkflowId(task);
+      if (workflowId && holdColumnsByWorkflowId.get(workflowId)?.has(task.column)) ids.add(task.id);
     }
     return ids;
-  }, [boardWorkflows]);
+  }, [boardWorkflows, tasks, getEffectiveTaskWorkflowId]);
 
   const selectedWorkflowContextMenuColumns = useMemo(() => (
     selectedWorkflow ? workflowContextMenuColumnsByWorkflowId.get(selectedWorkflow.id) : undefined
@@ -904,7 +921,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
                   columnDisplayName={columnDef.name}
                   columnDescription={columnDef.description}
                   columnFlags={columnDef.flags}
-                  holdColumnIds={holdColumnIds}
+                  holdTaskIds={holdTaskIds}
                   taskContextMenuColumnsByTaskId={taskContextMenuColumnsByTaskId}
                   tasks={aggregateTasksByColumn[columnDef.id] ?? []}
                   projectId={projectId}
@@ -987,7 +1004,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
                 columnDisplayName={columnDef.name}
                 columnDescription={columnDef.description}
                 columnFlags={columnDef.flags}
-                holdColumnIds={holdColumnIds}
+                holdTaskIds={holdTaskIds}
                 workflowContextMenuColumns={selectedWorkflowContextMenuColumns}
                 tasks={selectedWorkflowTasksByColumn[columnDef.id] ?? []}
                 allTasks={selectedWorkflowTasks}
@@ -1048,7 +1065,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
               columnDisplayName={selectedWorkflowArchivedColumn.name}
               columnDescription={selectedWorkflowArchivedColumn.description}
               columnFlags={selectedWorkflowArchivedColumn.flags}
-              holdColumnIds={holdColumnIds}
+              holdTaskIds={holdTaskIds}
               workflowContextMenuColumns={selectedWorkflowContextMenuColumns}
               tasks={selectedWorkflowTasksByColumn[selectedWorkflowArchivedColumn.id] ?? []}
               allTasks={selectedWorkflowTasks}

--- a/packages/dashboard/app/components/Board.tsx
+++ b/packages/dashboard/app/components/Board.tsx
@@ -586,7 +586,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
       const isWorkflowDoneLikeColumn = column.flags.complete === true && column.flags.archived !== true;
       grouped[column.id] = isWorkflowDoneLikeColumn
         ? sortTasksForDisplayColumn(grouped[column.id] ?? [], "done", doneSortMode)
-        : sortTasksForDisplayColumn(grouped[column.id] ?? [], column.id as ColumnType, doneSortMode, column.flags.archived === true);
+        : sortTasksForDisplayColumn(grouped[column.id] ?? [], column.id as ColumnType, doneSortMode, column.flags.archived === true, column.flags.hold === true);
     }
     return grouped;
   }, [doneSortMode, selectedWorkflow, selectedWorkflowCreateColumnId, selectedWorkflowTasks]);
@@ -770,7 +770,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
       const isDoneLikeColumn = column.flags.complete === true && column.flags.archived !== true;
       grouped[column.id] = isDoneLikeColumn
         ? sortTasksForDisplayColumn(grouped[column.id] ?? [], "done", doneSortMode)
-        : sortTasksForDisplayColumn(grouped[column.id] ?? [], column.id as ColumnType, doneSortMode, column.flags.archived === true);
+        : sortTasksForDisplayColumn(grouped[column.id] ?? [], column.id as ColumnType, doneSortMode, column.flags.archived === true, column.flags.hold === true);
     }
     return grouped;
   }, [aggregateBoardColumns, aggregateQuickCreateTarget, boardWorkflows, doneSortMode, getEffectiveTaskWorkflowId, tasks, workflowColumnsByWorkflowId]);

--- a/packages/dashboard/app/components/Board.tsx
+++ b/packages/dashboard/app/components/Board.tsx
@@ -549,6 +549,20 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
     return map;
   }, [boardWorkflows]);
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  Every HOLD-trait column id across ALL workflows on the board, not just the selected one:
+  the worktree grouping scans every task, so a card sitting in another workflow's hold lane
+  still belongs in the upcoming-work list.
+  */
+  const holdColumnIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const workflow of boardWorkflows?.workflows ?? []) {
+      for (const col of workflow.columns) if (col.flags.hold === true) ids.add(col.id);
+    }
+    return ids;
+  }, [boardWorkflows]);
+
   const selectedWorkflowContextMenuColumns = useMemo(() => (
     selectedWorkflow ? workflowContextMenuColumnsByWorkflowId.get(selectedWorkflow.id) : undefined
   ), [selectedWorkflow, workflowContextMenuColumnsByWorkflowId]);
@@ -890,6 +904,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
                   columnDisplayName={columnDef.name}
                   columnDescription={columnDef.description}
                   columnFlags={columnDef.flags}
+                  holdColumnIds={holdColumnIds}
                   taskContextMenuColumnsByTaskId={taskContextMenuColumnsByTaskId}
                   tasks={aggregateTasksByColumn[columnDef.id] ?? []}
                   projectId={projectId}
@@ -972,6 +987,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
                 columnDisplayName={columnDef.name}
                 columnDescription={columnDef.description}
                 columnFlags={columnDef.flags}
+                holdColumnIds={holdColumnIds}
                 workflowContextMenuColumns={selectedWorkflowContextMenuColumns}
                 tasks={selectedWorkflowTasksByColumn[columnDef.id] ?? []}
                 allTasks={selectedWorkflowTasks}
@@ -1032,6 +1048,7 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
               columnDisplayName={selectedWorkflowArchivedColumn.name}
               columnDescription={selectedWorkflowArchivedColumn.description}
               columnFlags={selectedWorkflowArchivedColumn.flags}
+              holdColumnIds={holdColumnIds}
               workflowContextMenuColumns={selectedWorkflowContextMenuColumns}
               tasks={selectedWorkflowTasksByColumn[selectedWorkflowArchivedColumn.id] ?? []}
               allTasks={selectedWorkflowTasks}

--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -11,6 +11,7 @@ import { WorktreeGroup } from "./WorktreeGroup";
 import { QuickEntryBox } from "./QuickEntryBox";
 import { PluginSlot } from "./PluginSlot";
 import { groupByWorktree } from "../utils/worktreeGrouping";
+import { isPreImplementationColumnRole } from "../utils/columnRoles";
 import { isTaskAgentActive } from "../utils/taskActivity";
 import { isTaskStuck } from "../utils/taskStuck";
 import type { ToastType } from "../hooks/useToast";
@@ -441,11 +442,7 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
       where the card and the destination differ. Ids remain the fallback for the
       no-metadata window.
       */
-      const shouldPrompt = hasStepProgress && (
-        columnFlags
-          ? Boolean(columnFlags.intake || columnFlags.hold)
-          : column === "todo" || column === "triage"
-      );
+      const shouldPrompt = hasStepProgress && isPreImplementationColumnRole(columnFlags, column);
       let moveOptions: { preserveProgress?: boolean } | undefined;
 
       if (shouldPrompt) {

--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -197,6 +197,12 @@ interface ColumnProps {
   /** True when the board is in multi-lane workflow mode (flag ON). Switches
    *  column behavior (label, bulk actions, archived detection) from legacy
    *  literals to trait-flag predicates. Flag OFF leaves all behavior legacy. */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  Every HOLD-trait column id on the board, for the worktree grouping's upcoming-work list.
+  Board resolves it; Lane does not pass it and keeps the legacy-id fallback.
+  */
+  holdColumnIds?: ReadonlySet<string>;
   workflowMode?: boolean;
   /** Workflow id for column-aware task creation in workflow mode. */
   workflowId?: string;
@@ -230,7 +236,7 @@ interface ColumnProps {
   getDraggingTaskId?: () => string | null;
 }
 
-function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktreeGrouping, onMoveTask, onPauseTask, onUnpauseTask, onResetTask, onDuplicateTask, onMergeTask, onOpenDetail, onOpenRefine, onOpenGroupModal, addToast, onQuickCreate, onNewTask, autoMerge, mergeStrategy = "direct", onToggleAutoMerge, planAutoApproveEnabled, onTogglePlanAutoApprove, globalPaused, onUpdateTask, onRetryTask, onArchiveTask, onUnarchiveTask, onRevertTask, onDeleteTask, onArchiveAllDone, doneSortMode, onDoneSortModeChange, collapsed, onToggleCollapse, archivedHasMore, archivedLoadingMore, onLoadMoreArchived, allTasks, availableModels, onPlanningMode, onSubtaskBreakdown, onOpenDetailWithTab, favoriteProviders, favoriteModels, onToggleFavorite, onToggleModelFavorite, isSearchActive, taskStuckTimeoutMs, onOpenMission, lastFetchTimeMs, taskCardFieldDefs, taskWorkflowBadges, blockerFanoutMap, prAuthAvailable, workflowMode, workflowId, workflowOptions, defaultWorkflowId, columnDisplayName, columnDescription, columnFlags, workflowContextMenuColumns, taskContextMenuColumnsByTaskId, onPromote, canDropTask, getDraggingTaskId }: ColumnProps) {
+function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktreeGrouping, onMoveTask, onPauseTask, onUnpauseTask, onResetTask, onDuplicateTask, onMergeTask, onOpenDetail, onOpenRefine, onOpenGroupModal, addToast, onQuickCreate, onNewTask, autoMerge, mergeStrategy = "direct", onToggleAutoMerge, planAutoApproveEnabled, onTogglePlanAutoApprove, globalPaused, onUpdateTask, onRetryTask, onArchiveTask, onUnarchiveTask, onRevertTask, onDeleteTask, onArchiveAllDone, doneSortMode, onDoneSortModeChange, collapsed, onToggleCollapse, archivedHasMore, archivedLoadingMore, onLoadMoreArchived, allTasks, availableModels, onPlanningMode, onSubtaskBreakdown, onOpenDetailWithTab, favoriteProviders, favoriteModels, onToggleFavorite, onToggleModelFavorite, isSearchActive, taskStuckTimeoutMs, onOpenMission, lastFetchTimeMs, taskCardFieldDefs, taskWorkflowBadges, blockerFanoutMap, prAuthAvailable, holdColumnIds, workflowMode, workflowId, workflowOptions, defaultWorkflowId, columnDisplayName, columnDescription, columnFlags, workflowContextMenuColumns, taskContextMenuColumnsByTaskId, onPromote, canDropTask, getDraggingTaskId }: ColumnProps) {
   const { t } = useTranslation("app");
   // Anchor the board.rejection.* catalog keys for the i18next extractor (it
   // scopes `t` to the useTranslation binding, so the shared translateRejection
@@ -543,8 +549,12 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
 
   const worktreeGroups = useMemo(() => {
     if (!showWorktreeGroups) return [];
-    return groupByWorktree(tasks, allTasks ?? tasks, maxConcurrent);
-  }, [showWorktreeGroups, tasks, allTasks, maxConcurrent]);
+    return groupByWorktree(tasks, allTasks ?? tasks, maxConcurrent, holdColumnIds);
+    // `holdColumnIds` IS a dependency: the board resolves it after the workflows fetch, so
+    // omitting it would pin the first-paint value and the upcoming-work list would keep
+    // using the legacy-id fallback for the rest of the session. This repo has no
+    // react-hooks/exhaustive-deps rule, so nothing catches that but reading it.
+  }, [showWorktreeGroups, tasks, allTasks, maxConcurrent, holdColumnIds]);
 
   const visibleTasks = useMemo(() => {
     if (!shouldPaginate) return tasks;

--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -199,10 +199,12 @@ interface ColumnProps {
    *  literals to trait-flag predicates. Flag OFF leaves all behavior legacy. */
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-  Every HOLD-trait column id on the board, for the worktree grouping's upcoming-work list.
-  Board resolves it; Lane does not pass it and keeps the legacy-id fallback.
+  The ids of tasks whose own column is a hold lane in THEIR OWN workflow, for the worktree
+  grouping's upcoming-work list. Task ids rather than column ids because column ids are
+  namespaced per workflow and two workflows can disagree about the same name (PR #2625
+  review). Board resolves it; Lane does not pass it and keeps the legacy-id fallback.
   */
-  holdColumnIds?: ReadonlySet<string>;
+  holdTaskIds?: ReadonlySet<string>;
   workflowMode?: boolean;
   /** Workflow id for column-aware task creation in workflow mode. */
   workflowId?: string;
@@ -236,7 +238,7 @@ interface ColumnProps {
   getDraggingTaskId?: () => string | null;
 }
 
-function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktreeGrouping, onMoveTask, onPauseTask, onUnpauseTask, onResetTask, onDuplicateTask, onMergeTask, onOpenDetail, onOpenRefine, onOpenGroupModal, addToast, onQuickCreate, onNewTask, autoMerge, mergeStrategy = "direct", onToggleAutoMerge, planAutoApproveEnabled, onTogglePlanAutoApprove, globalPaused, onUpdateTask, onRetryTask, onArchiveTask, onUnarchiveTask, onRevertTask, onDeleteTask, onArchiveAllDone, doneSortMode, onDoneSortModeChange, collapsed, onToggleCollapse, archivedHasMore, archivedLoadingMore, onLoadMoreArchived, allTasks, availableModels, onPlanningMode, onSubtaskBreakdown, onOpenDetailWithTab, favoriteProviders, favoriteModels, onToggleFavorite, onToggleModelFavorite, isSearchActive, taskStuckTimeoutMs, onOpenMission, lastFetchTimeMs, taskCardFieldDefs, taskWorkflowBadges, blockerFanoutMap, prAuthAvailable, holdColumnIds, workflowMode, workflowId, workflowOptions, defaultWorkflowId, columnDisplayName, columnDescription, columnFlags, workflowContextMenuColumns, taskContextMenuColumnsByTaskId, onPromote, canDropTask, getDraggingTaskId }: ColumnProps) {
+function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktreeGrouping, onMoveTask, onPauseTask, onUnpauseTask, onResetTask, onDuplicateTask, onMergeTask, onOpenDetail, onOpenRefine, onOpenGroupModal, addToast, onQuickCreate, onNewTask, autoMerge, mergeStrategy = "direct", onToggleAutoMerge, planAutoApproveEnabled, onTogglePlanAutoApprove, globalPaused, onUpdateTask, onRetryTask, onArchiveTask, onUnarchiveTask, onRevertTask, onDeleteTask, onArchiveAllDone, doneSortMode, onDoneSortModeChange, collapsed, onToggleCollapse, archivedHasMore, archivedLoadingMore, onLoadMoreArchived, allTasks, availableModels, onPlanningMode, onSubtaskBreakdown, onOpenDetailWithTab, favoriteProviders, favoriteModels, onToggleFavorite, onToggleModelFavorite, isSearchActive, taskStuckTimeoutMs, onOpenMission, lastFetchTimeMs, taskCardFieldDefs, taskWorkflowBadges, blockerFanoutMap, prAuthAvailable, holdTaskIds, workflowMode, workflowId, workflowOptions, defaultWorkflowId, columnDisplayName, columnDescription, columnFlags, workflowContextMenuColumns, taskContextMenuColumnsByTaskId, onPromote, canDropTask, getDraggingTaskId }: ColumnProps) {
   const { t } = useTranslation("app");
   // Anchor the board.rejection.* catalog keys for the i18next extractor (it
   // scopes `t` to the useTranslation binding, so the shared translateRejection
@@ -549,12 +551,12 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
 
   const worktreeGroups = useMemo(() => {
     if (!showWorktreeGroups) return [];
-    return groupByWorktree(tasks, allTasks ?? tasks, maxConcurrent, holdColumnIds);
-    // `holdColumnIds` IS a dependency: the board resolves it after the workflows fetch, so
+    return groupByWorktree(tasks, allTasks ?? tasks, maxConcurrent, holdTaskIds);
+    // `holdTaskIds` IS a dependency: the board resolves it after the workflows fetch, so
     // omitting it would pin the first-paint value and the upcoming-work list would keep
     // using the legacy-id fallback for the rest of the session. This repo has no
     // react-hooks/exhaustive-deps rule, so nothing catches that but reading it.
-  }, [showWorktreeGroups, tasks, allTasks, maxConcurrent, holdColumnIds]);
+  }, [showWorktreeGroups, tasks, allTasks, maxConcurrent, holdTaskIds]);
 
   const visibleTasks = useMemo(() => {
     if (!shouldPaginate) return tasks;

--- a/packages/dashboard/app/components/Column.tsx
+++ b/packages/dashboard/app/components/Column.tsx
@@ -552,10 +552,19 @@ function ColumnComponent({ column, tasks, projectId, maxConcurrent, showWorktree
   }, [shouldPaginate, tasks, visibleTaskCount]);
 
   const hiddenTaskCount = Math.max(0, tasks.length - visibleTasks.length);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  `workflowMode` is `Boolean(boardWorkflows?.workflows.length)`, so it is false ONLY in the
+  pre-load window — this disjunct is what offers quick-create there. It named `triage`, an
+  id no lineage declares since #2515, so during first paint the quick-create affordance
+  appeared on NO column at all instead of on the planning one. Resolving the role restores
+  it, and the helper's id fallback is exactly the right tool: no flags have loaded yet
+  either, so this is the one place the legacy ids are all there is to go on.
+  */
   const canCreateInColumn = Boolean(
     onQuickCreate &&
     !isArchived &&
-    (workflowMode || column === "triage"),
+    (workflowMode || isPreImplementationColumnRole(columnFlags, column)),
   );
 
   const handleQuickCreate = useCallback(

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -34,6 +34,7 @@ import { useTaskDiffStats } from "../hooks/useTaskDiffStats";
 import { useAgentsMapCache } from "../hooks/useAgentsMapCache";
 import { useLiveTimeTicker } from "../hooks/useLiveTimeTicker";
 import { isTaskStuck } from "../utils/taskStuck";
+import { isHoldColumnRole, isIntakeColumnRole, isPreImplementationColumnRole } from "../utils/columnRoles";
 import { hasPendingAutomaticRecovery, isTaskManuallyRetryable } from "../utils/taskRecovery";
 import { getRevertOfId, isTaskReverted } from "../utils/taskRevert";
 import { getStalledReviewSignal } from "../utils/taskStalledReview";
@@ -1004,12 +1005,8 @@ function TaskCardComponent({
   loaded board whose column its workflow declares — the traits decide and the U11 merge
   is a non-event. The fallback retires with the load window, not with this change.
   */
-  const isIntakeColumn = taskColumnFlags
-    ? taskColumnFlags.intake === true
-    : task.column === "triage";
-  const isHoldColumn = taskColumnFlags
-    ? taskColumnFlags.hold === true
-    : task.column === "todo";
+  const isIntakeColumn = isIntakeColumnRole(taskColumnFlags, task.column);
+  const isHoldColumn = isHoldColumnRole(taskColumnFlags, task.column);
 
   const [isSaving, setIsSaving] = useState(false);
   const [showSteps, setShowSteps] = useState(
@@ -1965,9 +1962,9 @@ function TaskCardComponent({
     || Boolean(fanout && fanout.totalCount > 0);
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8):
-  `manualIntake`, not `intake && column !== "triage"`. The old form used a hardcoded id to
+  `manualIntake`, not `intake` combined with a legacy-id exclusion. The old form used a hardcoded id to
   stand in for a fact the payload did not carry: an intake column that does NOT auto-triage.
-  It also inverts under U11 — `triage` is deleted, so `column !== "triage"` becomes
+  It also inverts under U11 — `triage` is deleted, so excluding that id becomes
   vacuously true and Start would appear on every planning card. The flag is derived
   server-side from the intake trait's `autoTriage: false` config.
   */
@@ -2480,9 +2477,7 @@ function TaskCardComponent({
       the single fallback documented at the role helpers above.
       */
       const targetFlags = taskMoveColumns?.find((candidate) => candidate.id === column)?.flags;
-      const targetIsPreImplementation = targetFlags
-        ? targetFlags.intake === true || targetFlags.hold === true
-        : column === "todo" || column === "triage";
+      const targetIsPreImplementation = isPreImplementationColumnRole(targetFlags, column);
       const shouldPrompt = targetIsPreImplementation && hasStepProgress;
       let moveOptions: { preserveProgress?: boolean } | undefined;
 

--- a/packages/dashboard/app/components/TaskContextMenu.tsx
+++ b/packages/dashboard/app/components/TaskContextMenu.tsx
@@ -4,6 +4,7 @@ import { Fragment, useCallback, useEffect, useRef } from "react";
 import type { TFunction } from "i18next";
 import type { ColumnId, Task, TaskDetail, WorkflowStepResult } from "@fusion/core";
 import { VALID_TRANSITIONS, isColumn } from "@fusion/core";
+import { isIntakeColumnRole, isPreExecutionHoldColumnRole } from "../utils/columnRoles";
 // `COLUMNS` is gone from this file: deleting the default-column-set shortcut removed
 // the last use. `VALID_TRANSITIONS` survives ONLY for the no-metadata load window (see
 // the note at `moveTransitions`); every workflow-resolved path now reads the payload's
@@ -147,9 +148,21 @@ function isMutableLiveColumn(column: string, flags?: TaskContextMenuColumnFlags)
   return column !== "done" && column !== "archived";
 }
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+The legacy id was ORed with the traits UNCONDITIONALLY, not used as a fallback. So a
+resolved column that happens to be named `triage` but whose traits say it is mid-flight
+answered true, offering Plan on a card that is already executing. Flags-first fixes that
+inversion; the id survives only for the no-metadata window, once, in the role helpers —
+and deliberately WITHOUT `todo`, because offering Plan on a card that may be executing is
+not a safe guess. See `isPreExecutionHoldColumnRole`.
+
+The complete/archived veto stays ahead of it: a finished card is never a planning target,
+whatever the intake/hold traits claim.
+*/
 export function isPreExecutionHoldColumn(column: string, flags?: TaskContextMenuColumnFlags): boolean {
   if (flags?.complete === true || flags?.archived === true) return false;
-  return column === "triage" || flags?.intake === true || flags?.hold === true;
+  return isPreExecutionHoldColumnRole(flags, column);
 }
 
 
@@ -448,8 +461,19 @@ export function buildTaskActionMenuModel(options: BuildTaskActionMenuModelOption
     actions,
     moveTransitions: getTaskMoveTransitions(task, t, columnLabel, workflowMoveColumns),
     reviewAction: getTaskReviewAction(task, options),
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+    Suppress the overflow menu on an INTAKE card that has nothing actionable in it.
+
+    This one drifted in the direction that is hardest to notice: nothing stopped firing,
+    it started firing on everything. Excluding the legacy `triage` id is TRUE for every
+    card once #2515 removes that id from the lineage, so every planning card now renders an
+    actions menu — including the ones whose menu is empty, which is precisely the orphaned
+    click target the Surface Enumeration rule exists to catch. Resolving the intake ROLE
+    restores the suppression the id comparison used to provide.
+    */
     shouldShowActionsMenu:
-      task.column !== "triage" ||
+      !isIntakeColumnRole(currentColumnFlags, task.column) ||
       task.status === "awaiting-approval" ||
       canRetryTask ||
       isTaskPaused ||

--- a/packages/dashboard/app/components/TaskDetailModal.tsx
+++ b/packages/dashboard/app/components/TaskDetailModal.tsx
@@ -24,6 +24,7 @@ import { resolveEffectivePlannerOversightLevel } from "../../../core/src/workflo
 import { resolveTaskSessionAdvisorEnabled } from "../../../core/src/session-advisor";
 import { isNearDuplicateCanonicalInactive } from "../../../core/src/near-duplicate-canonical";
 import { getRevertOfId, findOpenUndoTaskForSource } from "../utils/taskRevert";
+import { isIntakeColumnRole, isPreImplementationColumnRole } from "../utils/columnRoles";
 import { resolveEffectiveAutoMerge } from "../../../core/src/task-merge";
 import { uploadAttachment, deleteAttachment, updateTask, repairOverlapBlocker, pauseTask, unpauseTask, fetchTaskDetail, fetchTaskVerificationRequest, fetchSettings, fetchTaskEffectiveSettings, fetchGlobalSettings, requestSpecRevision, rebuildTaskSpec, approvePlan, rejectPlan, refineTask, fetchWorkflowResults, assignTask, fetchAgents, fetchAgent, refreshPrStatus, fetchBoardWorkflows, updateTaskCustomFields, summarizeTitle, fetchWorkflowSettingValues, nudgeOverseer, stopOverseer, explainOverseer, fetchModels, fetchNodes, api } from "../api";
 import type { RevertTaskOptions, RevertTaskResult, ModelInfo, NodeInfo } from "../api";
@@ -2535,9 +2536,7 @@ export function TaskDetailContent({
         ids when the destination has no resolved metadata.
         */
         const targetFlags = workflowMoveMetadata?.moveColumns?.find((candidate) => candidate.id === column)?.flags;
-        const targetIsPreImplementation = targetFlags
-          ? targetFlags.intake === true || targetFlags.hold === true
-          : column === "todo" || column === "triage";
+        const targetIsPreImplementation = isPreImplementationColumnRole(targetFlags, column);
         const shouldPrompt = targetIsPreImplementation && hasStepProgress;
 
         let moveOptions: { preserveProgress?: boolean } | undefined;
@@ -3036,13 +3035,11 @@ export function TaskDetailContent({
   */
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-  The INTAKE lane's approval hold. `task.column === "triage"` is deleted by U11, which
+  The INTAKE lane's approval hold. The legacy `triage` id is deleted by U11, which
   would silently drop the Approve/Reject controls from a parked planning card — the
   operator sees a task stuck "awaiting approval" with no way to answer it.
   */
-  const isIntakeColumn = workflowMoveMetadata?.currentColumnFlags
-    ? workflowMoveMetadata.currentColumnFlags.intake === true
-    : task.column === "triage";
+  const isIntakeColumn = isIntakeColumnRole(workflowMoveMetadata?.currentColumnFlags, task.column);
   const isAwaitingApproval = isIntakeColumn && task.status === "awaiting-approval";
   const isPlanReviewReplanCapApproval = isReviewBudgetExhaustedApproval(task);
 

--- a/packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx
@@ -320,3 +320,61 @@ describe("TaskContextMenu shared task action model", () => {
     expect(pause).toHaveFocus();
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+The overflow menu must be suppressed by the intake ROLE, not by the legacy intake id.
+
+WHY THIS DIRECTION IS THE DANGEROUS ONE. The cases above cover a card whose column IS
+literally `triage`, which is the only shape the id comparison ever got right — and they
+passed both before and after the conversion, so they prove nothing about it. What #2515
+broke is the opposite: with `triage` gone from the lineage, `task.column !== "triage"` is
+TRUE for every real card, so the suppression stopped applying anywhere and every planning
+card started rendering an actions menu, empty ones included. Nothing threw and no existing
+case noticed.
+
+REVERT CHECK, measured: restoring the id comparison fails the first case below with
+`expected true to be false`.
+*/
+describe("actions-menu suppression resolves the intake ROLE (post-#2515)", () => {
+  const INTAKE_FLAGS = { intake: true, hold: true } as const;
+
+  it("suppresses the menu for an intake card whose column id is NOT the legacy one", () => {
+    // `todo` is the merged planning column: intake by trait, and nothing actionable on it.
+    const model = buildTaskActionMenuModel({
+      task: makeTask({ column: "todo" }),
+      t,
+      columnLabel: columnLabel as any,
+      currentColumnFlags: INTAKE_FLAGS as any,
+    });
+    expect(model.shouldShowActionsMenu).toBe(false);
+  });
+
+  it("still shows the menu for an intake card that HAS something actionable", () => {
+    // The suppression must narrow, not swallow: a retryable planning card keeps its menu.
+    const model = buildTaskActionMenuModel({
+      task: makeTask({ column: "todo", status: "failed" as any }),
+      t,
+      columnLabel: columnLabel as any,
+      currentColumnFlags: INTAKE_FLAGS as any,
+      canRetryTask: true,
+      hasRetryHandler: true,
+    });
+    expect(model.shouldShowActionsMenu).toBe(true);
+  });
+
+  it("does NOT suppress the menu for a mid-flight card, whatever its id", () => {
+    /*
+    The inversion guard. `isPreExecutionHoldColumn` previously ORed the legacy id with the
+    traits unconditionally, so a column named `triage` whose traits say it is executing
+    answered true and offered Plan on a running card. Traits decide now.
+    */
+    const model = buildTaskActionMenuModel({
+      task: makeTask({ column: "triage" }),
+      t,
+      columnLabel: columnLabel as any,
+      currentColumnFlags: { intake: false, hold: false, countsTowardWip: true } as any,
+    });
+    expect(model.shouldShowActionsMenu).toBe(true);
+  });
+});

--- a/packages/dashboard/app/components/__tests__/column-role-id-invariance.test.tsx
+++ b/packages/dashboard/app/components/__tests__/column-role-id-invariance.test.tsx
@@ -1,0 +1,154 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8, completion criterion 3):
+EVIDENCE that the converted dashboard surfaces behave on a RENAMED board and on the
+MERGED board — stated as an invariance property rather than a pile of per-site cases.
+
+THE CLAIM THE CONVERSION MAKES. After resolving roles from traits, a surface's behaviour
+is a function of the column's TRAITS, not of its id. So the test is: hold the traits
+fixed, change only the id, and every decision must be identical. That is one assertion
+covering every site at once, and it fails for any site that still consults an id — which
+per-site cases cannot promise, because a per-site case only proves the site it names.
+
+WHY THIS IS NOT A RESTATEMENT OF THE HELPER TESTS. `columnRoles.test.ts` proves the
+helpers answer correctly. It cannot prove the CONSUMERS ask them: a component that kept an
+inline id comparison passes every helper test. These cases drive the real consumers —
+`buildTaskActionMenuModel` and `isTaskAgentActive`, the predicates behind the actions menu,
+the pulsing badge, the row border and the column header's executing count — and compare
+their outputs across three lineages that differ only in naming.
+
+THE THREE LINEAGES.
+  MERGED   — post-#2515 default: one pre-implementation column, id `todo`, "Planning".
+  LEGACY   — the pre-merge shape, id `triage`, same traits.
+  RENAMED  — a custom board: `backlog` / `building` / `shipped`, same traits.
+An id-sensitive site behaves differently on at least one of the three; a trait-driven one
+cannot tell them apart.
+
+REVERT CHECK, measured. Restoring `task.column !== "triage"` in `shouldShowActionsMenu`
+fails the actions-menu invariance case (MERGED and RENAMED start showing a menu that
+LEGACY suppresses). Restoring the intake-id comparison in `taskActivity`'s planner-lane
+check fails the agent-active case the same way. Both were run.
+*/
+import { describe, expect, it, vi } from "vitest";
+import type { Task } from "@fusion/core";
+import { buildTaskActionMenuModel } from "../TaskContextMenu";
+import { isTaskAgentActive } from "../../utils/taskActivity";
+
+const t = ((_key: string, fallback?: string) => fallback ?? _key) as never;
+const columnLabel = ((column: string) => column) as never;
+
+/**
+ * The same PRE-IMPLEMENTATION column expressed three ways. Traits are byte-identical;
+ * only `id` differs, which is the whole point.
+ */
+const PRE_IMPLEMENTATION_TRAITS = { intake: true, hold: true } as const;
+const LINEAGES = [
+  { label: "MERGED (post-#2515 default)", columnId: "todo" },
+  { label: "LEGACY (pre-merge)", columnId: "triage" },
+  { label: "RENAMED (custom board)", columnId: "backlog" },
+] as const;
+
+/** A mid-flight column, likewise expressed under three names. */
+const WIP_TRAITS = { countsTowardWip: true } as const;
+const WIP_LINEAGES = [
+  { label: "MERGED", columnId: "in-progress" },
+  { label: "RENAMED", columnId: "building" },
+] as const;
+
+function mkTask(overrides: Partial<Task> & { id: string; column: string }): Task {
+  return {
+    title: overrides.id,
+    description: "Task",
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    status: undefined,
+    paused: false,
+    log: [],
+    createdAt: "2026-07-27T00:00:00.000Z",
+    updatedAt: "2026-07-27T00:00:00.000Z",
+    ...overrides,
+  } as unknown as Task;
+}
+
+/** Every decision the actions menu exposes, as a comparable shape. */
+function menuDecisions(columnId: string, flags: Record<string, boolean>, task: Partial<Task> = {}) {
+  const model = buildTaskActionMenuModel({
+    task: mkTask({ id: "FN-1", column: columnId, ...task }),
+    t,
+    columnLabel,
+    currentColumnFlags: flags as never,
+    onPlan: vi.fn(),
+  } as never);
+  return {
+    shouldShowActionsMenu: model.shouldShowActionsMenu,
+    actionIds: model.actions.map((action: { id: string }) => action.id),
+  };
+}
+
+describe("column-role decisions are invariant under column RENAMING (U12 evidence)", () => {
+  it("the actions menu decides identically on merged, legacy and renamed lineages", () => {
+    const decisions = LINEAGES.map((lineage) => ({
+      label: lineage.label,
+      ...menuDecisions(lineage.columnId, PRE_IMPLEMENTATION_TRAITS as never),
+    }));
+
+    /*
+    Compared against the FIRST lineage rather than a hardcoded expectation: the property
+    under test is agreement, and hardcoding would quietly bake in whichever shape happened
+    to be current. If a site consults an id, the entries diverge and the diff names it.
+    */
+    const [first, ...rest] = decisions;
+    for (const other of rest) {
+      expect({ ...other, label: first!.label }).toEqual(first);
+    }
+
+    // And the shape is not vacuous: a pre-implementation card really does offer Plan.
+    expect(first!.actionIds).toContain("plan");
+  });
+
+  it("a mid-flight card decides identically whether its column is `in-progress` or `building`", () => {
+    const decisions = WIP_LINEAGES.map((lineage) => ({
+      label: WIP_LINEAGES[0]!.label,
+      ...menuDecisions(lineage.columnId, WIP_TRAITS as never),
+    }));
+    expect(decisions[1]).toEqual(decisions[0]);
+    // The inversion guard, stated positively: executing cards are never planning targets.
+    expect(decisions[0]!.actionIds).not.toContain("plan");
+  });
+
+  it("planner activity reads as agent-active identically across all three lineages", () => {
+    /*
+    `isTaskAgentActive` drives three separate surfaces from one predicate, so an id-sensitive
+    fallback here reports planning work as idle board-wide — the failure that motivated the
+    `taskActivity` conversion, and one that throws nothing.
+    */
+    const recent = new Date(Date.now() - 5_000).toISOString();
+    const verdicts = LINEAGES.map((lineage) =>
+      isTaskAgentActive(
+        mkTask({ id: "FN-2", column: lineage.columnId, recentAgentActivityAt: recent } as never),
+        { columnFlags: PRE_IMPLEMENTATION_TRAITS as never },
+      ),
+    );
+
+    expect(new Set(verdicts).size).toBe(1);
+    // Non-vacuous: fresh planner activity on a pre-implementation card IS active.
+    expect(verdicts[0]).toBe(true);
+  });
+
+  it("a stale planner card is inactive on all three lineages, so the invariance is not just `always true`", () => {
+    /*
+    Without this, the case above would pass for a predicate hardwired to `true`. Both
+    verdicts must be unanimous AND opposite each other for the invariance to mean anything.
+    */
+    const stale = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const verdicts = LINEAGES.map((lineage) =>
+      isTaskAgentActive(
+        mkTask({ id: "FN-3", column: lineage.columnId, recentAgentActivityAt: stale } as never),
+        { columnFlags: PRE_IMPLEMENTATION_TRAITS as never },
+      ),
+    );
+
+    expect(new Set(verdicts).size).toBe(1);
+    expect(verdicts[0]).toBe(false);
+  });
+});

--- a/packages/dashboard/app/components/__tests__/taskSorting.test.ts
+++ b/packages/dashboard/app/components/__tests__/taskSorting.test.ts
@@ -139,3 +139,63 @@ describe("sortTasksForDisplayColumn", () => {
     ]);
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+The hold lane's QUEUE ORDER must follow the hold trait, not the id `todo`.
+
+Priority-then-FIFO is what makes a high-priority card visibly next in the lane where work
+waits for capacity. Keyed on the id it degrades to the generic sort on any board whose
+hold column is renamed — the card order is simply wrong, and nothing fails. U11 is what
+separated the two questions: `todo` GAINED the hold trait, so "is this column named todo"
+and "is this the lane work waits in" stopped being the same test.
+
+REVERT CHECK, measured: restoring `if (column === "todo")` fails the renamed case below —
+the high-priority card comes back second instead of first.
+*/
+describe("hold-lane queue order follows the hold TRAIT", () => {
+  const mk = (id: string, priority: string, createdAt: string, column = "backlog") =>
+    ({ id, title: id, priority, createdAt, column, steps: [], dependencies: [], log: [] } as never);
+
+  /*
+  THE DISCRIMINATOR IS THE TIEBREAK, not the priority. Both branches sort by priority
+  first, so a priority difference proves nothing about which branch ran — my first attempt
+  at this asserted exactly that and passed for the wrong reason.
+
+  What is unique to the hold lane is FIFO: equal priority tiebreaks on `createdAt`, where
+  the generic sort tiebreaks on task id. So these two carry the same priority and have
+  createdAt order DISAGREEING with id order — FN-9 is older, FN-2 has the lower id.
+    hold branch    -> FIFO      -> FN-9 first
+    generic branch -> id ascending -> FN-2 first
+  */
+  const older = mk("FN-9", "normal", "2026-07-01T00:00:00.000Z");
+  const newer = mk("FN-2", "normal", "2026-07-05T00:00:00.000Z");
+
+  it("applies FIFO order on a RENAMED hold column when the trait is supplied", () => {
+    const sorted = sortTasksForDisplayColumn([newer, older], "backlog" as never, undefined, false, true);
+    expect(sorted.map((task) => task.id)).toEqual(["FN-9", "FN-2"]);
+  });
+
+  it("still applies it to the legacy `todo` id by default, for callers that resolve no flags", () => {
+    // Lane and ListView do not pass flags; the default keeps their behaviour unchanged.
+    const sorted = sortTasksForDisplayColumn(
+      [mk("FN-2", "normal", "2026-07-05T00:00:00.000Z", "todo"), mk("FN-9", "normal", "2026-07-01T00:00:00.000Z", "todo")],
+      "todo" as never,
+    );
+    expect(sorted.map((task) => task.id)).toEqual(["FN-9", "FN-2"]);
+  });
+
+  it("does NOT apply FIFO to a non-hold column, which sorts by id", () => {
+    // The narrowing guard: without it, a function that FIFO-sorted everything would pass
+    // the cases above while silently reordering the in-progress and review lanes.
+    const sorted = sortTasksForDisplayColumn([newer, older], "building" as never, undefined, false, false);
+    expect(sorted.map((task) => task.id)).toEqual(["FN-2", "FN-9"]);
+  });
+
+  it("keeps priority ahead of FIFO in the hold lane", () => {
+    // FIFO is the tiebreak, not the primary key: a newer high-priority card still leads.
+    const high = mk("FN-3", "high", "2026-07-09T00:00:00.000Z");
+    const sorted = sortTasksForDisplayColumn([older, high], "backlog" as never, undefined, false, true);
+    expect(sorted.map((task) => task.id)).toEqual(["FN-3", "FN-9"]);
+  });
+});

--- a/packages/dashboard/app/components/taskSorting.ts
+++ b/packages/dashboard/app/components/taskSorting.ts
@@ -54,6 +54,20 @@ export function sortTasksForDisplayColumn(
   column: Column,
   doneSortMode: DoneColumnSortMode = "completion-date-desc",
   isArchivedColumn: boolean = column === "archived",
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  Does this column HOLD planned work waiting for capacity? Follows the same
+  caller-supplies-the-trait shape `isArchivedColumn` already established, and defaults to
+  the legacy id so the callers that do not resolve flags (Lane, ListView) keep today's
+  behaviour exactly.
+
+  The priority-then-FIFO order below is the hold lane's queue order — it is what makes a
+  high-priority card visibly next. Keyed on the id, it silently degrades to the generic
+  sort on any board whose hold column is not named `todo`, so a renamed lineage loses
+  priority ordering with nothing failing. Not a rename: `todo` gained the hold trait in
+  U11, so the id and the role stopped being the same question.
+  */
+  isHoldColumn: boolean = column === "todo",
 ): Task[] {
   /*
   FNXC:ArchivePagination 2026-07-08-00:00:
@@ -70,7 +84,7 @@ export function sortTasksForDisplayColumn(
     return [...tasks];
   }
 
-  if (column === "todo") {
+  if (isHoldColumn) {
     return [...tasks].sort((a, b) => {
       const priorityCmp = compareTaskPriority(a.priority, b.priority);
       if (priorityCmp !== 0) return priorityCmp;

--- a/packages/dashboard/app/utils/__tests__/worktreeGrouping.test.ts
+++ b/packages/dashboard/app/utils/__tests__/worktreeGrouping.test.ts
@@ -174,7 +174,7 @@ describe("upcoming-work queue resolves the hold lane by trait", () => {
 
   it("finds waiting cards in a RENAMED hold column when the ids are supplied", () => {
     const waiting = mkTask("FN-50", "backlog");
-    const groups = groupByWorktree([], [waiting], 3, new Set(["backlog"]));
+    const groups = groupByWorktree([], [waiting], 3, new Set(["FN-50"]));
     const queued = groups.flatMap((group) => group.queuedTasks ?? []);
     expect(queued.map((task: { id: string }) => task.id)).toContain("FN-50");
   });
@@ -196,10 +196,51 @@ describe("upcoming-work queue resolves the hold lane by trait", () => {
     expect(queued.map((task: { id: string }) => task.id)).toContain("FN-52");
   });
 
-  it("does not treat a non-hold column as waiting even when ids are supplied", () => {
-    // The narrowing guard: a set-based lookup that ignored its set would pass the first case.
-    const groups = groupByWorktree([], [mkTask("FN-53", "building")], 3, new Set(["backlog"]));
+  it("does not treat a task outside the resolved set as waiting", () => {
+    /*
+    The narrowing guard: a lookup that ignored its set would pass the first case. It is keyed
+    on TASK id, so this also pins the per-workflow scoping — a card whose own workflow does
+    not mark its column `hold` is absent from the set even if another workflow reuses the id
+    (PR #2625 review).
+    */
+    const groups = groupByWorktree([], [mkTask("FN-53", "building")], 3, new Set(["FN-99"]));
     const queued = groups.flatMap((group) => group.queuedTasks ?? []);
     expect(queued.map((task: { id: string }) => task.id)).not.toContain("FN-53");
+  });
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2625 review — greptile):
+TWO WORKFLOWS, ONE COLUMN NAME, DIFFERENT TRAITS — the case that killed the first design.
+
+My first version passed a board-wide set of hold COLUMN ids. Column ids are namespaced per
+workflow, so workflow A can declare `staging` as its hold lane while workflow B declares
+`staging` as executing. A unioned id set answers "is `staging` a hold column?" — a question
+with no single answer — and every executing card in workflow B would have been listed under
+Up Next as waiting work. Confidently wrong, which is worse than the renamed-board emptiness
+the change set out to fix.
+
+Keying on TASK id moves the decision to the only place that can make it: the caller, which
+knows each task's own workflow. This case is the regression test for that, expressed the way
+the helper now sees it — one card in the set, one not, both in a column called `staging`.
+*/
+describe("hold resolution is scoped per workflow, not per column name", () => {
+  const mkTask = (id: string, column: string) =>
+    ({
+      id, title: id, description: "", column, dependencies: [], steps: [], currentStep: 0,
+      log: [], createdAt: "2026-07-01T00:00:00.000Z", updatedAt: "2026-07-01T00:00:00.000Z",
+    } as never);
+
+  it("lists only the card whose OWN workflow marks `staging` as hold", () => {
+    const waitingInA = mkTask("FN-60", "staging");
+    const executingInB = mkTask("FN-61", "staging");
+
+    // What Board computes: FN-60's workflow declares `staging` hold; FN-61's does not.
+    const groups = groupByWorktree([], [waitingInA, executingInB], 3, new Set(["FN-60"]));
+    const queued = groups.flatMap((group) => group.queuedTasks ?? []).map((task: { id: string }) => task.id);
+
+    expect(queued).toContain("FN-60");
+    // The assertion the column-id design could not satisfy: same column name, opposite answer.
+    expect(queued).not.toContain("FN-61");
   });
 });

--- a/packages/dashboard/app/utils/__tests__/worktreeGrouping.test.ts
+++ b/packages/dashboard/app/utils/__tests__/worktreeGrouping.test.ts
@@ -147,3 +147,59 @@ describe("groupByWorktree", () => {
     expect(upNext!.queuedTasks).toEqual([queued]);
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+The upcoming-work list must find the HOLD lane by trait, not by the id `todo`.
+
+WHY THIS ONE HID. On the default board the id and the role coincide — U11 gave `todo` the
+hold trait — so every existing case here passed and the site looked healthy. Rename the
+hold column and the filter matched nothing: the worktree view showed no upcoming work at
+all and read as idle. A whole panel silently empty, nothing thrown.
+
+Board resolves the hold ids across ALL workflows on the board (a card in another
+workflow's hold lane is still upcoming work); Lane passes nothing and keeps the legacy
+fallback, which is why the default case below omits the argument entirely.
+
+REVERT CHECK, measured: dropping the parameter back to `t.column === "todo"` fails the
+renamed case with an empty queue.
+*/
+describe("upcoming-work queue resolves the hold lane by trait", () => {
+  const mkTask = (id: string, column: string, extra: Record<string, unknown> = {}) =>
+    ({
+      id, title: id, description: "", column, dependencies: [], steps: [], currentStep: 0,
+      log: [], createdAt: "2026-07-01T00:00:00.000Z", updatedAt: "2026-07-01T00:00:00.000Z",
+      ...extra,
+    } as never);
+
+  it("finds waiting cards in a RENAMED hold column when the ids are supplied", () => {
+    const waiting = mkTask("FN-50", "backlog");
+    const groups = groupByWorktree([], [waiting], 3, new Set(["backlog"]));
+    const queued = groups.flatMap((group) => group.queuedTasks ?? []);
+    expect(queued.map((task: { id: string }) => task.id)).toContain("FN-50");
+  });
+
+  it("finds nothing in a renamed hold column when the ids are NOT supplied", () => {
+    /*
+    Pins the fallback's real limit rather than pretending it covers custom boards: with no
+    resolved ids the legacy guess is all there is, and it cannot know about `backlog`. This
+    is the case that used to be the ONLY behaviour, on every board.
+    */
+    const groups = groupByWorktree([], [mkTask("FN-51", "backlog")], 3);
+    const queued = groups.flatMap((group) => group.queuedTasks ?? []);
+    expect(queued.map((task: { id: string }) => task.id)).not.toContain("FN-51");
+  });
+
+  it("still finds legacy `todo` cards with no ids supplied, so Lane is unaffected", () => {
+    const groups = groupByWorktree([], [mkTask("FN-52", "todo")], 3);
+    const queued = groups.flatMap((group) => group.queuedTasks ?? []);
+    expect(queued.map((task: { id: string }) => task.id)).toContain("FN-52");
+  });
+
+  it("does not treat a non-hold column as waiting even when ids are supplied", () => {
+    // The narrowing guard: a set-based lookup that ignored its set would pass the first case.
+    const groups = groupByWorktree([], [mkTask("FN-53", "building")], 3, new Set(["backlog"]));
+    const queued = groups.flatMap((group) => group.queuedTasks ?? []);
+    expect(queued.map((task: { id: string }) => task.id)).not.toContain("FN-53");
+  });
+});

--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -81,3 +81,24 @@ export function isPreImplementationColumnRole(flags: ColumnRoleFlags | undefined
 export function isHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
   return flags ? flags.hold === true : columnId === LEGACY_HOLD_COLUMN_ID;
 }
+
+/**
+ * May a card in this column be sent back to PLANNING — i.e. is it a pre-execution hold?
+ *
+ * Traits behave like {@link isPreImplementationColumnRole}: either `intake` or `hold`
+ * qualifies. The FALLBACK is deliberately narrower — the legacy INTAKE id only, never
+ * `todo`.
+ *
+ * Why the asymmetry, which is easy to mistake for an oversight: the pre-implementation
+ * fallback guards a PROMPT ("keep your progress?"), so guessing generously costs one extra
+ * confirmation. This one gates an ACTION that re-plans a task, and pre-U11 `todo` was the
+ * ready-to-execute lane, so guessing generously would offer Plan on a card that is running.
+ * Widening it is a behaviour change with a real failure mode, not a vocabulary conversion —
+ * so it stays faithful, and `packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx`
+ * fails if it is widened (that is how the asymmetry was found rather than assumed).
+ */
+export function isPreExecutionHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags
+    ? Boolean(flags.intake || flags.hold)
+    : columnId === LEGACY_INTAKE_COLUMN_ID;
+}

--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -16,7 +16,7 @@ loses completed steps with no prompt and no error. That is why the fallback exis
 why deleting it is not the cleanup it looks like.
 
 What was wrong was having the fallback THREE TIMES, inline, as `column === "todo" ||
-column === "triage"`. Copies drift, none of them were reachable from a test, and each
+an inline `todo`-or-legacy-intake id test. Copies drift, none of them were reachable from a test, and each
 read like a lifecycle rule rather than the degraded mode it is. Here it is named, has one
 definition, and is covered — including the degraded path itself, which is the part that
 never had a test.
@@ -101,4 +101,22 @@ export function isPreExecutionHoldColumnRole(flags: ColumnRoleFlags | undefined,
   return flags
     ? Boolean(flags.intake || flags.hold)
     : columnId === LEGACY_INTAKE_COLUMN_ID;
+}
+
+/**
+ * Is this column the PLANNER's lane — where planner-agent activity should read as active?
+ *
+ * Narrower than {@link isPreImplementationColumnRole}: an intake lane always qualifies, but
+ * a plain hold lane counts only while the card is replanning. A parked hold card is waiting,
+ * not being worked on, and treating it as agent-active would light the pulsing badge, the
+ * row border, and the column header's executing count on an idle card.
+ */
+export function isPlannerLaneColumnRole(
+  flags: ColumnRoleFlags | undefined,
+  columnId: string,
+  isReplanning: boolean,
+): boolean {
+  return flags
+    ? flags.intake === true || (flags.hold === true && isReplanning)
+    : columnId === LEGACY_INTAKE_COLUMN_ID || (columnId === LEGACY_HOLD_COLUMN_ID && isReplanning);
 }

--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -42,6 +42,15 @@ const LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS: ReadonlySet<string> = new Set(["todo
 const LEGACY_INTAKE_COLUMN_ID = "triage";
 
 /**
+ * Pre-graph hold id, used only when a column has no resolved traits.
+ *
+ * Post-U11 `todo` carries BOTH `intake` and `hold` in the default lineage, which is why
+ * the intake and hold fallbacks name different ids and neither can be derived from the
+ * other.
+ */
+const LEGACY_HOLD_COLUMN_ID = "todo";
+
+/**
  * Does this column play the INTAKE role — the lane a card enters before implementation?
  *
  * Drives the transient Planning badge. Traits when resolved; the legacy intake id only
@@ -62,4 +71,13 @@ export function isPreImplementationColumnRole(flags: ColumnRoleFlags | undefined
   return flags
     ? Boolean(flags.intake || flags.hold)
     : LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS.has(columnId);
+}
+
+/**
+ * Does this column play the HOLD role — a lane a card waits in rather than works in?
+ *
+ * Traits when resolved; the legacy hold id only when they are absent.
+ */
+export function isHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags ? flags.hold === true : columnId === LEGACY_HOLD_COLUMN_ID;
 }

--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -1,122 +1,18 @@
 /*
 FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-ONE place that answers "what ROLE does this column play?" when trait metadata may be
-missing, replacing three copy-pasted id fallbacks in ListView.
+Re-export only. The column-ROLE helpers are defined in `@fusion/core`
+(`packages/core/src/column-roles.ts`) because the server side needs the same fallback —
+live agent counting and comment gating ask the same question. Keeping a second copy here
+would put the legacy-id guess in two places, which is the drift this conversion removes.
 
-WHY A HELPER AND NOT A BARE TRAIT READ. Trait flags come from the resolved workflow, so
-`columnFlagsById` legitimately has no entry in two states:
-
-  1. the pre-load window — the board renders before the workflows fetch resolves;
-  2. a stranded card resting in a column its workflow no longer declares.
-
-A bare `flags.intake === true` returns false in both, which is silent degradation rather
-than a visible failure: the Planning badge just stops appearing, and a move back into a
-pre-implementation lane stops asking whether to preserve step progress — so an operator
-loses completed steps with no prompt and no error. That is why the fallback exists and
-why deleting it is not the cleanup it looks like.
-
-What was wrong was having the fallback THREE TIMES, inline, as `column === "todo" ||
-an inline `todo`-or-legacy-intake id test. Copies drift, none of them were reachable from a test, and each
-read like a lifecycle rule rather than the degraded mode it is. Here it is named, has one
-definition, and is covered — including the degraded path itself, which is the part that
-never had a test.
+This shim exists so the ~8 dashboard call sites keep a local import path; delete it and
+point them at `@fusion/core` if that ever stops being worth a file.
 */
-
-/** The subset of a column's resolved trait flags these role questions need. */
-export interface ColumnRoleFlags {
-  readonly intake?: boolean;
-  readonly hold?: boolean;
-}
-
-/**
- * The pre-graph column ids that behaved as pre-implementation lanes.
- *
- * NOT a lifecycle rule — a last-resort guess used only when a column has no resolved
- * traits. `todo` is the post-U11 merged planning column; `triage` is its pre-merge
- * predecessor, retained because a project upgraded mid-flight can still hold cards there
- * while its workflow no longer declares it.
- */
-const LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS: ReadonlySet<string> = new Set(["todo", "triage"]);
-
-/** Pre-merge intake id, used only when a column has no resolved traits. */
-const LEGACY_INTAKE_COLUMN_ID = "triage";
-
-/**
- * Pre-graph hold id, used only when a column has no resolved traits.
- *
- * Post-U11 `todo` carries BOTH `intake` and `hold` in the default lineage, which is why
- * the intake and hold fallbacks name different ids and neither can be derived from the
- * other.
- */
-const LEGACY_HOLD_COLUMN_ID = "todo";
-
-/**
- * Does this column play the INTAKE role — the lane a card enters before implementation?
- *
- * Drives the transient Planning badge. Traits when resolved; the legacy intake id only
- * when they are absent, so the badge does not vanish during first paint.
- */
-export function isIntakeColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
-  return flags ? flags.intake === true : columnId === LEGACY_INTAKE_COLUMN_ID;
-}
-
-/**
- * Is this column a PRE-IMPLEMENTATION lane — intake or a hold?
- *
- * Drives the "preserve progress?" prompt when a card with completed steps is moved
- * backwards. Either trait qualifies: both mean work has not started there, so moving a
- * part-done card in risks discarding steps.
- */
-export function isPreImplementationColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
-  return flags
-    ? Boolean(flags.intake || flags.hold)
-    : LEGACY_PRE_IMPLEMENTATION_COLUMN_IDS.has(columnId);
-}
-
-/**
- * Does this column play the HOLD role — a lane a card waits in rather than works in?
- *
- * Traits when resolved; the legacy hold id only when they are absent.
- */
-export function isHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
-  return flags ? flags.hold === true : columnId === LEGACY_HOLD_COLUMN_ID;
-}
-
-/**
- * May a card in this column be sent back to PLANNING — i.e. is it a pre-execution hold?
- *
- * Traits behave like {@link isPreImplementationColumnRole}: either `intake` or `hold`
- * qualifies. The FALLBACK is deliberately narrower — the legacy INTAKE id only, never
- * `todo`.
- *
- * Why the asymmetry, which is easy to mistake for an oversight: the pre-implementation
- * fallback guards a PROMPT ("keep your progress?"), so guessing generously costs one extra
- * confirmation. This one gates an ACTION that re-plans a task, and pre-U11 `todo` was the
- * ready-to-execute lane, so guessing generously would offer Plan on a card that is running.
- * Widening it is a behaviour change with a real failure mode, not a vocabulary conversion —
- * so it stays faithful, and `packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx`
- * fails if it is widened (that is how the asymmetry was found rather than assumed).
- */
-export function isPreExecutionHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
-  return flags
-    ? Boolean(flags.intake || flags.hold)
-    : columnId === LEGACY_INTAKE_COLUMN_ID;
-}
-
-/**
- * Is this column the PLANNER's lane — where planner-agent activity should read as active?
- *
- * Narrower than {@link isPreImplementationColumnRole}: an intake lane always qualifies, but
- * a plain hold lane counts only while the card is replanning. A parked hold card is waiting,
- * not being worked on, and treating it as agent-active would light the pulsing badge, the
- * row border, and the column header's executing count on an idle card.
- */
-export function isPlannerLaneColumnRole(
-  flags: ColumnRoleFlags | undefined,
-  columnId: string,
-  isReplanning: boolean,
-): boolean {
-  return flags
-    ? flags.intake === true || (flags.hold === true && isReplanning)
-    : columnId === LEGACY_INTAKE_COLUMN_ID || (columnId === LEGACY_HOLD_COLUMN_ID && isReplanning);
-}
+export type { ColumnRoleFlags } from "@fusion/core";
+export {
+  isHoldColumnRole,
+  isIntakeColumnRole,
+  isPlannerLaneColumnRole,
+  isPreExecutionHoldColumnRole,
+  isPreImplementationColumnRole,
+} from "@fusion/core";

--- a/packages/dashboard/app/utils/taskActivity.ts
+++ b/packages/dashboard/app/utils/taskActivity.ts
@@ -1,5 +1,6 @@
 import type { Task } from "@fusion/core";
 import { getUnifiedTaskProgress } from "./taskProgress";
+import { isPlannerLaneColumnRole } from "./columnRoles";
 
 /** The shared status vocabulary for active task phases and lock/model policy. */
 export const ACTIVE_STATUSES = new Set([
@@ -23,7 +24,7 @@ export interface TaskAgentActivityOptions {
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
   The task's own column traits, when the caller has them. Fresh-planner-activity was
-  keyed on `column === "triage"`, so under U11 — merged planning column keeps the id
+  keyed on the legacy intake id, so under U11 — merged planning column keeps the id
   `todo`, `triage` deleted — a planning card with live planner logs stops reading as
   agent-active. That is not one badge: this predicate drives the pulsing status badge,
   the agent-active row border, and the column header's executing count, so the whole
@@ -84,9 +85,7 @@ export function isTaskAgentActive(
   "intake lane, or a hold lane that is replanning"; without them it falls back to the
   ids, which is the same shape the two lanes have today.
   */
-  const inPlannerLane = options.columnFlags
-    ? options.columnFlags.intake === true || (options.columnFlags.hold === true && isReplanning)
-    : task.column === "triage" || (task.column === "todo" && isReplanning);
+  const inPlannerLane = isPlannerLaneColumnRole(options.columnFlags, task.column, isReplanning);
   const hasFreshPlannerActivity = inPlannerLane
     && Number.isFinite(recentPlannerActivityAtMs)
     && nowMs - recentPlannerActivityAtMs >= 0

--- a/packages/dashboard/app/utils/worktreeGrouping.ts
+++ b/packages/dashboard/app/utils/worktreeGrouping.ts
@@ -61,13 +61,19 @@ export function groupByWorktree(
   maxConcurrent: number,
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-  The ids of every column on the board carrying the HOLD trait, when the caller resolved
-  them. A SET rather than one column's flags because this helper scans `allTasks`: it must
-  recognise the hold lane of any workflow represented on the board, which is the reason the
-  earlier note said there was no seam here. Board has that information; Lane does not, and
-  omitting it keeps the documented legacy-id fallback.
+  The ids of TASKS whose own column is a hold lane in their own workflow, when the caller
+  resolved them.
+
+  Task ids, not column ids (PR #2625 review — greptile). This helper scans `allTasks`, which
+  can span workflows, and column ids are namespaced per workflow — two workflows may both
+  declare `staging` with only one of them marking it `hold`. A unioned column-id set cannot
+  tell those apart and would list every executing card of the second workflow as waiting.
+  Only a card's own workflow can answer "is this waiting?", so the caller answers it per task
+  and passes the result.
+
+  Board resolves this; Lane does not pass it and keeps the legacy-id fallback.
   */
-  holdColumnIds?: ReadonlySet<string>,
+  holdTaskIds?: ReadonlySet<string>,
 ): WorktreeGroupData[] {
   // Separate assigned vs unassigned in-progress tasks
   const assigned = inProgressTasks.filter((t) => t.worktree);
@@ -98,9 +104,9 @@ export function groupByWorktree(
   */
   // Find queued hold-lane tasks: cards in the hold column with all deps satisfied.
   const taskById = new Map(allTasks.map((t) => [t.id, t]));
-  const isWaitingColumn = (column: string): boolean =>
-    holdColumnIds ? holdColumnIds.has(column) : isHoldColumnRole(undefined, column);
-  const todoTasks = allTasks.filter((t) => isWaitingColumn(t.column));
+  const isWaitingTask = (task: Task): boolean =>
+    holdTaskIds ? holdTaskIds.has(task.id) : isHoldColumnRole(undefined, task.column);
+  const todoTasks = allTasks.filter(isWaitingTask);
   const eligible = todoTasks.filter((t) =>
     !t.paused &&
     (t.dependencies || []).every((depId) => {

--- a/packages/dashboard/app/utils/worktreeGrouping.ts
+++ b/packages/dashboard/app/utils/worktreeGrouping.ts
@@ -1,5 +1,6 @@
 import type { Task } from "@fusion/core";
 import { getPathBasename } from "./pathDisplay";
+import { isHoldColumnRole } from "@fusion/core";
 
 export interface WorktreeGroupData {
   label: string;
@@ -58,6 +59,15 @@ export function groupByWorktree(
   inProgressTasks: Task[],
   allTasks: Task[],
   maxConcurrent: number,
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  The ids of every column on the board carrying the HOLD trait, when the caller resolved
+  them. A SET rather than one column's flags because this helper scans `allTasks`: it must
+  recognise the hold lane of any workflow represented on the board, which is the reason the
+  earlier note said there was no seam here. Board has that information; Lane does not, and
+  omitting it keeps the documented legacy-id fallback.
+  */
+  holdColumnIds?: ReadonlySet<string>,
 ): WorktreeGroupData[] {
   // Separate assigned vs unassigned in-progress tasks
   const assigned = inProgressTasks.filter((t) => t.worktree);
@@ -74,26 +84,23 @@ export function groupByWorktree(
 
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
-  NOT CONVERTED, deliberately, and this note is the reason rather than an oversight.
+  The filter wants "cards waiting for capacity" — the HOLD role, resolved from the board's
+  columns rather than the id `todo`.
 
-  The filter wants "cards waiting for capacity" — the HOLD role. It cannot resolve that
-  here: it scans `allTasks`, so it needs the traits of every OTHER column on the board,
-  while its only caller (`Column.tsx`) knows the flags of the column it is rendering. There
-  is no seam to pass a trait through, unlike `sortTasksForDisplayColumn`, whose caller
-  already supplies its own column's flags.
+  THE BUG THIS CLOSES, measured rather than assumed: on the default board the id and the
+  role coincide (U11 gave `todo` the hold trait), so this looked healthy. On a board whose
+  hold column is renamed the filter matched NOTHING, so the worktree view showed no upcoming
+  work at all and read as idle — a whole panel silently empty, with nothing failing.
 
-  Current behaviour, measured rather than assumed: correct on the default board, because U11
-  gave `todo` the hold trait, so the id and the role still coincide there. On a board whose
-  hold column is renamed this list is silently EMPTY — the worktree view shows no upcoming
-  work and looks idle. Wrong, but bounded and non-destructive.
-
-  Converting it means plumbing board-level column metadata (a hold-column id set, or the
-  resolved columns) from Board through Column into this helper — a signature change across
-  three files with its own review surface. Left as one unit of work rather than smuggled in.
+  Dependency satisfaction below still names terminal ids. That is a separate question from
+  the hold role and is left alone deliberately: it needs `complete`/`mergeBlocker`/`archived`
+  traits for the DEPENDENCY's column, which is another lookup and another unit of work.
   */
   // Find queued hold-lane tasks: cards in the hold column with all deps satisfied.
   const taskById = new Map(allTasks.map((t) => [t.id, t]));
-  const todoTasks = allTasks.filter((t) => t.column === "todo");
+  const isWaitingColumn = (column: string): boolean =>
+    holdColumnIds ? holdColumnIds.has(column) : isHoldColumnRole(undefined, column);
+  const todoTasks = allTasks.filter((t) => isWaitingColumn(t.column));
   const eligible = todoTasks.filter((t) =>
     !t.paused &&
     (t.dependencies || []).every((depId) => {

--- a/packages/dashboard/app/utils/worktreeGrouping.ts
+++ b/packages/dashboard/app/utils/worktreeGrouping.ts
@@ -72,7 +72,26 @@ export function groupByWorktree(
     worktreeMap.set(key, list);
   }
 
-  // Find queued todo tasks: "todo" tasks with all deps satisfied (done or in-review)
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (U12 — R8 drift conversion):
+  NOT CONVERTED, deliberately, and this note is the reason rather than an oversight.
+
+  The filter wants "cards waiting for capacity" — the HOLD role. It cannot resolve that
+  here: it scans `allTasks`, so it needs the traits of every OTHER column on the board,
+  while its only caller (`Column.tsx`) knows the flags of the column it is rendering. There
+  is no seam to pass a trait through, unlike `sortTasksForDisplayColumn`, whose caller
+  already supplies its own column's flags.
+
+  Current behaviour, measured rather than assumed: correct on the default board, because U11
+  gave `todo` the hold trait, so the id and the role still coincide there. On a board whose
+  hold column is renamed this list is silently EMPTY — the worktree view shows no upcoming
+  work and looks idle. Wrong, but bounded and non-destructive.
+
+  Converting it means plumbing board-level column metadata (a hold-column id set, or the
+  resolved columns) from Board through Column into this helper — a signature change across
+  three files with its own review surface. Left as one unit of work rather than smuggled in.
+  */
+  // Find queued hold-lane tasks: cards in the hold column with all deps satisfied.
   const taskById = new Map(allTasks.map((t) => [t.id, t]));
   const todoTasks = allTasks.filter((t) => t.column === "todo");
   const eligible = todoTasks.filter((t) =>

--- a/packages/dashboard/src/routes/board-workflows.ts
+++ b/packages/dashboard/src/routes/board-workflows.ts
@@ -141,9 +141,9 @@ for an operator to promote them (Coding (Ideas)'s "Ideas" lane).
 
 It exists because the distinction is trait CONFIG (`intake` with `autoTriage: false`),
 not a trait flag, so it was invisible to every client. The dashboard approximated it as
-`intake && column !== "triage"` — a hardcoded id doing the work of a missing fact. That
+`intake` minus a hardcoded legacy id — an id doing the work of a missing fact. That
 approximation inverts under U11: the merged Planning column keeps id `todo` and `triage`
-is deleted, so `column !== "triage"` becomes vacuously TRUE and a "Start" action would
+is deleted, so that exclusion becomes vacuously TRUE and a "Start" action would
 appear on every planning card. Surfacing the real fact is the fix; renaming the
 comparison would not have been.
 */

--- a/packages/engine/src/replan-target.ts
+++ b/packages/engine/src/replan-target.ts
@@ -125,7 +125,7 @@ export function hasAdvancedPastPlanning(
   while a replan is a legitimate BACKWARD move. `firstExecutionAt`/`executionStartedAt` are never
   cleared once implementation starts, so a card that executed, failed Plan Review, and was rebounded
   to a planner lane (`needs-replan`) read as "advanced past planning" forever: triage's discovery
-  filter (`column === "triage" && isTaskStillInPlanningStage`) never re-admitted it and the card sat
+  filter (intake column plus `isTaskStillInPlanningStage`) never re-admitted it and the card sat
   in triage/needs-replan permanently — "stuck in planning" on the board (FN-8594). It hit every
   triage-column workflow (builtin:coding, the default); plan-in-place Ideas cards escaped only
   because todo discovery admits `needs-replan` without consulting this guard.


### PR DESCRIPTION
Batched per the gate instruction: every held conversion in the **dashboard component cluster**, one PR, one CI run.

## Per-file guard counts

| file | before | after |
|---|---:|---:|
| `app/components/TaskCard.tsx` | 4 | **0** |
| `app/components/TaskDetailModal.tsx` | 3 | **0** |
| `app/components/TaskContextMenu.tsx` | 2 | **0** |
| `app/components/Column.tsx` | 2 | **0** |
| `app/utils/taskActivity.ts` | 2 | **0** |
| `src/routes/board-workflows.ts` | 2 | **0** (prose) |
| `engine/src/replan-target.ts` | 1 | **0** (prose) |
| `core/src/types/archive-planning.ts` | 1 | **0** (prose) |
| **total** | **17** | **0** |

`packages/dashboard/app` is now at **zero** lifecycle-column comparisons.

## Four defects, not renames

Per your point 1 — each of these was a guard answering a different question than the one asked:

**1. Every planning card renders an actions menu, including empty ones.** `shouldShowActionsMenu` was `task.column !== "triage"`, TRUE for every card once #2515 removed that id, so the suppression stopped applying anywhere. This is the orphaned click target the Surface Enumeration rule exists to catch. Drifted in the direction that is hardest to notice: nothing stopped firing, it started firing on everything.

**2. Quick-create missing during first paint.** `Column.tsx`'s gate was `(workflowMode || column === "triage")`. `workflowMode` is `Boolean(boardWorkflows?.workflows.length)`, so it is false *only* in the pre-load window — that disjunct is what offers quick-create there, and it named an id no lineage declares. Affordance appeared on no column instead of the planning one.

**3. Hold-lane FIFO ordering lost on renamed boards.** Priority-then-FIFO is what makes a high-priority card visibly next; keyed on `column === "todo"` it degraded to the generic id-ordered sort. U11 split the questions by giving `todo` the hold trait.

**4. Worktree upcoming-work list empty on renamed boards.** `groupByWorktree` filtered `t.column === "todo"`. On the default board id and role coincide so it looked healthy and every existing test passed; renamed, it matched nothing and a whole panel read as idle.

**5. `isPreExecutionHoldColumn` ORed the legacy id with the traits unconditionally**, so a resolved mid-flight column named `triage` offered Plan on a running card.

## Why the id fallbacks survive

The three copies of `column === "todo" || column === "triage"` were **not** renameable. Flags are legitimately absent during first paint and for a card stranded in an undeclared column, and a bare trait read there silently skips the preserve-progress prompt — so a move discards completed steps with no error. Kept, named, defined once in `@fusion/core` (`column-roles.ts`), with that reason at the definition.

Two helpers are **deliberately asymmetric** and tested to stay that way, because both look like they should just delegate:

- `isPreExecutionHoldColumnRole` will not fall back to `todo`. It gates an *action* (re-plan), not a prompt, and pre-U11 `todo` was the ready-to-execute lane — widening it offers re-plan on a running card. **The existing TaskContextMenu suite caught this when I widened it**, so the asymmetry is measured, not assumed.
- `isPlannerLaneColumnRole` counts a hold lane only while replanning. A parked hold card is waiting, not being worked on, and this one predicate drives three surfaces (pulsing badge, row border, column-header executing count).

## Completion criterion 3 — evidence

`column-role-id-invariance.test.tsx` states the claim as a property: hold traits fixed, vary only the column id across **MERGED** (`todo`), **LEGACY** (`triage`) and **RENAMED** (`backlog`), and every decision must agree. It drives the real consumers (`buildTaskActionMenuModel`, `isTaskAgentActive`), which is what helper tests cannot do — a component that kept an inline comparison passes every `columnRoles` case.

Includes a unanimous-and-**false** case so the invariance cannot be satisfied by a predicate hardwired to true.

## Revert checks, all measured

| change | mutation | result |
|---|---|---|
| menu suppression | restore the id literal | diff names `shouldShowActionsMenu` true/false |
| planner lane | restore the id literal | `expected 2 to be 1` (lineages disagree) |
| hold-lane sort | restore `column === "todo"` | `FN-2, FN-9` instead of `FN-9, FN-2` |
| worktree queue | restore `t.column === "todo"` | `expected [] to include 'FN-50'` |
| role helpers | ignore flags / ignore fallback | 4 failed / 2 passed, each way |

The sort test needed fixing: **both branches sort by priority**, so my first version asserted a priority difference and passed for the wrong reason. The real discriminator is the tiebreak — hold uses `createdAt`, generic uses task id — so the cases use equal-priority cards whose createdAt order disagrees with their id order.

## Three things I did NOT do

- **`live-agent-count.ts`** — I converted it, then reverted my own hunk. #2605 is open on that file arguing the two literals must keep both vocabularies; that is correct and my version agreed (the shared fallback keeps `todo` *and* `triage`, so their ratchet passes). We differ only on whether centralising counts as a conversion. Theirs lands first; mine re-applies on top cheaply.
- **`spec-staleness.ts` / `mission-feature-sync.ts`** — converted locally before the assignment list arrived; #2610 landed first and main is already at zero, so I dropped my duplicates and corrected the commit message rather than leave it claiming work it no longer contains.
- **~150 non-`triage` lifecycle comparisons** in `dashboard/app` (TaskCard 37, TaskDetailModal 23). Not bulk-converted: `in-review`/`done`/`archived` still map 1:1 to their traits on the default board, so exposure is renamed-board-only, and 150 edits across files other workers are touching is churn against a bar defined as the `triage` guards. I took only the slice where this program's own change flipped a meaning — the `todo` sites — and 3 of 4 were real defects.

Also left alone deliberately: `groupByWorktree`'s dependency-satisfaction check still names terminal ids. That needs the *dependency's* column traits — another lookup, another unit of work, not something to half-do inside a conversion.

## Note for reviewers

`holdColumnIds` is in Column's memo dep array with a comment explaining why: Board resolves it after the workflows fetch, so omitting it pins the first-paint value and leaves the fallback active all session. This repo has **no** `react-hooks/exhaustive-deps` rule, so nothing catches that automatically.

## Verification

`pnpm lint` clean. `pnpm test:gate` green (10 / 482 / 71). `tsc` clean on core, engine, and `tsconfig.app.json` (the app config — the root one silently skips `app/`). 303 tests across the affected suites.

Pre-existing failures, confirmed by stashing and re-running on the base to get identical counts — not introduced here: `TaskContextMenu.test.tsx` label casing (`"Back to In Progress"` vs `"Back to in-progress"`), and 50/98 in `TaskDetailModal.inline-editing`.