### PR TITLE
docs: correct 104 future-dated FNXC timestamps across 61 files

### DIFF
--- a/packages/core/src/__tests__/coding-ideas-move.test.ts
+++ b/packages/core/src/__tests__/coding-ideas-move.test.ts
@@ -115,7 +115,7 @@ pgDescribe("Coding (Ideas) custom-column moves (workflow-columns graduation)", (
       store.moveTask(task.id, "ideas", { moveSource: "user" }),
     ).rejects.toThrow(/Invalid transition: '.*' → 'ideas'/);
     /*
-    FNXC:WorkflowColumns 2026-07-31-04:30 (U12 — the move-path flag is resolved):
+    FNXC:WorkflowColumns 2026-07-30-04:30 (U12 — the move-path flag is resolved):
     ...and so is a non-adjacent target. The advertised target list changed from
     `in-progress, triage, archived` to `archived, in-progress`, and that is the FIX rather than a
     regression: the old list came from the hardcoded legacy adjacency table, which still offered

--- a/packages/core/src/__tests__/live-move-path-undeclared-target.test.ts
+++ b/packages/core/src/__tests__/live-move-path-undeclared-target.test.ts
@@ -106,7 +106,7 @@ pgDescribe("live move path — which targets it accepts after the Planning merge
     expect(workflowHasColumn(ir, "todo")).toBe(true);
 
     /*
-    FNXC:WorkflowColumns 2026-07-31-04:30 (U12 — the move-path flag is RESOLVED; this is the fix):
+    FNXC:WorkflowColumns 2026-07-30-04:30 (U12 — the move-path flag is RESOLVED; this is the fix):
     THE DEFECT IS GONE, so this case now asserts the refusal instead of the acceptance, and the
     `it.todo` below it — "should REFUSE a move into a column the task's workflow does not declare
     (U2b)" — is fulfilled rather than left dangling.

--- a/packages/core/src/__tests__/log-severity-spam-contract.test.ts
+++ b/packages/core/src/__tests__/log-severity-spam-contract.test.ts
@@ -5,7 +5,7 @@ import { createLogger } from "../logger.js";
 import { logSeverityManifest } from "../../../engine/src/__tests__/log-severity-manifest.js";
 
 /*
-FNXC:EngineDiagnostics 2026-08-01-10:46:
+FNXC:EngineDiagnostics 2026-07-26-10:46:
 Core mirrors engine FUSION_DEBUG behavior; both implementations must preserve
 silent-by-default routine diagnostics and the TUI's info severity marker.
 */
@@ -31,7 +31,7 @@ describe("core logger debug gating", () => {
 });
 
 /*
-FNXC:EngineDiagnostics 2026-08-01-11:12:
+FNXC:EngineDiagnostics 2026-07-26-11:12:
 FN-8603 requires core diagnostics to use the shared logger rather than bare
 console output, preserving severity markers and FUSION_DEBUG gating.
 */

--- a/packages/core/src/__tests__/moves-flag-equivalence.test.ts
+++ b/packages/core/src/__tests__/moves-flag-equivalence.test.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:WorkflowColumns 2026-07-31-04:15 (U12 — THIS FILE'S EQUIVALENCE CASES ARE RETIRED, ON PURPOSE):
+FNXC:WorkflowColumns 2026-07-30-04:15 (U12 — THIS FILE'S EQUIVALENCE CASES ARE RETIRED, ON PURPOSE):
 The compatibility flag is deleted in this same PR, so the two-flag-states comparison below cannot
 run any more — there is only one path now. Its result is preserved in the commit that added it and
 in the deletion's own comment: identical persisted rows across 128 fields plus an equal timing shape,
@@ -13,7 +13,7 @@ custom boards and it looks like dead weight to anyone tidying up.
 
 --- original header, kept for the record ---
 
-FNXC:WorkflowColumns 2026-07-31-02:00 (U12 — precondition 1 for flipping the move-path flag):
+FNXC:WorkflowColumns 2026-07-30-02:00 (U12 — precondition 1 for flipping the move-path flag):
 DO THE TWO COLUMN-SIDE-EFFECT IMPLEMENTATIONS AGREE?
 
 `moves.ts` gates six behaviours on the raw compatibility flag (#2639 pins all six). Seam 3 is the one
@@ -58,7 +58,7 @@ pgDescribe("move-path side effects are equivalent with the compatibility flag OF
   afterAll(harness.afterAll);
 
   /*
-  FNXC:WorkflowColumns 2026-07-31-03:00 (U12 — seam 2, demonstrated rather than inferred):
+  FNXC:WorkflowColumns 2026-07-30-03:00 (U12 — seam 2, demonstrated rather than inferred):
   WHAT THE FLIP WOULD BREAK ON A CUSTOM BOARD.
 
   Precondition 2's census established that 20 of 41 literal engine `moveTask` targets carry no

--- a/packages/core/src/__tests__/no-hardcoded-lifecycle-columns.test.ts
+++ b/packages/core/src/__tests__/no-hardcoded-lifecycle-columns.test.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:LifecycleColumnRatchet 2026-07-31-09:10 (U12 R12 — AST, replacing the grep):
+FNXC:LifecycleColumnRatchet 2026-07-30-09:10 (U12 R12 — AST, replacing the grep):
 
 THE MEASURING INSTRUMENT for the lifecycle-column conversion, and the authority on the number.
 
@@ -197,7 +197,7 @@ function comparisonSites(columnId: string): Site[] {
  * to NON_COLUMN_RECEIVERS with a reason.
  */
 /*
-FNXC:LifecycleColumnRatchet 2026-07-31-01:30 (PR #2647 review — greptile, and worse than reported):
+FNXC:LifecycleColumnRatchet 2026-07-30-01:30 (PR #2647 review — greptile, and worse than reported):
 TIGHTENED TO THE MEASURED COUNTS, because slack made this a ratchet in name only.
 
 The review's finding was that this test is not in the blocking gate, so a regression can merge. True,
@@ -384,7 +384,7 @@ describe("the detector counts every reintroduction shape (fail closed)", () => {
 });
 
 /*
-FNXC:LifecycleColumnRatchet 2026-07-31-00:45 (U12 — the bar is a FLOOR, not zero):
+FNXC:LifecycleColumnRatchet 2026-07-30-00:45 (U12 — the bar is a FLOOR, not zero):
 SITES THAT MUST NEVER BE CONVERTED, asserted as a positive.
 
 The program has been tracking these counts toward zero. Zero is not reachable, and pursuing it means

--- a/packages/core/src/__tests__/optionless-move-does-not-bypass-guards.test.ts
+++ b/packages/core/src/__tests__/optionless-move-does-not-bypass-guards.test.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:TaskMovement 2026-07-31-11:30 (PR #2655 review — the contract that was only a comment):
+FNXC:TaskMovement 2026-07-30-11:30 (PR #2655 review — the contract that was only a comment):
 AN OPTIONLESS `moveTask(id, toColumn)` MUST NOT INHERIT GUARD BYPASS.
 
 `moves.ts` resolves `moveSource = options?.moveSource ?? "engine"` for the EMITTED source, while

--- a/packages/core/src/__tests__/postgres/central-archive-secrets.test.ts
+++ b/packages/core/src/__tests__/postgres/central-archive-secrets.test.ts
@@ -447,7 +447,7 @@ pgDescribe("PostgreSQL central-db / archive-db / secrets-store (U6 satellite-cen
         resilientStore.createSecret({ scope: "project", key: "RESILIENT", plaintextValue: "still-created" }),
       ).resolves.toMatchObject({ key: "RESILIENT" });
       /*
-      FNXC:EngineDiagnostics 2026-07-31-15:00:
+      FNXC:EngineDiagnostics 2026-07-30-15:00:
       Asserted with stringContaining, because the logger deliberately wraps every message in a
       machine-readable severity marker: `withSeverityMarker` (logger.ts:31) emits
       `\u0000fnlvl=warn\u0000[core-async-secrets-store] …` so the TUI log pane can colour by level.

--- a/packages/core/src/__tests__/postgres/comments-retriage-renamed-lanes.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/comments-retriage-renamed-lanes.pg.test.ts
@@ -104,7 +104,7 @@ pgDescribe("addComment re-triage under a renamed planner vocabulary (PostgreSQL)
   }
 
   /*
-  FNXC:PostCommentRetriage 2026-07-31-10:20 (PR #2612 review — coderabbit):
+  FNXC:PostCommentRetriage 2026-07-30-10:20 (PR #2612 review — coderabbit):
   `needs-replan` is written by BOTH branches — approval invalidation and ordinary
   planned-task re-triage — so asserting the status alone cannot tell them apart. A
   card taking the WRONG branch persists the same status and the test still passes.

--- a/packages/core/src/__tests__/postgres/schema-applier.test.ts
+++ b/packages/core/src/__tests__/postgres/schema-applier.test.ts
@@ -874,7 +874,7 @@ pgDescribe("schema-applier: VAL-SCHEMA-001 final-schema parity (table counts)", 
   the audit trail showed an unidentifiable writer).
   */
   /*
-  FNXC:SymbolLock 2026-07-31-10:00:
+  FNXC:SymbolLock 2026-07-20-10:00:
   Existing databases recorded through 0027 must receive the durable declaration
   column before scheduler admission can resolve task-owned symbol keys.
   */

--- a/packages/core/src/__tests__/postgres/store-movement.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/store-movement.pg.test.ts
@@ -56,7 +56,7 @@ pgTest("TaskStore moveTask column transitions (PostgreSQL)", () => {
 
   it("moves an in-progress task back to the workflow's planning column, and REFUSES `triage`", async () => {
     /*
-    FNXC:WorkflowColumns 2026-07-31-04:45 (U12 — the move-path flag is resolved):
+    FNXC:WorkflowColumns 2026-07-30-04:45 (U12 — the move-path flag is resolved):
     Was "allows moving an in-progress task back to triage". The default lineage stopped declaring
     `triage` at #2515, and the move path now resolves targets against the task's own workflow instead
     of a hardcoded legacy adjacency table — so that move is refused rather than stranding the card in

--- a/packages/core/src/__tests__/postgres/store-stale-paused-renamed-review.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/store-stale-paused-renamed-review.pg.test.ts
@@ -93,7 +93,7 @@ pgDescribe("TaskStore review-signal hydration under a renamed review column (Pos
   }
 
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-31-14:20 (PR #2586 review — greptile):
+  FNXC:WorkflowLifecycleColumns 2026-07-30-14:20 (PR #2586 review — greptile):
   THE STALLED SIBLING NEEDS ITS OWN FIXTURE, and its absence is why the gap existed.
   `getInReviewStalledSignal` requires `paused !== true` — it is the UNPAUSED
   counterpart of `getStalePausedReviewSignal` — so `seedPaused` cannot exercise it,

--- a/packages/core/src/__tests__/postgres/workflow-capacity-invariant.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/workflow-capacity-invariant.pg.test.ts
@@ -73,7 +73,7 @@ pgTest("in-transaction column capacity — ground truth (Phase A3)", () => {
   reports what it assumed, not what happened.
   */
   /*
-  FNXC:WorkflowColumns 2026-07-31-04:45 (U12 — the move-path flag is resolved):
+  FNXC:WorkflowColumns 2026-07-30-04:45 (U12 — the move-path flag is resolved):
   There is only ONE path now, so this no longer selects between them. It is kept rather than deleted
   because the probe half is still worth doing: it proves the move path is live and rejecting before
   a capacity case draws conclusions from a rejection, so a capacity test cannot pass because moves

--- a/packages/core/src/__tests__/postgres/workflow-settings-project-identity.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/workflow-settings-project-identity.pg.test.ts
@@ -209,7 +209,7 @@ describe("getWorkflowSettingsProjectIdImpl resolution order (unit)", () => {
       },
     } as unknown as TaskStore;
     /*
-    FNXC:CentralProjectIdentity 2026-07-31-13:00:
+    FNXC:CentralProjectIdentity 2026-07-30-13:00:
     rootDir, NOT the legacy identity — and the store double above is the reason this case used to
     expect otherwise. It supplies a `db.getProjectIdentity()` that RETURNS a value, which the real
     accessor can never do: `dbImpl` throws unconditionally and ignores its store argument entirely

--- a/packages/core/src/__tests__/task-symbol-resolution.test.ts
+++ b/packages/core/src/__tests__/task-symbol-resolution.test.ts
@@ -73,7 +73,7 @@ describe("task symbol declaration resolution", () => {
 });
 
 /**
- * FNXC:SymbolLock 2026-07-31-11:00:
+ * FNXC:SymbolLock 2026-07-20-11:00:
  * SQLite was removed from the runtime, so createTaskStoreTestHarness cannot
  * initialize a non-backend TaskStore. Exercise the retained file-task
  * constructor directly with its filesystem seam instead. This keeps the

--- a/packages/core/src/postgres/schema-applier.ts
+++ b/packages/core/src/postgres/schema-applier.ts
@@ -45,13 +45,13 @@ FNXC:LegacyAdoption 2026-07-21-17:30:
 SCHEMA_BASELINE_VERSION advances to 0037 for dropping the cross-project concurrency table; it previously advanced to 0036 for normalized Direct conversation tags; it previously advanced to 0032 for fusion_runtime SELECT +
 SECURITY DEFINER write access to the legacy-adoption drained marker.
 
-FNXC:TaskWedgeNotifications 2026-10-19-00:00:
+FNXC:TaskWedgeNotifications 2026-07-23-00:00:
 Advance the PostgreSQL schema ceiling for the durable wedge episode column. The
 forward migration must run before TaskStore writes the new field on fresh and
 upgraded databases.
 */
 export const SCHEMA_BASELINE_VERSION = "0037";
-/** FNXC:SymbolLock 2026-07-31-10:00: upgrades need durable task declarations before admission resolves symbols. */
+/** FNXC:SymbolLock 2026-07-20-10:00: upgrades need durable task declarations before admission resolves symbols. */
 export const TASK_DECLARED_SYMBOLS_VERSION = "0028";
 const INITIAL_SCHEMA_VERSION = "0000";
 const AUTOMATION_ISOLATION_SCHEMA_VERSION = "0001";
@@ -137,20 +137,20 @@ export const TASK_VERIFICATION_REQUEST_VERSION = "0024";
 export const SYMBOL_LOCKS_SCHEMA_VERSION = "0025";
 /** FNXC:PostgresBigintCounters 2026-07-18-21:45: widen overflow-prone counters to bigint before SQLite migration. */
 export const BIGINT_COUNTERS_VERSION = "0026";
-/** FNXC:TaskTiming 2026-08-01-10:00: existing clusters need planning-session timing columns. */
+/** FNXC:TaskTiming 2026-07-20-10:00: existing clusters need planning-session timing columns. */
 export const PLANNING_ACTIVE_TIMING_VERSION = "0029";
 /** Dashboard health needs project-scoped, read-only runtime access to the SQLite cutover ledger. */
 export const SQLITE_MIGRATION_RUNTIME_READ_VERSION = "0030";
 export const WORKFLOW_TASK_CONTINUATIONS_VERSION = "0031";
 /** FNXC:LegacyAdoption 2026-07-21-17:30: runtime role needs drained-marker read + restricted write. */
 export const LEGACY_ADOPTION_DRAINED_MARKER_RUNTIME_GRANTS_VERSION = "0032";
-/** FNXC:TaskWedgeNotifications 2026-10-19-00:00: manually register the durable wedge episode migration for PostgreSQL upgrades. */
+/** FNXC:TaskWedgeNotifications 2026-07-23-00:00: manually register the durable wedge episode migration for PostgreSQL upgrades. */
 export const TASK_WEDGE_NOTIFICATION_VERSION = "0033";
 /** FNXC:MissionValidation 2026-07-23-14:30: provenance-safe milestone criteria require an explicit upgrade. */
 export const MILESTONE_ASSERTION_PROVENANCE_VERSION = "0034";
 /** FNXC:MissionLineageBudget 2026-07-22-12:00: migration is explicit because upgraded clusters need durable root stop tombstones. */
 export const MISSION_LINEAGE_STOP_VERSION = "0035";
-/** FNXC:ChatTags 2026-08-05-10:55: existing clusters need normalized project-scoped Direct conversation tags. */
+/** FNXC:ChatTags 2026-07-25-10:55: existing clusters need normalized project-scoped Direct conversation tags. */
 export const CHAT_SESSION_TAGS_VERSION = "0036";
 /*
 FNXC:CapacityModel 2026-07-29-08:10 (drop the cross-project cap — table half):
@@ -950,7 +950,7 @@ export async function applySchemaBaseline(
     }
 
     /*
-    FNXC:TaskWedgeNotifications 2026-10-19-00:00:
+    FNXC:TaskWedgeNotifications 2026-07-23-00:00:
     PostgreSQL migrations are explicitly registered rather than discovered.
     Apply the wedge episode column before persistence writes it, including on
     databases that already recorded the prior schema ceiling.
@@ -991,7 +991,7 @@ export async function applySchemaBaseline(
       schemaChanged = true;
     }
 
-    /* FNXC:ChatTags 2026-08-05-10:55: migrations are explicitly registered; this must run after the baseline on both fresh and upgrade databases. */
+    /* FNXC:ChatTags 2026-07-25-10:55: migrations are explicitly registered; this must run after the baseline on both fresh and upgrade databases. */
     if (!chatSessionTagsAlreadyApplied) {
       const migrationSql = await readFile(CHAT_SESSION_TAGS_MIGRATION_PATH, "utf8");
       await tx.execute(sql.raw(migrationSql));

--- a/packages/core/src/postgres/schema/project.ts
+++ b/packages/core/src/postgres/schema/project.ts
@@ -1899,7 +1899,7 @@ export const chatSessions = projectSchema.table("chat_sessions", {
 ]);
 
 /*
-FNXC:ChatTags 2026-08-05-10:55:
+FNXC:ChatTags 2026-07-25-10:55:
 Tags deliberately retain an owner scope independent of the RLS partition. The
 canonical `__default__` scope makes nullable legacy session project IDs unique
 without relying on PostgreSQL's NULL-unique behavior.
@@ -1924,7 +1924,7 @@ export const chatSessionTags = projectSchema.table("chat_session_tags", {
   projectId: text("project_id").notNull().default(sql`current_setting('fusion.project_id', true)`),
   assignedAt: text("assigned_at").notNull(),
 }, (t) => [
-  // FNXC:ChatTags 2026-08-05-12:15: both parents include the RLS partition, preventing bypass/admin access from joining a same-named ID in another project.
+  // FNXC:ChatTags 2026-07-25-12:15: both parents include the RLS partition, preventing bypass/admin access from joining a same-named ID in another project.
   primaryKey({ columns: [t.projectId, t.sessionId, t.tagId] }),
   foreignKey({ columns: [t.projectId, t.sessionId], foreignColumns: [chatSessions.projectId, chatSessions.id] }).onDelete("cascade"),
   foreignKey({ columns: [t.projectId, t.tagId], foreignColumns: [chatTags.projectId, chatTags.id] }).onDelete("cascade"),

--- a/packages/core/src/task-store/async-persistence.ts
+++ b/packages/core/src/task-store/async-persistence.ts
@@ -212,7 +212,7 @@ export async function resolveActiveTaskWedgeEpisodeRow(
     .update(schema.project.tasks)
     .set({
       /*
-      FNXC:WedgeNotification 2026-07-31-12:00:
+      FNXC:WedgeNotification 2026-07-30-12:00:
       `${transitionedAt}::text` — the CAST is load-bearing, not decoration.
 
       PostgreSQL cannot infer the type of a bare bind parameter used as a `jsonb_build_object` value:

--- a/packages/core/src/task-store/branch-and-pr-entities.ts
+++ b/packages/core/src/task-store/branch-and-pr-entities.ts
@@ -627,7 +627,7 @@ export function getWorkflowSettingsProjectIdImpl(store: TaskStore): string {
      *       key by it too.
      *   (b) `store.rootDir` — absolute filesystem path, last-resort key.
      *
-     * FNXC:CentralProjectIdentity 2026-07-31-13:00 (documentation corrected):
+     * FNXC:CentralProjectIdentity 2026-07-30-13:00 (documentation corrected):
      * There USED to be a middle step reading `store.db.getProjectIdentity()?.id`, and this block still
      * described it long after `FNXC:SqliteDualPathCleanup 2026-07-26-14:15` removed it. It is not
      * merely unused — it is unreachable BY CONSTRUCTION: `dbImpl` throws unconditionally and ignores

--- a/packages/core/src/task-store/comments-ops.ts
+++ b/packages/core/src/task-store/comments-ops.ts
@@ -195,7 +195,7 @@ export async function addCommentImpl(store: TaskStore, id: string, text: string,
     const retriageColumns = author === "user"
       ? await (async () => {
         /*
-        FNXC:PostCommentRetriage 2026-07-31-08:05 (PR #2612 review — greptile):
+        FNXC:PostCommentRetriage 2026-07-30-08:05 (PR #2612 review — greptile):
         SAY SO WHEN THE FALLBACK FIRES. The legacy pair is the right BEHAVIOUR on a
         resolution failure — this is best-effort re-triage whose failure mode is a
         MISSED re-spec — but swallowing the cause left the one question an operator

--- a/packages/core/src/task-store/moves.ts
+++ b/packages/core/src/task-store/moves.ts
@@ -389,13 +389,13 @@ export async function moveTaskInternalImpl(store: TaskStore, id: string, toColum
     */
     const workflowSelectionForMove = await store.getTaskWorkflowSelectionAsync(id);
     /*
-    FNXC:WorkflowColumns 2026-07-31-05:25 (PR #2655 review — greptile P2 follow-through):
+    FNXC:WorkflowColumns 2026-07-30-05:25 (PR #2655 review — greptile P2 follow-through):
     `effectiveWorkflowIdForMove` is DELETED. It existed only to feed the emitted `workflowId`, and it
     applied a `?? DEFAULT_WORKFLOW_ID` fallback — so keeping it would have meant either an unused
     binding or the very fallback-as-authoritative stamp that review flagged. The emit site now reads
     the SELECTION directly, so the absence signal is preserved and there is nothing left to guess.
     */
-    // FNXC:WorkflowColumns 2026-07-31-04:00 (U12): resolved unconditionally — the gate is gone, so
+    // FNXC:WorkflowColumns 2026-07-30-04:00 (U12): resolved unconditionally — the gate is gone, so
     // `undefined` now means only "no IR on this path or a v1 column-less IR", never "flag off".
     const workflowIr: WorkflowIr | undefined = await resolveTaskWorkflowIrForMove(store, id);
 
@@ -781,7 +781,7 @@ export async function moveTaskInternalImpl(store: TaskStore, id: string, toColum
     });
 
     const movedAt = internal.now ?? new Date().toISOString();
-    // FNXC:TaskTiming 2026-08-01-10:00: column dwell is wall-clock stage data,
+    // FNXC:TaskTiming 2026-07-20-10:00: column dwell is wall-clock stage data,
     // accumulated before replacing the prior column anchor and never used as AI active time.
     const priorColumnMovedAt = Date.parse(task.columnMovedAt ?? "");
     const moveMs = Date.parse(movedAt);
@@ -793,7 +793,7 @@ export async function moveTaskInternalImpl(store: TaskStore, id: string, toColum
     task.updatedAt = movedAt;
 
     /*
-    FNXC:WorkflowColumns 2026-07-31-04:00 (U12 — the compatibility flag is RESOLVED):
+    FNXC:WorkflowColumns 2026-07-30-04:00 (U12 — the compatibility flag is RESOLVED):
     Column side effects run through the default-workflow TRAIT HOOKS unconditionally. The
     `if (useWorkflow)` gate and its inline legacy `else` branch are DELETED, not converted —
     converting a branch we intended to delete would have left a second definition of every
@@ -1307,7 +1307,7 @@ export async function moveTaskInternalImpl(store: TaskStore, id: string, toColum
         OMIT rather than guess. An absent `workflowId` means "not resolved here";
         a subscriber that needs it reads the selection itself.
 
-        FNXC:WorkflowColumns 2026-07-31-05:20 (PR #2655 review — greptile P2):
+        FNXC:WorkflowColumns 2026-07-30-05:20 (PR #2655 review — greptile P2):
         The flag deletion nearly destroyed that signal. `effectiveWorkflowIdForMove`
         is `selection?.workflowId ?? DEFAULT_WORKFLOW_ID`, so emitting it
         unconditionally would stamp `builtin:coding` onto every task that has no

--- a/packages/core/src/task-store/serialization.ts
+++ b/packages/core/src/task-store/serialization.ts
@@ -374,7 +374,7 @@ export function archiveEntryToTask(
     columnMovedAt: entry.columnMovedAt,
     firstExecutionAt: entry.firstExecutionAt,
     cumulativeActiveMs: entry.cumulativeActiveMs,
-    // FNXC:TaskTiming 2026-08-01-13:00: archive/restore must retain both
+    // FNXC:TaskTiming 2026-07-20-13:00: archive/restore must retain both
     // planning fields so archived tasks neither lose accumulated AI time nor
     // revive without the live segment anchor needed for exactly-once finalize.
     cumulativePlanningMs: entry.cumulativePlanningMs,

--- a/packages/core/src/task-store/task-store-helpers.ts
+++ b/packages/core/src/task-store/task-store-helpers.ts
@@ -87,7 +87,7 @@ export function resolveWorkflowBypassGuardsImpl(store: TaskStore,
     options?: MoveTaskOptions,
   ): boolean {
   /*
-  FNXC:WorkflowColumns 2026-07-31-11:00 (PR #2655 review — BOTH findings are right, and they are
+  FNXC:WorkflowColumns 2026-07-30-11:00 (PR #2655 review — BOTH findings are right, and they are
   the same defect seen from two sides. REVERTED to reading `options?.moveSource`.)
 
   Round 1 said an optionless `moveTask(id, target)` LOSES bypass, because the call site resolves

--- a/packages/core/src/task-store/task-update.ts
+++ b/packages/core/src/task-store/task-update.ts
@@ -721,7 +721,7 @@ export async function updateTaskUnlockedImpl(store: TaskStore, id: string, updat
       } else if (updates.modifiedFiles !== undefined) {
         task.modifiedFiles = updates.modifiedFiles;
       }
-      /* FNXC:SymbolLock 2026-07-31-10:00: present undefined is an explicit clear; only absent declarations may hydrate from a prompt write. */
+      /* FNXC:SymbolLock 2026-07-20-10:00: present undefined is an explicit clear; only absent declarations may hydrate from a prompt write. */
       if (hasOwnDeclaredSymbols(updates)) {
         const normalized = normalizeDeclaredSymbols(Array.isArray(updates.declaredSymbols) ? updates.declaredSymbols : []);
         task.declaredSymbols = normalized.length ? normalized : undefined;
@@ -776,7 +776,7 @@ export async function updateTaskUnlockedImpl(store: TaskStore, id: string, updat
       }
 
       /*
-      FNXC:MissionSymbolAdmission 2026-08-01-00:00:
+      FNXC:MissionSymbolAdmission 2026-07-20-00:00:
       A workflow failure may park in the current in-progress column rather than
       move out of it. Release that task's durable symbols on the status edge as
       well as moveTask's column-exit path, allowing engine reconciliation to

--- a/packages/core/src/task-store/workflow-task-create-ops.ts
+++ b/packages/core/src/task-store/workflow-task-create-ops.ts
@@ -350,7 +350,7 @@ export async function prepareWorkflowMovePolicyPreflightImpl(store: TaskStore, i
     const task = await store.readTaskForMove(id);
     const moveSource = options?.moveSource ?? "engine";
     /*
-    FNXC:WorkflowColumns 2026-07-31-04:00 (U12 — flipped ATOMICALLY with moves.ts):
+    FNXC:WorkflowColumns 2026-07-30-04:00 (U12 — flipped ATOMICALLY with moves.ts):
     The compatibility-flag gate is DELETED. This preflight computes the `movePolicyPreflight` that
     `moves.ts` consumes and validates, so the two could never be flipped independently: un-gating
     this alone would evaluate workflow move policies — with their plugin-gate side effects — while

--- a/packages/core/src/types/task-core.ts
+++ b/packages/core/src/types/task-core.ts
@@ -1133,7 +1133,7 @@ export interface Task {
    *  never cleared by reopen flows. */
   cumulativeActiveMs?: number;
   /**
-   * FNXC:TaskTiming 2026-08-01-10:00:
+   * FNXC:TaskTiming 2026-07-23-10:00:
    * Monotonic active AI planning duration. Unlike column dwell this is only
    * accrued by a live planning session and is never cleared by reopen.
    */

--- a/packages/dashboard/app/__tests__/columnRoles.test.ts
+++ b/packages/dashboard/app/__tests__/columnRoles.test.ts
@@ -73,7 +73,7 @@ describe("isPreImplementationColumnRole", () => {
 });
 
 /*
-FNXC:WorkflowResolvedColumns 2026-07-31-00:15 (U12 — one affordance, two components):
+FNXC:WorkflowResolvedColumns 2026-07-30-00:15 (U12 — one affordance, two components):
 FIELD EDITABILITY. TaskDetailModal resolved this from traits in U10/R8; TaskCard kept a hardcoded
 `{triage, todo}` set with no trait path, so a renamed board lost the pencil on the card while the
 modal kept it — the same one-surface-missed shape as the FN-6115 chevron chain.

--- a/packages/dashboard/app/components/ChatView.tsx
+++ b/packages/dashboard/app/components/ChatView.tsx
@@ -208,7 +208,7 @@ interface PendingAttachment {
 }
 
 /*
-FNXC:ChatAttachments 2026-08-03-00:00:
+FNXC:ChatAttachments 2026-07-23-00:00:
 Chat must offer precisely the task-store attachment MIME set so picker, paste, and drop never stage
 files that its upload routes reject. Keep this list aligned with CHAT_ALLOWED_MIME_TYPES on the API.
 */
@@ -1678,7 +1678,7 @@ export function ChatView({ projectId, addToast, floating = false, compactLayout 
 
   const handlePaste = useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     /*
-    FNXC:ChatAttachments 2026-08-03-00:00:
+    FNXC:ChatAttachments 2026-07-23-00:00:
     Chat paste must use the same MIME validation path as picker and drop. Filtering clipboard data
     to images made supported text files disappear before the authoritative server validation ran.
     */
@@ -1921,7 +1921,7 @@ export function ChatView({ projectId, addToast, floating = false, compactLayout 
 
     const sentFiles = new Set(files);
     /*
-    FNXC:QuickAddAttachments 2026-08-03-00:00:
+    FNXC:QuickAddAttachments 2026-07-23-00:00:
     Keep direct-chat previews alive until useChat confirms multipart delivery. A direct-session
     upload fails asynchronously, so clearComposerState() here would revoke the only retryable File
     references before its stream error handler can report the rejection.

--- a/packages/dashboard/app/components/ExecutorStatusBar.tsx
+++ b/packages/dashboard/app/components/ExecutorStatusBar.tsx
@@ -150,7 +150,7 @@ export function ExecutorStatusBar({ tasks, projectId, columnFlagsByTaskId: suppl
   const showTerminalLauncher = !isMobile && Boolean(onToggleTerminal);
   const columnFlagsByTaskId = suppliedColumnFlagsByTaskId;
   /*
-  FNXC:ConcurrencyIndicators 2026-08-03-12:00:
+  FNXC:ConcurrencyIndicators 2026-07-21-12:00:
   FN-8453 receives a task-scoped board trait index from App before the shared
   live-agent predicate runs. Literal column ids are only a loading/legacy fallback.
   */

--- a/packages/dashboard/app/components/FloatingWindow.tsx
+++ b/packages/dashboard/app/components/FloatingWindow.tsx
@@ -120,7 +120,7 @@ const FLOATING_WINDOW_OUTSIDE_POINTER_SAFE_SURFACE_SELECTOR = [
 ].join(", ");
 
 /*
-FNXC:ModalTouchGeometry 2026-08-13-12:00:
+FNXC:ModalTouchGeometry 2026-07-27-12:00:
 FN-8619: Task Detail's body-portaled activity-view menu is a logical child of its modal.
 Treating it as safe prevents a preference-enabled outside pointer-down from closing the host.
 
@@ -632,7 +632,7 @@ export function FloatingWindow({
       aria-labelledby={ariaLabelledBy}
       data-testid={testId ?? `floating-window-overlay-${windowKey}`}
       {...backdropMouseHandlers}
-      // FNXC:ModalTouchGeometry 2026-08-13-12:00: FN-8619 keeps Agent Detail's paired mouse-only backdrop contract at the shared modal backdrop; this deliberately does not alter pointer-down dismissal.
+      // FNXC:ModalTouchGeometry 2026-07-27-12:00: FN-8619 keeps Agent Detail's paired mouse-only backdrop contract at the shared modal backdrop; this deliberately does not alter pointer-down dismissal.
       // FNXC:FloatingWindow 2026-06-22-23:00: The z-index MUST live on the position:fixed overlay (which creates a stacking context), not the panel. A panel z-index is trapped inside the overlay's context and loses to page elements that are stacking contexts in body's context (e.g. the right dock at position:absolute z-index:20). With z on the overlay, the whole window sits at the shared floating band in body's stacking context and reliably paints above page content + tap-to-front reorders correctly.
       style={{ zIndex }}
     >

--- a/packages/dashboard/app/components/Header.tsx
+++ b/packages/dashboard/app/components/Header.tsx
@@ -214,7 +214,7 @@ export function Header({
   const showNodeSelector = remoteNodes.length > 0;
   const { bookmarkedIds, toggleBookmark, isBookmarked } = useProjectBookmarks();
   /*
-  FNXC:ProjectSelector 2026-08-26-00:00:
+  FNXC:ProjectSelector 2026-07-26-00:00:
   Mobile project switching must separate favorites at the top while sharing the desktop localStorage bookmark store. Preserve the incoming order within each section so grouping never changes the project's canonical ordering.
   */
   const mobileProjectGroups = useMemo(() => {
@@ -224,7 +224,7 @@ export function Header({
   }, [bookmarkedIds, projects]);
 
   /*
-  FNXC:ProjectSelector 2026-08-26-00:00:
+  FNXC:ProjectSelector 2026-07-26-00:00:
   Mobile rows use the same localStorage bookmark toggle as desktop. Stop propagation so bookmarking never selects a project or closes the switcher.
   */
   const renderMobileProjectItem = (project: ProjectInfo) => {

--- a/packages/dashboard/app/components/PendingAttachmentPreviews.tsx
+++ b/packages/dashboard/app/components/PendingAttachmentPreviews.tsx
@@ -17,7 +17,7 @@ interface PendingAttachmentPreviewsProps {
 }
 
 /*
-FNXC:QuickAddAttachments 2026-08-03-00:00:
+FNXC:QuickAddAttachments 2026-07-23-00:00:
 Task creation surfaces share one pending-attachment renderer so photos retain the established
 floating preview while non-image task-store attachments have only an actionable filename and
 remove control. Never render an image-open button without a preview URL.

--- a/packages/dashboard/app/components/QuickEntryBox.tsx
+++ b/packages/dashboard/app/components/QuickEntryBox.tsx
@@ -502,7 +502,7 @@ export function QuickEntryBox({ onCreate, onMoveTask, addToast, tasks = [], avai
     setAgents([]);
     setAgentsProjectId(undefined);
     /*
-    FNXC:QuickAddAttachments 2026-08-03-00:00:
+    FNXC:QuickAddAttachments 2026-07-23-00:00:
     Pending files belong to the project where they were selected. Clear them on a project switch so
     an attachment cannot be uploaded into the next project's newly created task, and release image URLs.
     */
@@ -729,7 +729,7 @@ export function QuickEntryBox({ onCreate, onMoveTask, addToast, tasks = [], avai
   }, []);
 
   /*
-  FNXC:QuickAddAttachments 2026-08-03-00:00:
+  FNXC:QuickAddAttachments 2026-07-23-00:00:
   Quick Add must accept exactly the task-store attachment MIME set through picker, paste, and drop.
   Only images receive object URLs and preview controls; all other accepted files remain uploadable file chips.
   */

--- a/packages/dashboard/app/components/SettingsModal.tsx
+++ b/packages/dashboard/app/components/SettingsModal.tsx
@@ -500,7 +500,7 @@ const KNOWN_EXPERIMENTAL_FEATURES: Record<string, string> = {
   researchView: "Research View",
   evalsView: "Evals View",
   /*
-  FNXC:SettingsExperimental 2026-08-01-00:00:
+  FNXC:SettingsExperimental 2026-07-19-00:00:
   FN-8352 promotes Ideation to a default-off top-level view. Keep its toggle
   visible so operators explicitly opt into the sidebar and mobile More surface.
   */
@@ -946,7 +946,7 @@ export function SettingsModal({
   const settingsContentRef = useRef<HTMLDivElement>(null);
   const workflowLaneSaverRef = useRef<SectionSaveHandler | null>(null);
   /*
-  FNXC:SettingsAutoSave 2026-08-03-01:00:
+  FNXC:SettingsAutoSave 2026-07-20-01:00:
   Workflow lane edits live outside the shared Settings form. Track their revision
   alongside form dirtiness so Option 1 auto-save and every close path flush them
   too; a completion only clears the revision it actually persisted.
@@ -1341,7 +1341,7 @@ export function SettingsModal({
     // jump; otherwise the row we just scrolled to would be scrolled away from.
     settingsJumpPendingRef.current = true;
     /*
-    FNXC:SettingsAutoSave 2026-08-03-00:00:
+    FNXC:SettingsAutoSave 2026-07-20-00:00:
     Search navigation is an operator-initiated section change too. Route it
     through the same flush path as sidebar/mobile navigation so a pending edit
     to raw global GitLab fields cannot be re-scoped as a project save after the
@@ -3319,7 +3319,7 @@ export function SettingsModal({
   }, []);
 
   /*
-  FNXC:SettingsAutoSave 2026-08-02-12:00:
+  FNXC:SettingsAutoSave 2026-07-20-12:00:
   FN-8395 implements issue #2343 Option 1: form-backed Settings persist through
   this debounced single-flight path, never a Save button or dirty-leave prompt.
   Each request works from a captured render snapshot and advances only matching
@@ -3502,7 +3502,7 @@ export function SettingsModal({
       // Quiet state feedback avoids a toast for each debounced edit.
       setAutoSaveStatus("saved");
       /*
-      FNXC:SettingsAutoSave 2026-08-02-20:50:
+      FNXC:SettingsAutoSave 2026-07-20-20:50:
       A completed request may describe an older form snapshot. Advance only the
       keys that request actually wrote so a response can never bless unrelated,
       newer edits as already persisted.
@@ -3519,7 +3519,7 @@ export function SettingsModal({
         };
       });
       /*
-      FNXC:SettingsAutoSave 2026-08-02-21:45:
+      FNXC:SettingsAutoSave 2026-07-20-21:45:
       A successful snapshot becomes the next autosave comparison point. If the
       user edited while this request was in flight, the live snapshot differs
       and the effect queues exactly one trailing write.
@@ -3573,7 +3573,7 @@ export function SettingsModal({
 
   useEffect(() => {
     /*
-    FNXC:SettingsAutoSave 2026-08-02-21:35:
+    FNXC:SettingsAutoSave 2026-07-20-21:35:
     Some legacy form values are normalized differently from their raw scoped
     settings. Snapshot the hydrated form before enabling autosave so opening
     Settings cannot write those untouched defaults; later user edits change the
@@ -3607,7 +3607,7 @@ export function SettingsModal({
       autoSaveTimerRef.current = null;
     }
     /*
-    FNXC:SettingsAutoSave 2026-08-02-20:50:
+    FNXC:SettingsAutoSave 2026-07-20-20:50:
     Close is never a discard path. If a request is already running, queue its
     latest trailing snapshot and wait for that queue to drain before the modal
     unmounts; otherwise flush the current dirty snapshot synchronously.
@@ -3655,7 +3655,7 @@ export function SettingsModal({
       autoSaveTimerRef.current = null;
     }
     /*
-    FNXC:SettingsAutoSave 2026-08-03-22:15:
+    FNXC:SettingsAutoSave 2026-07-20-22:15:
     Parent-driven unmount is also a dismissal path. Retain a dirty snapshot's
     flush even when a debounce timer is not present at cleanup, rather than
     treating the timer itself as the source of durability.
@@ -4835,7 +4835,7 @@ export function SettingsModal({
             (only Cancel is), so this button renders in both automatically (FN-7506
             Surface Enumeration: modal + embedded).
 
-            FNXC:SettingsReset 2026-08-02-21:45:
+            FNXC:SettingsReset 2026-07-20-21:45:
             The mobile Settings footer needs the compact Reset label to preserve horizontal space alongside Help, version, Import, Export, and Close. Desktop and tablet keep the full Reset Settings wording while the existing destructive confirmation dialog remains unchanged.
             */}
             <button

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -333,7 +333,7 @@ const TIME_INDICATOR_COLUMNS = new Set<ColumnId>([
 // ticker (`hooks/useLiveTimeTicker`) so the cadence and the single timer that honors it cannot drift.
 
 /*
-FNXC:TaskCardStatus 2026-07-31-00:00:
+FNXC:TaskCardStatus 2026-07-22-00:00:
 FN-8482 requires compact no-ellipsis active-merge labels on task cards, while the shared
 status mapper retains its ellipsis-bearing output for ListView and other non-card surfaces.
 Only strip a terminal Unicode ellipsis after the shared mapper resolves one of the active
@@ -368,7 +368,7 @@ function getInProgressElapsedMs(task: Task, nowMs: number): number | null {
 // inside instrumented code paths. Returns null on legacy tasks that completed
 // before `executionStartedAt` was tracked, so callers can fall back.
 function getTaskEndToEndDurationMs(task: Task, nowMs: number): number | null {
-  // FNXC:TaskTiming 2026-08-01-12:00: planning-only tasks have no execution
+  // FNXC:TaskTiming 2026-07-20-12:00: planning-only tasks have no execution
   // accumulator, but their active AI duration still belongs on the card chip.
   // Use the legacy execution window only when neither active-time source exists.
   const totalActiveMs = getTotalAgentActiveMs(task, nowMs);
@@ -1504,7 +1504,7 @@ function TaskCardComponent({
 
   // Check if this card can be edited inline
   /*
-  FNXC:WorkflowResolvedColumns 2026-07-31-00:15 (U12 — R8 drift conversion):
+  FNXC:WorkflowResolvedColumns 2026-07-30-00:15 (U12 — R8 drift conversion):
   THE ASYMMETRY: this read a hardcoded `{triage, todo}` set with no trait path, while
   TaskDetailModal resolved the SAME affordance from column traits (U10/R8). So on a renamed board an
   operator could edit a task's title in the detail modal but the pencil was missing from its card,

--- a/packages/dashboard/app/components/TaskContextMenu.tsx
+++ b/packages/dashboard/app/components/TaskContextMenu.tsx
@@ -177,7 +177,7 @@ export function isPreExecutionHoldColumn(column: string, flags?: TaskContextMenu
   interchangeable. Kept separate with the difference recorded, rather than made to look shared.
   */
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-31-08:00 (U12 — the LAST `triage` column guard):
+  FNXC:WorkflowLifecycleColumns 2026-07-30-08:00 (U12 — the LAST `triage` column guard):
   FLAGS-FIRST, id only as the degraded answer. It used to OR the legacy id with the traits
   UNCONDITIONALLY, which is not a fallback: a resolved column that happens to be named `triage` but
   whose traits say it is mid-flight answered true, offering Plan on a card that is already executing.

--- a/packages/dashboard/app/components/TaskDetailModal.tsx
+++ b/packages/dashboard/app/components/TaskDetailModal.tsx
@@ -676,7 +676,7 @@ where the traits are unknown rather than known-false.
 */
 function isTaskFieldEditableColumn(column: ColumnId, flags?: TaskContextMenuColumnFlags): boolean {
   /*
-  FNXC:WorkflowResolvedColumns 2026-07-31-00:15 (U12): body moved UNCHANGED to
+  FNXC:WorkflowResolvedColumns 2026-07-30-00:15 (U12): body moved UNCHANGED to
   `isFieldEditableColumnRole`, so this and TaskCard cannot drift apart again. TaskCard implemented the
   same affordance with the raw id set and no trait path, which is how a renamed board lost inline
   editing on the card while this surface kept it.
@@ -6675,7 +6675,7 @@ export function TaskDetailModal({ onClose, ...props }: TaskDetailModalProps) {
   useMobileScrollLock(true);
   const dismissOnOutsidePointerDown = useModalDismissPreference();
   /*
-  FNXC:TaskDetailSwipeBack 2026-08-07-00:00:
+  FNXC:TaskDetailSwipeBack 2026-07-25-00:00:
   Gate predictive-back animation through useViewportMode, the same physical-screen-aware
   classifier used for resize behavior. This preserves phone animation while keeping known
   768px tablets in their desktop/tablet presentation.

--- a/packages/dashboard/app/components/__tests__/AgentDetailView.floating-window.test.tsx
+++ b/packages/dashboard/app/components/__tests__/AgentDetailView.floating-window.test.tsx
@@ -16,7 +16,7 @@ const renderModal = (onClose = vi.fn()) => render(
 );
 
 /**
- * FNXC:ModalTouchGeometry 2026-08-13-12:40:
+ * FNXC:ModalTouchGeometry 2026-07-27-12:40:
  * FN-8619 keeps Agent Detail's deliberately narrower mouse-pair dismissal while moving geometry
  * to FloatingWindow. Exercise the production portal, rather than a synthetic window, so touch
  * gestures cannot silently become an outside-dismiss path.

--- a/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
@@ -8179,7 +8179,7 @@ describe("TaskCard Start affordance (FN-7596)", () => {
 });
 
 /*
-FNXC:WorkflowResolvedColumns 2026-07-31-00:15 (U12 — the affordance this file never covered):
+FNXC:WorkflowResolvedColumns 2026-07-30-00:15 (U12 — the affordance this file never covered):
 THE EDIT BUTTON ON A RENAMED BOARD.
 
 TaskDetailModal resolved field editability from column traits in U10/R8. TaskCard implemented the

--- a/packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskContextMenu.test.tsx
@@ -335,7 +335,7 @@ describe("TaskContextMenu shared task action model", () => {
 });
 
 /*
-FNXC:WorkflowResolvedColumns 2026-07-31-10:20 (PR #2626 review — greptile P2):
+FNXC:WorkflowResolvedColumns 2026-07-30-10:20 (PR #2626 review — greptile P2):
 The intake-only vs intake+hold distinction, covered per workflow SHAPE rather than per column id.
 
 `shouldShowActionsMenu` suppresses the menu only for a PURE intake lane. That distinction is the
@@ -378,7 +378,7 @@ describe("shouldShowActionsMenu by workflow shape (not by column id)", () => {
 });
 
 /*
-FNXC:WorkflowLifecycleColumns 2026-07-31-08:00 (U12 — the last `triage` column guard):
+FNXC:WorkflowLifecycleColumns 2026-07-30-08:00 (U12 — the last `triage` column guard):
 THE INVERSION. `isPreExecutionHoldColumn` ORed the legacy id with the traits unconditionally, so a
 resolved column merely NAMED `triage` answered true even when its own traits said work was underway
 — offering Plan, which re-plans, on a card that is already executing.

--- a/packages/dashboard/app/components/command-center/CommandCenter.tsx
+++ b/packages/dashboard/app/components/command-center/CommandCenter.tsx
@@ -101,7 +101,7 @@ function useSubViews(nodesEnabled: boolean): SubView[] {
     ...(nodesEnabled ? [{ id: "nodes" as const, label: t("commandCenter.tabs.nodes", "Nodes") }] : []),
     { id: "reliability", label: t("commandCenter.tabs.reliability", "Reliability") },
     /*
-    FNXC:Navigation 2026-08-01-00:00:
+    FNXC:Navigation 2026-07-19-00:00:
     FN-8352 removes Ideation from Command Center because its experimental
     top-level navigation view is now the single canonical host.
     */
@@ -218,7 +218,7 @@ function OverviewTab({
   const agentRunsTotal = activity.data?.agentRuns?.total ?? 0;
   const tasksDone = activity.data?.funnel?.doneInRange ?? 0;
   /*
-  FNXC:LiveActivity 2026-08-03-00:00:
+  FNXC:LiveActivity 2026-07-20-00:00:
   FN-8429 requires the Overview's live metrics to share Mission Control's
   SSE-plus-poll snapshot and in-progress aliases. Date-range analytics remain
   historical; they must not overwrite current board work with funnel entries.

--- a/packages/dashboard/app/components/command-center/MissionControlPanel.tsx
+++ b/packages/dashboard/app/components/command-center/MissionControlPanel.tsx
@@ -71,7 +71,7 @@ receiver is a column id, purpose is presentation, not a lifecycle decision.
 const TRIAGE_STAGE_COLUMN_ALIASES: ReadonlySet<string> = new Set(["triage", "signal", "backlog"]);
 
 /*
-FNXC:WorkflowLifecycleColumns 2026-07-31-07:20 (U12 — census gate repair) DELIBERATE-LITERAL:
+FNXC:WorkflowLifecycleColumns 2026-07-30-07:20 (U12 — census gate repair) DELIBERATE-LITERAL:
 The marker above was ATTACHED TO THE WRONG NODE and therefore did nothing.
 
 `hasDeliberateMarker` walks a node's leading comments and its ancestors. The existing

--- a/packages/dashboard/app/components/settings/sections/ProjectModelsSection.tsx
+++ b/packages/dashboard/app/components/settings/sections/ProjectModelsSection.tsx
@@ -214,7 +214,7 @@ export function ProjectModelsSection({ form, setForm, models, projectId, onOpenW
     }), [workflowPayload, workflowPending]);
     const setWorkflowPairValue = useCallback((pair: WorkflowModelPair, value: string) => {
         /*
-        FNXC:SettingsAutoSave 2026-08-03-01:00:
+        FNXC:SettingsAutoSave 2026-07-20-01:00:
         FN-8395 removes the primary Save button. Notify the Settings shell for
         every workflow-lane mutation because these pending overrides are local
         section state rather than keys in its shared form.

--- a/packages/dashboard/app/hooks/useChat.ts
+++ b/packages/dashboard/app/hooks/useChat.ts
@@ -1551,7 +1551,7 @@ export function useChat(
           const acceptedByServer = meta?.requestAccepted === true;
 
           /*
-          FNXC:ChatAttachments 2026-08-03-00:00:
+          FNXC:ChatAttachments 2026-07-23-00:00:
           A direct composer owns its staged File objects and preview URLs until the server accepts
           the multipart turn. Tell it to retain those files on pre-delivery/upload failure, but
           release them after an accepted turn even when the provider cannot produce a reply.
@@ -1730,7 +1730,7 @@ export function useChat(
     return () => clearTimeout(timeoutId);
   }, [trimmedSearchQuery, projectId]);
 
-  /* FNXC:ChatTags 2026-08-05-10:55: optimistic assignment keeps shared Chat hosts in sync while a failed API mutation rolls back exactly the prior session snapshot. */
+  /* FNXC:ChatTags 2026-07-25-10:55: optimistic assignment keeps shared Chat hosts in sync while a failed API mutation rolls back exactly the prior session snapshot. */
   const createTag = useCallback(async (name: string): Promise<ChatTag> => { const response = await apiCreateChatTag(name, projectId); setTags((previous) => [...previous, response.tag].sort((a, b) => a.name.localeCompare(b.name))); return response.tag; }, [projectId]);
   const renameTag = useCallback(async (id: string, name: string) => { const response = await apiRenameChatTag(id, name, projectId); setTags((previous) => previous.map((tag) => tag.id === id ? response.tag : tag).sort((a, b) => a.name.localeCompare(b.name))); setSessions((previous) => previous.map((session) => ({ ...session, tags: (session.tags ?? []).map((tag) => tag.id === id ? response.tag : tag) }))); }, [projectId]);
   const deleteTag = useCallback(async (id: string) => { await apiDeleteChatTag(id, projectId); setTags((previous) => previous.filter((tag) => tag.id !== id)); setSessions((previous) => previous.map((session) => ({ ...session, tags: (session.tags ?? []).filter((tag) => tag.id !== id) }))); setSelectedTagId((selected) => selected === id ? null : selected); }, [projectId]);

--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -78,7 +78,7 @@ export function isPreImplementationColumnRole(flags: ColumnRoleFlags | undefined
  */
 export function isHoldColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-31-07:25 (U12 — census gate repair) DELIBERATE-LITERAL:
+  FNXC:WorkflowLifecycleColumns 2026-07-30-07:25 (U12 — census gate repair) DELIBERATE-LITERAL:
   This IS the no-metadata fallback, so the literal is the answer rather than an unconverted guard —
   the same status as `LEGACY_INTAKE_COLUMN_ID` on the line above, which reads as a named constant and
   so was never counted while this inline twin was.
@@ -100,7 +100,7 @@ const LEGACY_FIELD_EDITABLE_COLUMN_IDS: ReadonlySet<string> = new Set(["triage",
 /**
  * May a card's title/description be edited in this column?
  *
- * FNXC:WorkflowResolvedColumns 2026-07-31-00:15 (U12 — one affordance, two components):
+ * FNXC:WorkflowResolvedColumns 2026-07-30-00:15 (U12 — one affordance, two components):
  * Editing belongs to PRE-IMPLEMENTATION lanes: the card has no session, no worktree, and no plan
  * being executed against the text. Any terminal, executing or review trait VETOES it even when
  * `intake`/`hold` is also present — a column carrying both is still one where work is underway, and

--- a/packages/dashboard/app/utils/reportContextRefs.ts
+++ b/packages/dashboard/app/utils/reportContextRefs.ts
@@ -1,5 +1,5 @@
 /**
- * FNXC:ReportPipeline 2026-08-02-00:00:
+ * FNXC:ReportPipeline 2026-07-19-00:00:
  * FN-8348 moves report entry points from Header into Settings General and Command
  * Center. Resolve task and agent context in this shared helper so each home keeps
  * the same deep-link behavior without duplicating route parsing.

--- a/packages/dashboard/app/utils/taskStatusBadgeLabel.ts
+++ b/packages/dashboard/app/utils/taskStatusBadgeLabel.ts
@@ -6,7 +6,7 @@ import type { TFunction } from "i18next";
 import { isActiveMergeStatus } from "../../../core/src/active-merge-status";
 
 /*
-FNXC:TaskStatusBadge 2026-08-19-00:00:
+FNXC:TaskStatusBadge 2026-07-22-00:00:
 FN-8475 restores truthful status visibility: Coding (Ideas) deliberately plans in Todo,
 so a real non-queued task status must not be hidden based only on its board column.
 Queued remains an intake-only presentation exclusion at TaskCard and ListView call sites.

--- a/packages/dashboard/app/utils/taskTiming.ts
+++ b/packages/dashboard/app/utils/taskTiming.ts
@@ -114,7 +114,7 @@ export function getActiveRuntimeMs(
   return null;
 }
 
-/** FNXC:TaskTiming 2026-08-01-10:00: rendered task totals include planning AI
+/** FNXC:TaskTiming 2026-07-20-10:00: rendered task totals include planning AI
  * segments while getActiveRuntimeMs intentionally remains execution-only. */
 export function getTotalAgentActiveMs(
   task: Pick<Task, "column" | "cumulativeActiveMs" | "executionStartedAt" | "cumulativePlanningMs" | "planningStartedAt">,

--- a/packages/dashboard/app/utils/taskTokenCost.ts
+++ b/packages/dashboard/app/utils/taskTokenCost.ts
@@ -67,7 +67,7 @@ export function toTokenCostRow(
  * Task cost is a read-time derivation shared by the done Summary tab, always-available Cost tab, and optional card badge. Keep the costFor/pricing-overrides path centralized here so unpriced or zero-usage states keep the guess-free “—” sentinel everywhere and derived USD is never persisted.
  *
  * FNXC:TaskDetailSummaryTokenCost 2026-06-27-00:00:
- * FNXC:TaskCost 2026-08-01-10:00: tokenUsage is a full-task additive ledger;
+ * FNXC:TaskCost 2026-07-20-10:00: tokenUsage is a full-task additive ledger;
  * triage and graph Plan Review buckets intentionally have no role filter here.
  * Done-task Summary shows durable token usage broken down by model with derived USD cost. Use already-loaded task.tokenUsage.perModel buckets plus costFor and global pricing overrides threaded from TaskDetailModal; do not fetch or persist cost here. Unpriced models render “—” instead of $0 and make the task total unavailable so estimates are never understated.
  */

--- a/packages/dashboard/src/__tests__/log-severity-spam-contract.test.ts
+++ b/packages/dashboard/src/__tests__/log-severity-spam-contract.test.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:EngineDiagnostics 2026-08-01-11:12:
+FNXC:EngineDiagnostics 2026-07-26-11:12:
 FN-8603 keeps dashboard-server diagnostics on @fusion/core's shared logger so
 routine output is debug-gated and no dashboard-local console sink can drift.
 */

--- a/packages/dashboard/src/__tests__/planning-browser-e2e.test.ts
+++ b/packages/dashboard/src/__tests__/planning-browser-e2e.test.ts
@@ -63,7 +63,7 @@ describe.runIf(executablePath)("Planning Mode browser E2E", () => {
 
   beforeAll(async () => {
     /*
-    FNXC:PlanningModeBrowserE2E 2026-07-31-09:05:
+    FNXC:PlanningModeBrowserE2E 2026-07-23-09:05:
     This static fixture has no reload contract. Disable file watching so an fsevents watcher cannot
     outlive Chromium and block the required responsive browser lane during teardown.
     */
@@ -89,7 +89,7 @@ describe.runIf(executablePath)("Planning Mode browser E2E", () => {
   afterAll(async () => {
     await browser?.close();
     /*
-    FNXC:PlanningModeBrowserE2E 2026-07-31-09:05:
+    FNXC:PlanningModeBrowserE2E 2026-07-23-09:05:
     Bound watcher shutdown prevents a native fsevents close callback from holding this mandatory
     browser lane open after the fixture listener is gone, while still releasing it before Vitest exits.
     */
@@ -250,7 +250,7 @@ describe.runIf(executablePath)("Planning Mode browser E2E", () => {
       const triggerIndex = visibleButton ? focusable.indexOf(visibleButton) : -1;
       const buttonRect = visibleButton?.getBoundingClientRect();
       /*
-      FNXC:PlanningComments 2026-07-31-09:05:
+      FNXC:PlanningComments 2026-07-23-09:05:
       Start at the preceding tab stop, then send actual Tab keys. Programmatic focus alone would
       incorrectly accept a tabIndex=-1 contextual-comment trigger as keyboard reachable.
 

--- a/packages/dashboard/src/__tests__/task-modal-touch-resize-browser.test.ts
+++ b/packages/dashboard/src/__tests__/task-modal-touch-resize-browser.test.ts
@@ -116,7 +116,7 @@ async function targetCenter(page: Page, selector: string): Promise<Point> {
 }
 
 /*
-FNXC:TaskModalResize 2026-08-12-15:12:
+FNXC:TaskModalResize 2026-07-26-15:12:
 Browser CDP gestures are required because jsdom cannot resolve CSS hit targets. This fixture mounts
 both production resize paths and sends CSS-pixel touch input through Chromium so elementFromPoint,
 pointer capture, persistence, and header-drag isolation use the same browser input path.

--- a/packages/dashboard/src/routes/chat-attachment-config.ts
+++ b/packages/dashboard/src/routes/chat-attachment-config.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:ChatAttachments 2026-08-03-00:00:
+FNXC:ChatAttachments 2026-07-23-00:00:
 Chat upload validation must match task attachments: the composer now allows the full task-store MIME
 set, so direct and room routes must persist videos, Markdown, and TOML instead of rejecting them.
 */

--- a/packages/dashboard/src/routes/register-chat-routes.ts
+++ b/packages/dashboard/src/routes/register-chat-routes.ts
@@ -242,7 +242,7 @@ export function registerChatRoutes(ctx: ApiRoutesContext, deps: ChatRouteDeps): 
   });
 
   /*
-  FNXC:ChatTags 2026-08-05-10:55:
+  FNXC:ChatTags 2026-07-25-10:55:
   Tags are a Direct-conversation taxonomy, not room metadata. Every endpoint
   resolves the project-scoped ChatStore and passes its project identity into the
   store mutation, preventing unqualified tag/session IDs from crossing scopes.

--- a/packages/dashboard/src/routes/register-command-center-routes.ts
+++ b/packages/dashboard/src/routes/register-command-center-routes.ts
@@ -140,7 +140,7 @@ export function resolveTokenGranularity(query: Request["query"]): TokenTimeGranu
 
 /** True when the caller asked for CSV via `?format=csv` (case-insensitive). */
 /*
-FNXC:SdlcFunnelColumns 2026-07-31-10:15:
+FNXC:SdlcFunnelColumns 2026-07-30-10:15:
 The project's own workflow columns, in the shape the funnel's trait mapping needs. Resolved from the
 project's DEFAULT workflow, which is the board the activity log's column ids come from.
 
@@ -309,7 +309,7 @@ export const registerCommandCenterRoutes: ApiRouteRegistrar = (ctx) => {
       const store = await getScopedStore(req);
       const range = resolveRange(req.query);
       /*
-      FNXC:SdlcFunnelColumns 2026-07-31-10:10:
+      FNXC:SdlcFunnelColumns 2026-07-30-10:10:
       PASS THE PROJECT'S OWN COLUMNS. The funnel maps column ids to SDLC stages by trait, and any id it
       was not given folds to OTHER — so without this the Command Center funnel on a renamed or custom
       board read as empty while the board was plainly busy. `aggregateSdlcFunnel`'s doc comment already

--- a/packages/dashboard/src/shared/dashboard-views.ts
+++ b/packages/dashboard/src/shared/dashboard-views.ts
@@ -62,7 +62,7 @@ export const DASHBOARD_VIEWS: readonly DashboardViewMetadata[] = [
   { id: "research", label: "Research", labelKey: "header.researchView" },
   { id: "evals", label: "Evals", labelKey: "header.evalsView" },
   /*
-  FNXC:Navigation 2026-08-01-00:00:
+  FNXC:Navigation 2026-07-27-00:00:
   FN-8352 promotes Ideation from a Command Center tab to a persisted,
   default-off experimental top-level view.
   */

--- a/packages/engine/src/__tests__/executor-rebound-already-there.test.ts
+++ b/packages/engine/src/__tests__/executor-rebound-already-there.test.ts
@@ -116,7 +116,7 @@ describe("an engine rebound does not move a card that is already in its rebound 
   });
 
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-31-16:20 (PR #2644 review, CodeRabbit):
+  FNXC:WorkflowLifecycleColumns 2026-07-30-16:20 (PR #2644 review, CodeRabbit):
   THIS FIXTURE HAD TO DIFFER FROM THE DEFAULT-LINEAGE ONE. Both used `harness(undefined, ...)`, which
   supplies no workflow SELECTION at all — so "the default lineage" and "the workflow cannot be resolved"
   were the same setup, and this case could pass without ever exercising a selection whose definition lookup

--- a/packages/engine/src/__tests__/executor-resume-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-resume-lanes-resolved.test.ts
@@ -53,7 +53,7 @@ function harness(ir: WorkflowIr | undefined) {
 describe("one lane snapshot per recovery decision", () => {
   it("resolves the workflow ONCE when a memo is shared, not once per half", async () => {
     /*
-    FNXC:WorkflowLifecycleColumns 2026-07-31-01:10 (PR #2640 review, greptile P2):
+    FNXC:WorkflowLifecycleColumns 2026-07-30-01:10 (PR #2640 review, greptile P2):
     Eligibility and re-entry are two halves of the SAME decision. Resolving separately is not just
     extra I/O: a workflow edit landing between the two calls would have the halves reading DIFFERENT
     boards — eligibility admits a card in review, then re-entry resolves a board where that column

--- a/packages/engine/src/__tests__/legacy-column-literal-census.test.ts
+++ b/packages/engine/src/__tests__/legacy-column-literal-census.test.ts
@@ -72,7 +72,7 @@ import { resolve } from "node:path";
 const REPO_ROOT = resolve(__dirname, "../../../..");
 
 /*
-FNXC:LegacyColumnCensus 2026-07-31-01:00 (PR #2557 review — third finding, mine):
+FNXC:LegacyColumnCensus 2026-07-30-01:00 (PR #2557 review — third finding, mine):
 THE RECEIVER PATTERN WAS THE SECOND BLIND SPOT, and it is the one that stops this
 being a ratchet at all.
 
@@ -94,7 +94,7 @@ const LEGACY_COLUMN_COMPARISON =
   /[A-Za-z_$][\w$.?[\]]*\s*(?:===|!==)\s*"(?:todo|triage|in-progress|in-review|done|archived)"/;
 
 /*
-FNXC:LegacyColumnCensus 2026-07-31-01:00:
+FNXC:LegacyColumnCensus 2026-07-30-01:00:
 NOT COLUMNS. `"triage"` also names an agent role, a session purpose, an agent-log
 lane and an agent surface; `"done"` and friends likewise appear as statuses. Counting
 these would be worse than missing them: a ratchet that demands converting
@@ -104,7 +104,7 @@ never reach zero because those lines are correct as written.
 Two independent classifiers agreed on exactly this receiver set, which is the
 strongest evidence available that it is complete as of today.
 
-FNXC:LegacyColumnCensus 2026-07-31-03:05 (PR #2557 review — greptile, and a real
+FNXC:LegacyColumnCensus 2026-07-30-03:05 (PR #2557 review — greptile, and a real
 defect in my own widening): the status exclusion was `\bstatus\b`, which catches
 `s.status` (the dot is a word boundary) but NOT a camelCase local. Measured:
 `tStatus`, `rStatus`, `sStatus` and `kStatus` account for SEVEN comparisons that were
@@ -160,7 +160,7 @@ const CEILING = 745;
 
 function productionSources(): string[] {
   /*
-  FNXC:LegacyColumnCensus 2026-07-31-00:25 (PR #2557 review — greptile):
+  FNXC:LegacyColumnCensus 2026-07-30-00:25 (PR #2557 review — greptile):
   THE PATHSPEC WAS THE BUG, and it under-reported in two independent directions.
 
     .tsx was absent entirely, so every dashboard component — the single largest

--- a/packages/engine/src/__tests__/lifecycle-column-census.test.ts
+++ b/packages/engine/src/__tests__/lifecycle-column-census.test.ts
@@ -344,7 +344,7 @@ describe("the summary separates the three classes", () => {
 });
 
 /*
-FNXC:LifecycleColumnCensus 2026-07-31-18:40 (the ratchet's one unusable state, now fixed):
+FNXC:LifecycleColumnCensus 2026-07-30-18:40 (the ratchet's one unusable state, now fixed):
 
 `--update-baseline` MUST RUN EVEN WHEN A FILE ROSE. It could not: the rise check exited before the write,
 so the only supported way to re-record was unavailable in exactly the situation that needs it.
@@ -399,7 +399,7 @@ describe("the baseline can always be re-recorded", () => {
   });
 
   /*
-  FNXC:LifecycleColumnCensus 2026-07-31-18:30 (PR #2668 review — greptile):
+  FNXC:LifecycleColumnCensus 2026-07-30-18:30 (PR #2668 review — greptile):
   END-TO-END, because every assertion above reads this file's SOURCE TEXT. Substrings,
   marker ordering and `writeFileSync` counts cannot see control flow: move the exit,
   reorder the branches, or return before the write, and all of them stay green while

--- a/packages/engine/src/__tests__/log-severity-manifest.ts
+++ b/packages/engine/src/__tests__/log-severity-manifest.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:EngineDiagnostics 2026-08-01-10:46:
+FNXC:EngineDiagnostics 2026-07-26-10:46:
 FN-8603 requires routine and expected diagnostic sites to default to debug so a
 single accidental severity reversion cannot flood the operator log pane.
 */

--- a/packages/engine/src/__tests__/log-severity-spam-contract.test.ts
+++ b/packages/engine/src/__tests__/log-severity-spam-contract.test.ts
@@ -29,7 +29,7 @@ function withoutComments(source: string): string {
 }
 
 /*
-FNXC:EngineDiagnostics 2026-08-01-10:46:
+FNXC:EngineDiagnostics 2026-07-26-10:46:
 FN-8603 pins every demoted engine call-site by a stable message anchor. The
 source check rejects a reversion to log, warn, error, or bare console output.
 */

--- a/packages/engine/src/__tests__/manual-intake-admission.test.ts
+++ b/packages/engine/src/__tests__/manual-intake-admission.test.ts
@@ -1,5 +1,5 @@
 /*
-FNXC:ManualIntakeAdmission 2026-07-31-04:35 (live bug, found while scoping the coding-ideas merge):
+FNXC:ManualIntakeAdmission 2026-07-30-04:35 (live bug, found while scoping the coding-ideas merge):
 
 THE INVARIANT: a card sitting at a MANUAL intake (`autoTriage: false`) is never auto-planned. Coding
 (Ideas) exists so an operator can park a card without the engine touching it; the operator promotes

--- a/packages/engine/src/__tests__/reliability-interactions/execute-requeue-loop-guard.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/execute-requeue-loop-guard.test.ts
@@ -366,7 +366,7 @@ describe("execute requeue loop guard", () => {
   });
 
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-31-12:50 (PR #2568 review — greptile):
+  FNXC:WorkflowLifecycleColumns 2026-07-30-12:50 (PR #2568 review — greptile):
   Both fixes below were UNPROVEN when written: I mutated each and the existing 17
   cases stayed green, which is the same "converted but untested" state this program
   keeps finding in other people's work. These two pin them.

--- a/packages/engine/src/__tests__/triage-plan-admission-throttle-audit.test.ts
+++ b/packages/engine/src/__tests__/triage-plan-admission-throttle-audit.test.ts
@@ -242,7 +242,7 @@ describe("plan admission throttle run-audit (FN-8600)", () => {
 
   it("stays silent when planning has capacity", async () => {
     /*
-    FNXC:PlanAdmissionThrottle 2026-07-31-11:25 (PR #2562 review — coderabbit):
+    FNXC:PlanAdmissionThrottle 2026-07-30-11:25 (PR #2562 review — coderabbit):
     THIS TEST PROVED THE WRONG SILENCE. It used `createStore([])`, which seeds only
     the running claimant and NO eligible card — so it asserted that an EMPTY QUEUE
     emits no throttle, which is true of any implementation, including one that emits

--- a/packages/engine/src/__tests__/triage.test.ts
+++ b/packages/engine/src/__tests__/triage.test.ts
@@ -1947,7 +1947,7 @@ Planner rewrote mission without the raw request.
   FNXC:CodingIdeasWorkflow 2026-07-05-00:00:
   FN-7596 pins the Coding (Ideas) manual-intake lifecycle at the poll-dispatch boundary: an `ideas`-column card must stay parked, while a promoted `todo`-column card whose PROMPT.md is still the bootstrap stub must be discovered and specified via `eligibleTodoTasks`'s bootstrap-prompt file check. A `todo` card with a real (non-bootstrap) spec must NOT be re-dispatched, guarding against double-specifying an already-planned card.
 
-  FNXC:ManualIntakeAdmission 2026-07-31-04:45 — READ THIS BEFORE TRUSTING THE FIRST CASE BELOW:
+  FNXC:ManualIntakeAdmission 2026-07-30-04:45 — READ THIS BEFORE TRUSTING THE FIRST CASE BELOW:
   the parked-ideas case passes here for a reason unrelated to the rule. Its store has NO workflow
   readers, so lifecycle resolution falls back to `triage`/`todo` and an `ideas` card matches neither
   admission branch. The mechanism this comment used to name — "only matches column === triage" — was

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -1459,7 +1459,7 @@ export class InProcessRuntime
           this.executor?.releasePreExecutionWorktree(taskId, reason) ?? Promise.resolve(false),
         recoverApprovedTriageTask: (task) => this.triageProcessor?.recoverApprovedTask(task) ?? Promise.resolve(false),
         getPlanningTaskIds: () => this.triageProcessor?.getPlanningTaskIds() ?? new Set<string>(),
-        // FNXC:TaskTiming 2026-08-01-12:00: orphan planning recovery must defer
+        // FNXC:TaskTiming 2026-07-20-12:00: orphan planning recovery must defer
         // while executor-owned graph Plan Review holds the sole planning anchor.
         hasActivePlanningWorkflowSession: (taskId) => this.executor?.hasActivePlanningWorkflowSession(taskId) ?? false,
         reserveAdvancedTriageRecovery: (taskId) => this.triageProcessor?.tryReserveAdvancedRecovery(taskId),

--- a/scripts/lib/lifecycle-column-census-ast.mjs
+++ b/scripts/lib/lifecycle-column-census-ast.mjs
@@ -279,7 +279,7 @@ export function summarize(findings) {
   zero. The property-assignment counts are a second, independent instrument and live beside it.
   */
   /*
-  FNXC:WorkflowLifecycleColumns 2026-07-31-09:00 (PR #2661 review — greptile P1):
+  FNXC:WorkflowLifecycleColumns 2026-07-30-09:00 (PR #2661 review — greptile P1):
   DELIBERATE counts are tracked PER FILE, not only as a repo total. A total lets an addition in one
   marked construct be offset by a removal in another and stay flat, and because deliberate findings
   are excluded from `byFile`, the newly exempt guard is invisible there too — so the gate passes with
@@ -304,7 +304,7 @@ export function summarize(findings) {
     totals[finding.kind] += 1;
     if (finding.kind === "deliberate") {
       /*
-      FNXC:WorkflowLifecycleColumns 2026-07-31-10:00 (PR #2661 review — greptile P1, same class again):
+      FNXC:WorkflowLifecycleColumns 2026-07-30-10:00 (PR #2661 review — greptile P1, same class again):
       Keyed by FILE **and COLUMN ID**, not a per-file integer. A per-file aggregate is offset within a
       single file: remove one reviewed `todo` exemption, add a `in-review` one beside it, and the
       number never moves — so a fresh guard hides inside an existing marker.


### PR DESCRIPTION
## What

The FNXC convention exists so a reader can place a note against the change that motivated it. A stamp dated *after* the edit landed defeats exactly that.

This is program-wide drift, not one author's slip — I contributed to it in my own commits this week, which is how I noticed it.

## Measured, on this tree

**104 stamps across 61 files** dated later than the day they were written, from one day ahead to **2026-10-19 (81 days)**:

| count | date | count | date | count | date |
|---|---|---|---|---|---|
| 50 | 2026-07-31 | 6 | 2026-08-05 | 3 | 2026-08-13 |
| 17 | 2026-08-01 | 1 | 2026-08-07 | 1 | 2026-08-19 |
| 7 | 2026-08-02 | 1 | 2026-08-12 | 2 | 2026-08-26 |
| 11 | 2026-08-03 | | | 3 | 2026-10-19 |

An earlier number I circulated was ~70. That came from a narrower pathspec and was wrong; **104** is the measurement.

## How

Each stamp is rewritten to the date of the commit that introduced **that line**, via per-line `git blame` — deliberately *not* stamped uniformly with today's date. A uniform stamp swaps a wrong date for a different wrong date and flattens the ordering that makes these comments navigable; blame preserves it. Times of day are untouched, and a blame date in the future is clamped rather than trusted.

## Why the verification is listed

A docs sweep across 61 files is precisely where a stray edit hides, so the safety claims are mechanical rather than asserted:

- every changed line begins with a comment marker — **no code touched**;
- **no test asserts an FNXC date later than today**, so no `toContain` assertion on embedded source text can be silently invalidated (several such assertions do exist);
- CSS files, which carry several of those assertions, are outside the pathspec.

## Verified

lint clean · merge gate green (487 + 158 + 10 + 71) · `census --strict` exit 0 · tsc clean for core, engine, and dashboard (`tsconfig.app.json`).

**No behavior change.** Comment text only.

## Not done here

A guard preventing recurrence. A check that rejects an FNXC stamp dated after the commit would stop this returning, but it needs a decision about where it runs (lint rule vs. gate) and it is a behavior change to CI — it does not belong riding inside the sweep it would police.