### PR TITLE
consolidate/e2e — E2E evidence: already-finalized terminal roles (real merge entry, no git) + ledger corrections

### DIFF
--- a/packages/engine/src/__tests__/workflow-already-finalized-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-already-finalized-live-e2e.pg.test.ts
@@ -1,0 +1,134 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-29-17:30 (E2E evidence — the last tractable ledger entry):
+
+`isAlreadyFinalizedColumn` (merger-ai.ts) was the final converted site my unproven-sites ledger
+listed as needing the real-git lane, on the grounds that it is module-private and reached only from
+inside `runAiMerge`. Reading the function instead of costing the lane: `runAiMerge` reaches it after
+only `store.getTask`, `assertNotWorkspaceTaskMerge` (a pure check), and `resolveTaskWorkingBranch`
+(pure) — BEFORE the merge blocker, before settings, before any branch sync. `projectRootDir` is not
+touched on that path.
+
+So it is reachable through the REAL public merge entry point with no repository at all, and the
+short-circuit returns a `noOp` result rather than throwing. Sixth wrong lane-cost inference in that
+ledger; the rule it keeps violating is still "read what the function touches".
+
+WHAT THIS PROVES, and why the shape matters. The guard resolves the terminal columns PER ROLE:
+
+    terminal = [lifecycle.complete ?? "done", lifecycle.archived ?? "archived"]
+
+The first cut replaced the whole legacy PAIR whenever ANY terminal role resolved, so a workflow
+declaring `complete` but no `archived` collapsed to a one-element set and silently lost the archived
+short-circuit — an archived card then fell through to `getTaskMergeBlocker` and threw "must be in
+'in-review'" for a card whose real state was "already done, nothing to do". That is a caught-in-
+review defect (#2471 P1) whose regression test has to exercise BOTH halves independently, because a
+per-set rule passes for whichever role happens to be declared and fails for the other.
+
+The shared fixture declares a `complete` column and NO `archived` column, so it is exactly the
+partially-declared workflow that defect needed — the resolved half and the fallback half are both
+live in one board.
+
+WHAT IS REAL: a PostgreSQL TaskStore, a real persisted renamed workflow, and the real `runAiMerge`
+entry point. Assertions read the returned decision, which is weaker than a persisted row and is
+labelled as such: this proves the renamed board resolves and short-circuits correctly, not that a
+card is moved.
+*/
+import { beforeAll, beforeEach, afterEach, afterAll, expect, it } from "vitest";
+import "@fusion/core";
+
+import {
+  pgDescribe,
+  createSharedPgTaskStoreTestHarness,
+  type SharedPgTaskStoreHarness,
+} from "../../../core/src/__test-utils__/pg-test-harness.js";
+import { runAiMerge } from "../merger-ai.js";
+import { RENAMED_VOCAB, lifecycleIr } from "./_workflow-vocabulary-fixture.js";
+
+/** Never read on the path under test — the short-circuit precedes all git work. */
+const UNUSED_PROJECT_ROOT = "/nonexistent-by-design";
+
+pgDescribe("live already-finalized E2E: terminal roles resolved PER ROLE on a renamed board", () => {
+  const h: SharedPgTaskStoreHarness = createSharedPgTaskStoreTestHarness({
+    prefix: "fusion_already_final_e2e",
+  });
+
+  beforeAll(h.beforeAll);
+  beforeEach(h.beforeEach);
+  afterEach(h.afterEach);
+  afterAll(h.afterAll);
+
+  async function seedWorkflow(key: string): Promise<string> {
+    const created = await h.store().createWorkflowDefinition({
+      name: `Finalized ${key}`,
+      kind: "workflow",
+      /* Declares `complete` (renamed to `shipped`) and NO `archived` column — the
+         partially-declared shape the per-role fallback exists for. */
+      ir: lifecycleIr(RENAMED_VOCAB, `custom:final-${key}`, { mergeOrchestration: true }),
+    } as never);
+    return (created as { id: string }).id;
+  }
+
+  async function seedTask(taskId: string, column: string, workflowId: string): Promise<void> {
+    const store = h.store();
+    await store.createTaskWithReservedId(
+      { description: `finalized ${taskId}`, column } as never,
+      { taskId, applyDefaultWorkflowSteps: false } as never,
+    );
+    await store.writeTaskWorkflowSelection(taskId, workflowId, []);
+    store.taskCache.delete(taskId);
+  }
+
+  it("treats a card in the RENAMED complete column as already finalized", async () => {
+    /* The resolved half. Pre-conversion the literal `done` did not match `shipped`, so this card
+       fell through to the merge blocker and threw instead of returning a clean no-op. */
+    const wf = await seedWorkflow("complete");
+    await seedTask("FN-AF-1", RENAMED_VOCAB.complete, wf);
+
+    const result = await runAiMerge(h.store(), UNUSED_PROJECT_ROOT, "FN-AF-1");
+
+    expect(result.noOp).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("already-finalized");
+    expect(result.merged).toBe(false);
+  });
+
+  it("STILL treats a card in the legacy `archived` column as finalized — the per-role fallback", async () => {
+    /*
+    The fallback half, and the actual #2471 P1 regression. This workflow declares no `archived`
+    column, so `lifecycle.archived` is undefined and the guard must keep the legacy `archived` id
+    for that role ALONE while using the resolved `shipped` for the other.
+
+    A per-SET rule — replace both legacy ids as soon as any terminal role resolves — yields
+    `["shipped"]` here, this card stops short-circuiting, and it throws "must be in 'in-review'".
+    That is why the two halves are separate cases: one rule passes whichever role is declared and
+    fails the other, so a single case cannot distinguish per-role from per-set.
+    */
+    const wf = await seedWorkflow("archived");
+    await seedTask("FN-AF-2", "archived", wf);
+
+    const result = await runAiMerge(h.store(), UNUSED_PROJECT_ROOT, "FN-AF-2");
+
+    expect(result.noOp).toBe(true);
+    expect(result.reason).toBe("already-finalized");
+  });
+
+  it("does NOT treat a card in the renamed REVIEW column as finalized", async () => {
+    /* The differential. Without it both cases above would also pass for a guard that reported
+       every card finalized — which would make every merge a silent no-op, the worst possible
+       failure of this function. A review-column card must get past the short-circuit; it then
+       fails for a merge-pipeline reason, which is proof it was NOT short-circuited. */
+    const wf = await seedWorkflow("review");
+    await seedTask("FN-AF-3", RENAMED_VOCAB.review, wf);
+
+    const outcome = await runAiMerge(h.store(), UNUSED_PROJECT_ROOT, "FN-AF-3").then(
+      (r) => ({ threw: false as const, r }),
+      (e: unknown) => ({ threw: true as const, message: String(e) }),
+    );
+
+    if (!outcome.threw) {
+      // Whatever it did, it must not have claimed "already finalized".
+      expect(outcome.r.reason).not.toBe("already-finalized");
+    } else {
+      expect(outcome.message).not.toContain("already-finalized");
+    }
+  });
+});

--- a/packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts
@@ -902,9 +902,32 @@ NOT PROVEN end to end — real callers this suite does not reach:
   - merger-ai.ts:1039        isAlreadyFinalizedColumn — LIVE, but module-private and
     reached only from runAiMerge, so it does need the real-git lane
   - executor.ts:1763,6339,6341        rebound target, merge-orchestration probe, complete column
-  - core/live-agent-count.ts    columnIsIntakeOrHold (the WAITING predicate) — the running
-    predicate never reads it, so the admission-count E2E cannot reach it
-  - dashboard register-task-workflow-routes.ts:151,166,175,1797
+
+FNXC:WorkflowLifecycleColumns 2026-07-29-16:40 — TWO ENTRIES RETIRED, both wrong the same way.
+Recorded rather than deleted, because the ERROR is the reusable part: each stated a LANE cost as
+if it were an impossibility, and neither claim was checked against the function.
+
+  - core/live-agent-count.ts  columnIsIntakeOrHold — NOW PROVEN, and never unreachable. The old
+    entry read "the running predicate never reads it, so the admission-count E2E cannot reach it",
+    which is true and irrelevant: the WAITING predicate has exactly ONE consumer,
+    `deriveStatsFromTasks`, and that is an exported PURE function. The narrow seam FN-5048 asks for
+    was already there. Covered by useExecutorStats.queued-column-roles.test.ts on renamed AND
+    merged boards (mutation-verified: forcing the legacy id pair fails exactly those two cases),
+    plus a characterization test pinning the undercount live-agent-count.ts admits in prose for a
+    column absent from the flag map.
+
+  - dashboard register-task-workflow-routes.ts — COVERED BY ITS OWNER (#2614), not by this file.
+    The old reason, that standing up the route shell is the mock-the-world pattern FN-5048 forbids,
+    was simply false: `createApiRoutes` + `test-request.js` is this repo's ESTABLISHED route-test
+    convention, with ten existing `register-task-workflow-routes.*` suites driving a real express
+    app against a stubbed store. #2614's plan-approval-intake-column.test.ts covers the merged lane,
+    a renamed merged lane, and a negative case. Not duplicated here.
+
+FOURTH and fifth wrong lane-cost inferences in this ledger (after auto-merge-finalization, both
+self-healing rebounds, and resolveFinalizeReboundColumn). The rule written after the third still
+stands and was still under-applied: READ WHAT THE FUNCTION TOUCHES before costing a lane for it.
+"Its consumers are elsewhere" is a statement about where to put the test, not about whether one
+can exist.
 
 FNXC:WorkflowLifecycleColumns 2026-07-29-17:20 — WHY, and what each would take. Two lanes,
 and neither is another table row:


### PR DESCRIPTION
Consolidation branch for the E2E-evidence worker. Two commits, both engine test/comment only — **no production code, census unchanged**.

## Census (the authoritative instrument)

`node scripts/lifecycle-column-census.mjs` on this branch: **triage 10, total 784** — identical to its base. `lifecycle-column-census-ast.test.ts` and `lifecycle-column-census.test.ts` pass (15). This PR neither shrinks nor grows the backlog; it is evidence.

## What it contains, file by file

| file | change |
|---|---|
| `packages/engine/src/__tests__/workflow-already-finalized-live-e2e.pg.test.ts` | **new** — 3 cases, live PG store + real `runAiMerge` |
| `packages/engine/src/__tests__/workflow-lifecycle-live-e2e.pg.test.ts` | comment only — retires two unproven-ledger entries |

## The evidence: `isAlreadyFinalizedColumn` never needed the real-git lane

My unproven-sites ledger listed it as requiring a git harness because it is module-private inside `runAiMerge`. Reading the function instead of costing the lane: `runAiMerge` reaches it after only `store.getTask`, a pure workspace assert, and a pure branch resolve — **before** the merge blocker, settings, and any branch sync. `projectRootDir` is never touched on that path, and the short-circuit returns a `noOp` rather than throwing. Reachable through the real public entry point with no repository at all.

### Why two cases and not one

The guard resolves terminal columns **per role**:

```ts
terminal = [lifecycle.complete ?? "done", lifecycle.archived ?? "archived"]
```

#2471's P1 caught the first cut replacing the whole legacy **pair** as soon as *any* terminal role resolved — a workflow declaring `complete` but no `archived` collapsed to one element, silently lost the archived short-circuit, and an archived card then threw *"must be in 'in-review'"* for a card whose real state was "already done, nothing to do".

A per-set rule passes for whichever role **is** declared and fails the other, so a single case cannot tell the two rules apart. The shared fixture declares `complete` (renamed `shipped`) and **no** `archived`, so it is exactly that partially-declared shape — resolved half and fallback half live on one board.

Mutation-verified, each killing only its own case:

| mutation | kills |
|---|---|
| per-**set** replacement (the #2471 defect) | the legacy-`archived` fallback case |
| legacy pair only (conversion reverted) | the renamed-`shipped` case |

Plus a differential: a renamed **review** card must not report already-finalized. Without it both cases above would pass for a guard that finalizes everything — turning every merge into a silent no-op, the worst failure this function has.

Evidence strength is stated in the file header rather than overclaimed: this reads a returned **decision**, not a persisted row, so it proves the renamed board resolves and short-circuits — not that a card moves.

## Ledger corrections (comment only)

Two entries retired, both wrong the same way — each stated a **lane cost** as if it were an impossibility:

- `columnIsIntakeOrHold` — "consumers are dashboard-side" is true and irrelevant; its one consumer is an exported pure function. Proven on merged and renamed boards by work already merged in #2631.
- `register-task-workflow-routes.ts` — "standing up the route shell is mock-the-world" was false; `createApiRoutes` + `test-request.js` is this repo's established convention with ten existing suites for that file. Covered by its owner in #2614.

Counting this PR's own subject, that is **seven** wrong lane-cost inferences in that ledger. The rule it keeps violating is unchanged and now recorded in the file: read what the FUNCTION touches before costing a lane for it.

## Verification

`pnpm test:gate` exit 0 (695), `pnpm lint` exit 0, engine typecheck clean, 28 tests green across the AST ratchet and the three merged-board/planner-lane/already-finalized families.

## Not in scope here

The `performWorkflowRerunBounce` E2E. The harness exists (`new TaskExecutor(store, "/tmp/test", {})`), but `executor.ts:4305` gates the rebound on the legacy `in-progress`/`in-review` pair while resolving its target by role — so on a renamed board the bounce never fires and the resolved target is unreachable. An E2E asserting today's behaviour would cement that. It is executor.ts's owner's fix; evidence should follow it. Detail in #2632's thread.