### PR TITLE
TAKING executor.ts rebound guards: the "already there?" check could not see the column the move targeted (8 sites, 151 -> 143)

### DIFF
--- a/.changeset/executor-rebound-already-there.md
+++ b/.changeset/executor-rebound-already-there.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Engine retries no longer re-queue a task into the column it is already sitting in on renamed boards.
+category: fix
+dev: Eight executor rebound guards compared `column !== "todo"` before moving to `resolveReboundColumnFor(...)`; they now resolve once and compare against that value. The FN-1404 `task:move` audit metadata records the resolved column instead of a hardcoded `"todo"`.

--- a/packages/engine/src/__tests__/executor-rebound-already-there.test.ts
+++ b/packages/engine/src/__tests__/executor-rebound-already-there.test.ts
@@ -1,0 +1,125 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-15:30 (Phase C convergence — executor rebound guards):
+
+THE INVARIANT: an engine rebound moves the card only when it is NOT already in the column the
+rebound resolves to — on ANY workflow, not just the default lineage.
+
+WHAT WAS BROKEN. `resolveReboundColumnFor` was converted in U5b, so every rebound MOVE targeted
+the workflow's own backlog column. The eight `X.column !== "todo"` guards standing in front of
+those moves were not converted. On a renamed board the guard was therefore always true, and the
+engine issued a move into the column the card was already sitting in.
+
+WHY THAT IS NOT HARMLESS. `moveTaskInternal` runs the reset-on-entry effects on every real move.
+So the redundant move re-cleared status/error/pause state, and at the stale-parse-pins site
+(`preserveProgress: false`) it RESET STEP PROGRESS a second time on a card that had merely been
+re-checked. The half-conversion shape again: the right target, reached through a check that could
+not see it.
+
+This drives `parkCompletedBlockedTask` — the FN-7926 completed-but-blocked park — because it is
+the rebound site reachable without standing up a graph run. The other seven sites take the
+identical shape and are covered by the same predicate; that is stated rather than implied.
+*/
+import { describe, expect, it, vi } from "vitest";
+import "./executor-test-helpers.js";
+import { TaskExecutor } from "../executor.js";
+import { createMockStore } from "./executor-test-helpers.js";
+import type { WorkflowIr } from "@fusion/core";
+
+/** Standard traits, non-default names: the backlog role lives on `queued`. */
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "queued", name: "Queued", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", name: "Checking", traits: [{ trait: "merge" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+} as unknown as WorkflowIr;
+
+function blockedCompletedTask(column: string) {
+  return {
+    id: "FN-BLOCKED",
+    title: "completed but blocked",
+    description: "",
+    column,
+    worktree: "/repo/.worktrees/blocked",
+    branch: "fusion/fn-blocked",
+    steps: [{ name: "Implement", status: "done" as const }],
+    currentStep: 0,
+    dependencies: [],
+    log: [],
+    createdAt: "2026-07-30T00:00:00.000Z",
+    updatedAt: "2026-07-30T00:00:00.000Z",
+  };
+}
+
+function harness(ir: WorkflowIr | undefined, column: string) {
+  const store = createMockStore();
+  let task: Record<string, unknown> = blockedCompletedTask(column);
+  const moves: Array<[string, string]> = [];
+
+  const selection = { workflowId: "wf-renamed", stepIds: [] as string[] };
+  const widened = store as unknown as Record<string, unknown>;
+  widened.getTaskWorkflowSelection = () => (ir ? selection : undefined);
+  widened.getTaskWorkflowSelectionAsync = async () => (ir ? selection : undefined);
+  widened.getWorkflowDefinition = async () => (ir ? { ir } : undefined);
+
+  store.getTask.mockImplementation(async () => ({ ...task }));
+  store.updateTask.mockImplementation(async (_id: string, updates: Record<string, unknown>) => {
+    task = { ...task, ...updates };
+    return task;
+  });
+  store.moveTask.mockImplementation(async (id: string, to: string) => {
+    moves.push([id, to]);
+    task = { ...task, column: to };
+    return { ...task };
+  });
+  store.recordRunAuditEvent = vi.fn().mockResolvedValue(undefined);
+
+  const executor = new TaskExecutor(store as never, "/repo");
+  const park = (t: Record<string, unknown>) =>
+    (executor as unknown as {
+      parkCompletedBlockedTask: (task: unknown, blocker: string, source: string, workComplete?: boolean) => Promise<boolean>;
+    }).parkCompletedBlockedTask(t, "unmet dependency FN-OTHER", "test", true);
+
+  return { store, moves, park };
+}
+
+describe("an engine rebound does not move a card that is already in its rebound column", () => {
+  it("issues NO move when the renamed board's backlog column already holds the card", async () => {
+    // Pre-fix: `queued !== "todo"` was true, so a move into `queued` was issued — a real move,
+    // which re-runs the reset-on-entry effects on a card nothing had actually moved.
+    const h = harness(RENAMED_IR, "queued");
+
+    const parked = await h.park(blockedCompletedTask("queued"));
+
+    expect(parked).toBe(true);
+    expect(h.moves).toEqual([]);
+  });
+
+  it("DOES move when the card is elsewhere on the renamed board", async () => {
+    // The paired positive: "never move" must not be able to pass for "compare properly".
+    const h = harness(RENAMED_IR, "building");
+
+    await h.park(blockedCompletedTask("building"));
+
+    expect(h.moves).toEqual([["FN-BLOCKED", "queued"]]);
+  });
+
+  it("still skips the redundant move on the default lineage", async () => {
+    const h = harness(undefined, "todo");
+
+    await h.park(blockedCompletedTask("todo"));
+
+    expect(h.moves).toEqual([]);
+  });
+
+  it("still moves to the legacy backlog when the workflow cannot be resolved", async () => {
+    const h = harness(undefined, "in-progress");
+
+    await h.park(blockedCompletedTask("in-progress"));
+
+    expect(h.moves).toEqual([["FN-BLOCKED", "todo"]]);
+  });
+});

--- a/packages/engine/src/__tests__/executor-rebound-guard-shape.test.ts
+++ b/packages/engine/src/__tests__/executor-rebound-guard-shape.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-18:55 (PR #2635 review, greptile P2):
+
+"Seven rebound sites remain untested" — fair, and stating it as a coverage note was not an answer.
+Seven of the eight sit inside graph-failure / stuck-kill / dependency-gate paths that need a live
+graph run to reach, so behavioural coverage for each would cost more scaffolding than the change
+itself. What they share is a SHAPE, so the shape is what gets pinned.
+
+This is a static check over `executor.ts`: every guard in front of a rebound move must compare
+against a RESOLVED value, never a column literal. It fails on the exact defect the PR fixes — a
+`column !== "todo"` check standing in front of a `moveTask(..., reboundColumn)` — at whichever of
+the eight sites it is reintroduced, including sites added later that no behavioural test knows about.
+
+It is a static check and is labelled as one: it proves the pattern is absent, not that each path
+behaves. `executor-rebound-already-there.test.ts` carries the behavioural proof for the one
+reachable site (`parkCompletedBlockedTask`).
+
+It lives in its OWN file because the shared executor test helpers mock `node:fs`, so a suite that
+imports them cannot read source off disk — a detail worth writing down, since the failure looks
+like a broken path rather than a mocked module.
+*/
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+describe("no rebound move is guarded by a column literal", () => {
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "executor.ts"),
+    "utf8",
+  );
+  /** Comments blanked in place so prose about the old shape is not read as code. */
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, (comment) => comment.replace(/[^\n]/g, " "))
+    .replace(/\/\/.*$/gm, "");
+  const lines = code.split("\n");
+
+  it("resolves the rebound column before every guarded rebound move", () => {
+    const offenders: string[] = [];
+
+    lines.forEach((line, index) => {
+      if (!/moveTask\([^)]*reboundColumn/.test(line) && !/reboundColumn,/.test(line)) return;
+      // Walk back a few lines to the guard that admits this move.
+      for (let i = Math.max(0, index - 6); i <= index; i += 1) {
+        if (/column\s*(?:===|!==)\s*["'](?:todo|triage|in-progress|in-review|done|archived)["']/.test(lines[i] ?? "")) {
+          offenders.push(`${i + 1}: ${(lines[i] ?? "").trim()}`);
+        }
+      }
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("finds the defect when it is reintroduced (the check is not vacuous)", () => {
+    // Same detection, run over a fixture carrying the original shape. Without this, a regex that
+    // silently stopped matching would report a clean file forever.
+    const reintroduced = [
+      `    if (task.column !== "todo") {`,
+      `      await this.store.moveTask(task.id, reboundColumn, { preserveProgress: true });`,
+      `    }`,
+    ];
+    const offenders: string[] = [];
+
+    reintroduced.forEach((line, index) => {
+      if (!/moveTask\([^)]*reboundColumn/.test(line)) return;
+      for (let i = Math.max(0, index - 6); i <= index; i += 1) {
+        if (/column\s*(?:===|!==)\s*["'](?:todo|triage|in-progress|in-review|done|archived)["']/.test(reintroduced[i] ?? "")) {
+          offenders.push(String(i + 1));
+        }
+      }
+    });
+
+    expect(offenders).toEqual(["1"]);
+  });
+
+  it("still sees the eight rebound moves it is meant to cover", () => {
+    // A guard that reports success on zero matches is worse than no guard.
+    const reboundMoves = lines.filter((line) => /moveTask\([^)]*(?:rebound|Rebound)Column/.test(line));
+
+    expect(reboundMoves.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1761,6 +1761,17 @@ resume state); the KTD-1 exhaustion parks (FN-8141 blocked, retry-exhausted) set
 `status:"failed"` in place WITHOUT a move and are intentionally untouched here.
 One IR resolution per rebound (a recovery path, not an enumeration loop); any
 resolution failure falls back to the legacy "todo" so a rebound is never stranded.
+
+FNXC:WorkflowLifecycleColumns 2026-07-30-15:10 (Phase C convergence):
+THE "ALREADY THERE?" GUARDS NOW COMPARE AGAINST THIS RESULT. Eight call sites read
+`X.column !== "todo"` before moving to the resolved column — so on a renamed board the
+guard was ALWAYS true and the engine issued a move into the column the card was already
+in. That is a real move: `moveTaskInternal` runs the reset-on-entry effects again. At the
+`preserveProgress: false` site (stale workflow parse pins) it reset step progress a second
+time on a card that had only been re-checked, and every site re-ran the status/error/pause
+clears. The move TARGET was converted here in U5b; the guards in front of it were not,
+which is the half-conversion shape: the correct target reached through a check that could
+not see it. Each site now resolves once and uses the same value for both.
 */
 async function resolveReboundColumnFor(store: TaskStore, taskId: string): Promise<string> {
   try {
@@ -4400,8 +4411,9 @@ export class TaskExecutor {
     FNXC:WorkflowLifecycle 2026-07-12-23:13:
     FN-7926: completed work with a persistent `getTaskCompletionBlocker` result must not self-requeue through the execute node. Re-running implementation cannot clear dependency/blockedBy state, so it only feeds FN-7863's generic no-progress backstop and misclassifies good work as `EXECUTION_DISPATCH_LOOP_EXHAUSTED`. Park in a scheduler-skipped todo state, preserve worktree/branch/steps, and reset the FN-7863 signature so the backstop remains reserved for genuinely incomplete no-progress loops.
     */
-    if (task.column !== "todo") {
-      await this.store.moveTask(task.id, await resolveReboundColumnFor(this.store, task.id), {
+    const reboundColumn = await resolveReboundColumnFor(this.store, task.id);
+    if (task.column !== reboundColumn) {
+      await this.store.moveTask(task.id, reboundColumn, {
         preserveProgress: true,
         preserveResumeState: true,
         preserveWorktree: true,
@@ -11453,8 +11465,9 @@ export class TaskExecutor {
       status: null,
       error: null,
     }, this.getRunContextFor(live.id));
-    if (live.column !== "todo") {
-      await this.store.moveTask(live.id, await resolveReboundColumnFor(this.store, live.id), {
+    const reboundColumn = await resolveReboundColumnFor(this.store, live.id);
+    if (live.column !== reboundColumn) {
+      await this.store.moveTask(live.id, reboundColumn, {
         preserveProgress: true,
         moveSource: "engine",
         recoveryRehome: true,
@@ -11501,8 +11514,9 @@ export class TaskExecutor {
       error: null,
       graphResumeRetryCount: 0,
     }, this.getRunContextFor(live.id));
-    if (live.column !== "todo") {
-      await this.store.moveTask(live.id, await resolveReboundColumnFor(this.store, live.id), { preserveProgress: false });
+    const reboundColumn = await resolveReboundColumnFor(this.store, live.id);
+    if (live.column !== reboundColumn) {
+      await this.store.moveTask(live.id, reboundColumn, { preserveProgress: false });
     }
     const message = "Auto-recovered: cleared stale workflow parse pins after reset/retry — task requeued before execution";
     executorLog.warn(`${live.id}: ${message}`);
@@ -11658,8 +11672,9 @@ export class TaskExecutor {
     Workflow-graph and workflow-authoritative executor dispatches can be invoked outside the classic scheduler loop, so they must re-apply the shared scheduling dependency gate before graph routing, column-agent seams, or review handoff can run.
     Requeue with blockedBy instead of executing so missing or soft-deleted dependency residue keeps the scheduler helper's non-blocking semantics while live todo/queued/in-progress/triage dependencies block every dispatch surface.
     */
-    if (liveTask.column !== "todo") {
-      await this.store.moveTask(liveTask.id, await resolveReboundColumnFor(this.store, liveTask.id), {
+    const reboundColumn = await resolveReboundColumnFor(this.store, liveTask.id);
+    if (liveTask.column !== reboundColumn) {
+      await this.store.moveTask(liveTask.id, reboundColumn, {
         preserveProgress: true,
         preserveWorktree: true,
         preserveResumeState: true,
@@ -11701,8 +11716,9 @@ export class TaskExecutor {
     }
 
     const liveTask = (await this.store.getTask(task.id).catch(() => null)) ?? task;
-    if (liveTask.column !== "todo") {
-      await this.store.moveTask(liveTask.id, await resolveReboundColumnFor(this.store, liveTask.id), {
+    const reboundColumn = await resolveReboundColumnFor(this.store, liveTask.id);
+    if (liveTask.column !== reboundColumn) {
+      await this.store.moveTask(liveTask.id, reboundColumn, {
         preserveProgress: true,
         preserveWorktree: true,
         preserveResumeState: true,
@@ -12994,10 +13010,11 @@ export class TaskExecutor {
                   worktree: null,
                   branch: null,
                 });
-                if (latestTask.column !== "todo") {
+                const reboundColumn = await resolveReboundColumnFor(this.store, task.id);
+                if (latestTask.column !== reboundColumn) {
                   this.markGraphExecuteSelfRequeued(task.id);
-                  await this.store.moveTask(task.id, await resolveReboundColumnFor(this.store, task.id), preserveProgress ? { preserveProgress: true } : undefined);
-                  executorLog.log(`${task.id} moved to todo for retry after stuck kill${preserveProgress ? " (progress preserved)" : ""}`);
+                  await this.store.moveTask(task.id, reboundColumn, preserveProgress ? { preserveProgress: true } : undefined);
+                  executorLog.log(`${task.id} moved to ${reboundColumn} for retry after stuck kill${preserveProgress ? " (progress preserved)" : ""}`);
                 }
               }
             } catch (err: unknown) {
@@ -14923,16 +14940,17 @@ export class TaskExecutor {
                 status: null,
                 error: null,
               });
-              if (latestTask.column !== "todo") {
+              const continuationReboundColumn = await resolveReboundColumnFor(this.store, task.id);
+              if (latestTask.column !== continuationReboundColumn) {
                 this.markGraphExecuteSelfRequeued(task.id);
                 this.activeWorktrees.delete(task.id);
                 executingTaskLock.release(task.id);
                 cleanupLockHeld = false;
-                await this.store.moveTask(task.id, await resolveReboundColumnFor(this.store, task.id), { preserveResumeState: true });
+                await this.store.moveTask(task.id, continuationReboundColumn, { preserveResumeState: true });
               } else {
                 this.activeWorktrees.delete(task.id);
               }
-              executorLog.log(`${task.id} stale assistant-continuation session cleared — requeued to todo with progress preserved`);
+              executorLog.log(`${task.id} stale assistant-continuation session cleared — requeued to ${continuationReboundColumn} with progress preserved`);
             } else {
               executorLog.debug(`${task.id} stale assistant-continuation requeue skipped — task is now in '${latestTask.column}'`);
             }
@@ -15011,14 +15029,22 @@ export class TaskExecutor {
             // latestTask.column rather than the stale captured task.column —
             // the captured snapshot can be hours old and would race against
             // any concurrent recovery (see comment above).
-            if (latestTask.column !== "todo") {
+            const stuckReboundColumn = await resolveReboundColumnFor(this.store, task.id);
+            if (latestTask.column !== stuckReboundColumn) {
               this.markGraphExecuteSelfRequeued(task.id);
-              await this.store.moveTask(task.id, await resolveReboundColumnFor(this.store, task.id), preserveProgress ? { preserveProgress: true } : undefined);
-              // Audit trail: record task move (FN-1404)
-              await audit.database({ type: "task:move", target: task.id, metadata: { to: "todo" } });
-              executorLog.log(`${task.id} moved to todo for retry after stuck kill${preserveProgress ? " (progress preserved)" : ""}`);
+              await this.store.moveTask(task.id, stuckReboundColumn, preserveProgress ? { preserveProgress: true } : undefined);
+              /*
+              Audit trail: record task move (FN-1404).
+              FNXC:WorkflowLifecycleColumns 2026-07-30-15:15: `to` records the column the card was
+              ACTUALLY moved to. It was hardcoded `"todo"` while the move target was already
+              resolved from the workflow, so on a renamed board the audit row named a column the
+              move never touched — a run-audit trail that disagrees with the move it describes is
+              worse than none, because it is the record an operator reaches for afterwards.
+              */
+              await audit.database({ type: "task:move", target: task.id, metadata: { to: stuckReboundColumn } });
+              executorLog.log(`${task.id} moved to ${stuckReboundColumn} for retry after stuck kill${preserveProgress ? " (progress preserved)" : ""}`);
             } else {
-              executorLog.debug(`${task.id} already in todo — skipping redundant move`);
+              executorLog.debug(`${task.id} already in ${stuckReboundColumn} — skipping redundant move`);
             }
           }
           } catch (err: unknown) {


### PR DESCRIPTION
`resolveReboundColumnFor(...)` was converted in U5b, so every engine rebound **move** targets the task's own trait-derived backlog column. The eight guards standing in front of those moves were left as `X.column !== "todo"`.

**On a renamed board the guard is therefore always true, and the engine issues a move into the column the card is already sitting in.**

## Per-file before → after

| file | column guards before | after |
|---|---:|---:|
| `packages/engine/src/executor.ts` | 151 | **143** |

`todo` 22 → 16 in this file. (The 3 remaining `triage` guards here are #2628's, already converted on that branch. Counts measured with the census in #2633.)

## Why the redundant move is not a no-op

`moveTaskInternal` runs the **reset-on-entry effects on every real move**. So the redundant move re-cleared status / error / pause state — and at the stale-workflow-parse-pins site, which passes `preserveProgress: false`, it **reset step progress a second time** on a card that had merely been re-checked.

This is the half-conversion shape again, and it is the third time this program has produced it: the correct target, reached through a check that cannot see it. Each site now resolves once and uses the same value for both the comparison and the move.

Sites converted: the FN-7926 completed-blocked park, the graph-failure remediation bounce, the stale-parse-pin recovery, both dependency-gate requeues, both stuck-kill requeues, and the stale assistant-continuation cleanup.

## The audit row was lying, and no census counts it

The FN-1404 `task:move` event recorded `metadata: { to: "todo" }` while the move target was already resolved from the workflow. On a renamed board the audit named a column the move never touched. A run-audit trail that disagrees with the move it describes is worse than none — it is the record an operator reaches for *afterwards*. Three log lines had the same hardcoding and now report the resolved column. Not a comparison, so invisible to any grep-based count.

## Revert proof

Restoring `!== "todo"` at the park site → **1 of 4 fails**: the "already in the renamed backlog column" case. The paired positive (card elsewhere on the renamed board *does* move) and both default-lineage cases pass under the revert, so neither "never move" nor "always move" can pass for "compare against the resolved column".

## Deliberately not converted

The four remaining `!== "todo"` in this file are compound **resume-eligibility** conditions (`resumeTask.column !== "todo" && !== "in-progress"`) — a different invariant about which columns a resume may start from. They need the same treatment and a different test, and they do not ride here.

## Coverage note

Stated rather than implied: the test drives `parkCompletedBlockedTask` because it is the rebound site reachable without standing up a graph run. The other seven are the identical shape through the same helper.

## Verification

- 4/4 new (`executor-rebound-already-there.test.ts`)
- 77/77 across executor-rebound, executor-task-done-blocked, planning-evacuation, replan-target
- `pnpm test:gate` **71/71**; engine typecheck clean; `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
