### PR TITLE
fix(test): re-pin the blocking-shellout allowlist after source lines moved (5 lines, 0 new sanctions)

### DIFF
--- a/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
+++ b/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
@@ -63,7 +63,7 @@ const allowlist: AllowlistEntry[] = [
   { file: "src/merger.ts", line: 10217, primitive: "execSync", signature: "const squashIsEmpty = execSync(", reason: SHORT_GIT_PLUMBING },
   { file: "src/merger.ts", line: 10251, primitive: "execSync", signature: "const squashIsEmpty = execSync(", reason: SHORT_GIT_PLUMBING },
   { file: "src/merger.ts", line: 10438, primitive: "execSync", signature: "execSync(\"git reset --merge\", { cwd: rootDir, stdio: \"pipe\" });", reason: SHORT_GIT_PLUMBING },
-  { file: "src/executor.ts", line: 17106, primitive: "execSync", signature: "execSync(`git merge-base --is-ancestor ${task.baseCommitSha} HEAD`, {", reason: SHORT_GIT_PLUMBING },
+  { file: "src/executor.ts", line: 17198, primitive: "execSync", signature: "execSync(`git merge-base --is-ancestor ${task.baseCommitSha} HEAD`, {", reason: SHORT_GIT_PLUMBING },
 ];
 
 function scanSource(file: string, source: string): ShelloutSite[] {

--- a/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
+++ b/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
@@ -38,10 +38,10 @@ const allowlist: AllowlistEntry[] = [
   { file: "src/already-merged-detector.ts", line: 270, primitive: "execSync", signature: "branchTip = execSync(`git rev-parse --verify ${shellQuote(branchName)}`, {", reason: SHORT_GIT_PLUMBING },
   { file: "src/already-merged-detector.ts", line: 345, primitive: "execSync", signature: "execSync(`git rev-parse --verify ${shellQuote(treeBranchName)}`, {", reason: SHORT_GIT_PLUMBING },
   // FNXC:EngineProcessRules 2026-07-26-14:27: Re-pin all audited shellouts after current main moved source lines without changing the sanctioned short-git-plumbing calls.
-  { file: "src/self-healing.ts", line: 4445, primitive: "execSync", signature: "const tipSha = String(execSync(`git rev-parse --verify ${shellQuote(branch)}`, {", reason: SHORT_GIT_PLUMBING },
-  { file: "src/self-healing.ts", line: 4451, primitive: "execSync", signature: "const uniqueCommitCount = Number.parseInt(String(execSync(`git rev-list --count ${shellQuote(branch)} --not ${shellQuote(\"main\")}`, {", reason: SHORT_GIT_PLUMBING },
-  { file: "src/self-healing.ts", line: 4488, primitive: "execSync", signature: "const branchesRaw = String(execSync(\"git branch --list 'fusion/*'\", {", reason: SHORT_GIT_PLUMBING },
-  { file: "src/self-healing.ts", line: 13399, primitive: "execSync", signature: "execSync(`git branch -d ${shellQuote(branch)}`, {", reason: SHORT_GIT_PLUMBING },
+  { file: "src/self-healing.ts", line: 4127, primitive: "execSync", signature: "const tipSha = String(execSync(`git rev-parse --verify ${shellQuote(branch)}`, {", reason: SHORT_GIT_PLUMBING },
+  { file: "src/self-healing.ts", line: 4133, primitive: "execSync", signature: "const uniqueCommitCount = Number.parseInt(String(execSync(`git rev-list --count ${shellQuote(branch)} --not ${shellQuote(\"main\")}`, {", reason: SHORT_GIT_PLUMBING },
+  { file: "src/self-healing.ts", line: 4170, primitive: "execSync", signature: "const branchesRaw = String(execSync(\"git branch --list 'fusion/*'\", {", reason: SHORT_GIT_PLUMBING },
+  { file: "src/self-healing.ts", line: 12877, primitive: "execSync", signature: "execSync(`git branch -d ${shellQuote(branch)}`, {", reason: SHORT_GIT_PLUMBING },
   { file: "src/merger-workspace-test-commands.ts", line: 204, primitive: "execSync", signature: "changedFilesOutput = execSync(", reason: BOUNDED_GIT_DIFF },
   { file: "src/merger-workspace-test-commands.ts", line: 301, primitive: "execSync", signature: "changedFilesOutput = execSync(", reason: BOUNDED_GIT_DIFF },
   { file: "src/integration-branch.ts", line: 71, primitive: "execSync", signature: "const stdout = execSync(\"git symbolic-ref --short refs/remotes/origin/HEAD\", {", reason: SHORT_GIT_PLUMBING },
@@ -63,7 +63,7 @@ const allowlist: AllowlistEntry[] = [
   { file: "src/merger.ts", line: 10217, primitive: "execSync", signature: "const squashIsEmpty = execSync(", reason: SHORT_GIT_PLUMBING },
   { file: "src/merger.ts", line: 10251, primitive: "execSync", signature: "const squashIsEmpty = execSync(", reason: SHORT_GIT_PLUMBING },
   { file: "src/merger.ts", line: 10438, primitive: "execSync", signature: "execSync(\"git reset --merge\", { cwd: rootDir, stdio: \"pipe\" });", reason: SHORT_GIT_PLUMBING },
-  { file: "src/executor.ts", line: 16772, primitive: "execSync", signature: "execSync(`git merge-base --is-ancestor ${task.baseCommitSha} HEAD`, {", reason: SHORT_GIT_PLUMBING },
+  { file: "src/executor.ts", line: 17106, primitive: "execSync", signature: "execSync(`git merge-base --is-ancestor ${task.baseCommitSha} HEAD`, {", reason: SHORT_GIT_PLUMBING },
 ];
 
 function scanSource(file: string, source: string): ShelloutSite[] {


### PR DESCRIPTION
**A failing ratchet, fixed without widening it.** 5-line diff, no production change. `pnpm test:gate` green.

`engine-no-blocking-shellout.test.ts` was red on main, reporting **5 unaudited synchronous shellouts** (1 in `executor.ts`, 4 in `self-healing.ts`).

## No new violation — the allowlist went stale

The allowlist is keyed by `(file, LINE, primitive, signature)`. `self-healing.ts` shrank during the U4 extractions, so the recorded lines drifted. Every flagged signature was **already sanctioned**: self-healing's three sat at 4445/4451/4488 and are now at 4127/4133/4170. The file carries an FNXC note for precisely this case — *"Re-pin all audited shellouts after current main moved source lines without changing the sanctioned short-git-plumbing calls."*

**Re-pinned by signature, not by hand:** for each of the 33 entries, find the line whose trimmed text equals the recorded signature and take the occurrence closest to the old line — which stays stable when a signature repeats, e.g. `merger.ts`'s six identical `git reset --merge` calls. Result: **5 lines moved, 0 signatures unfound**, so nothing became sanctioned that was not sanctioned before.

## A wrong turn worth recording

I first read the guard's *"only after proving timeout and maxBuffer bounds"* as applying to every sanctioned site. I checked all 5, found none had `timeout` or `maxBuffer`, and was about to add bounds to `executor.ts` and `self-healing.ts` — an unnecessary production change in two files other workers are actively editing.

Re-reading the guard's own comment corrected it: the bounds criterion belongs to `BOUNDED_GIT_DIFF` (data-dependent diff output, where the buffer can grow with the repo), not to `SHORT_GIT_PLUMBING`. All 5 are `rev-parse` / `merge-base --is-ancestor` / `rev-list --count` / `branch --list` — fixed-size output, already the sanctioned category.

## Verified the ratchet still bites

A re-pin could silently widen a guard, so I checked rather than assumed: injecting an unaudited `execSync("git log --all")` into `integration-branch.ts` **fails** the ratchet and it names the offending signature; reverting returns it to green.

## Why this one was worth taking

A red ratchet is the worst failure mode for a guard — it stops being a signal and starts being noise someone silences. This one had already caught a real class of defect (unbounded sync shellouts on the shared event loop), and it was red for a purely mechanical reason.

`workflow-lifecycle-live-e2e` (#2634, merged) and `executor-review-verdicts` (#2641) clear two more of main's 13 failing engine-default files; this is a third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)