### PR TITLE
fix(dashboard): restore traits-over-legacy-id — a reviewed fix that #2645 merged without

### DIFF
--- a/packages/dashboard/app/components/TaskContextMenu.tsx
+++ b/packages/dashboard/app/components/TaskContextMenu.tsx
@@ -191,6 +191,16 @@ export function isPreExecutionHoldColumn(column: string, flags?: TaskContextMenu
   the PR that reported it is closed.
   */
   if (flags) return flags.intake === true || flags.hold === true;
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-01:40 DELIBERATE-LITERAL: the fallback arm only.
+  Now that traits decide first, this is reachable ONLY when the caller supplies no flags at all —
+  the pre-load window before the board resolves columns, and a card stranded on an id its workflow
+  no longer declares. There is nothing to resolve FROM in that state, so this is not an unconverted
+  guard: deleting it does not remove a decision, it picks the other guess ("not a pre-implementation
+  lane") and silently drops the Plan affordance during first paint. Same class as the marked
+  fallbacks in `TaskCard.tsx`, `TaskDetailModal.tsx`, and `live-agent-count.ts`. Retires with the
+  pre-load window.
+  */
   return column === "triage";
 }
 

--- a/packages/dashboard/app/components/TaskContextMenu.tsx
+++ b/packages/dashboard/app/components/TaskContextMenu.tsx
@@ -176,7 +176,22 @@ export function isPreExecutionHoldColumn(column: string, flags?: TaskContextMenu
   Same shape, different degraded answer: the trait path is identical and the fallbacks are not
   interchangeable. Kept separate with the difference recorded, rather than made to look shared.
   */
-  return column === "triage" || flags?.intake === true || flags?.hold === true;
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-01:15 (RESTORED — see below):
+  RESOLVED TRAITS ARE AUTHORITATIVE. The legacy id was an unconditional disjunct, so
+  `isPreExecutionHoldColumn("triage", { intake: false, hold: false })` returned true — explicit
+  traits saying "planning does not happen in this column" were overruled by the id, exposing the
+  Plan action on a card whose workflow says otherwise. The id now serves only as the NO-METADATA
+  fallback, which still covers a card stranded on an id its workflow no longer declares (that card
+  has no flags at all).
+
+  PROVENANCE: this fix was reviewed and approved on PR #2645 (coderabbit, Major) and then LOST —
+  the consolidation branch it lived on was force-pushed by another worker, and #2645 merged
+  unrelated content under its number. Restored here with its test, because the defect is real and
+  the PR that reported it is closed.
+  */
+  if (flags) return flags.intake === true || flags.hold === true;
+  return column === "triage";
 }
 
 

--- a/packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { Task } from "@fusion/core";
-import { TaskContextMenu, buildTaskActionMenuModel } from "../TaskContextMenu";
+import { TaskContextMenu, buildTaskActionMenuModel, isPreExecutionHoldColumn } from "../TaskContextMenu";
 
 const t = ((key: string, fallback: string, vars?: Record<string, string>) => {
   if (!vars) return fallback;
@@ -374,5 +374,57 @@ describe("shouldShowActionsMenu by workflow shape (not by column id)", () => {
     // The assertion that fails if anyone reintroduces an id comparison: `backlog` matches no
     // legacy literal, so a correct answer here can only come from the trait.
     expect(model("backlog", { intake: true })).toBe(false);
+  });
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-01:15 (RESTORED with the fix it covers):
+Reviewed and approved on PR #2645 (coderabbit, Major), then lost when that consolidation branch was
+force-pushed and #2645 merged unrelated content under its number. Restored because the defect is
+real and the reporting PR is closed.
+
+The predicate drives the Plan action, so both the classifier and the caller are pinned: a classifier
+assertion alone cannot tell you the menu behaved correctly.
+*/
+describe("isPreExecutionHoldColumn — explicit traits outrank the legacy id", () => {
+  it("returns FALSE for `triage` when traits explicitly deny the lane", () => {
+    // The regression. With the legacy id as an unconditional disjunct this returns true.
+    expect(isPreExecutionHoldColumn("triage", { intake: false, hold: false })).toBe(false);
+  });
+
+  it("still honours the legacy id when NO traits are supplied", () => {
+    // Must survive: a card stranded on an undeclared id has no flags, and dropping it from the
+    // pre-implementation lane would silently remove its affordances.
+    expect(isPreExecutionHoldColumn("triage", undefined)).toBe(true);
+  });
+
+  it("treats either trait as qualifying, and complete/archived as disqualifying", () => {
+    expect(isPreExecutionHoldColumn("anything", { intake: true })).toBe(true);
+    expect(isPreExecutionHoldColumn("anything", { hold: true })).toBe(true);
+    expect(isPreExecutionHoldColumn("triage", { complete: true })).toBe(false);
+    expect(isPreExecutionHoldColumn("triage", { archived: true })).toBe(false);
+  });
+
+  it("does NOT offer the Plan action through the caller when traits deny the lane", () => {
+    // Caller-level: the predicate is not the product. `onPlan` must be injected or Plan is
+    // omitted entirely regardless of column, which would make this pass for the wrong reason.
+    const model = buildTaskActionMenuModel({
+      task: { id: "FN-1", column: "triage", dependencies: [], steps: [], currentStep: 0, log: [] } as never,
+      t: ((_k: string, fallback: string) => fallback) as never,
+      columnLabel: ((c: string) => c) as never,
+      currentColumnFlags: { intake: false, hold: false } as never,
+      onPlan: () => {},
+    });
+    expect(model.actions.some((a) => a.id === "plan")).toBe(false);
+  });
+
+  it("DOES offer Plan on the legacy id with no traits (the fallback still works end to end)", () => {
+    const model = buildTaskActionMenuModel({
+      task: { id: "FN-1", column: "triage", dependencies: [], steps: [], currentStep: 0, log: [] } as never,
+      t: ((_k: string, fallback: string) => fallback) as never,
+      columnLabel: ((c: string) => c) as never,
+      onPlan: () => {},
+    });
+    expect(model.actions.some((a) => a.id === "plan")).toBe(true);
   });
 });


### PR DESCRIPTION
## A merged PR does not contain its own fix

coderabbit raised a **Major** on #2645: `isPreExecutionHoldColumn("triage", { intake: false, hold: false })` returned `true`, so explicit resolved traits saying *"planning does not happen in this column"* were overruled by the legacy id, exposing the **Plan** action on a card whose workflow says otherwise.

I fixed it, answered the thread, and pushed to `consolidate/u11`. **#2645 is now merged — and main does not have the fix.** `origin/main` still reads:

```ts
return column === "triage" || flags?.intake === true || flags?.hold === true;
```

The merge commit `177c2309d` touches three files of unrelated planner-lane work. My commit appears nowhere in `git log --all`. The branch was force-pushed by another worker while I did not hold it, and the PR merged under a number whose review thread describes a different change. Lost with it: the three tests and the `isPreExecutionIntakeLane` / `legacyLifecycleColumns` helpers.

I flagged this exact risk when I noticed another worktree had taken the branch — *"a second agent force-pushing that branch would drop it."* Recording it plainly because **the failure mode is invisible**: the PR is green, closed, merged, and its review threads read as resolved. Nothing would ever have revisited it. If other workers shared consolidation branches, this is worth auditing beyond my one case.

## What this PR does

Restores the predicate **minimally**, against main's actual code — no reintroduction of helpers that no longer exist here. Traits decide when present; the legacy id is the no-metadata fallback only, which still covers a card stranded on an id its workflow no longer declares (that card has no flags at all).

## Verification

**Mutation-verified: reverting to the disjunct fails exactly 2 of 20** — the classifier case and the caller-level Plan-action case. 20/20 with the fix; dashboard `tsconfig.app.json` typecheck clean.

The caller-level test injects `onPlan` deliberately: Plan is omitted entirely when the host does not wire it, so without that the assertion would pass for the wrong reason.

## Census

Unchanged (787 / triage 10). This is a **behavior** fix — the literal survives as the documented fallback, so it is not a conversion and does not move the count. Worth stating because #2645's title claimed `triage 11 -> 10` for work that did not include this.