### PR TITLE
fix(test): dep-abort rebound asserts the resolved column, not the retired `triage` literal

### DIFF
--- a/packages/engine/src/__tests__/executor-review-verdicts.test.ts
+++ b/packages/engine/src/__tests__/executor-review-verdicts.test.ts
@@ -867,8 +867,24 @@ describe("fn_task_add_dep tool", () => {
     );
     expect(branchDeleteCalls.length).toBeGreaterThan(0);
 
-    // Task should be moved to triage
-    expect(store.moveTask).toHaveBeenCalledWith("FN-DEP", "triage");
+    /*
+    FNXC:DepAbortRebound 2026-07-30-08:10 (lifecycle-column vocabulary):
+    The dep-abort cleanup no longer hardcodes a column: `handleDepAbortCleanup` moves the
+    card to `resolveReboundColumnFor(store, taskId)` (executor.ts:16576), which resolves
+    the task's OWN workflow rebound target by trait — hold, else intake, else the first
+    column — falling back to `todo`. For this fixture's default workflow that resolves to
+    `todo`, which post-U11 IS the merged Planning column; `triage` is no longer declared
+    on the default lineage at all, so the old literal expectation was asserting a column
+    the workflow does not have.
+
+    Asserted as the concrete resolved value rather than by re-calling the resolver:
+    deriving the expectation from the code under test makes the assertion agree with
+    whatever the resolver happens to return, which is how a broken rebound target would
+    slip through. Per-workflow resolution itself is covered by replan-target's own tests.
+    */
+    expect(store.moveTask).toHaveBeenCalledWith("FN-DEP", "todo");
+    // And explicitly NOT the retired legacy planner id.
+    expect(store.moveTask).not.toHaveBeenCalledWith("FN-DEP", "triage");
 
     // Worktree and status should be cleared
     expect(store.updateTask).toHaveBeenCalledWith("FN-DEP", { worktree: null, status: null });


### PR DESCRIPTION
**Review-lane test, 1 failed → 21 passed.** Test-only. `pnpm test:gate` green, `pnpm lint` clean.

## Production was right; the test was stale

```
expected moveTask("FN-DEP", "triage")
received moveTask("FN-DEP", "todo")
```

`handleDepAbortCleanup` no longer hardcodes a column. It moves the card to `resolveReboundColumnFor(store, taskId)` (`executor.ts:16576`), which resolves the task's **own** workflow rebound target by trait — hold, else intake, else first column — with a `todo` fallback. For this fixture's default workflow that resolves to `todo`, which post-U11 **is** the merged Planning column. `triage` is not declared on the default lineage at all, so the old expectation was asserting a column the workflow does not have.

## Why the concrete value, not the resolver

I asserted `"todo"` rather than re-calling `resolveReboundColumnFor` in the test. Deriving the expectation from the code under test makes the assertion agree with whatever the resolver happens to return — the exact anti-pattern `task-delete-notice.test.ts` documents for its notify table ("deriving the expectation from the value under test makes the suite agree with whatever the production constant happens to say").

That's only legitimate because **per-workflow resolution already has its own coverage** — `replan-target-merged-planning-column.test.ts` and `replan-target-renamed-planner.test.ts`. I checked they exist rather than assuming; without them, pinning a concrete id here would be hiding the interesting behaviour.

Also added the negative: the move must **not** be `triage`, so a regression that reinstates the literal fails instead of quietly passing on a column the default lineage no longer declares.

**Red-green:** reinstating `moveTask(taskId, "triage")` in production fails exactly this test (`NEW-failures=1`).

## Context — main's engine-default census

Measured on `origin/main` just now: **66 failed / 9382 passed across 13 files**. This clears one. `workflow-lifecycle-live-e2e.pg.test.ts` is another and is already fixed in #2634 (pending merge), which takes it from 2 failures to 0 and adds two new scenarios.

Of the remaining 11, none are in the review/merge lane: `agent-tools-intake-column`, `builtin-workflows-lifecycle`, `workflow-graph-optional-step-fix` and `workflow-settings-fallback-alignment` are column-vocabulary drift belonging to the U11/U12 owners (the optional-step-fix one expects `triage` where the replan rebound now resolves `todo` — same class as this fix, different owner's file); the rest are executor/CE/goal-anchoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)