### PR TITLE
census: main is RED on the ratchet — mark the 4 unmarked-but-justified guards (779 → 775)

### DIFF
--- a/packages/dashboard/app/components/command-center/MissionControlPanel.tsx
+++ b/packages/dashboard/app/components/command-center/MissionControlPanel.tsx
@@ -70,6 +70,14 @@ receiver is a column id, purpose is presentation, not a lifecycle decision.
 */
 const TRIAGE_STAGE_COLUMN_ALIASES: ReadonlySet<string> = new Set(["triage", "signal", "backlog"]);
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-01:55 DELIBERATE-LITERAL: alias table, not lifecycle guards.
+Same rationale as the marker above, which covers `TRIAGE_STAGE_COLUMN_ALIASES` but NOT this separate
+declaration — the census excuses the construct a marker is attached to, so a sibling const needs its
+own. These arms map arbitrary OPERATOR-CHOSEN column names ("to do", "ready", "shipped") onto the
+five canonical funnel stages. They are not asking "what lifecycle role does this column play?" —
+they are normalising free text before any role lookup can happen, so there is no trait to read.
+*/
 const FUNNEL_STAGES: Array<{ id: string; match: (column: string) => boolean }> = [
   { id: "triage", match: (c) => TRIAGE_STAGE_COLUMN_ALIASES.has(c) },
   { id: "todo", match: (c) => c === "todo" || c === "to-do" || c === "to do" || c === "ready" },

--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -75,6 +75,11 @@ export function isPreImplementationColumnRole(flags: ColumnRoleFlags | undefined
  *
  * Same shape, different degraded answer — the asymmetry U11 verified for
  * `isPreExecutionHoldColumn` and this file already documents elsewhere.
+ *
+ * FNXC:WorkflowResolvedColumns 2026-07-30-01:55 DELIBERATE-LITERAL: the fallback arm only.
+ * The reasoning above was already reviewed; only the machine-readable token was missing, so the
+ * census counted this as an unconverted guard. Traits decide when present; the id answers only
+ * when the column has no resolved flags, where there is nothing to resolve from.
  */
 export function isHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
   return flags ? flags.hold === true : columnId === "todo";

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 776,
+    "column": 775,
     "role": 0,
     "status": 182,
     "deliberate": 16
@@ -11,7 +11,7 @@
     "in-progress": 146,
     "in-review": 208,
     "archived": 152,
-    "todo": 60,
+    "todo": 59,
     "triage": 5
   },
   "byFile": {
@@ -54,7 +54,6 @@
     "packages/core/src/task-store/task-store-helpers.ts": 4,
     "packages/dashboard/app/components/TaskReviewTab.tsx": 4,
     "packages/dashboard/app/components/taskSorting.ts": 4,
-    "packages/dashboard/app/utils/worktreeGrouping.ts": 4,
     "packages/dashboard/src/gitlab-tracking-comments.ts": 4,
     "packages/dashboard/src/routes/register-git-github.ts": 4,
     "packages/engine/src/agent-heartbeat.ts": 4,
@@ -70,6 +69,7 @@
     "packages/dashboard/app/components/TaskChangesTab.tsx": 3,
     "packages/dashboard/app/components/TaskChatTab.tsx": 3,
     "packages/dashboard/app/utils/taskActivity.ts": 3,
+    "packages/dashboard/app/utils/worktreeGrouping.ts": 3,
     "packages/dashboard/src/chat.ts": 3,
     "packages/dashboard/src/routes/register-chat-routes.ts": 3,
     "packages/engine/src/cli-agent/state-machine.ts": 3,


### PR DESCRIPTION
**`node scripts/lifecycle-column-census.mjs --strict` exits 1 on `origin/main` right now.** Item 4's final verification pass cannot go green until this is fixed, so this PR fixes it.

## The +3 investigation, answered

It is **+4**, it is **still on main**, and the answer to "were they justified?" is **yes in substance, no in bookkeeping** — both merges added real guards and neither marked them.

| file | delta | source | verdict |
|---|---|---|---|
| `MissionControlPanel.tsx` | 0 → 3 | #2645 ("funnel aliases") | justified — **alias table**, not lifecycle guards |
| `columnRoles.ts` | 0 → 1 | #2647 (`isHoldColumnRole`) | justified — documented no-metadata fallback |

**MissionControlPanel** maps operator-chosen column names (`"to do"`, `"ready"`, `"shipped"`) onto the five canonical funnel stages. Those arms do not ask what lifecycle role a column plays — they normalise free text *before* any role lookup can happen, so there is no trait to read. The file **already carried a `DELIBERATE-LITERAL` marker**, but on `TRIAGE_STAGE_COLUMN_ALIASES`; the census excuses only the construct a marker is attached to, so the sibling `FUNNEL_STAGES` const needed its own.

**columnRoles** `isHoldColumnRole` is a no-metadata fallback whose asymmetry with `isPreImplementationColumnRole` is already spelled out in its own doc comment. Only the machine-readable token was missing.

So no bad code landed. The ratchet was correctly reporting **unrecorded growth**, and nobody saw it because nothing runs the census — which is #2654.

## This is the second time the same placement trap has bitten

A marker on a *sibling* construct counts for nothing. It caught #2645's author, and it caught me an hour ago on `TaskContextMenu` (#2657) — my first attempt marked nothing and I only noticed because the count did not move.

**For the fleet brief: verify a marker by the count moving, not by the comment existing.** Until #2654 lands, nothing else will tell you.

## Verification

- `--strict` **exit 1 → 0**
- **779 → 775** total, DELIBERATE 12 → 16, **triage unchanged at 5**
- baseline re-recorded in the same commit, per the tool's instruction — that also closed one stale allowance (`worktreeGrouping.ts` 4 → 3)
- dashboard typecheck clean, **165/165** across the touched suites

## Where the closing bar stands after this

Main's remaining triage guards are `moves.ts` ×4 (die with U12's flag flip) and `TaskContextMenu.tsx:179` (marked by #2657). **Triage reaches 0 with U12 + #2657 — no further conversion work.**