### PR TITLE
fix(test): decouple the audit-emitter assertion from log formatting (last of the 4 red PG suites)

### DIFF
--- a/packages/core/src/__tests__/postgres/central-archive-secrets.test.ts
+++ b/packages/core/src/__tests__/postgres/central-archive-secrets.test.ts
@@ -446,10 +446,22 @@ pgDescribe("PostgreSQL central-db / archive-db / secrets-store (U6 satellite-cen
       await expect(
         resilientStore.createSecret({ scope: "project", key: "RESILIENT", plaintextValue: "still-created" }),
       ).resolves.toMatchObject({ key: "RESILIENT" });
-      expect(warning).toHaveBeenCalledWith(
-        "[async-secrets-store] audit emitter failed",
-        expect.objectContaining({ message: "audit transport unavailable" }),
-      );
+      /*
+      FNXC:EngineDiagnostics 2026-07-31-15:00:
+      Asserted with stringContaining, because the logger deliberately wraps every message in a
+      machine-readable severity marker: `withSeverityMarker` (logger.ts:31) emits
+      `\u0000fnlvl=warn\u0000[core-async-secrets-store] …` so the TUI log pane can colour by level.
+      This case pinned the raw string and so broke when that convention landed — the assertion was
+      coupled to log FORMATTING, not to the behaviour it exists to check.
+
+      What it actually cares about is that a failing audit emitter is reported and does not take the
+      create down with it. Both are still asserted: the resolves.toMatchObject above proves the secret
+      was created anyway, and this proves the failure was surfaced with its cause.
+      */
+      expect(warning).toHaveBeenCalledTimes(1);
+      const [loggedMessage, loggedCause] = warning.mock.calls[0]!;
+      expect(String(loggedMessage)).toContain("[async-secrets-store] audit emitter failed");
+      expect((loggedCause as { message?: string })?.message).toBe("audit transport unavailable");
     } finally {
       warning.mockRestore();
     }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,22 +1,22 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 748,
+    "column": 746,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 200,
+    "done": 199,
     "in-progress": 144,
     "in-review": 205,
-    "archived": 148,
+    "archived": 147,
     "todo": 47,
     "triage": 4
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 87,
+    "packages/engine/src/executor.ts": 85,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/core/src/task-store/moves.ts": 39,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,


### PR DESCRIPTION
Last of the four long-red live-PG suites. **This one is a stale test — the only one of the four that is.**

## The cause

`withSeverityMarker` (`logger.ts:31`) deliberately wraps every message in a machine-readable severity marker so the TUI log pane can colour by level. The emitted string carries a `fnlvl=warn` marker and a `[core-async-secrets-store]` subsystem tag ahead of the real text.

The assertion pinned the raw message with `toHaveBeenCalledWith`, so it broke when that convention landed. It was coupled to log **formatting**, not to the behaviour it exists to check.

## The fix

Rewritten to assert what it actually cares about: exactly one warning, whose message **contains** the subsystem-tagged text, carrying the underlying cause.

Both halves of the behaviour stay pinned — the `resolves.toMatchObject` above proves the secret is still created when the audit emitter fails, and this proves the failure is surfaced rather than swallowed.

**Mutation-verified rather than assumed green:** deleting the `severityAuditLog.warn` call in `async-secrets-store.ts` fails with `expected "warn" to be called 1 times, but got 0 times`. A `stringContaining` assertion that passes because it matches nothing would be worse than the brittle one it replaces.

## The four, complete

| suite | verdict |
|---|---|
| `store-wedge-resolution` | **product bug** — `42P18`, total runtime failure of wedge resolution in PG (#2669) |
| `workflow-settings-project-identity` | **stale docs** — resolver contradicted its own documented order (#2671) |
| `agent-logs-and-monitor` | **real defect** — funnel mis-bucketing from the U11 merge; half fixed in #2674, half needs a product call |
| `central-archive-secrets` | **stale test** — this PR |

**Three of four were real problems**, sitting behind "pre-existing, fails on main too". That phrase answers *whose* problem it is, not *what* is wrong.

## Census, again

`check:lifecycle-columns` is **still** exiting 1 on `origin/main` — `executor.ts: allows 87, tree has 85` — the same staleness flagged on #2674. Re-recorded here too, because the blocking check stays red for every open PR until some PR carries it, and I do not know which of #2674 / this one lands first.

## Verification

`pnpm test:gate` green (10 / 158 / 487 / 71). Suite **14/15 → 15/15**. `pnpm check:lifecycle-columns` exits 0 after the re-record. `pnpm lint` clean.

No changeset: test-only plus an internal baseline.
