### PR TITLE
fleet: TaskCard.tsx 42 -> 0

### DIFF
--- a/packages/dashboard/app/__tests__/columnRoles.test.ts
+++ b/packages/dashboard/app/__tests__/columnRoles.test.ts
@@ -151,6 +151,14 @@ describe("terminal and mid-flight column roles", () => {
     is finished but not COMPLETED. Surfaces that count throughput would double-count it otherwise.
     */
     expect(isCompleteColumnRole({ archived: true }, "archived")).toBe(false);
+    /*
+    FNXC:ColumnRoles 2026-07-30-16:05 (PR #2688 review — coderabbit):
+    RESOLVED METADATA WINS, asserted against the MATCHING legacy id. Every other false case here
+    passes a non-matching id, so a `trait || legacyId` implementation satisfies them all — the id
+    is false too, and the bug hides. Only a board that renamed the ROLE while keeping the legacy
+    NAME can tell the two apart.
+    */
+    expect(isCompleteColumnRole({ archived: true }, "done")).toBe(false);
     expect(isCompleteColumnRole(undefined, "done")).toBe(true);
     expect(isCompleteColumnRole(undefined, "shipped")).toBe(false);
   });
@@ -158,6 +166,7 @@ describe("terminal and mid-flight column roles", () => {
   it("isArchivedColumnRole reads the archived trait", () => {
     expect(isArchivedColumnRole({ archived: true }, "cold-storage")).toBe(true);
     expect(isArchivedColumnRole({ complete: true }, "done")).toBe(false);
+    expect(isArchivedColumnRole({ complete: true }, "archived")).toBe(false);
     expect(isArchivedColumnRole(undefined, "archived")).toBe(true);
     expect(isArchivedColumnRole(undefined, "cold-storage")).toBe(false);
   });
@@ -170,6 +179,7 @@ describe("terminal and mid-flight column roles", () => {
     */
     expect(isWipColumnRole({ countsTowardWip: true }, "building")).toBe(true);
     expect(isWipColumnRole({ intake: true }, "backlog")).toBe(false);
+    expect(isWipColumnRole({ intake: true }, "in-progress")).toBe(false);
     expect(isWipColumnRole(undefined, "in-progress")).toBe(true);
     expect(isWipColumnRole(undefined, "building")).toBe(false);
   });
@@ -180,6 +190,7 @@ describe("terminal and mid-flight column roles", () => {
     expect(isReviewColumnRole({ mergeBlocker: true }, "signoff")).toBe(true);
     expect(isReviewColumnRole({ humanReview: true }, "signoff")).toBe(true);
     expect(isReviewColumnRole({ countsTowardWip: true }, "building")).toBe(false);
+    expect(isReviewColumnRole({ countsTowardWip: true }, "in-review")).toBe(false);
     expect(isReviewColumnRole(undefined, "in-review")).toBe(true);
     expect(isReviewColumnRole(undefined, "signoff")).toBe(false);
   });

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -34,7 +34,15 @@ import { useTaskDiffStats } from "../hooks/useTaskDiffStats";
 import { useAgentsMapCache } from "../hooks/useAgentsMapCache";
 import { useLiveTimeTicker } from "../hooks/useLiveTimeTicker";
 import { isTaskStuck } from "../utils/taskStuck";
-import { isFieldEditableColumnRole } from "../utils/columnRoles";
+import {
+  isArchivedColumnRole,
+  isCompleteColumnRole,
+  isHoldColumnRole,
+  isIntakeColumnRole,
+  isFieldEditableColumnRole,
+  isReviewColumnRole,
+  isWipColumnRole,
+} from "../utils/columnRoles";
 import { hasPendingAutomaticRecovery, isTaskManuallyRetryable } from "../utils/taskRecovery";
 import { getRevertOfId, isTaskReverted } from "../utils/taskRevert";
 import { getStalledReviewSignal } from "../utils/taskStalledReview";
@@ -376,7 +384,18 @@ function getTaskEndToEndDurationMs(task: Task, nowMs: number): number | null {
 }
 
 function getInReviewCompletionMs(task: Task): number | null {
-  return task.column === "done" ? getDoneCompletionMs(task) : null;
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-20:30 (fleet: TaskCard.tsx):
+  CENTRALISED, not trait-resolved — stated plainly because the difference matters. This is a
+  module-scope helper taking only `task`, so no column flags are in scope; passing `undefined`
+  selects the shared fallback and yields behaviour identical to the literal it replaces.
+
+  What it buys is that the legacy id lives in ONE place, and that this site is greppable as "still
+  needs its flags threaded" rather than looking already converted. Threading them means giving every
+  caller of this helper a flags argument, which is a signature change across the card's duration
+  helpers — a separate unit of work, not a vocabulary edit.
+  */
+  return isCompleteColumnRole(undefined, task.column) ? getDoneCompletionMs(task) : null;
 }
 
 function getMergeElapsedMs(task: Task, nowMs: number): number | null {
@@ -1009,16 +1028,24 @@ function TaskCardComponent({
   and in that state there is nothing to resolve FROM. Deleting it does not remove a guard, it picks a
   different guess ("not intake") and silently drops planning affordances during first paint.
   */
-  const isIntakeColumn = taskColumnFlags
-    ? taskColumnFlags.intake === true
-    : task.column === "triage";
-  const isHoldColumn = taskColumnFlags
-    ? taskColumnFlags.hold === true
-    : task.column === "todo";
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-20:15 (fleet: TaskCard.tsx):
+  The card's ROLES, all four resolved the same way — traits when the board has loaded, the documented
+  legacy id only for the pre-load window and for a card in a column its workflow no longer declares.
+
+  The intake/hold pair were already flags-first but written inline; routed through the helpers so this
+  file has ONE definition of each role rather than an expression per site. The wip/review pair are new
+  bindings for the same reason: nine `in-progress` and seven `in-review` comparisons below collapse
+  onto them.
+  */
+  const isIntakeColumn = isIntakeColumnRole(taskColumnFlags, task.column);
+  const isHoldColumn = isHoldColumnRole(taskColumnFlags, task.column);
+  const isWipColumn = isWipColumnRole(taskColumnFlags, task.column);
+  const isReviewColumn = isReviewColumnRole(taskColumnFlags, task.column);
 
   const [isSaving, setIsSaving] = useState(false);
   const [showSteps, setShowSteps] = useState(
-    task.column === "in-progress" ||
+    isWipColumn ||
     (isIntakeColumn && task.steps.some(s => s.status === "done" || s.status === "skipped"))
   );
   const [missionTitle, setMissionTitle] = useState<string | null>(null);
@@ -1381,7 +1408,13 @@ function TaskCardComponent({
     }
   }, [onOpenDetail, addToast]);
 
-  const isDoneColumn = task.column === "done";
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-20:00 (fleet: TaskCard.tsx):
+  The card's TERMINAL role, from its own column's traits. `taskColumnFlags` is already threaded into
+  this component, so this is a trait read with the documented id fallback for the pre-load window —
+  not a rename.
+  */
+  const isDoneColumn = isCompleteColumnRole(taskColumnFlags, task.column);
   const visualStatus = isDoneColumn ? "done" : task.status;
   const hasPendingRecovery = hasPendingAutomaticRecovery(task, lastFetchTimeMs);
   const isFailed = !isDoneColumn && task.status === "failed" && !hasPendingRecovery;
@@ -1397,7 +1430,7 @@ function TaskCardComponent({
   const PriorityBadgeIcon = getPriorityIcon(normalizedPriority);
   const isStuck = isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs);
   const stalledReview = getStalledReviewSignal(task);
-  const showStalledReview = Boolean(stalledReview && task.column === "in-review" && !isPaused);
+  const showStalledReview = Boolean(stalledReview && isReviewColumn && !isPaused);
   const hasInReviewStall = shouldShowInReviewStallBadge(task);
   /*
   FNXC:TaskCardPlanReviewBadge 2026-07-11-12:05:
@@ -1437,7 +1470,7 @@ function TaskCardComponent({
   const isAwaitingApproval = isIntakeColumn && task.status === "awaiting-approval";
   const isPlanReviewReplanCapApproval = isReviewBudgetExhaustedApproval(task);
   const isAwaitingInput = task.status === "awaiting-user-input";
-  const isArchived = task.column === "archived";
+  const isArchived = isArchivedColumnRole(taskColumnFlags, task.column);
   /*
   FNXC:WorkflowResolvedColumns 2026-07-29-00:00 (PR #2566 review — greptile):
   Pass the card's column traits. Without them the planner-lane clause falls back to the
@@ -1547,8 +1580,8 @@ function TaskCardComponent({
    */
   const showNearDuplicateChip = Boolean(task.sourceMetadata?.nearDuplicateOf)
     && task.sourceMetadata?.nearDuplicateDismissed !== true
-    && task.column !== "archived"
-    && task.column !== "done"
+    && !isArchived
+    && !isDoneColumn
     && nearDuplicateCanonicalInactive !== true;
   /**
    * FNXC:TaskRevert 2026-07-04-00:00:
@@ -1579,7 +1612,7 @@ function TaskCardComponent({
    * preserves the done/archived invariant without adding a view-specific badge.
    */
   const showRevertedChip = isTaskReverted(task.sourceMetadata)
-    && (task.column === "done" || task.column === "archived");
+    && (isDoneColumn || isArchived);
   const branchMetadata = useMemo(() => getVisibleTaskCardBranches(task), [task.id, task.branch, task.baseBranch]);
   const hasBranchMetadata = Boolean(branchMetadata.branch || branchMetadata.baseBranch);
   const isAgentCreated = isAgentCreatedTask(task);
@@ -1634,7 +1667,7 @@ function TaskCardComponent({
   FN-7676 — cards in the Planning/`triage` column must not surface the steps breakdown (progress bar, active badge, step-count toggle, expandable list); enumerated implementation steps are premature planning artifacts, not execution progress. The affordance now appears only after the task leaves Planning (`in-progress` / `executing`), matching `ListView.shouldShowTaskProgress`. FN-7831 adds a separate header "Reviewing" badge for a running Plan Review, but the progress breakdown itself remains hidden in Planning.
   */
   const showProgressSection =
-    unifiedProgress.total > 0 && (task.status === "executing" || task.column === "in-progress");
+    unifiedProgress.total > 0 && (task.status === "executing" || isWipColumn);
 
   /*
   FNXC:BoardPerformance 2026-07-26-09:46:
@@ -1648,14 +1681,14 @@ function TaskCardComponent({
   old effect used, so cadence, formatting, and which cards animate are unchanged.
   */
   const wantsLiveTimeIndicator = useMemo(() => {
-    if (task.column !== "in-progress" && task.column !== "in-review") {
+    if (!isWipColumn && !isReviewColumn) {
       return false;
     }
 
     const merging = task.status != null && ACTIVE_MERGE_STATUSES.has(task.status);
     const nowMs = Date.now();
 
-    if (task.column === "in-progress") {
+    if (isWipColumn) {
       const endToEndMs = getTaskEndToEndDurationMs(task, nowMs);
       const elapsedMs = getInProgressElapsedMs(task, nowMs);
       const instrumentedMs = getInstrumentedDurationMs(task, nowMs);
@@ -1664,7 +1697,7 @@ function TaskCardComponent({
       }
     }
 
-    if (!merging && task.column === "in-review") {
+    if (!merging && isReviewColumn) {
       const endToEndMs = getTaskEndToEndDurationMs(task, nowMs);
       const instrumentedMs = getInstrumentedDurationMs(task, nowMs);
       if (endToEndMs == null && instrumentedMs == null) {
@@ -1704,7 +1737,7 @@ function TaskCardComponent({
       }
     }
 
-    if (task.column === "in-progress") {
+    if (isWipColumn) {
       // Prefer the persistent execution start (set on first transition to
       // in-progress, never reset on retry-loop bounces). Fall back to the
       // columnMovedAt heuristic for legacy tasks predating the new field.
@@ -1762,8 +1795,8 @@ function TaskCardComponent({
   const lifecycleDates = useMemo(() => {
     const created = formatCompactLifecycleDate(task.createdAt, locale, new Date(lifecycleNowMs));
     const completionSource = task.executionCompletedAt
-      ?? (task.column === "archived" ? task.archivedAt : undefined);
-    const completed = (task.column === "done" || task.column === "archived")
+      ?? (isArchived ? task.archivedAt : undefined);
+    const completed = (isDoneColumn || isArchived)
       ? formatCompactLifecycleDate(completionSource, locale, new Date(lifecycleNowMs))
       : null;
     return { created, completed };
@@ -1801,13 +1834,13 @@ function TaskCardComponent({
   }, [hasGitHubBadgeSource, isInViewport, subscribeToBadge, task.id, unsubscribeFromBadge]);
 
   // Compute step version for diff stats refresh when steps change
-  const isActiveColumn = task.column === "in-progress" || task.column === "in-review";
+  const isActiveColumn = isWipColumn || isReviewColumn;
   const stepVersion = useMemo(
     () => task.steps.map((s) => `${s.name}:${s.status}`).join("|"),
     [task.steps],
   );
   const mergeSignature = useMemo(() => {
-    if (task.column !== "done") {
+    if (!isDoneColumn) {
       return undefined;
     }
 
@@ -1961,7 +1994,7 @@ function TaskCardComponent({
    * is unaffected and continues to render per its own gate.
    */
   const showCreatePrQuickAction =
-    task.column === "in-review"
+    isReviewColumn
     && !effectiveAutoMerge
     && !livePrInfo
     && prAuthAvailable === true
@@ -2147,7 +2180,7 @@ function TaskCardComponent({
   time. This mirrors the parent FN-7501 issue's "undo a change" framing: only
   tasks that actually changed the tree are revertable.
   */
-  const isRevertable = (task.column === "done" || task.column === "archived")
+  const isRevertable = (isDoneColumn || isArchived)
     && Boolean(task.mergeDetails?.commitSha);
 
   /*
@@ -2652,10 +2685,10 @@ function TaskCardComponent({
       return [];
     }
     const actions = [...taskActionMenuModel.actions];
-    if (task.column === "done" && onArchiveTask) {
+    if (isDoneColumn && onArchiveTask) {
       actions.push({ id: "archive", label: t("tasks.archive", "Archive"), onSelect: handleTaskActionArchive });
     }
-    if (task.column === "archived" && onUnarchiveTask) {
+    if (isArchived && onUnarchiveTask) {
       actions.push({ id: "unarchive", label: t("tasks.unarchive", "Unarchive"), onSelect: handleTaskActionUnarchive });
     }
     /*
@@ -2665,7 +2698,7 @@ function TaskCardComponent({
     commit to revert, so the menu communicates WHY the affordance is inert
     instead of silently hiding it.
     */
-    if ((task.column === "done" || task.column === "archived") && onRevertTask) {
+    if ((isDoneColumn || isArchived) && onRevertTask) {
       actions.push({
         id: "revert",
         label: t("tasks.revert", "Revert"),
@@ -2682,11 +2715,22 @@ function TaskCardComponent({
       FNXC:BoardCardActions 2026-07-16-00:00 (FN-8149):
       The retired in-review Move dropdown offered Done (no merge) and Triage in addition to the shared menu model's Todo/In Progress defaults. Fold those targets into this TaskCard-only menu so card consolidation retains every move capability without changing ListView or TaskDetail menus.
       */
-      if (task.column === "in-review") {
+      if (isReviewColumn) {
         for (const column of ["done", "triage"] as const) {
           if (moveTransitions.some((transition) => transition.column === column)) continue;
           moveTransitions.push({
             column,
+            /*
+            FNXC:WorkflowResolvedColumns 2026-07-30-20:30 (fleet: TaskCard.tsx) DELIBERATE-LITERAL:
+            NOT a lifecycle guard. `column` here is the loop variable over the hardcoded
+            `["done", "triage"]` array two lines above — this asks "which entry of my own literal list
+            am I on" in order to pick a label, not "what role does this card's column play".
+
+            Converting it would resolve a trait for a string this code just wrote itself, which is
+            meaningless. The array is the thing worth revisiting (it names move targets by id), but
+            that is a behaviour question about which targets a review card should offer, and it is out
+            of scope for a vocabulary conversion.
+            */
             label: column === "done"
               ? t("tasks.doneNoMerge", "Done (no merge)")
               : t("taskDetail.move.moveTo", "Move to {{column}}", { column: taskActionColumnLabel(column) }),
@@ -2931,7 +2975,7 @@ function TaskCardComponent({
   const cardClass = `card${dragging ? " dragging" : ""}${queued ? " queued" : ""}${isAgentActive ? " agent-active" : ""}${isFailed ? " failed" : ""}${isPaused ? " paused" : ""}${isStuck ? " stuck" : ""}${isAwaitingApproval ? " awaiting-approval" : ""}${isAwaitingInput ? " awaiting-input" : ""}${fileDragOver ? " file-drop-target" : ""}${isEditing ? " card-editing" : ""}${isSaving ? " card-saving" : ""}`;
 
   const filesChangedButton = (() => {
-    if (task.column === "in-progress") {
+    if (isWipColumn) {
       const activeDiffCount = diffStats?.filesChanged;
       const fallbackCount =
         activeDiffCount == null
@@ -2955,7 +2999,7 @@ function TaskCardComponent({
       );
     }
 
-    if (task.column === "in-review") {
+    if (isReviewColumn) {
       const reviewDiffCount = diffStats?.filesChanged;
       const fallbackCount =
         reviewDiffCount == null
@@ -2979,7 +3023,7 @@ function TaskCardComponent({
       );
     }
 
-    if (task.column === "done") {
+    if (isDoneColumn) {
       // Done cards only display committed diff counts from authoritative lineage
       // stats or recorded landed files; transient execution-touched files are not shown.
       let displayCount: number | undefined;
@@ -3240,10 +3284,10 @@ function TaskCardComponent({
   const hasHeaderActions = Boolean(isAwaitingInput && onOpenDetailWithTab)
     || Boolean(canEdit)
     || Boolean(isIntakeColumn && onDeleteTask)
-    || Boolean(task.column === "done" && onArchiveTask)
-    || Boolean(task.column === "archived" && onUnarchiveTask)
-    || Boolean((task.column === "done" || task.column === "archived") && onRevertTask && isRevertable)
-    || Boolean(task.column === "in-progress" && onMoveTask)
+    || Boolean(isDoneColumn && onArchiveTask)
+    || Boolean(isArchived && onUnarchiveTask)
+    || Boolean((isDoneColumn || isArchived) && onRevertTask && isRevertable)
+    || Boolean(isWipColumn && onMoveTask)
     || Boolean(task.size)
     || hasContextMenuActions;
 
@@ -3686,7 +3730,7 @@ function TaskCardComponent({
               <Trash2 size={12} />
             </button>
           )}
-          {task.column === "archived" && onUnarchiveTask && (
+          {isArchived && onUnarchiveTask && (
             <button
               className="card-unarchive-btn"
               onClick={handleUnarchiveClick}
@@ -3706,7 +3750,7 @@ function TaskCardComponent({
           Reuses `card-archive-btn`'s tokenized styling via a shared class so no new
           one-off CSS/colors are introduced.
           */}
-          {task.column === "archived" && onRevertTask && isRevertable && (
+          {isArchived && onRevertTask && isRevertable && (
             <button
               className="card-archive-btn card-revert-btn"
               onClick={handleRevertClick}
@@ -3982,7 +4026,7 @@ function TaskCardComponent({
               </span>
             </span>
           )}
-          {(queued || task.status === "queued") && task.column !== "in-progress" && <span className="queued-badge"><Clock size={12} style={{ verticalAlign: "middle" }} /> {t("tasks.queued", "Queued")}</span>}
+          {(queued || task.status === "queued") && !isWipColumn && <span className="queued-badge"><Clock size={12} style={{ verticalAlign: "middle" }} /> {t("tasks.queued", "Queued")}</span>}
           {placeFooterRightInMeta && footerRightCluster}
         </div>
       )}

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -2776,7 +2776,7 @@ function TaskCardComponent({
       }
     }
     return actions.filter((action) => action.tone === "note" || action.disabled === true || Boolean(action.onSelect));
-  }, [handleTaskActionArchive, handleTaskActionMove, handleTaskActionRevert, handleTaskActionUnarchive, isRevertable, onArchiveTask, onDeleteTask, onDuplicateTask, onMergeTask, onMoveTask, onPlanningMode, onOpenRefine, onPauseTask, onResetTask, onRetryTask, onRevertTask, onUnarchiveTask, onUnpauseTask, onUpdateTask, t, task.column, taskActionColumnLabel, taskActionMenuModel.actions, taskActionMenuModel.moveTransitions, taskActionMenuModel.reviewAction]);
+  }, [handleTaskActionArchive, handleTaskActionMove, handleTaskActionRevert, handleTaskActionUnarchive, isRevertable, onArchiveTask, onDeleteTask, onDuplicateTask, onMergeTask, onMoveTask, onPlanningMode, onOpenRefine, onPauseTask, onResetTask, onRetryTask, onRevertTask, onUnarchiveTask, onUnpauseTask, onUpdateTask, t, task.column, taskActionColumnLabel, taskActionMenuModel.actions, taskActionMenuModel.moveTransitions, taskActionMenuModel.reviewAction, isDoneColumn, isArchived, isReviewColumn]);
   const hasContextMenuActions = contextMenuActions.length > 0;
 
   const closeContextMenu = useCallback(() => {

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -1044,10 +1044,31 @@ function TaskCardComponent({
   const isReviewColumn = isReviewColumnRole(taskColumnFlags, task.column);
 
   const [isSaving, setIsSaving] = useState(false);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-21:15 (PR #2688 review — greptile P2):
+  A `useState` INITIALIZER runs once, so on a custom board this captured the pre-load fallback
+  answer — `isWipColumn === false` because `taskColumnFlags` had not arrived — and never reconciled.
+  The progress section then stayed collapsed on a running card even though the operator never
+  collapsed it.
+
+  This is a consequence of the conversion rather than a pre-existing bug: before, `task.column ===
+  "in-progress"` was stable across renders, so a once-only read was safe. A trait-derived value is
+  not stable — it flips when the workflows fetch resolves.
+
+  The effect below reconciles ONE-WAY and only while untouched: it opens the section when the card
+  turns out to be WIP after all, and `stepsTouchedRef` makes it stop as soon as the operator toggles
+  it, so we never fight a deliberate collapse. Auto-collapsing on the reverse transition is
+  deliberately not done — closing a section a user is reading is worse than leaving it open.
+  */
   const [showSteps, setShowSteps] = useState(
     isWipColumn ||
     (isIntakeColumn && task.steps.some(s => s.status === "done" || s.status === "skipped"))
   );
+  const stepsTouchedRef = useRef(false);
+  useEffect(() => {
+    if (stepsTouchedRef.current) return;
+    if (isWipColumn) setShowSteps(true);
+  }, [isWipColumn]);
   const [missionTitle, setMissionTitle] = useState<string | null>(null);
   const [agentName, setAgentName] = useState<string | null>(null);
   const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null);
@@ -1706,7 +1727,7 @@ function TaskCardComponent({
     }
 
     return true;
-  }, [task.column, task.status, task.columnMovedAt, task.updatedAt, task.workflowStepResults, task.timedExecutionMs, task.firstExecutionAt, task.cumulativeActiveMs, task.executionStartedAt, task.executionCompletedAt]);
+  }, [task.column, task.status, task.columnMovedAt, task.updatedAt, task.workflowStepResults, task.timedExecutionMs, task.firstExecutionAt, task.cumulativeActiveMs, task.executionStartedAt, task.executionCompletedAt, isWipColumn, isReviewColumn]);
 
   const timeIndicatorNowMs = useLiveTimeTicker(wantsLiveTimeIndicator);
 
@@ -1790,7 +1811,7 @@ function TaskCardComponent({
       title: t("tasks.executionTimeCompleted", "Execution time {{elapsed}}. Completed {{completedAt}}", { elapsed: elapsedLabel, completedAt }),
       ariaLabel: t("tasks.executionTimeCompleted", "Execution time {{elapsed}}. Completed {{completedAt}}", { elapsed: elapsedLabel, completedAt }),
     };
-  }, [task.column, task.status, task.columnMovedAt, task.timedExecutionMs, task.updatedAt, task.workflowStepResults, task.log, task.firstExecutionAt, task.cumulativeActiveMs, task.cumulativePlanningMs, task.planningStartedAt, task.executionStartedAt, task.executionCompletedAt, timeIndicatorNowMs]);
+  }, [task.column, task.status, task.columnMovedAt, task.timedExecutionMs, task.updatedAt, task.workflowStepResults, task.log, task.firstExecutionAt, task.cumulativeActiveMs, task.cumulativePlanningMs, task.planningStartedAt, task.executionStartedAt, task.executionCompletedAt, timeIndicatorNowMs, isWipColumn]);
 
   const lifecycleDates = useMemo(() => {
     const created = formatCompactLifecycleDate(task.createdAt, locale, new Date(lifecycleNowMs));
@@ -1800,7 +1821,7 @@ function TaskCardComponent({
       ? formatCompactLifecycleDate(completionSource, locale, new Date(lifecycleNowMs))
       : null;
     return { created, completed };
-  }, [task.createdAt, task.executionCompletedAt, task.archivedAt, task.column, locale, lifecycleNowMs]);
+  }, [task.createdAt, task.executionCompletedAt, task.archivedAt, task.column, locale, lifecycleNowMs, isDoneColumn, isArchived]);
 
   const liveBadgeData = badgeUpdates.get(`${projectId ?? "default"}:${task.id}`);
 
@@ -1847,7 +1868,7 @@ function TaskCardComponent({
     const landedFilesCount = task.mergeDetails?.landedFiles?.length ?? "";
     const filesChanged = task.mergeDetails?.filesChanged ?? "";
     return `${landedFilesCount}:${filesChanged}`;
-  }, [task.column, task.mergeDetails?.landedFiles?.length, task.mergeDetails?.filesChanged]);
+  }, [task.column, task.mergeDetails?.landedFiles?.length, task.mergeDetails?.filesChanged, isDoneColumn]);
 
   // Viewport-gated diff stats fetching - only fetch when card is visible
   const { stats: diffStats, loading: diffLoading } = useTaskDiffStats(
@@ -2907,6 +2928,9 @@ function TaskCardComponent({
 
   const handleToggleSteps = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+    // Marks the section operator-controlled, so the late-flags reconciliation above stops
+    // reopening it. Without this, resolving workflow metadata would undo a deliberate collapse.
+    stepsTouchedRef.current = true;
     setShowSteps((current) => !current);
   }, []);
 

--- a/packages/dashboard/app/components/TaskCard.tsx
+++ b/packages/dashboard/app/components/TaskCard.tsx
@@ -1065,10 +1065,18 @@ function TaskCardComponent({
     (isIntakeColumn && task.steps.some(s => s.status === "done" || s.status === "skipped"))
   );
   const stepsTouchedRef = useRef(false);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-18:05 (PR #2688 review — greptile):
+  BOTH ARMS OF THE INITIALIZER RECONCILE, not just the WIP one. The initializer opens the section for
+  a WIP card OR for an intake card that already has finished steps; the first version of this effect
+  only re-checked `isWipColumn`, so a RENAMED intake lane whose flags arrive late kept the pre-load
+  answer and stayed collapsed. Same defect as the one this effect was added to fix, one arm over.
+  */
+  const hasSettledSteps = task.steps.some(s => s.status === "done" || s.status === "skipped");
   useEffect(() => {
     if (stepsTouchedRef.current) return;
-    if (isWipColumn) setShowSteps(true);
-  }, [isWipColumn]);
+    if (isWipColumn || (isIntakeColumn && hasSettledSteps)) setShowSteps(true);
+  }, [isWipColumn, isIntakeColumn, hasSettledSteps]);
   const [missionTitle, setMissionTitle] = useState<string | null>(null);
   const [agentName, setAgentName] = useState<string | null>(null);
   const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null);

--- a/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
@@ -8289,6 +8289,31 @@ describe("TaskCard reconciles late-arriving workflow flags", () => {
     expect(expanded()).toBe("true");
   });
 
+  it("opens the steps section when flags reveal the card is a RENAMED INTAKE lane with settled steps", () => {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-18:05 (PR #2688 review — greptile):
+    The initializer has TWO arms — WIP, and intake-with-finished-steps — and the first version of the
+    reconciliation effect re-checked only the WIP one. So a renamed intake lane hit exactly the bug the
+    effect was added to fix. This is the second arm.
+
+    REVERT CHECK: drop `isIntakeColumn && hasSettledSteps` from the effect and this fails while the WIP
+    case above still passes, which is precisely how the gap survived the first fix.
+    */
+    const intakeTask = () => makeTask({
+      column: "inbox" as never,
+      status: "executing" as never,
+      steps: [{ id: "s1", title: "step one", status: "done" } as never],
+    });
+
+    const { rerender } = render(<TaskCard task={intakeTask()} onOpenDetail={noop} addToast={noop} />);
+
+    rerender(
+      <TaskCard task={intakeTask()} taskColumnFlags={{ intake: true } as never} onOpenDetail={noop} addToast={noop} />,
+    );
+
+    expect(expanded()).toBe("true");
+  });
+
   it("does NOT reopen a section the operator collapsed", () => {
     /*
     The half that makes the reconciliation safe. Without the touched-ref, resolving workflow metadata

--- a/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
@@ -804,6 +804,61 @@ describe("TaskCard", () => {
     }
   });
 
+  it("rebuilds the context menu when workflow flags arrive AFTER first render", async () => {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-02:40 (PR #2688 review — greptile, third round on this file):
+    `contextMenuActions` is a useMemo whose body reads `isDoneColumn` / `isArchived` / `isReviewColumn`.
+    Those derive from `taskColumnFlags`, which arrives after first paint, so omitting them from the
+    dependency array left the menu built from the PRE-RESOLUTION answer for the life of the card.
+
+    On a renamed complete column (`shipped`) the legacy fallback says "not done", so Archive and Revert
+    were absent — permanently, on a card that IS complete. The operator sees a finished card with no way
+    to archive it and no indication why.
+
+    WHAT THIS TEST DOES AND DOES NOT PROVE, stated because I nearly claimed more than I measured.
+
+    It pins the OPERATOR-VISIBLE behaviour: a card whose flags land late must end up with a menu built
+    from the resolved roles. That is the thing worth protecting.
+
+    It does NOT discriminate the dependency-array line. Removing the three role deps leaves this test —
+    and all 389 others — green, because `taskActionMenuModel` already lists `taskColumnFlags` among its
+    own deps, so its identity changes when the flags land and this memo recomputes transitively. So the
+    review finding is correct as written and currently UNREACHABLE: there is no state where the roles
+    change without that dep changing too.
+
+    The three deps are kept anyway, as hygiene: they make this memo correct on its own terms rather than
+    correct by accident of a neighbour's dependency list, which is exactly the kind of accident a later
+    refactor of `taskActionMenuModel` would silently remove. This test is what would catch that
+    refactor.
+    */
+    const cleanupGeometry = mockBoardContextMenuGeometry();
+    const completedTask = () => makeTask({ column: "shipped" as never, status: "done" as never });
+    try {
+      const { rerender } = render(
+        <TaskCard task={completedTask()} onOpenDetail={noop} addToast={noop} onArchiveTask={vi.fn()} />,
+      );
+
+      /* Flags resolve: `shipped` is this board's complete column. */
+      rerender(
+        <TaskCard
+          task={completedTask()}
+          taskColumnFlags={{ complete: true } as never}
+          onOpenDetail={noop}
+          addToast={noop}
+          onArchiveTask={vi.fn()}
+        />,
+      );
+
+      const card = document.querySelector(".card") as HTMLElement;
+      card.focus();
+      fireEvent.keyDown(card, { key: "F10", shiftKey: true });
+
+      expect(screen.getByRole("menuitem", { name: "Archive" })).toBeInTheDocument();
+    } finally {
+      cleanupGeometry();
+    }
+  });
+
   it("opens the board card context menu from keyboard as a viewport portal, selects an action, and closes", async () => {
     const cleanupGeometry = mockBoardContextMenuGeometry();
     const onOpenDetail = vi.fn();

--- a/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskCard.test.tsx
@@ -8244,3 +8244,67 @@ describe("TaskCard field editability resolves column traits (U12 — R8)", () =>
     expect(screen.getByRole("button", EDIT_LABEL)).toBeInTheDocument();
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-21:20 (PR #2688 review — greptile P2):
+LATE-ARRIVING FLAGS must reconcile the steps section.
+
+`taskColumnFlags` arrives after first paint. A `useState` initializer runs once, so on a custom board
+whose WIP lane is renamed it captured the pre-load fallback (`isWipColumn === false`) and never
+updated — the progress section stayed collapsed on a running card the operator never collapsed.
+
+Not a pre-existing bug: before the conversion `task.column === "in-progress"` was stable across
+renders, so reading it once was safe. A trait-derived value is not stable.
+
+REVERT CHECK: delete the reconciliation effect and the first case fails — the section stays closed
+after the flags resolve.
+*/
+describe("TaskCard reconciles late-arriving workflow flags", () => {
+  const wipTask = () => makeTask({
+    column: "building" as never,
+    steps: [{ id: "s1", title: "step one", status: "done" } as never],
+  });
+
+  /*
+  Asserted on the toggle's `aria-expanded`, not on step text. That attribute IS the section's state —
+  it is what the control reports to assistive tech — so it cannot pass because some unrelated text
+  happens to render, and it does not couple the test to the steps markup.
+  */
+  const expanded = () => screen.getByRole("button", { name: /steps/i }).getAttribute("aria-expanded");
+
+  it("opens the steps section when flags reveal the card is WIP after first paint", () => {
+    const { rerender } = render(<TaskCard task={wipTask()} onOpenDetail={noop} addToast={noop} />);
+    /*
+    Pre-load the whole progress section is absent, not merely collapsed: `showProgressSection` is
+    itself gated on `isWipColumn`, and `building` is not the legacy WIP id. That is the exact
+    sequence the review described — the section appears later, and the bug was that it appeared
+    COLLAPSED because the `useState` initializer had already captured the pre-load answer.
+    */
+    expect(screen.queryByRole("button", { name: /steps/i })).not.toBeInTheDocument();
+
+    rerender(
+      <TaskCard task={wipTask()} taskColumnFlags={{ countsTowardWip: true } as never} onOpenDetail={noop} addToast={noop} />,
+    );
+    // It arrives, and it arrives OPEN.
+    expect(expanded()).toBe("true");
+  });
+
+  it("does NOT reopen a section the operator collapsed", () => {
+    /*
+    The half that makes the reconciliation safe. Without the touched-ref, resolving workflow metadata
+    would undo a deliberate collapse — a UI fighting the user, which is worse than the bug it fixes.
+    */
+    const { rerender } = render(
+      <TaskCard task={wipTask()} taskColumnFlags={{ countsTowardWip: true } as never} onOpenDetail={noop} addToast={noop} />,
+    );
+    expect(expanded()).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: /steps/i }));
+    expect(expanded()).toBe("false");
+
+    rerender(
+      <TaskCard task={wipTask()} taskColumnFlags={{ countsTowardWip: true } as never} onOpenDetail={noop} addToast={noop} />,
+    );
+    expect(expanded()).toBe("false");
+  });
+});

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -3,7 +3,6 @@
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/engine/src/executor.ts": 57,
-    "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 26,
     "packages/core/src/store.ts": 12,
@@ -141,7 +140,6 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts": 1
   },
   "deliberateByFile": {
-    "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 2,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000triage": 2,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000done": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000in-review": 1,
@@ -149,7 +147,9 @@
     "packages/dashboard/app/components/RoutineEditor.tsx\u0000triage": 1,
     "packages/dashboard/app/components/ScheduleForm.tsx\u0000triage": 1,
     "packages/dashboard/app/components/ScheduleStepsEditor.tsx\u0000triage": 1,
+    "packages/dashboard/app/components/TaskCard.tsx\u0000done": 1,
     "packages/dashboard/app/components/TaskCard.tsx\u0000todo": 1,
+    "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 1,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000triage": 1,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000todo": 1,
     "packages/dashboard/app/utils/columnRoles.ts\u0000todo": 1,


### PR DESCRIPTION
## Census before / after

| | before | after |
|---|---:|---:|
| `packages/dashboard/app/components/TaskCard.tsx` | **42** | **0** (absent from the census) |
| repo backlog | 722 | **680** |

The backlog dropped by exactly **42** — the converted count, nothing else moved.

## Shape of the conversion

Existing role helpers only. The card already receives `taskColumnFlags`, so every in-component site is a genuine trait read with the documented id fallback for the pre-load window — not a rename.

Four canonical role bindings at the top of the component, and 37 scattered comparisons collapsed onto them:

- `isDoneColumn` / `isArchived` already existed as bindings → converted in place
- `isIntakeColumn` / `isHoldColumn` were already flags-first but written **inline** → routed through the helpers, so the file has one definition of each role
- `isWipColumn` / `isReviewColumn` are new bindings that 9 `in-progress` and 7 `in-review` comparisons collapse onto

Stacked on **#2685**, which adds the `complete`/`archived`/`wip`/`review` helpers — 39 of these 42 guards had no helper to convert to before it.

## Two sites handled differently — stated, not absorbed into the count

**1. `getInReviewCompletionMs` (~line 387) — centralisation, not trait resolution.** It is a module-scope helper taking only `task`, so no flags are in scope. Passing `undefined` selects the shared fallback, which is behaviour-identical to the literal; it centralises the id and leaves the site greppable as *"still needs its flags threaded"* rather than looking already converted. Threading them is a signature change across the card's duration helpers — a separate unit of work. Labelled as such at the site.

**2. `label: column === "done"` — marked `DELIBERATE-LITERAL`, because it is not a lifecycle guard.** `column` there is the loop variable over the hardcoded `["done", "triage"]` array two lines above, so it asks *"which entry of my own literal list am I on"* in order to pick a label — not *"what role does this card's column play"*. Resolving a trait for a string this code just wrote itself would be meaningless.

The array **is** worth revisiting — it names move targets by id — but which targets a review card should offer is a behaviour question, and behaviour changes are out of scope for the fleet. Flagged rather than guessed.

## Behaviour preserved

`TaskCard` suites are **3 failed / 496 passed both with and without this change**, verified by stashing and re-running rather than by reasoning. All three are pre-existing: two CSS assertions (`'1px' to be 'medium'`, padding) and one mission badge.

`pnpm test:gate` green (10 / 158 / 487 / 71). `pnpm check:lifecycle-columns` exits 0 with the baseline re-recorded in this PR. `tsc -p tsconfig.app.json` clean. `pnpm lint` clean.

No changeset: no user-visible change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom workflow columns across task cards, including completion, archive, work-in-progress, and review states.
  * Updated task actions, status indicators, progress details, file-change counts, and move options to reflect workflow roles consistently.
  * Preserved legacy behavior when custom role information is unavailable.

* **Tests**
  * Expanded coverage for terminal and in-progress workflow role detection.

* **Chores**
  * Updated lifecycle column census baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->