### PR TITLE
consolidate/u9 — review+merge lane: E2E evidence, re-greens, and the conversion blocker

### DIFF
--- a/packages/engine/src/__tests__/ce-workflow-step-executor.test.ts
+++ b/packages/engine/src/__tests__/ce-workflow-step-executor.test.ts
@@ -617,19 +617,37 @@ describe("CE workflow-step executor integration", () => {
         value: "implementation-incomplete",
       }));
       expect(mergeRequester).not.toHaveBeenCalled();
-      // FNXC:WorkflowMerge 2026-07-07-08:38: The merge boundary (executor.ts:6305, 6fc50d8d9e) now moves the task to in-review and logs the boundary move BEFORE the implementation-proof gate runs, then the proof failure is logged separately. The proof-failure text (executor.ts:6345) changed from the static "implementation steps are incomplete" to the parse-step-aware "implementation did not run: parsed coding steps are missing or incomplete". Assert both log entries so the new two-stage merge-boundary behavior is pinned.
+      /*
+      FNXC:WorkflowMerge 2026-07-30-11:40:
+      The boundary no longer MOVES then checks — it blocks first. `ensureWorkflowMergeBoundaryTask`
+      (executor.ts:7809) now returns early when a foreach step-execute region has incomplete proof,
+      logging "Workflow merge boundary blocked: <reason>" and leaving the card where it is. The
+      previous two-stage sequence this test pinned is gone: the string "Workflow merge boundary moved
+      task to in-review before requesting merge" no longer exists anywhere in production.
+
+      That change is an improvement worth asserting rather than tolerating, so this pins the stronger
+      property the new order gives us: an unproven card is NOT moved into the review column at all.
+      The old assertion could only say "it was moved, then blocked".
+
+      Log text asserted by its stable prefix, not the whole sentence — the reason clause enumerates
+      missing foreach instance ids, which is legitimately volatile detail, and pinning it verbatim
+      would make this test fail on unrelated node-id changes.
+      */
       expect(store.logEntry).toHaveBeenCalledWith(
         "FN-CE-1",
-        "Workflow merge boundary moved task to in-review before requesting merge",
+        expect.stringContaining("Workflow merge boundary blocked:"),
         undefined,
         undefined,
       );
       expect(store.logEntry).toHaveBeenCalledWith(
         "FN-CE-1",
-        "Workflow merge blocked before requester: implementation did not run: parsed coding steps are missing or incomplete",
+        expect.stringContaining("implementation did not run:"),
         undefined,
         undefined,
       );
+      // The card must never reach the review column on unproven implementation.
+      expect(store.moveTask).not.toHaveBeenCalledWith("FN-CE-1", "in-review", expect.anything());
+      expect(store.moveTask).not.toHaveBeenCalledWith("FN-CE-1", "in-review");
     });
 
     it("uses moveTask for workflow graph column transitions so lifecycle notifications fire", async () => {
@@ -678,6 +696,20 @@ describe("CE workflow-step executor integration", () => {
       let live = baseStepTask({
         column: "in-progress",
         steps: [{ name: "Implement", status: "done" }],
+        /*
+        FNXC:WorkflowMerge 2026-07-30-12:05:
+        The merge boundary now REFUSES a foreach step-execute region with no pre-merge node
+        proof (executor.ts:7808) — it logs "Workflow merge boundary blocked: no pre-merge node
+        result recorded" and returns without moving. This fixture must therefore model a run
+        that actually FINISHED its per-instance work, or it measures the block instead of the
+        behaviour its name describes.
+
+        Shape matched to the evaluator: `source: "node"` and `phase: "pre-merge"` are what it
+        filters on, and `passed` is terminal for it.
+        */
+        workflowStepResults: [
+          { workflowStepId: "steps#0:step-execute", workflowStepName: "Implement", source: "node", phase: "pre-merge", status: "passed" },
+        ],
       });
       store.getTask.mockImplementation(async () => live as any);
       store.moveTask.mockImplementation(async (_id: string, column: string) => {
@@ -744,6 +776,17 @@ describe("CE workflow-step executor integration", () => {
             source: "node",
             status: "passed",
           },
+          /*
+          FNXC:WorkflowMerge 2026-07-30-12:15:
+          A `plan` result alone no longer clears the boundary: it proves SOME pre-merge node ran,
+          but the gate also requires an instance result per foreach step-execute
+          (`missingInstanceIds`, executor.ts:7813). Without these two the boundary blocks with
+          "foreach step instances incomplete" and the checklist projection this test exists to
+          assert never happens — so the fixture would be measuring the block, not the projection.
+          One instance per declared step, matching the two steps above.
+          */
+          { workflowStepId: "steps#0:step-execute", workflowStepName: "Diagnose", phase: "pre-merge", source: "node", status: "passed" },
+          { workflowStepId: "steps#1:step-execute", workflowStepName: "Implement", phase: "pre-merge", source: "node", status: "passed" },
         ],
       });
       store.getTask.mockImplementation(async () => live as any);

--- a/packages/engine/src/__tests__/executor-step-numbering-zero-based.test.ts
+++ b/packages/engine/src/__tests__/executor-step-numbering-zero-based.test.ts
@@ -283,6 +283,24 @@ describe("executor tool step numbering is 0-based", () => {
       undefined,
       expect.objectContaining({ agentId: "executor" }),
     );
-    expect(store.moveTask).toHaveBeenCalledWith("FN-6607-P", "in-review");
+    /*
+    FNXC:ReviewHandoff 2026-07-30-10:15:
+    The handoff now passes a THIRD argument (workflow move provenance), and a two-argument
+    `toHaveBeenCalledWith` demands an exact match — so this failed on the extra options
+    object even though the card moved to the review column correctly.
+
+    Accepting the options with `expect.anything()` rather than pinning their contents. I
+    tried the stronger form first — asserting `workflowMoveSource: "workflow-graph"` and
+    `workflowMoveMetadata.nodeId` — and could NOT attribute it: five separate mutations
+    (the boundary hook's provenance, the review-handoff reason, the node id, and both
+    moveTask call sites) each left it green. `toHaveBeenCalledWith` matches ANY recorded
+    call and this flow makes two, so the specific-looking assertion was being satisfied by
+    whichever call happened to fit rather than by the provenance it named.
+
+    An assertion I cannot make fail is not evidence, so this pins only what it can prove:
+    the card reaches the review column. Provenance is worth asserting somewhere it can be
+    attributed to one call — that needs a single-call seam, not this suite.
+    */
+    expect(store.moveTask).toHaveBeenCalledWith("FN-6607-P", "in-review", expect.anything());
   });
 });

--- a/packages/engine/src/__tests__/executor-step-numbering-zero-based.test.ts
+++ b/packages/engine/src/__tests__/executor-step-numbering-zero-based.test.ts
@@ -284,23 +284,29 @@ describe("executor tool step numbering is 0-based", () => {
       expect.objectContaining({ agentId: "executor" }),
     );
     /*
-    FNXC:ReviewHandoff 2026-07-30-10:15:
-    The handoff now passes a THIRD argument (workflow move provenance), and a two-argument
-    `toHaveBeenCalledWith` demands an exact match — so this failed on the extra options
-    object even though the card moved to the review column correctly.
+    FNXC:ReviewHandoff 2026-07-30-11:00 (#2646 review — greptile P2):
+    ISOLATE the handoff call instead of matching any of them. This flow records TWO
+    moveTask calls, so `toHaveBeenCalledWith(id, "in-review", expect.anything())` is
+    satisfied by the workflow-boundary move even if the review handoff itself regresses —
+    the review was right, and it is the same objection I had already raised against my own
+    first attempt without then fixing it properly.
 
-    Accepting the options with `expect.anything()` rather than pinning their contents. I
-    tried the stronger form first — asserting `workflowMoveSource: "workflow-graph"` and
-    `workflowMoveMetadata.nodeId` — and could NOT attribute it: five separate mutations
-    (the boundary hook's provenance, the review-handoff reason, the node id, and both
-    moveTask call sites) each left it green. `toHaveBeenCalledWith` matches ANY recorded
-    call and this flow makes two, so the specific-looking assertion was being satisfied by
-    whichever call happened to fit rather than by the provenance it named.
+    The handoff call is identifiable by its own provenance marker
+    (`workflowMoveMetadata.reason === "workflow-review-handoff"`, set at
+    workflow-node-handlers.ts's `review-handoff` seam), so select THAT call and assert its
+    target column. Now a regression has nowhere to hide: drop the handoff and no such call
+    exists; retarget it and the column assertion fails.
 
-    An assertion I cannot make fail is not evidence, so this pins only what it can prove:
-    the card reaches the review column. Provenance is worth asserting somewhere it can be
-    attributed to one call — that needs a single-call seam, not this suite.
+    Attribution verified by mutation, which the previous version could not manage —
+    changing the seam's `reason` and changing its target column each fail this test.
     */
-    expect(store.moveTask).toHaveBeenCalledWith("FN-6607-P", "in-review", expect.anything());
+    const handoffCalls = (store.moveTask as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) =>
+        (call[2] as { workflowMoveMetadata?: { reason?: string } } | undefined)
+          ?.workflowMoveMetadata?.reason === "workflow-review-handoff",
+    );
+    expect(handoffCalls).toHaveLength(1);
+    expect(handoffCalls[0]?.[0]).toBe("FN-6607-P");
+    expect(handoffCalls[0]?.[1]).toBe("in-review");
   });
 });

--- a/packages/engine/src/__tests__/goal-anchoring-audit.test.ts
+++ b/packages/engine/src/__tests__/goal-anchoring-audit.test.ts
@@ -72,12 +72,35 @@ describe("goal anchoring audit helpers", () => {
     expect(recordRunAuditEvent).not.toHaveBeenCalled();
   });
 
-  it("swallows retrieval audit failures and warns once", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  /*
+  FNXC:GoalAuditLogging 2026-07-30-13:10:
+  The swallow path reports at DEBUG now, not `console.warn` — `emitGoalRetrievalAudit`'s
+  catch calls `log.debug` (goal-anchoring-audit.ts:93), a deliberate demotion of
+  high-frequency log noise. Two consequences the old assertion tripped over: the channel
+  moved (createLogger's debug writes to console.ERROR, like the rest of that logger), and
+  `debug` is GATED on FUSION_DEBUG (logger.ts:43), which vitest never sets — so nothing
+  was emitted at all and the case failed on 0 calls.
+
+  Kept BOTH halves of the contract rather than dropping the reporting one: the failure is
+  swallowed (does not throw) AND it is still reported. Enabling the flag for this case is
+  what makes the second half assertable; re-pointing the assertion at another channel
+  would just describe whatever the code happens to do.
+  */
+  it("swallows retrieval audit failures and still reports them at debug level", () => {
+    const previous = process.env.FUSION_DEBUG;
+    process.env.FUSION_DEBUG = "goal-anchoring-audit";
+    const reported = vi.spyOn(console, "error").mockImplementation(() => {});
     const store = { recordRunAuditEvent: vi.fn(() => { throw new Error("boom"); }) } as unknown as TaskStore;
-    expect(() => emitGoalRetrievalAudit(store, { runId: "r1", agentId: "a1" }, { toolName: "fn_goal_show", resultCount: 0, goalId: "G-1", notFound: true })).not.toThrow();
-    expect(warn).toHaveBeenCalledTimes(1);
-    warn.mockRestore();
+    try {
+      expect(() => emitGoalRetrievalAudit(store, { runId: "r1", agentId: "a1" }, { toolName: "fn_goal_show", resultCount: 0, goalId: "G-1", notFound: true })).not.toThrow();
+      expect(reported).toHaveBeenCalledTimes(1);
+      expect(reported.mock.calls[0]?.[0]).toContain("goal retrieval audit emission skipped");
+    } finally {
+      reported.mockRestore();
+      // Restore rather than delete: the flag may legitimately be set by the caller.
+      if (previous === undefined) delete process.env.FUSION_DEBUG;
+      else process.env.FUSION_DEBUG = previous;
+    }
   });
 
   it("persists goal IDs across injection/retrieval and aggregates cited IDs", async () => {


### PR DESCRIPTION
**U9's consolidation branch.** Supersedes nothing — #2637 and #2643 are green with zero threads and left for your sweep per rule 3.

## Contents

| File | Change | Before → After |
|---|---|---|
| `__tests__/executor-step-numbering-zero-based.test.ts` | isolate the review-handoff `moveTask` call so the assertion is attributable | **1 failed / 3 passed → 4 passed** |
| `__tests__/ce-workflow-step-executor.test.ts` | re-green against the block-first merge boundary | **3 failed / 48 passed → 51 passed** |
| `__tests__/goal-anchoring-audit.test.ts` | swallow path reports at debug, not `console.warn` | **1 failed / 6 passed → 7 passed** |

Triage-guard counts: **no change**. My lane has no remaining column receivers — the rest belong to the capacity/U7/U8/U11/U12 workers, or are deliberate compat retentions I verified individually (`spec-staleness.ts` carries its own "U11 proof" block; `live-agent-count.ts`'s literal fallback is reachable by flag-less callers).

Commits kept small and separated: signature fix, then attribution fix, then the boundary re-green, then the debug-channel fix.

**Census reconciliation:** `node scripts/lifecycle-column-census.mjs` reports **11** triage guards on main, and **none are in the review/merge lane** — they are the `moves.ts` flag-OFF branch plus the dashboard cluster. Nothing in this branch moves that number, and I am not chasing the 779 non-triage guards per your instruction.

## 1. The review-handoff assertion (and a lesson)

The handoff gained a third argument (workflow move provenance), so a two-arg `toHaveBeenCalledWith` failed on the extra options object while the card moved correctly.

My first fix used `expect.anything()` — and I *documented in the comment* that six mutations couldn't make it fail, then shipped it anyway. Greptile (P2) correctly called that out: this flow records two `moveTask` calls, so the assertion is satisfied by the boundary move even if the handoff regresses. **Documenting a weakness is not removing it.**

Now the test selects the handoff call by its own marker (`workflowMoveMetadata.reason === "workflow-review-handoff"`), asserts exactly one such call, and asserts its target column:

| Mutation | Before | After |
|---|---|---|
| change the seam's `reason` | green | **NEW=1**, this test only |
| retarget the seam to `"done"` | green | **NEW=1**, this test only |

## 2. The merge boundary changed shape

`ensureWorkflowMergeBoundaryTask` (`executor.ts:7808`) now **refuses** a foreach step-execute region with incomplete pre-merge node proof — logging `"Workflow merge boundary blocked: <reason>"` and returning **without moving**. The move-then-check sequence this file pinned is gone: `"Workflow merge boundary moved task to in-review before requesting merge"` no longer exists anywhere in production.

Three fixes, one per failure:

1. **negative case** pinned the retired move-first log. Now pins the *stronger* property the new order gives: an unproven card is **not moved into review at all**. The old assertion could only say "it was moved, then blocked". Log text asserted by stable prefix — the reason clause enumerates missing instance ids, which is legitimately volatile.
2. **"moves direct-to-merge tasks into in-review"** got zero calls: its fixture recorded no node results, so the gate blocked it. Added one `steps#0:step-execute` pre-merge result.
3. **"completes graph-native checklist projection"** also got zero calls. Its existing `plan` result proves *some* pre-merge node ran but not the per-instance work; the gate additionally requires an instance per foreach step-execute. Added the two matching its two steps.

(2) and (3) are the same class as the lifecycle E2E `seedTask` fix in #2634: a fixture that never modelled completed work, asking the engine to advance it, and reading the correct refusal as a failure. Proof shape matched to the evaluator (`source: "node"`, `phase: "pre-merge"`, terminal = `passed`/`skipped`) rather than guessed.

Verified the gate is what these fixtures exercise: disabling the boundary proof check fails the negative case (`NEW=1`, that test only).

`pnpm test:gate` green, `pnpm lint` clean.

## Where U9 actually stands

The conversion (S06/S07/S08) is **not** done, and is now precisely characterised rather than "blocked on U8":

`workflow-graph-executor.ts:310` short-circuits every `MERGE_REGION_KINDS` entry to the legacy merge seam, so `merge-gate`, `merge-attempt`, `manual-merge-hold`, `retry-backoff`, `recovery-router` and both `branch-group-*` handlers **never execute**. `createMergeGateHandler` does read `task.autoMerge` and emit auto-on/auto-off — and is never called. The builtin IR's `outcome:auto-*` edges are unreachable.

**U9's conversion, concretely: stop short-circuiting `MERGE_REGION_KINDS` and let those nodes run.** S06/S07/S08 all hang off that one change. Safeguard 2 has no node-level representation today, so enabling the region without carrying the `autoMerge` contract into it would let an `autoMerge:false` card merge on PR-readiness alone. Full write-up in `docs/plans/workflow-owned-merge-stack/u9-safeguard-baseline.md` (#2634).

## 3. A recurring class worth a shared helper

`goal-anchoring-audit`'s swallow path now reports via `log.debug` (a deliberate demotion of log noise), and `debug` is FUSION_DEBUG-gated so vitest emits nothing — the test asserted a channel that was both wrong *and* disabled. I kept both halves of the contract (swallowed **and** reported) by enabling the flag for that case, rather than deleting the awkward assertion.

**This is the third instance this session** — `worktree-pool`, `self-healing`'s auto-archive line, and now this. If a fourth appears it deserves a shared test helper rather than three bespoke fixes.

## Two failing files I could NOT responsibly take — flagged, not touched

**`executor-prompt.test.ts` (3 failures) — I ESCALATED THIS AND I WAS WRONG. Retracting.**

I flagged these as a possible real pause-contract violation: an agent session spawning while an operator has globally paused the engine. I then finished the diagnosis, and the evidence goes the other way. Recording the retraction with the same detail as the alarm, because a false alarm aimed at another unit costs them a chase.

**The discriminator I asked for, resolved.** Six tests in that file assert `expect(mockedCreateFnAgent).not.toHaveBeenCalled()` during global pause; 3 fail. Splitting them by what they drive:

| Assertions | Drives | Result |
|---|---|---|
| `does not resume unpaused in-progress task while global pause is active` (+2 siblings) | no executor method — `task:updated` / resume paths | **pass** |
| `parks todo tasks in in-progress when fn_task_done…` (+2 siblings) | `executor.execute(...)` **directly** | **fail** |

So the guard holds on every event-driven path and is absent only from the direct `execute()` entry.

**And `execute()` is not the guard site — the scheduler is.** `scheduler.ts:1491` is an explicit hard stop (*"Global pause (hard stop): halt all scheduling activity"*), with a second gate at `:1055`, and the scheduler never calls `.execute(` at all — dispatch routes through the runtime. In production a global pause halts scheduling before anything reaches the executor.

**Conclusion: the pause contract is intact in production.** The 3 failing tests call `execute()` directly, bypassing the upstream gate, and assert a defence-in-depth check *inside* `execute()` that is not there. They are testing a path production does not take during a pause.

What that leaves is a real but much smaller question, and a design one rather than a defect: should `execute()` carry its own pause check as defence-in-depth, given non-scheduler callers exist (self-healing, manual retry)? If yes, add the guard and all six assertions pass. If no, the 3 direct-`execute` assertions are asserting a guarantee the architecture places elsewhere and should be retired. **I have not changed either the code or the tests** — but nobody needs to hunt a pause-contract regression, because there isn't one.

**`executor-fast-mode-workflows.test.ts` (1 failure) — mechanism not isolated.** `visitedNodeIds` is `['review']` where the test expects `['start','review']`. Three probes failed to explain it: giving the review node an explicit `column: "in-progress"` changed nothing (so it is not column-based entry resolution), and swapping `seam: "review"` for a plain prompt config did not isolate it either. Two structurally identical sibling tests in the same file still pass with `['start', ...]`, so something in graph traversal distinguishes them that I did not find. That is U8/graph-executor territory; I am not asserting a `visitedNodeIds` shape I cannot explain.

## Still open and green

- **#2637** — `task-delete-notice` 21 failed → 34 passed.
- **#2643** — shellout allowlist re-pin. **Merge early:** it re-drifts whenever `executor.ts`/`self-healing.ts` line counts shift, with no git conflict to warn you. It already drifted once while open (`executor.ts:17106 → 17198`) and I re-pinned it.



