### PR TITLE
OFF-BAR (merge last): a task interrupted by an engine pause never resumed on a renamed board — executor resume lanes

### DIFF
--- a/.changeset/executor-resume-lanes.md
+++ b/.changeset/executor-resume-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A task interrupted by an engine pause now resumes on boards with renamed columns.
+category: fix
+dev: `reenterPausedAbortedWorkflowNode` resolves hold/wip/review once via a new `resolveResumeLanes` helper; `preservedInReview`, the audit `mode` label, the retry-callback recheck and the execute-vs-graph branch all read from it instead of four independent literals.

--- a/packages/engine/src/__tests__/executor-resume-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-resume-lanes-resolved.test.ts
@@ -1,0 +1,91 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-21:10 (Phase C convergence — resume eligibility):
+
+THE INVARIANT: the columns a paused-node RESUME may start from are the task's own hold, wip and
+review lanes.
+
+Four literal comparisons decided that one question and had to agree with each other:
+`preservedInReview`, the audit `mode` label, the resume-safety recheck inside the retry callback,
+and the branch choosing `execute()` versus `executeWorkflowGraph()`. On a renamed board
+`preservedInReview` was false for a card sitting in review AND the recheck rejected it, so the
+paused-node re-entry silently never happened — an engine pause/resume left the card parked with
+nothing to resume it.
+
+OFF THE `triage` BAR, deliberately: these are `in-review`/`in-progress`/`todo` guards. Same defect
+class, different literals; recorded here so the next sweep of that class has a worked example and a
+shared resolver to reuse.
+*/
+import { describe, expect, it, vi } from "vitest";
+import "./executor-test-helpers.js";
+import { TaskExecutor } from "../executor.js";
+import { createMockStore } from "./executor-test-helpers.js";
+import type { WorkflowIr } from "@fusion/core";
+
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "queued", name: "Queued", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", name: "Checking", traits: [{ trait: "merge" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+} as unknown as WorkflowIr;
+
+function harness(ir: WorkflowIr | undefined) {
+  const store = createMockStore();
+  const selection = { workflowId: "wf-renamed", stepIds: [] as string[] };
+  const widened = store as unknown as Record<string, unknown>;
+  widened.getTaskWorkflowSelection = () => (ir ? selection : undefined);
+  widened.getTaskWorkflowSelectionAsync = async () => (ir ? selection : undefined);
+  widened.getWorkflowDefinition = async () => (ir ? { ir } : undefined);
+  store.recordRunAuditEvent = vi.fn().mockResolvedValue(undefined);
+
+  const executor = new TaskExecutor(store as never, "/repo");
+  const lanes = (taskId: string) =>
+    (executor as unknown as {
+      resolveResumeLanes: (id: string) => Promise<{ hold: string; wip: string; review: string }>;
+    }).resolveResumeLanes(taskId);
+
+  return { store, executor, lanes };
+}
+
+describe("resume lanes come from the task's own workflow", () => {
+  it("resolves the renamed hold, wip and review columns", async () => {
+    // Pre-fix these three were the default lineage's names, so every resume-safety comparison on a
+    // renamed board answered "not a safe resume state" and the re-entry never fired.
+    const h = harness(RENAMED_IR);
+
+    await expect(h.lanes("FN-1")).resolves.toEqual({
+      hold: "queued",
+      wip: "building",
+      review: "checking",
+    });
+  });
+
+  it("falls back to the legacy trio when no workflow resolves", async () => {
+    // A v1 / column-less workflow has no vocabulary to read, so the legacy names ARE the answer
+    // and the default lineage behaves exactly as before.
+    const h = harness(undefined);
+
+    await expect(h.lanes("FN-1")).resolves.toEqual({
+      hold: "todo",
+      wip: "in-progress",
+      review: "in-review",
+    });
+  });
+
+  it("never throws, so a resume decision is never blocked on IR resolution", async () => {
+    // The re-entry path runs inside a retry callback; a throw here would strand the card silently.
+    const h = harness(RENAMED_IR);
+    (h.store as unknown as Record<string, unknown>).getWorkflowDefinition = async () => {
+      throw new Error("workflow store unavailable");
+    };
+
+    await expect(h.lanes("FN-1")).resolves.toEqual({
+      hold: "todo",
+      wip: "in-progress",
+      review: "in-review",
+    });
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -10306,7 +10306,46 @@ export class TaskExecutor {
       if (!sharedBranchMember && !allowsAutoMergeProcessing(live, settings)) return false;
       if (live.mergeDetails?.mergeConfirmed === true) return false;
     }
-    return live.column === "todo" || live.column === "in-review" || live.column === "in-progress";
+    const resumeLanes = await this.resolveResumeLanes(live.id);
+    return live.column === resumeLanes.hold
+      || live.column === resumeLanes.review
+      || live.column === resumeLanes.wip;
+  }
+
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-16:00 (Phase C convergence — resume eligibility):
+  The columns a RESUME may legitimately start from, resolved from the task's own workflow: the
+  hold (backlog) lane, the wip lane, and the review lane.
+
+  These decisions were spelled as the default lineage's three names, so on a renamed board every
+  resume-safety check answered "not a safe resume state" and the paused-node re-entry, the
+  pause-abort auto-continue, and the benign-todo abort-marker clear all stopped firing. The last
+  of those is the one that bites: FN-6478's benign path exists so a re-queued card clears its
+  abort marker instead of being parked `failed` for an operator — and on a renamed board it took
+  the operator-action branch instead, which is the retry storm that path was written to end.
+
+  ASYNC on purpose: every call site here is already async (a store read precedes each one), so
+  there is no listener-ordering hazard of the kind that forced the synchronous planner-lane
+  resolver in `replan-target.ts`.
+
+  Fail-soft to the legacy trio so an unresolvable or column-less workflow behaves as before.
+
+  FOLLOW-UP, deliberately not done here: PR #2628 exports a synchronous `resolvePlannerLanes`
+  (hold/intake/wip) from `replan-target.ts`. Once both land, this helper and that one should
+  become one resolver returning the full lane set — two resolvers for the same question is the
+  drift this program keeps paying for. Kept separate now only to avoid a cross-branch dependency.
+  */
+  private async resolveResumeLanes(taskId: string): Promise<{ hold: string; wip: string; review: string }> {
+    try {
+      const lifecycle = resolveLifecycleColumns(await resolveWorkflowIrForTask(this.store, taskId));
+      return {
+        hold: lifecycle?.hold ?? "todo",
+        wip: lifecycle?.wip ?? "in-progress",
+        review: lifecycle?.review ?? "in-review",
+      };
+    } catch {
+      return { hold: "todo", wip: "in-progress", review: "in-review" };
+    }
   }
 
   private async reenterPausedAbortedWorkflowNode(
@@ -10318,7 +10357,15 @@ export class TaskExecutor {
     const priorRetries = live.graphResumeRetryCount ?? 0;
     if (priorRetries >= MAX_TRANSIENT_GRAPH_RESUME_RETRIES) return false;
     const nextRetries = priorRetries + 1;
-    const preservedInReview = live.column === "in-review";
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-16:05: resolved ONCE for the whole re-entry —
+    `preservedInReview`, the audit `mode` label, the resume-safety recheck, and the branch that
+    picks execute() vs executeWorkflowGraph() must all agree on which column is which. They were
+    four independent literal comparisons, so on a renamed board `preservedInReview` was false for
+    a card in review AND the recheck rejected it, and the re-entry silently never happened.
+    */
+    const reentryLanes = await this.resolveResumeLanes(live.id);
+    const preservedInReview = live.column === reentryLanes.review;
     this.clearPausedAborted(live.id);
     this.activeWorktrees.delete(live.id);
     const message = `Workflow graph node '${nodeId}' was interrupted by engine pause/resume — re-entering workflow graph (${nextRetries}/${MAX_TRANSIENT_GRAPH_RESUME_RETRIES})`;
@@ -10341,7 +10388,7 @@ export class TaskExecutor {
           maxAttempts: MAX_TRANSIENT_GRAPH_RESUME_RETRIES,
           abortProvenance: abortProvenance ?? "unknown",
           preservedInReview,
-          mode: preservedInReview ? "preserved-in-review" : live.column === "todo" ? "reexecuted-from-todo" : "reentered-graph",
+          mode: preservedInReview ? "preserved-in-review" : live.column === reentryLanes.hold ? "reexecuted-from-todo" : "reentered-graph",
         },
       });
     } catch (error) {
@@ -10359,7 +10406,9 @@ export class TaskExecutor {
             || resumeTask.userPaused
             || resumeTask.status != null
             || resumeTask.error != null
-            || (preservedInReview ? resumeTask.column !== "in-review" : resumeTask.column !== "todo" && resumeTask.column !== "in-progress")
+            || (preservedInReview
+              ? resumeTask.column !== reentryLanes.review
+              : resumeTask.column !== reentryLanes.hold && resumeTask.column !== reentryLanes.wip)
             || this.activeSessions.has(live.id)
             || this.activeStepExecutors.has(live.id)
             || this.activeWorkflowStepSessions.has(live.id)
@@ -10371,7 +10420,7 @@ export class TaskExecutor {
           }
           if (preservedInReview) {
             await this.executeWorkflowGraph(resumeTask);
-          } else if (resumeTask.column === "todo") {
+          } else if (resumeTask.column === reentryLanes.hold) {
             await this.execute(resumeTask);
           } else {
             await this.executeWorkflowGraph(resumeTask);


### PR DESCRIPTION
**Not on the `triage` bar** — these are `in-review`/`in-progress`/`todo` guards. Same defect class, different literals. It touches no site any owner is converting, so merge it last; it competes with nothing on the bar.

## The defect

Four literal comparisons decided **one** question — "is this card in a state a resume may start from?" — and they had to agree with each other:

| decision | was |
|---|---|
| `preservedInReview` | `live.column === "in-review"` |
| audit `mode` label | `live.column === "todo" ? "reexecuted-from-todo" : …` |
| resume-safety recheck (inside the retry callback) | `resumeTask.column !== "todo" && !== "in-progress"` |
| `execute()` vs `executeWorkflowGraph()` | `resumeTask.column === "todo"` |

On a renamed board `preservedInReview` was false for a card sitting in review **and** the recheck rejected it, so the paused-node re-entry silently never happened: an engine pause/resume left the card parked with nothing to resume it.

They now resolve once per re-entry through `resolveResumeLanes` and share the result. Async on purpose — every call site already awaits a store read, so there is none of the listener-ordering hazard that forced the *synchronous* planner-lane resolver in `replan-target.ts`.

## Revert proof

Hard-coding the legacy trio → **1 of 3 fails** (the renamed case). The legacy-fallback case passes under the revert, which is why both exist. The third case pins that the resolver never throws — that one matters because this runs inside a retry callback, where a throw strands the card silently rather than loudly.

## Follow-up, recorded at the helper

#2628 exports a synchronous `resolvePlannerLanes` (hold/intake/wip) from `replan-target.ts`. Once both land, these should become **one** resolver returning the full lane set — two resolvers for the same question is exactly the drift this program keeps paying for. Kept separate now only to avoid a cross-branch dependency.

## Verification

- 3/3 new (`executor-resume-lanes-resolved.test.ts`)
- 48/48 across executor-abort-provenance, planning-evacuation, executor-task-done-blocked
- `pnpm test:gate` **71/71**; engine typecheck clean; `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)