### PR TITLE
chore: re-record the census baseline — check:lifecycle-columns is RED on main, blocking every PR

### DIFF
--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,22 +1,22 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 748,
+    "column": 746,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 200,
+    "done": 199,
     "in-progress": 144,
     "in-review": 205,
-    "archived": 148,
+    "archived": 147,
     "todo": 47,
     "triage": 4
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 87,
+    "packages/engine/src/executor.ts": 85,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/core/src/task-store/moves.ts": 39,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,


### PR DESCRIPTION
**`pnpm check:lifecycle-columns` exits 1 on a pristine `origin/main` checkout**, and it is wired into `.github/workflows/pr-checks.yml` — so the blocking check is failing for **every open PR** for a reason unrelated to any of them.

```
packages/engine/src/executor.ts: allows 87, tree has 85
```

## Cause

A merge converted two guards in `executor.ts` without re-recording the baseline in the same PR. The ratchet caught it correctly and immediately — but only **after** the merge, because it runs on PR head, where that PR was green.

## Why this is its own PR

One file, four lines, so it merges fast. The diff is **purely downward**:

```
column      748 -> 746
done        200 -> 199
archived    148 -> 147
executor.ts  87 -> 85
```

Guards were **removed** — the direction the program wants. Nothing is widened, and no allowance grows.

I have been carrying this same re-record inside #2669, #2674 and #2675 because each needs it to go green. None has merged, so main stayed red across three turns. Splitting it out means it lands on its own and those three become trivial rebases.

## Follow-up, not fixed here

This is the **second distinct occurrence**. The check works; the gap is *when* it runs. A PR that is green at open can still land a stale baseline, because nothing re-validates at merge time. Running the census on the merge queue rather than only on PR head closes that window.

That is a CI-topology change and belongs to whoever owns the workflow files, so I have not made it unilaterally — but it will keep happening until someone does, and every occurrence blocks the whole queue.

## Verification

`pnpm check:lifecycle-columns` exits 0 after the re-record. No source change, no behaviour change, no changeset.