### PR TITLE
fleet: executor.ts 85 → 15 (70 guards; 3 live defects incl. the reverse half-conversion) — DUPLICATE of #2689, see comment

### DIFF
--- a/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
@@ -197,3 +197,70 @@ describe("FN-5147: unusable-worktree recovery does not run on a finished or huma
     expect(recover).toHaveBeenCalledTimes(1);
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-10:30 (fleet: executor.ts wip-lane liveness family):
+
+THE INVARIANT: "is this card still executing?" is the board's WIP lane.
+
+TWO DIRECTIONS, and this is why the family is converted per method rather than by matching the text.
+Most of these guards read `column !== "in-progress"` and REFUSE when they do not match, so a renamed
+board silently disabled them (the completion handoff was deferred on every card, the deferred
+approval resume never resumed, the completed-task watchdog returned on every tick). But the rerun
+watchdog reads `column === "in-progress"` and SKIPS when it matches — so on a renamed board that one
+never skipped, and a rerun could fire on a card that was still mid-execution. A mechanical swap of
+every `!== "in-progress"` would have converted the refusals and left the admission.
+
+`resumeApprovalAfterUnwindIfNeeded` is the case pinned here: it is a private method with a single
+boolean answer and no side effects on the refusal path, so the assertion is direct.
+*/
+describe("the wip-lane liveness family resolves the board's own wip column", () => {
+  function resumeApproval(executor: TaskExecutor, taskId: string): Promise<boolean> {
+    return (executor as unknown as {
+      resumeApprovalAfterUnwindIfNeeded: (id: string) => Promise<boolean>;
+    }).resumeApprovalAfterUnwindIfNeeded(taskId);
+  }
+
+  function armed(live: Record<string, unknown>, ir: WorkflowIr | undefined) {
+    const { executor, store } = harness(ir, live);
+    // The deferral marker this method consumes, plus a stub for the dispatch it guards.
+    (executor as unknown as { approvalResumeAfterUnwind: Set<string> }).approvalResumeAfterUnwind.add(live.id as string);
+    const dispatch = vi.fn().mockResolvedValue(true);
+    (executor as unknown as Record<string, unknown>).dispatchUnpauseResume = dispatch;
+    return { executor, store, dispatch };
+  }
+
+  it("resumes a deferred approval for a card in the board's wip lane", async () => {
+    // Pre-fix: `building` !== "in-progress", so the resume refused on every renamed board.
+    const live = { id: "FN-11", column: "building" };
+    const { executor, dispatch } = armed(live, RENAMED_IR);
+
+    expect(await resumeApproval(executor, "FN-11")).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refuses a card that has LEFT the wip lane", async () => {
+    // The paired negative: the fix must not resume work on a card that moved on.
+    const live = { id: "FN-12", column: "checking" };
+    const { executor, dispatch } = armed(live, RENAMED_IR);
+
+    expect(await resumeApproval(executor, "FN-12")).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a PAUSED card in the wip lane, so the lane is not the only gate", async () => {
+    const live = { id: "FN-13", column: "building", paused: true };
+    const { executor, dispatch } = armed(live, RENAMED_IR);
+
+    expect(await resumeApproval(executor, "FN-13")).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("behaves identically on the DEFAULT board", async () => {
+    const live = { id: "FN-14", column: "in-progress" };
+    const { executor, dispatch } = armed(live, undefined);
+
+    expect(await resumeApproval(executor, "FN-14")).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
@@ -264,3 +264,44 @@ describe("the wip-lane liveness family resolves the board's own wip column", () 
     expect(dispatch).toHaveBeenCalledTimes(1);
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-11:20 (fleet: executor.ts review-lane family):
+
+THE INVARIANT: "is this card in review?" is the board's review lane.
+
+`finalizeAlreadyReviewedTask` is the case pinned here because its failure is the loudest: it returns
+"missing" — a word that reads as "the task is gone" — for a card that is sitting in review on a
+renamed board. Everything downstream of the already-reviewed finalize path was therefore dead on any
+board that renamed its merge lane, and the log line said the task could not be found.
+*/
+describe("the review-lane family resolves the board's own review column", () => {
+  function finalizeAlreadyReviewed(executor: TaskExecutor, taskId: string): Promise<string> {
+    return (executor as unknown as {
+      finalizeAlreadyReviewedTask: (id: string) => Promise<string>;
+    }).finalizeAlreadyReviewedTask(taskId);
+  }
+
+  it("does not report a review-lane card as MISSING", async () => {
+    // Pre-fix: `checking` !== "in-review", so this returned "missing" for a card plainly in review.
+    const live = { id: "FN-15", column: "checking", steps: [], workflowStepResults: [] };
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await finalizeAlreadyReviewed(executor, "FN-15")).not.toBe("missing");
+  });
+
+  it("still reports a card OUTSIDE the review lane as missing", async () => {
+    // The paired negative: the guard must still refuse a card that is not in review at all.
+    const live = { id: "FN-16", column: "building", steps: [], workflowStepResults: [] };
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await finalizeAlreadyReviewed(executor, "FN-16")).toBe("missing");
+  });
+
+  it("behaves identically on the DEFAULT board", async () => {
+    const live = { id: "FN-17", column: "in-review", steps: [], workflowStepResults: [] };
+    const { executor } = harness(undefined, live);
+
+    expect(await finalizeAlreadyReviewed(executor, "FN-17")).not.toBe("missing");
+  });
+});

--- a/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
@@ -305,3 +305,60 @@ describe("the review-lane family resolves the board's own review column", () => 
     expect(await finalizeAlreadyReviewed(executor, "FN-17")).not.toBe("missing");
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-13:30 (fleet: executor.ts — the REVERSE half-conversion):
+
+`routeGraphFailureToExecutionResume`'s move DESTINATION was already resolved from the workflow (U7's
+`resolveReboundColumnFor`) while its entry gate compared against three default-lineage literals. So on
+a renamed board the router refused before it ever reached the resolved move: a recovery that was fully
+implemented, never running.
+
+That is the mirror image of the dangerous half-conversion. The familiar direction admits a card and
+then sends it to a column the board does not declare; this direction refuses a card whose recovery
+already worked. Both are one decision reading two boards, and only the second is silent — which is
+why it survived.
+
+The gate admits three shapes, so all three are asserted plus the refusal, which is what stops a gate
+that returns true unconditionally from passing.
+*/
+describe("the execution-resume router's gate reads the same board as its destination", () => {
+  function routeResume(executor: TaskExecutor, live: Record<string, unknown>, failureValue: string): Promise<boolean> {
+    return (executor as unknown as {
+      routeGraphFailureToExecutionResume: (live: unknown, failedNode: string, failureValue: string) => Promise<boolean>;
+    }).routeGraphFailureToExecutionResume(live, "merge", failureValue);
+  }
+
+  const withIncompleteSteps = (column: string, id: string) => ({
+    id, column, worktree: "/wt", steps: [{ name: "s", status: "pending" }], workflowStepResults: [],
+  });
+
+  it("admits a review-lane card", async () => {
+    const live = withIncompleteSteps("checking", "FN-18");
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await routeResume(executor, live, "other")).toBe(true);
+  });
+
+  it("admits a HOLD-lane card that still has unfinished steps", async () => {
+    const live = withIncompleteSteps("queued", "FN-19");
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await routeResume(executor, live, "other")).toBe(true);
+  });
+
+  it("admits a WIP-lane card after a premature merge attempt", async () => {
+    // The third shape: implementation-incomplete merge failure with steps still open.
+    const live = withIncompleteSteps("building", "FN-20");
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await routeResume(executor, live, "implementation-incomplete")).toBe(true);
+  });
+
+  it("still REFUSES a card in the intake lane, which is none of the three shapes", async () => {
+    const live = withIncompleteSteps("backlog", "FN-21");
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await routeResume(executor, live, "other")).toBe(false);
+  });
+});

--- a/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-graph-failure-lanes-resolved.test.ts
@@ -1,0 +1,199 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-08:10 (fleet: executor.ts graph-failure recovery family):
+
+THE INVARIANT: every lifecycle question the graph-failure recovery family asks is answered from the
+task's OWN workflow, and the halves of one decision answer it from ONE snapshot.
+
+Two of the conversions in this family fix behaviour rather than vocabulary, and both are the
+half-conversion shape — a gate that reads the wrong board is not merely inert, it ADMITS work the
+gate existed to refuse:
+
+  1. `isReentrantPausedAbortedInFlightNode` resolved lanes at the END, for its return value, while its
+     four `in-review` eligibility gates were literals. On a renamed board those gates all read false,
+     so a card in review skipped the global-pause recheck, the `autoMerge === false` refusal, the
+     shared-branch-member arbitration and the merge-confirmed refusal — and then the lane-resolved
+     final line answered "re-entrant". FN-7214's own comment says an auto-merge-off review row must
+     stay terminal, so this was the documented invariant failing silently on any renamed board.
+
+  2. `routeUnusableWorktreeGraphFailureToRecovery` asked "already finished?" and "in review?" as three
+     literals. On a renamed board it read not-finished AND not-in-review, so recovery proceeded with
+     the FN-5147 gate skipped: an automatic recovery moving a human-review-terminal card backward.
+
+WHY THE RENAMED BOARD IS THE FIXTURE. On the default lineage every one of these guards is correct by
+coincidence — the literals ARE the board. A test on the default board passes before and after the
+change and proves nothing, which is how this class of defect survived every previous suite.
+
+REVERT PROOF, measured: restore either literal and the matching case here fails (`autoMerge:false`
+review row is admitted as re-entrant; the finished card is admitted into worktree recovery).
+*/
+import { describe, expect, it, vi } from "vitest";
+import "./executor-test-helpers.js";
+import { TaskExecutor } from "../executor.js";
+import { createMockStore } from "./executor-test-helpers.js";
+import type { WorkflowIr } from "@fusion/core";
+
+/** A board whose lifecycle columns share NO id with the default lineage. */
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "queued", name: "Queued", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", name: "Checking", traits: [{ trait: "merge" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    { id: "filed", name: "Filed", traits: [{ trait: "archived" }] },
+  ],
+} as unknown as WorkflowIr;
+
+function harness(ir: WorkflowIr | undefined, task: Record<string, unknown>, settingsOverride: Record<string, unknown> = {}) {
+  const store = createMockStore();
+  const selection = { workflowId: "wf-renamed", stepIds: [] as string[] };
+  const widened = store as unknown as Record<string, unknown>;
+  widened.getTaskWorkflowSelection = () => (ir ? selection : undefined);
+  widened.getTaskWorkflowSelectionAsync = async () => (ir ? selection : undefined);
+  widened.getWorkflowDefinition = async () => (ir ? { ir } : undefined);
+  widened.getTask = async () => task;
+  widened.getSettings = async () => ({ maxConcurrent: 4, maxWorktrees: 4, pollIntervalMs: 1000, autoMerge: true, globalPause: false, enginePaused: false, ...settingsOverride });
+  store.recordRunAuditEvent = vi.fn().mockResolvedValue(undefined);
+
+  const executor = new TaskExecutor(store as never, "/repo");
+  return { store, executor };
+}
+
+const pauseAbortResult = {
+  interruptedAbortKind: "engine-pause",
+  interruptedNodeId: "execute",
+  visitedNodeIds: ["execute"],
+  context: {},
+} as never;
+
+function reentrant(executor: TaskExecutor, live: unknown): Promise<boolean> {
+  return (executor as unknown as {
+    isReentrantPausedAbortedInFlightNode: (
+      live: unknown, result: unknown, provenance: string, pausedAborted: boolean, userCanceled: boolean,
+    ) => Promise<boolean>;
+  }).isReentrantPausedAbortedInFlightNode(live, pauseAbortResult, "engine-abort", true, false);
+}
+
+describe("FN-7214: an auto-merge-off review row stays terminal on a RENAMED board", () => {
+  it("refuses re-entry for a review-lane card with autoMerge:false", async () => {
+    /*
+    The measured pre-fix behaviour: the four `in-review` gates compared against the literal, `checking`
+    is not `in-review`, so every refusal was skipped — and the final lane-resolved line then matched
+    `resumeLanes.review` and returned TRUE. The card was re-entered behind a human review gate.
+    */
+    const live = { id: "FN-1", column: "checking", autoMerge: false, graphResumeRetryCount: 0 };
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await reentrant(executor, live)).toBe(false);
+  });
+
+  it("still admits a review-lane card whose auto-merge is ON, so the fix is not 'refuse review rows'", async () => {
+    // The paired positive. A gate that returns false unconditionally would pass the case above.
+    const live = { id: "FN-2", column: "checking", autoMerge: true, graphResumeRetryCount: 0 };
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await reentrant(executor, live)).toBe(true);
+  });
+
+  it("keeps the same answers on the DEFAULT board, where the literals happened to be right", async () => {
+    // The conversion must not change behaviour where the old spelling was already correct.
+    const offLive = { id: "FN-3", column: "in-review", autoMerge: false, graphResumeRetryCount: 0 };
+    const onLive = { id: "FN-4", column: "in-review", autoMerge: true, graphResumeRetryCount: 0 };
+
+    expect(await reentrant(harness(undefined, offLive).executor, offLive)).toBe(false);
+    expect(await reentrant(harness(undefined, onLive).executor, onLive)).toBe(true);
+  });
+
+  it("refuses a card in the board's COMPLETE column — and this one passes either way", async () => {
+    /*
+    HONEST LABEL, because I checked: reverting the terminal-pair literal here does NOT redden this case.
+    The method's final line already answers "is the card in a resume lane", and `shipped` is not one, so
+    the terminal guard is redundant *in this method*. Kept as the paired negative — it pins that a
+    finished card is refused however the refusal is reached — but it is not evidence for the conversion.
+    The terminal conversions that DO change behaviour are proven in the worktree-recovery block below.
+    */
+    const live = { id: "FN-5", column: "shipped", autoMerge: true, graphResumeRetryCount: 0 };
+    const { executor } = harness(RENAMED_IR, live);
+
+    expect(await reentrant(executor, live)).toBe(false);
+  });
+});
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-08:40:
+ASSERT THE CALL, NOT THE RETURN VALUE. My first version of this block asserted
+`routeUnusableWorktreeGraphFailureToRecovery(...) === false` and passed with the literals restored —
+the pre-fix path ran the whole recovery and then returned false for an unrelated reason (the mock's
+outcome is not `requeue-todo`). A revert check that stays green is the signal I keep re-learning to
+respect: the assertion was not touching the behaviour it claimed to cover.
+
+Spying on `recoverMissingWorktreeSessionStartFailure` asks the question the guard actually decides —
+was recovery ATTEMPTED on this card? — and it discriminates in both directions.
+*/
+describe("FN-5147: unusable-worktree recovery does not run on a finished or human-review card (RENAMED board)", () => {
+  const SESSION_FAILURE = "Refusing to start coding agent in missing worktree: /gone";
+
+  function harnessWithSpy(live: Record<string, unknown>, settingsOverride: Record<string, unknown> = {}) {
+    const { executor, store } = harness(RENAMED_IR, live, settingsOverride);
+    const recover = vi.fn().mockResolvedValue("requeue-todo");
+    (executor as unknown as Record<string, unknown>).recoverMissingWorktreeSessionStartFailure = recover;
+    return { executor, store, recover };
+  }
+
+  function route(executor: TaskExecutor, live: Record<string, unknown>): Promise<boolean> {
+    return (executor as unknown as {
+      routeUnusableWorktreeGraphFailureToRecovery: (task: unknown, live: unknown, result: unknown) => Promise<boolean>;
+    }).routeUnusableWorktreeGraphFailureToRecovery({ id: live.id }, live, {
+      context: { "node:execute:error": SESSION_FAILURE },
+      visitedNodeIds: ["execute"],
+    });
+  }
+
+  it("does not attempt recovery for a card in the board's COMPLETE column", async () => {
+    // Pre-fix: `shipped` is neither `done` nor `archived`, so recovery ran on a finished card.
+    const live = { id: "FN-7", column: "shipped", worktree: "/gone" };
+    const { executor, recover } = harnessWithSpy(live);
+
+    expect(await route(executor, live)).toBe(false);
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt recovery for a card in the board's ARCHIVED column", async () => {
+    const live = { id: "FN-8", column: "filed", worktree: "/gone" };
+    const { executor, recover } = harnessWithSpy(live);
+
+    expect(await route(executor, live)).toBe(false);
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it("applies the FN-5147 auto-merge gate to the board's REVIEW lane", async () => {
+    /*
+    The half-conversion in its most consequential form: pre-fix the `in-review` literal did not match
+    `checking`, so the auto-merge-off refusal never ran and an automatic recovery moved a
+    human-review-terminal card backward. `allowsAutoMergeProcessing` is what must be consulted, and it
+    can only be reached once the review lane is resolved.
+    */
+    /*
+    THE GATE KEYS ON THE GLOBAL SETTING, not on `task.autoMerge`: `allowsAutoMergeProcessing` is
+    `(settings.autoMerge !== false || task.autoMerge === true) && no manual open PR`. My first fixture
+    set only `task.autoMerge: false` and the case failed — the recovery ran, correctly, because a
+    per-task false does not withdraw a card from automatic processing. Correcting the fixture rather
+    than the assertion: FN-5147 is about the OPERATOR turning auto-merge off for the project.
+    */
+    const live = { id: "FN-9", column: "checking", worktree: "/gone" };
+    const { executor, recover } = harnessWithSpy(live, { autoMerge: false });
+
+    expect(await route(executor, live)).toBe(false);
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it("STILL recovers a wip-lane card, so the fix is not 'never recover'", async () => {
+    // The paired positive: the guards above must not have turned the recovery path off wholesale.
+    const live = { id: "FN-10", column: "building", worktree: "/gone" };
+    const { executor, recover } = harnessWithSpy(live);
+
+    expect(await route(executor, live)).toBe(true);
+    expect(recover).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -3594,7 +3594,12 @@ export class TaskExecutor {
         // Handle unpause of an in-progress task with no active session.
         // Approval can be decided while the old session is still unwinding;
         // remember that edge instead of losing the only task:updated event.
-        if (!task.paused && task.column === "in-progress" && this.approvalSuspended.has(task.id)) {
+        /* FNXC:WorkflowLifecycleColumns 2026-08-01-13:10 (fleet: executor.ts unpause listener): both
+           checks in this listener ask "is this card still in the wip lane?"; one snapshot for the pair so
+           the approval-suspension edge and the orphaned-resume branch cannot disagree. With the literal,
+           neither fired on a renamed board — an unpaused card with no active session was never resumed. */
+        const unpauseWipLane = (await this.resolveResumeLanes(task.id)).wip;
+        if (!task.paused && task.column === unpauseWipLane && this.approvalSuspended.has(task.id)) {
           if (
             this.executing.has(task.id)
             || this.activeSessions.has(task.id)
@@ -3612,7 +3617,7 @@ export class TaskExecutor {
         // dispatchUnpauseResume owns the terminal-failure and duplicate guards.
         if (
           !task.paused
-          && task.column === "in-progress"
+          && task.column === unpauseWipLane
           && !this.activeSessions.has(task.id)
           && !this.activeStepExecutors.has(task.id)
           && !this.activeWorkflowStepSessions.has(task.id)
@@ -11833,7 +11838,21 @@ export class TaskExecutor {
     const implementationIncompleteMergeFailure = this.isMergeGraphFailure(failedNode) && failureValue === "implementation-incomplete";
     if (implementationIncompleteMergeFailure && !incompleteSteps) return false;
     const prematureMergeWithIncompleteSteps = implementationIncompleteMergeFailure && incompleteSteps;
-    if (live.column !== "in-review" && !(incompleteSteps && live.column === "todo") && !(prematureMergeWithIncompleteSteps && live.column === "in-progress")) return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-13:00 (fleet: executor.ts — the REVERSE half-conversion):
+    THE DESTINATION WAS ALREADY RESOLVED HERE AND THE GATE WAS NOT. `resolveReboundColumnFor` below picks
+    the board's rebound column (U7), but this gate compared against three default-lineage literals — so on
+    a renamed board the router refused before ever reaching the resolved move. That is the mirror image of
+    the dangerous half-conversion: instead of admitting a card and sending it nowhere, it refuses a card
+    whose recovery was fully implemented. Same one-decision-two-boards defect, opposite direction.
+
+    Three lanes, one snapshot: proceed for a card in review, OR in the hold lane with unfinished steps, OR
+    in the wip lane after a premature merge attempt.
+    */
+    const resumeRouterLanes = await this.resolveResumeLanes(live.id);
+    if (live.column !== resumeRouterLanes.review
+      && !(incompleteSteps && live.column === resumeRouterLanes.hold)
+      && !(prematureMergeWithIncompleteSteps && live.column === resumeRouterLanes.wip)) return false;
 
     const message = incompleteSteps
       ? `Workflow graph failed at node '${failedNode}'${failureValue ? ` (${failureValue})` : ""} with incomplete steps — moved back to todo for execution resume`
@@ -14175,7 +14194,9 @@ export class TaskExecutor {
               }
               const hasExplicitWorktreeBinding = typeof liveTask.worktree === "string" || liveTask.worktree === null;
               const hasExplicitBranchBinding = typeof liveTask.branch === "string" || liveTask.branch === null;
-              const worktreeContractIntact = liveTask.column === "in-progress"
+              /* FNXC:WorkflowLifecycleColumns 2026-08-01-13:15 (fleet): the contract holds while the card
+                 is in ITS board's wip lane; the literal made every renamed-board retry look reclaimed. */
+              const worktreeContractIntact = liveTask.column === (await this.resolveResumeLanes(task.id)).wip
                 && !liveTask.paused
                 && (!hasExplicitWorktreeBinding || liveTask.worktree === worktreePath)
                 && (!hasExplicitBranchBinding || (typeof liveTask.branch === "string" && liveTask.branch.length > 0));
@@ -14642,7 +14663,10 @@ export class TaskExecutor {
         this.clearPausedAborted(task.id);
         const latestTask = await this.store.getTask(task.id);
         if (
-          latestTask?.column === "todo" &&
+          /* FNXC:WorkflowLifecycleColumns 2026-08-01-13:18 (fleet): the HOLD lane — this recognises a card
+             the abort already parked with its progress preserved, and skipping the cleanup is what keeps
+             that progress. On a renamed board the cleanup ran anyway and discarded it. */
+          latestTask?.column === (await this.resolveResumeLanes(task.id)).hold &&
           latestTask.paused === true &&
           ((latestTask.currentStep ?? 0) > 0 || latestTask.steps?.some((step) => step.status === "done" || step.status === "in-progress"))
         ) {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -2336,7 +2336,10 @@ export class TaskExecutor {
 
   private async finalizeAlreadyReviewedTask(taskId: string): Promise<"merged" | "blocked" | "missing"> {
     const latestTask = await this.store.getTask(taskId);
-    if (!latestTask || latestTask.column !== "in-review") {
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-10:55 (fleet: executor.ts review-lane family): the board's
+       own review lane. Spelled as the literal, this reported "missing" for every card on a renamed board
+       and the already-reviewed finalize never ran. */
+    if (!latestTask || latestTask.column !== (await this.resolveResumeLanes(taskId)).review) {
       return "missing";
     }
 
@@ -4363,7 +4366,11 @@ export class TaskExecutor {
       the task back for remediation, so `in-review` must bounce back exactly like
       `in-progress` regardless of the column the completion race left it in.
       */
-      if (latestTask.column === "in-progress" || latestTask.column === "in-review") {
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-10:58 (fleet): both lanes from ONE snapshot — the comment
+         above says in-review must bounce EXACTLY like in-progress, so the two must be resolved together
+         or the bounce handles one lane and throws on the other, which is the bug that comment describes. */
+      const bounceLanes = await this.resolveResumeLanes(taskId);
+      if (latestTask.column === bounceLanes.wip || latestTask.column === bounceLanes.review) {
         const originalExecutionStartedAt = latestTask.executionStartedAt;
         // Preserve step progress across the in-progress/in-review → todo hop:
         // moveTask's default reopen-to-todo path resets every step to
@@ -4624,8 +4631,12 @@ export class TaskExecutor {
     // FNXC:Lifecycle 2026-07-16-21:40: FN-8141 — the step-status "already complete" branch
     // must not treat skip-bypass-tainted skips as completion; an accepted done / in-review
     // column are honest completion signals and stay unaffected.
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-11:02 (fleet): SYNCHRONOUS predicate, so the sync planner
+       lanes; a board with no review lane cannot hold a card in review, so an undefined lane simply does
+       not contribute this completion signal (the other two still apply). */
+    const reviewLane = resolvePlannerLanes(this.store, task.id).review;
     return taskDone
-      || task.column === "in-review"
+      || (reviewLane !== undefined && task.column === reviewLane)
       || (this.isTaskWorkComplete(task) && !evaluateSkipBypassTaint(task).blocked);
   }
 
@@ -4649,7 +4660,7 @@ export class TaskExecutor {
 
     await this.persistTokenUsage(task.id);
 
-    if (liveTask.column === "in-review") {
+    if (liveTask.column === (await this.resolveResumeLanes(task.id)).review) {
       this.clearCompletedTaskWatchdog(task.id);
       this.signalTaskComplete(liveTask);
       return true;

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -2406,7 +2406,11 @@ export class TaskExecutor {
       return true;
     }
 
-    if ((latestTask && latestTask.column !== "in-progress") || this.userCanceledTaskIds.has(taskId)) {
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-10:05 (fleet: executor.ts wip-lane liveness family):
+       "still executing" is the board's WIP lane. Spelled as the literal, a renamed board deferred EVERY
+       completion handoff — the card was never in `in-progress`, so this read "no longer active" for a
+       card that was actively executing, and the handoff was dropped with a log line. */
+    if ((latestTask && latestTask.column !== (await this.resolveResumeLanes(taskId)).wip) || this.userCanceledTaskIds.has(taskId)) {
       this.clearCompletedTaskWatchdog(taskId);
       executorLog.log(`${taskId}: completion handoff deferred — task no longer active (${context})`);
       await this.store.logEntry(
@@ -3337,7 +3341,10 @@ export class TaskExecutor {
       executorLog.warn(`${taskId}: failed to read latest task state for deferred approval resume: ${error instanceof Error ? error.message : String(error)}`);
       return false;
     }
-    if (latestTask.paused || latestTask.userPaused || latestTask.column !== "in-progress") return false;
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-10:07 (fleet): the deferred approval resume only runs
+       for a card still in its board's wip lane; the literal made it refuse on every renamed board. */
+    if (latestTask.paused || latestTask.userPaused
+      || latestTask.column !== (await this.resolveResumeLanes(taskId)).wip) return false;
     return this.dispatchUnpauseResume(latestTask);
   }
 
@@ -4251,7 +4258,11 @@ export class TaskExecutor {
           return;
         }
 
-        if (!currentTask || currentTask.column !== "in-progress" || currentTask.paused) {
+        /* FNXC:WorkflowLifecycleColumns 2026-08-01-10:09 (fleet): the watchdog fires only while the card
+           is still in the wip lane. On a renamed board it returned immediately every tick, so the
+           completed-task watchdog never did anything. */
+        if (!currentTask || currentTask.paused
+          || currentTask.column !== (await this.resolveResumeLanes(taskId)).wip) {
           return;
         }
         if (!this.isTaskWorkComplete(currentTask)) {
@@ -4453,7 +4464,13 @@ export class TaskExecutor {
         return;
       }
 
-      if (!currentTask || currentTask.paused || currentTask.column === "in-progress") {
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-10:11 (fleet): the inverse of the guard above — the rerun
+         watchdog skips a card that is STILL executing. Note the direction: with the literal on a renamed
+         board this guard never matched, so the rerun could fire on a card mid-execution. Converting an
+         inverted guard changes behaviour in the opposite direction from its neighbours, which is why the
+         family is converted per method rather than by pattern-matching the text. */
+      if (!currentTask || currentTask.paused
+        || currentTask.column === (await this.resolveResumeLanes(taskId)).wip) {
         return;
       }
 

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -6426,7 +6426,12 @@ export class TaskExecutor {
           });
         }
         const live = await this.store.getTask(task.id).catch(() => task);
-        if ((live as TaskDetail).mergeDetails?.mergeConfirmed === true && (live as TaskDetail).column !== "done") {
+        /* FNXC:WorkflowLifecycleColumns 2026-08-01-12:35 (fleet): the board's COMPLETE column, not the
+           terminal union — the union carries the legacy ids, which would read a card in a column merely
+           NAMED `done` as already finalized and skip the finalize. Same distinction as the finalize guard
+           in handleGraphFailure. */
+        const completedLane = resolvePlannerLanes(this.store, task.id).complete ?? "done";
+        if ((live as TaskDetail).mergeDetails?.mergeConfirmed === true && (live as TaskDetail).column !== completedLane) {
           await this.finalizeMergeConfirmedWorkflowGraphTask(task.id, "graph-completed");
         }
         await this.advanceNoMergeWorkflowToCompleteColumn(live as TaskDetail);
@@ -7906,7 +7911,10 @@ export class TaskExecutor {
     A prior review handoff can move a graph-native workflow into its merge column before this boundary projects successful node results onto the legacy checklist. Preserve the no-move behavior, but do not return until the projection has run.
     */
     const alreadyAtMergeColumn = live.column === targetColumn;
-    if (live.column === "done") return live;
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-12:42 (fleet): "already finished, do not move it" — the
+       TERMINAL union (not the complete column) because over-inclusion is the safe direction for a refusal
+       to move, while under-inclusion moves a finished card out of its terminal column. */
+    if ((await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) return live;
     if (live.paused || live.userPaused) return live;
 
     /*
@@ -9054,7 +9062,11 @@ export class TaskExecutor {
 
   private async finalizeMergeConfirmedWorkflowGraphTask(taskId: string, reason: string): Promise<boolean> {
     const live = await this.store.getTask(taskId).catch(() => null);
-    if (!live || live.mergeDetails?.mergeConfirmed !== true || live.column === "done") return false;
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-12:38 (fleet): merge confirmation is durable proof of
+       landing, and this finalizes the row from any NON-COMPLETE column — so the comparison is the board's
+       complete column. With the literal, a renamed board re-finalized a row that was already complete. */
+    const finalizeCompleteLane = resolvePlannerLanes(this.store, taskId).complete ?? "done";
+    if (!live || live.mergeDetails?.mergeConfirmed !== true || live.column === finalizeCompleteLane) return false;
     /*
     FNXC:WorkflowMerge 2026-06-29-08:32:
     A workflow graph merge node can await a successful ProjectEngine merge request and return before the row reaches `done`. Merge confirmation is durable proof of landing; the executor must finalize that row from any non-terminal column instead of re-running parse or clearing mergeDetails.
@@ -12381,7 +12393,17 @@ export class TaskExecutor {
     // executor can still recover by falling through to the fresh-worktree
     // path below, but we emit a loud audit record so these states stop being
     // silent.
-    if (task.column === "in-progress" && task.mergeDetails?.mergeConfirmed === true) {
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-12:30 (fleet: executor.ts execute() preflight):
+    THREE DRIFT CHECKS, ONE SNAPSHOT. All three ask "is this card in the wip lane, in a state it should
+    not be in?" — merge-confirmed while still executing, stale mergeDetails, and in-wip with no worktree.
+    On a renamed board none of them fired, so every recovery they perform (finalize the half-landed row,
+    reset stale merge state, rebuild a missing worktree) silently stopped happening. The third is the one
+    whose own message says it "usually indicates a partial updateTask/moveTask sequence failed" — a
+    diagnostic that could never print on a renamed board.
+    */
+    const preflightWipLane = (await this.resolveResumeLanes(task.id)).wip;
+    if (task.column === preflightWipLane && task.mergeDetails?.mergeConfirmed === true) {
       if (await this.finalizeMergeConfirmedWorkflowGraphTask(task.id, "execute-preflight")) {
         this.executing.delete(task.id);
         executingTaskLock.release(task.id);
@@ -12390,7 +12412,7 @@ export class TaskExecutor {
       }
     }
 
-    if (task.column === "in-progress" && task.mergeDetails) {
+    if (task.column === preflightWipLane && task.mergeDetails) {
       executorLog.warn(`${task.id}: stale mergeDetails found while executing in-progress task — resetting merge state before continuing`);
       task = await this.cleanupMergeStateForReverification(
         task,
@@ -12398,7 +12420,7 @@ export class TaskExecutor {
       );
     }
 
-    if (task.column === "in-progress" && !task.worktree) {
+    if (task.column === preflightWipLane && !task.worktree) {
       executorLog.error(
         `${task.id}: drift detected — task is in-progress with no worktree. ` +
           `Recovering by creating a fresh worktree. This usually indicates a partial ` +

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -13340,8 +13340,14 @@ export class TaskExecutor {
               // was unwinding; continuing the cleanup would clobber a valid
               // recovery (see the analogous block in the outer finally for the
               // full reasoning).
+              /* FNXC:WorkflowLifecycleColumns 2026-08-01-11:40 (fleet: executor.ts stuck-requeue family):
+                 "has a concurrent recovery already moved this card on?" — the pre-completion lanes are the
+                 board's wip and hold. Spelled as literals, a renamed board answered "moved on" for a card
+                 that was still executing, so the stuck-requeue cleanup was skipped every time; the log line
+                 then blamed a concurrent recovery that had not happened. */
               const latestTask = await this.store.getTask(task.id);
-              if (latestTask.column !== "in-progress" && latestTask.column !== "todo") {
+              const requeueLanes = await this.resolveResumeLanes(task.id);
+              if (latestTask.column !== requeueLanes.wip && latestTask.column !== requeueLanes.hold) {
                 executorLog.log(
                   `${task.id} stuck-requeue skipped — task is now in '${latestTask.column}' (recovered concurrently)`,
                 );
@@ -15301,7 +15307,8 @@ export class TaskExecutor {
           let cleanupLockHeld = true;
           try {
             const latestTask = await this.store.getTask(task.id);
-            if (latestTask.column === "in-progress" || latestTask.column === "todo") {
+            const continuationLanes = await this.resolveResumeLanes(task.id);
+            if (latestTask.column === continuationLanes.wip || latestTask.column === continuationLanes.hold) {
               await this.store.updateTask(task.id, {
                 sessionFile: null,
                 status: null,
@@ -15353,7 +15360,8 @@ export class TaskExecutor {
           // all step progress reset, undoing valid completion. Skip the
           // entire cleanup if the column has moved on past in-progress/todo.
           const latestTask = await this.store.getTask(task.id);
-          if (latestTask.column !== "in-progress" && latestTask.column !== "todo") {
+          const outerRequeueLanes = await this.resolveResumeLanes(task.id);
+          if (latestTask.column !== outerRequeueLanes.wip && latestTask.column !== outerRequeueLanes.hold) {
             executorLog.log(
               `${task.id} stuck-requeue skipped — task is now in '${latestTask.column}' (recovered concurrently)`,
             );
@@ -16881,20 +16889,44 @@ export class TaskExecutor {
 
         const latestTask = await store.getTask(taskId);
         let latestColumn = latestTask.column;
-        if (latestColumn === "todo") {
+        /*
+        FNXC:WorkflowLifecycleColumns 2026-08-01-12:00 (fleet: executor.ts — the GUARD AND ITS DESTINATION
+        in one change):
+        `fn_task_done` arriving while the card still rests in the hold lane promotes it into the wip lane so
+        the completion handoff has somewhere to run. Converting the guard alone is the half-conversion that
+        this program's worst regressions are made of: a lane-resolved guard admitting a card and then a
+        literal `moveTask(..., "in-progress")` sending it to a column the board does not declare. The move
+        is REJECTED there, and the card is left mid-promotion with its completion already logged.
+
+        So the destination comes from the same snapshot, and it comes from `resolvePlannerLanes` rather than
+        `resolveResumeLanes` precisely because a MOVE needs a column that exists: `PlannerLanes` leaves `wip`
+        undefined when the board declares no wip lane, and the promotion is then skipped with a log line
+        instead of issuing a move to an invented column. The completion handoff below is gated on the wip
+        lane anyway, so skipping is the honest outcome rather than a silent one.
+        */
+        const donePromotionLanes = resolvePlannerLanes(store, taskId);
+        const doneWipLane = donePromotionLanes.wip;
+        if (latestColumn === donePromotionLanes.hold && doneWipLane !== undefined) {
           await store.logEntry(
             taskId,
             hardPauseActive
-              ? "fn_task_done called while task was in todo during pause — promoting to in-progress for deferred completion handoff"
-              : "fn_task_done called while task was in todo — promoting to in-progress before completion handoff",
+              ? `fn_task_done called while task was in ${latestColumn} during pause — promoting to ${doneWipLane} for deferred completion handoff`
+              : `fn_task_done called while task was in ${latestColumn} — promoting to ${doneWipLane} before completion handoff`,
             undefined,
             this.getRunContextFor(taskId),
           );
-          await store.moveTask(taskId, "in-progress");
-          latestColumn = "in-progress";
+          await store.moveTask(taskId, doneWipLane);
+          latestColumn = doneWipLane;
+        } else if (latestColumn === donePromotionLanes.hold) {
+          await store.logEntry(
+            taskId,
+            `fn_task_done called while task was in ${latestColumn}, but this workflow declares no wip column — leaving the card where it is`,
+            undefined,
+            this.getRunContextFor(taskId),
+          );
         }
 
-        if (latestColumn === "in-progress" && !hardPauseActive) {
+        if (latestColumn === doneWipLane && !hardPauseActive) {
           this.scheduleCompletedTaskWatchdog(taskId, "fn_task_done");
         }
 
@@ -20932,7 +20964,9 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
             `${taskId} force-requeue could not read latest task state: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
-        if (latestColumn && latestColumn !== "in-progress") {
+        /* FNXC:WorkflowLifecycleColumns 2026-08-01-11:45 (fleet): the board's wip lane; with the literal a
+           renamed board skipped every force-requeue as "recovered concurrently". */
+        if (latestColumn && latestColumn !== (await this.resolveResumeLanes(taskId)).wip) {
           executorLog.log(
             `${taskId} force-requeue skipped — task is now in '${latestColumn}' (recovered concurrently)`,
           );

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -10801,6 +10801,20 @@ export class TaskExecutor {
       }
       const live = loadedLive;
       /*
+      FNXC:WorkflowLifecycleColumns 2026-08-01-09:10 (fleet: executor.ts graph-failure recovery family):
+      ONE LANE SNAPSHOT AND ONE MEMO FOR THE WHOLE METHOD. `handleGraphFailure` asked "is the card still
+      in the wip lane?" and "did the abort bounce it back to the hold lane?" as the default lineage's
+      literals in five places, and separately created a lane memo further down for the re-entry
+      classifiers — so the classifiers read the board while the surrounding branches read the default
+      names. Declared here, where `live` first exists, and threaded into the classifiers via the memo
+      that was already there, so every half of this decision reads the same board.
+
+      The `todo` branches below are the HOLD lane, not intake: FN-6782's benign re-queue is about a card
+      the abort bounced back to wait for a fresh dispatch.
+      */
+      const resumeLanesMemo: { lanes?: { hold: string; wip: string; review: string } } = {};
+      const failureLanes = await this.resolveResumeLanes(live.id, resumeLanesMemo);
+      /*
       FNXC:Lifecycle 2026-07-16-21:22:
       FN-8141 follow-up 1 — an honest `fn_task_done(outcome="blocked")` park (status="failed",
       error "BLOCKED: <reason>", executor ~14657) must SURVIVE the same graph-teardown machinery
@@ -10944,7 +10958,21 @@ export class TaskExecutor {
         await this.persistTokenUsage(task.id);
         return;
       }
-      if (live.mergeDetails?.mergeConfirmed === true && live.column !== "done") {
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-08-01-09:30 (fleet: executor.ts):
+      "MERGE CONFIRMED BUT NOT YET IN THE FINISHED COLUMN" — the board's COMPLETE column, resolved
+      from its own IR. `resolveTerminalColumnsFor` is deliberately NOT used here: it is a UNION with the
+      legacy ids (so a silently-substituted default IR still recognises them), which is the right
+      answer for "is this card finished?" and the wrong one for "is this card in the ONE column
+      finalize would move it to" — the union would treat a card in a column merely NAMED `done` as
+      already finalized and skip the finalize.
+
+      A board that declares no complete column keeps the legacy literal: this guard's false branch
+      skips finalize entirely, so refusing here would strand a merge-confirmed card, and
+      `finalizeMergeConfirmedWorkflowGraphTask` resolves its own move target anyway.
+      */
+      const completeColumn = resolvePlannerLanes(this.store, live.id).complete;
+      if (live.mergeDetails?.mergeConfirmed === true && live.column !== (completeColumn ?? "done")) {
         if (await this.finalizeMergeConfirmedWorkflowGraphTask(live.id, "graph-failure")) {
           await this.persistTokenUsage(task.id);
           return;
@@ -10969,7 +10997,7 @@ export class TaskExecutor {
       FN-6647 closes the remaining durability gap by deriving already-finalized completion from the persisted task row: non-in-progress column, completed steps, no live pause/status/error, and the finalize-to-review log entry. The volatile `completionFinalizedTaskIds` marker still helps within one executor lifecycle, but teardown/restart loss must not reclassify a completed in-review row as a hard-cancel pause abort.
       */
       const alreadyFinalizedToReview = Boolean(
-        live.column !== "in-progress"
+        live.column !== failureLanes.wip
           && persistedCompletedProgress
           && live.status == null
           && live.error == null
@@ -10993,7 +11021,7 @@ export class TaskExecutor {
       const completionFinalized = completionFinalizeAborted || this.completionFinalizedTaskIds.has(task.id) || alreadyFinalizedToReview;
       const suppressFinalizedCompletionAbort = Boolean(
         completionFinalized
-          && live.column !== "in-progress"
+          && live.column !== failureLanes.wip
           && !live.userPaused
           // FN-6648: `paused !== true` intentionally dropped here too — the
           // suppression is already gated on `completionFinalized` (completed
@@ -11024,8 +11052,10 @@ export class TaskExecutor {
       FNXC:WorkflowLifecycleColumns 2026-07-31-01:05 (PR #2640 review, greptile P2): one lane
       snapshot for one recovery decision — see `resolveResumeLanes`. Eligibility and re-entry are two
       halves of the SAME decision and must not read different boards.
+
+      FNXC:WorkflowLifecycleColumns 2026-08-01-09:12 (fleet): the memo is now declared at the top of
+      the method beside `failureLanes`, so the branches AROUND these classifiers share the snapshot too.
       */
-      const resumeLanesMemo: { lanes?: { hold: string; wip: string; review: string } } = {};
       if (genuinePauseAbort && await this.isReentrantPausedAbortedInFlightNode(live, result, abortProvenance, pausedAborted, this.userCanceledTaskIds.has(task.id), resumeLanesMemo)) {
         if (await this.reenterPausedAbortedWorkflowNode(live, result, abortProvenance, resumeLanesMemo)) {
           return;
@@ -11119,7 +11149,7 @@ export class TaskExecutor {
         // the human-readable provenance label is ever revised.
         const isEngineInternalAbort =
           pausedAborted && !live.paused && !live.userPaused && abortProvenance !== "global-pause";
-        if (live.column !== "in-progress") {
+        if (live.column !== failureLanes.wip) {
           // FN-6782: a pause/resume abort that has left the task back in `todo`
           // is benign — the work is simply re-queued for a fresh dispatch, not
           // stranded. Parking it `status: "failed"` (operator action required)
@@ -11130,7 +11160,7 @@ export class TaskExecutor {
           // dispatch starts clean, log, and return WITHOUT parking failed. The
           // operator-action failure is preserved only for genuinely stranded
           // non-todo columns (e.g. in-review), per FN-6478.
-          if (live.column === "todo") {
+          if (live.column === failureLanes.hold) {
             this.clearPausedAborted(task.id);
             // FNXC:WorkflowLifecycle 2026-06-20-00:00: FN-6782 leak fix — a task
             // parked back to `todo` must not keep pinning its in-memory worktree
@@ -11197,7 +11227,7 @@ export class TaskExecutor {
                         resumeTask.deletedAt
                         || resumeTask.paused
                         || resumeTask.userPaused
-                        || resumeTask.column !== "todo"
+                        || resumeTask.column !== failureLanes.hold
                       ) {
                         executorLog.log(
                           `${task.id}: skipping pause-abort auto-continue — task is now ${resumeTask.deletedAt ? "deleted" : resumeTask.paused || resumeTask.userPaused ? "paused" : `in '${resumeTask.column}'`} at retry fire time`,

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -5459,7 +5459,7 @@ export class TaskExecutor {
     source: { source: "graph-entry" | "workflow-step"; nodeId?: string },
   ): Promise<void> {
     const currentTask = await this.store.getTask(task.id).catch(() => null);
-    if (!currentTask || this.isRequiredArtifactRecoveryProtected(currentTask)) return;
+    if (!currentTask || await this.isRequiredArtifactRecoveryProtected(currentTask)) return;
     task = currentTask;
     const decision = computeRecoveryDecision({
       recoveryRetryCount: task.recoveryRetryCount,
@@ -5490,7 +5490,7 @@ export class TaskExecutor {
 
     if (!decision.shouldRetry) {
       const liveTask = await this.store.getTask(task.id).catch(() => null);
-      if (!liveTask || this.isRequiredArtifactRecoveryProtected(liveTask)) return;
+      if (!liveTask || await this.isRequiredArtifactRecoveryProtected(liveTask)) return;
       const error = `REQUIRED_ARTIFACT_RECOVERY_EXHAUSTED: ${artifactKeys.join(", ")} remained missing after ${MAX_RECOVERY_RETRIES} automatic planning retries.`;
       await this.store.logEntry(task.id, error, undefined, context);
       await this.store.updateTask(task.id, {
@@ -5512,7 +5512,7 @@ export class TaskExecutor {
     this.workflowLifecycleMovesInFlight.add(task.id);
     try {
       const liveTask = await this.store.getTask(task.id).catch(() => null);
-      if (!liveTask || this.isRequiredArtifactRecoveryProtected(liveTask)) return;
+      if (!liveTask || await this.isRequiredArtifactRecoveryProtected(liveTask)) return;
       await moveTaskToReplanColumn(this.store, { id: task.id, column: liveTask.column }, replanColumn);
     } finally {
       this.workflowLifecycleMovesInFlight.delete(task.id);
@@ -5526,15 +5526,30 @@ export class TaskExecutor {
     }, context);
   }
 
-  private isRequiredArtifactRecoveryProtected(task: Task): boolean {
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-08-01-13:50 (fleet: executor.ts — made ASYNC to own its resolution):
+  This predicate protects a card from artifact-recovery replanning, and three of its four conditions are
+  lifecycle columns: the terminal pair, and a review row whose auto-merge is off (a human owns it).
+  Spelled as literals, every one of them read false on a renamed board — so a finished card, or a review
+  row a human was holding, could be moved to the replan column and have its status rewritten to
+  needs-replan.
+
+  ASYNC rather than lane-parameters: all four callers already `await store.getTask` immediately before
+  calling this, so there is no new I/O ordering, and a parameter list would put the resolution in four
+  places that must agree. The archived half is why the SYNC planner-lane resolver was not an option — it
+  exposes no archived lane — and widening a shared resolver from inside a call-site sweep is the kind of
+  scope creep that makes a conversion unreviewable.
+  */
+  private async isRequiredArtifactRecoveryProtected(task: Task): Promise<boolean> {
+    const terminalColumns = await resolveTerminalColumnsFor(this.store, task.id);
+    const reviewLane = (await this.resolveResumeLanes(task.id)).review;
     return Boolean(
       task.deletedAt
       || task.paused
       || task.userPaused === true
-      || task.column === "done"
-      || task.column === "archived"
+      || terminalColumns.includes(task.column)
       || task.mergeDetails?.mergeConfirmed === true
-      || (task.column === "in-review" && task.autoMerge === false),
+      || (task.column === reviewLane && task.autoMerge === false),
     );
   }
 
@@ -10952,7 +10967,7 @@ export class TaskExecutor {
             void (async () => {
               try {
                 const resumeTask = await this.store.getTask(task.id);
-                if (this.isRequiredArtifactRecoveryProtected(resumeTask) || resumeTask.status === "failed") return;
+                if (await this.isRequiredArtifactRecoveryProtected(resumeTask) || resumeTask.status === "failed") return;
                 await this.execute(resumeTask);
               } catch (err) {
                 executorLog.error(`Failed required-artifact read retry for ${task.id}:`, err);

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -9959,7 +9959,20 @@ export class TaskExecutor {
   ): Promise<boolean> {
     if (live.deletedAt) return false;
     if (live.paused || live.userPaused === true) return false;
-    if (live.column === "done" || live.column === "archived") return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-06:10 (fleet: executor.ts graph-failure recovery family):
+    ONE LANE SNAPSHOT FOR THE WHOLE DECISION. This method asked two lifecycle questions as three
+    literals — "already finished?" and "in review, so FN-5147 applies?" — and on a renamed board both
+    answered wrong in the SAME direction: not-finished (so recovery proceeded) and not-in-review (so
+    the auto-merge-off gate was skipped). That combination is the one FN-5147 exists to prevent: a
+    human-review-terminal card moved backward by an automatic recovery.
+
+    Resolved together, once, because a workflow edit landing between two resolutions would have the
+    two halves of one decision reading different boards — the hazard `resolveResumeLanes` documents.
+    */
+    const terminalColumns = await resolveTerminalColumnsFor(this.store, live.id);
+    const lanes = await this.resolveResumeLanes(live.id);
+    if (terminalColumns.includes(live.column)) return false;
     // Pause/abort provenance owns aborted runs; a genuine abort never carries the
     // session-start refusal as its terminal node error in the same walk.
     if (this.pausedAborted.has(task.id)) return false;
@@ -9971,7 +9984,7 @@ export class TaskExecutor {
     not move those tasks backward or re-enqueue them. Mirrors the gating the in-review
     self-healing sweep (recoverMissingWorktreeReviewFailures) applies before the same recovery.
     */
-    if (live.column === "in-review") {
+    if (live.column === lanes.review) {
       const settings = await this.store.getSettings();
       if (!allowsAutoMergeProcessing(live, settings)) return false;
     }
@@ -10124,7 +10137,10 @@ export class TaskExecutor {
     */
     if (!await this.isPreMergeRemediationGraphNode(live.id, failedNode)) return false;
     if (live.deletedAt || live.paused || live.userPaused === true) return false;
-    if (live.column === "done" || live.column === "archived") return false;
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-06:15 (fleet: executor.ts): "already finished" is the
+       task's own terminal pair, not the default lineage's two ids. On a renamed board this guard was
+       inert, so a completed card's parked graph failure was routed into a pre-merge fix retry. */
+    if ((await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) return false;
     if (!live.worktree) return false;
     const settings = await this.store.getSettings().catch(() => undefined);
     if (!settings || settings.globalPause === true || settings.enginePaused === true) return false;
@@ -10172,7 +10188,16 @@ export class TaskExecutor {
     if (!pausedAborted) return false;
     if (abortProvenance === "global-pause" || live.userPaused === true) return false;
     if (abortProvenance === "completion-finalize") return false;
-    if (live.column !== "in-review" || !this.isRetryableMergePauseAbortStatus(live.status) || live.error != null) return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-06:40 (fleet: executor.ts graph-failure recovery family):
+    "IS THIS CARD IN THE REVIEW LANE?" resolved from the task's own workflow. Five pause-abort
+    classifiers asked it as the default lineage's literal, so on a renamed board every one of them
+    refused — and each refusal drops the card through to the operator-action park these paths exist
+    to avoid (FN-6796's benign in-review abort, the manual-merge-hold abort, the two stale-replay
+    handlers, the retryable merge abort). The literal made the recovery inert, silently.
+    */
+    if (live.column !== (await this.resolveResumeLanes(live.id)).review
+      || !this.isRetryableMergePauseAbortStatus(live.status) || live.error != null) return false;
     if (live.mergeDetails?.mergeConfirmed === true) return false;
     const failureValue = this.graphFailureValue(result);
     if (this.isTerminalMergeGraphFailureValue(failureValue)) return false;
@@ -10210,7 +10235,17 @@ export class TaskExecutor {
     if (!pausedAborted) return false;
     if (!isGenericAbortProvenance(abortProvenance)) return false;
     if (userCanceled) return false;
-    if (live.column !== "in-review") return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-06:45 (fleet: executor.ts):
+    SYNCHRONOUS classifier, so the sync `resolvePlannerLanes` is the resolver rather than the async
+    `resolveResumeLanes` used by its neighbours. The two disagree on ONE case and the difference is
+    deliberate here: `resolveResumeLanes` substitutes the legacy `in-review` when a board declares no
+    review lane, while `PlannerLanes` leaves a forward lane undefined precisely so a caller refuses
+    instead of inventing a column. A board with no review lane holds no card in review, so refusing
+    is the honest answer. (The two resolvers becoming one is already an open follow-up.)
+    */
+    const reviewLane = resolvePlannerLanes(this.store, live.id).review;
+    if (reviewLane === undefined || live.column !== reviewLane) return false;
     if (live.userPaused === true) return false;
     if (live.status != null || live.error != null) return false;
     if (live.mergeDetails?.mergeConfirmed === true) return false;
@@ -10243,7 +10278,7 @@ export class TaskExecutor {
     if (!pausedAborted) return false;
     if (!isGenericAbortProvenance(abortProvenance)) return false;
     if (live.paused || live.userPaused === true) return false;
-    if (live.column !== "in-review") return false;
+    if (live.column !== (await this.resolveResumeLanes(live.id)).review) return false;
     if (live.mergeDetails?.mergeConfirmed === true) return false;
     if (this.isTerminalMergeGraphFailureValue(this.graphFailureValue(result))) return false;
     const failedNode = result.visitedNodeIds[result.visitedNodeIds.length - 1];
@@ -10276,7 +10311,7 @@ export class TaskExecutor {
     if (!pausedAborted) return false;
     if (!isGenericAbortProvenance(abortProvenance) && abortProvenance !== "global-pause") return false;
     if (userCanceled) return false;
-    if (live.column !== "in-review") return false;
+    if (live.column !== (await this.resolveResumeLanes(live.id)).review) return false;
     if (live.paused || live.userPaused === true) return false;
     if (live.autoMerge === false) return false;
     if (live.mergeDetails?.mergeConfirmed === true) return false;
@@ -10348,7 +10383,15 @@ export class TaskExecutor {
     if (!pausedAborted) return false;
     if (!isGenericAbortProvenance(abortProvenance) && abortProvenance !== "global-pause") return false;
     if (userCanceled) return false;
-    if (live.column !== "in-review") return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-07:00 (fleet: executor.ts):
+    ONE SNAPSHOT for the entry gate AND the deferred recheck inside `scheduleRetry` below. The recheck
+    is the second half of THIS decision — "is the card still where it was when we admitted it?" — so
+    resolving the board again inside the timeout callback would let a workflow edit make the two halves
+    disagree, which is the hazard `resolveResumeLanes` was given a caller-owned memo for.
+    */
+    const replayLanes = await this.resolveResumeLanes(live.id);
+    if (live.column !== replayLanes.review) return false;
     if (live.paused || live.userPaused === true) return false;
     if (live.autoMerge === false) return false;
     if (live.mergeDetails?.mergeConfirmed === true) return false;
@@ -10415,7 +10458,7 @@ export class TaskExecutor {
             || resumeTask.userPaused
             || resumeTask.status != null
             || resumeTask.error != null
-            || resumeTask.column !== "in-review"
+            || resumeTask.column !== replayLanes.review
             || this.activeSessions.has(live.id)
             || this.activeStepExecutors.has(live.id)
             || this.activeWorkflowStepSessions.has(live.id)
@@ -10460,15 +10503,30 @@ export class TaskExecutor {
     if (userCanceled) return false;
     if (live.paused || live.userPaused === true) return false;
     if (live.status != null || live.error != null) return false;
-    if (live.column === "done" || live.column === "archived") return false;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-06:25 (fleet: executor.ts graph-failure recovery family):
+    THE LANES ARE RESOLVED HERE, AT THE TOP, because this method already resolved them — at the very
+    END, for its return value — while every eligibility check above compared against the default
+    lineage's literals. That is the split-snapshot shape this program keeps paying for, in its most
+    consequential form: on a renamed board the four `in-review` gates below all read false, so a
+    card in review skipped the global-pause recheck, the `autoMerge === false` refusal, the
+    shared-branch-member arbitration and the merge-confirmed refusal — and then the final line, which
+    DOES resolve lanes, happily answered "re-entrant". An auto-merge-off review row is exactly what
+    FN-7214's comment above says must stay terminal.
+
+    Hoisting the resolution changes only when the IR is read (before, not after, the pure checks on
+    `live`); the memo is caller-owned, so the recovery's other halves still share this one snapshot.
+    */
+    const resumeLanes = await this.resolveResumeLanes(live.id, resumeLanesMemo);
+    if ((await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) return false;
     if (result.interruptedAbortKind !== WORKFLOW_NODE_ENGINE_PAUSE_ABORT_KIND) return false;
     if (!result.interruptedNodeId) return false;
-    if (live.column === "in-review" && result.interruptedNodeId === "plan") return false;
+    if (live.column === resumeLanes.review && result.interruptedNodeId === "plan") return false;
     if (this.isMergeGraphFailure(result.interruptedNodeId)) return false;
     if (this.isTerminalMergeGraphFailureValue(this.graphFailureValue(result))) return false;
     if ((live.graphResumeRetryCount ?? 0) >= MAX_TRANSIENT_GRAPH_RESUME_RETRIES) return false;
     let settings: Settings | undefined;
-    if (abortProvenance === "global-pause" || live.column === "in-review") {
+    if (abortProvenance === "global-pause" || live.column === resumeLanes.review) {
       try {
         settings = await this.store.getSettings();
       } catch {
@@ -10476,14 +10534,13 @@ export class TaskExecutor {
       }
       if (settings.globalPause === true) return false;
     }
-    if (live.column === "in-review") {
+    if (live.column === resumeLanes.review) {
       if (live.autoMerge === false) return false;
       if (!settings) return false;
       const sharedBranchMember = await this.isLiveSharedBranchGroupMember(live);
       if (!sharedBranchMember && !allowsAutoMergeProcessing(live, settings)) return false;
       if (live.mergeDetails?.mergeConfirmed === true) return false;
     }
-    const resumeLanes = await this.resolveResumeLanes(live.id, resumeLanesMemo);
     return live.column === resumeLanes.hold
       || live.column === resumeLanes.review
       || live.column === resumeLanes.wip;
@@ -10689,7 +10746,11 @@ export class TaskExecutor {
     const message = `Workflow graph merge blocked at node '${failedNode}': implementation incomplete with no executable proof to resume — failing instead of retrying merge`;
     executorLog.warn(`${live.id}: ${message}`);
     await this.store.logEntry(live.id, message, undefined, this.getRunContextFor(live.id));
-    if (live.column !== "done" && live.column !== "archived" && live.error == null) {
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-07:20 (fleet: executor.ts terminal-guard family): the
+       task's OWN terminal pair (union'd with the legacy ids by `resolveTerminalColumnsFor`, so a
+       silently-substituted default IR still recognises them). Spelled as two literals, every one of
+       these read "not finished" on a renamed board. */
+    if (!(await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column) && live.error == null) {
       await this.store.updateTask(live.id, { error: message, status: "failed" }, this.getRunContextFor(live.id));
     }
     await this.persistTokenUsage(live.id);
@@ -11222,7 +11283,11 @@ export class TaskExecutor {
           benign completion note, and never emit the PAUSE_ABORT_PARK markers
           (so self-healing's recoverPausedAbortFailures has nothing to chase).
           */
-          if (live.column === "done" || live.column === "archived") {
+          /* FNXC:WorkflowLifecycleColumns 2026-08-01-07:22 (fleet): the benign arm must recognise the
+             board's own terminal columns — otherwise a renamed board took the PAUSE_ABORT_PARK path for a
+             card that had already completed, which is exactly the operator-action park this arm exists to
+             avoid, and self-healing then chases it. */
+          if ((await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) {
             this.clearPausedAborted(task.id);
             this.activeWorktrees.delete(task.id);
             const doneBenign = `Workflow graph run ended during ${pauseProvenance} after the task already completed ('${live.column}') — benign, no action needed`;
@@ -11359,8 +11424,10 @@ export class TaskExecutor {
         }
         const canTerminalizeExecuteLoop = live.userPaused !== true
           && live.paused !== true
-          && live.column !== "done"
-          && live.column !== "archived";
+          /* FNXC:WorkflowLifecycleColumns 2026-08-01-07:24 (fleet): FN-7863's loop terminalization must
+             not stamp a terminal error on a card that already finished; that is the board's terminal
+             pair, not the default lineage's. */
+          && !(await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column);
         if (nextCount >= MAX_EXECUTE_REQUEUE_LOOP_CYCLES && canTerminalizeExecuteLoop) {
           const terminalError = `EXECUTION_DISPATCH_LOOP_EXHAUSTED: execute node re-queued task to todo ${nextCount} times with no forward progress (last value=${failureValue ?? "no-value"}). No further automatic retries will run. Manually retry, decompose, or rescope the task.`;
           await this.store.updateTask(task.id, {
@@ -11403,7 +11470,10 @@ export class TaskExecutor {
       if (mergeGraphFailure && !this.isTerminalMergeGraphFailureValue(failureValue) && await this.routeGraphMergeFailureToRetry(live, result, abortProvenance)) {
         return;
       }
-      if (mergeGraphFailure && this.isTerminalMergeGraphFailureValue(failureValue) && live.column !== "done" && live.column !== "archived") {
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-07:26 (fleet): same terminal question, same board-owned
+         answer — a finished card must not be re-parked for operator action. */
+      if (mergeGraphFailure && this.isTerminalMergeGraphFailureValue(failureValue)
+        && !(await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) {
         const message = `Workflow graph terminal merge failure at node '${failedNode ?? "unknown"}' (${failureValue}) — operator action required`;
         executorLog.warn(`${task.id}: ${message}`);
         await this.store.logEntry(task.id, message, undefined, this.getRunContextFor(task.id));
@@ -11677,7 +11747,7 @@ export class TaskExecutor {
      */
     if (live.deletedAt) return false;
     if (live.paused || live.userPaused === true) return false;
-    if (live.column === "done" || live.column === "archived") return false;
+    if ((await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) return false;
     /*
      * FNXC:WorkflowCompletion 2026-07-01-16:26:
      * Backstop for issue #1863. The advisory completion-summary node must never
@@ -11729,7 +11799,7 @@ export class TaskExecutor {
     */
     if (live.deletedAt) return false;
     if (live.paused || live.userPaused === true) return false;
-    if (live.column === "done" || live.column === "archived") return false;
+    if ((await resolveTerminalColumnsFor(this.store, live.id)).includes(live.column)) return false;
     const hasImplementationProgress =
       (live.currentStep ?? 0) > 0
       || (live.steps ?? []).some((step) => step.status === "done" || step.status === "in-progress" || step.status === "skipped");
@@ -15150,7 +15220,7 @@ export class TaskExecutor {
         this.branchConflictErrorCount.delete(task.id);
       } else {
         const latestTask = await this.store.getTask(task.id);
-        if (latestTask.column === "done" || latestTask.column === "archived") {
+        if ((await resolveTerminalColumnsFor(this.store, task.id)).includes(latestTask.column)) {
           this.branchConflictErrorCount.delete(task.id);
         }
       }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,25 +1,25 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 662,
+    "column": 655,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
     "done": 181,
-    "in-progress": 122,
-    "in-review": 186,
+    "in-progress": 118,
+    "in-review": 185,
     "archived": 137,
-    "todo": 36
+    "todo": 34
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 28,
-    "packages/engine/src/executor.ts": 25,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
+    "packages/engine/src/executor.ts": 18,
     "packages/core/src/task-store/moves.ts": 15,
     "packages/core/src/store.ts": 12,
     "packages/engine/src/project-engine.ts": 12,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,22 +1,22 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 677,
+    "column": 668,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
     "done": 184,
-    "in-progress": 130,
+    "in-progress": 125,
     "in-review": 186,
     "archived": 137,
-    "todo": 40
+    "todo": 36
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
-    "packages/engine/src/executor.ts": 40,
+    "packages/engine/src/executor.ts": 31,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 28,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,21 +1,21 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 686,
+    "column": 682,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
     "done": 184,
-    "in-progress": 135,
+    "in-progress": 131,
     "in-review": 190,
     "archived": 137,
     "todo": 40
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 49,
+    "packages/engine/src/executor.ts": 45,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 28,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,22 +1,22 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 682,
+    "column": 677,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
     "done": 184,
-    "in-progress": 131,
-    "in-review": 190,
+    "in-progress": 130,
+    "in-review": 186,
     "archived": 137,
     "todo": 40
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 45,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
+    "packages/engine/src/executor.ts": 40,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 28,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,16 +1,16 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 654,
+    "column": 651,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 182,
+    "done": 181,
     "in-progress": 116,
-    "in-review": 184,
-    "archived": 138,
+    "in-review": 183,
+    "archived": 137,
     "todo": 34
   },
   "byFile": {
@@ -19,8 +19,8 @@
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 27,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
-    "packages/engine/src/executor.ts": 18,
     "packages/core/src/task-store/moves.ts": 15,
+    "packages/engine/src/executor.ts": 15,
     "packages/core/src/store.ts": 12,
     "packages/engine/src/project-engine.ts": 12,
     "packages/engine/src/mission-execution-loop.ts": 10,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,24 +1,24 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 721,
+    "column": 692,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 195,
-    "in-progress": 137,
-    "in-review": 200,
-    "archived": 147,
+    "done": 185,
+    "in-progress": 138,
+    "in-review": 190,
+    "archived": 137,
     "todo": 42
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 85,
+    "packages/engine/src/executor.ts": 55,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
-    "packages/engine/src/scheduler.ts": 27,
+    "packages/engine/src/scheduler.ts": 28,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
     "packages/core/src/task-store/moves.ts": 15,
     "packages/core/src/store.ts": 12,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,23 +1,23 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 655,
+    "column": 654,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 181,
-    "in-progress": 118,
-    "in-review": 185,
-    "archived": 137,
+    "done": 182,
+    "in-progress": 116,
+    "in-review": 184,
+    "archived": 138,
     "todo": 34
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
-    "packages/engine/src/scheduler.ts": 28,
+    "packages/engine/src/scheduler.ts": 27,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
     "packages/engine/src/executor.ts": 18,
     "packages/core/src/task-store/moves.ts": 15,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,14 +1,14 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 668,
+    "column": 662,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 184,
-    "in-progress": 125,
+    "done": 181,
+    "in-progress": 122,
     "in-review": 186,
     "archived": 137,
     "todo": 36
@@ -16,9 +16,9 @@
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
-    "packages/engine/src/executor.ts": 31,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 28,
+    "packages/engine/src/executor.ts": 25,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
     "packages/core/src/task-store/moves.ts": 15,
     "packages/core/src/store.ts": 12,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,21 +1,21 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 692,
+    "column": 686,
     "role": 5,
     "status": 186,
     "deliberate": 17
   },
   "byColumnId": {
-    "done": 185,
-    "in-progress": 138,
+    "done": 184,
+    "in-progress": 135,
     "in-review": 190,
     "archived": 137,
-    "todo": 42
+    "todo": 40
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 55,
+    "packages/engine/src/executor.ts": 49,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 28,


### PR DESCRIPTION
**Claim: `packages/engine/src/executor.ts` — the largest unclaimed file on the work order (85 guards).** Converted the graph-failure recovery family: **85 → 49**, 36 guards, three commits.

Not 0, and I am not claiming 0. The remaining 49 are enumerated at the bottom with what each needs; two of them I am flagging as **do-not-convert-blind** rather than guessing.

## Census

| file | before | after |
|---|---:|---:|
| `packages/engine/src/executor.ts` | 85 | **49** |

Repo backlog 722 → **686**. Baseline re-recorded in the same commits as the conversions (`--strict` exits 0).

## Converted per METHOD, not per literal

Every method I touched resolves **one lane snapshot** and answers every lifecycle question in it from that snapshot. That is not tidiness: this file's worst defects are methods that resolved lanes for *part* of a decision and used literals for the rest.

Helpers used — **no new abstraction**: the existing `resolveTerminalColumnsFor` (in-file, union'd with the legacy ids), `resolveResumeLanes` (in-file, caller-owned memo), and `resolvePlannerLanes` (the sync resolver, for the one synchronous classifier).

## Two live defects, not vocabulary cleanups

**1. `isReentrantPausedAbortedInFlightNode` — FN-7214's invariant was already broken.** The method resolved lanes at the **end**, for its return value, while its four `in-review` eligibility gates were literals. On a renamed board those gates all read false, so a review card skipped the global-pause recheck, the `autoMerge === false` refusal, the shared-branch-member arbitration **and** the merge-confirmed refusal — then the lane-resolved final line answered *"re-entrant"*. The method's own comment says an auto-merge-off review row must stay terminal.

**2. `routeUnusableWorktreeGraphFailureToRecovery` — FN-5147's gate was skipped.** It read not-finished **and** not-in-review, so recovery proceeded with the auto-merge-off gate bypassed: an automatic recovery moving a human-review-terminal card backward.

Both are the half-conversion shape this program keeps paying for — **a gate reading the wrong board does not go quiet, it admits what the gate existed to refuse.**

**3. `handleGraphFailure`'s completion suppression.** `alreadyFinalizedToReview` and `suppressFinalizedCompletionAbort` keyed on `column !== "in-progress"`, so on a renamed board a completed, already-finalized row read as still-in-wip: FN-6644/FN-6647's suppression never fired and the row was re-parked as an operator-action pause abort — precisely the durability gap those tickets closed.

## Revert proof

`executor-graph-failure-lanes-resolved.test.ts`, on a board sharing **no** column id with the default lineage (on the default board these guards are right by coincidence — the literals *are* the board, so a default-board test proves nothing).

**4 of 8 cases go red with the literals restored.** The 4 that stay green are labelled as such **in the file**: two paired positives that must not redden, the default-board no-change case, and one case where the terminal guard is genuinely redundant with the method's final lane check. I would rather label a case as non-evidence than count it.

Two fixture corrections recorded at the sites, both my own assertions not touching the behaviour they claimed:
- asserting the router's **return value** passed with the literals restored — the pre-fix path ran the whole recovery and returned false for an unrelated reason. Spying on `recoverMissingWorktreeSessionStartFailure` asks what the guard actually decides.
- `allowsAutoMergeProcessing` keys on the **global** setting, not `task.autoMerge`, so my first FN-5147 fixture never engaged the gate. Corrected the fixture, not the assertion.

## One decision worth review

The merge-confirmed finalize guard resolves the **complete** column via `resolvePlannerLanes` and deliberately **not** the terminal union: the union includes the legacy ids, so a card in a column merely *named* `done` would read as already finalized and the finalize would be skipped. A board declaring no complete column keeps the literal — refusing there would strand a merge-confirmed card, and `finalizeMergeConfirmedWorkflowGraphTask` resolves its own target anyway.

Also noted at a site: `resolveResumeLanes` substitutes the legacy `in-review` when a board declares no review lane, while `PlannerLanes` leaves forward lanes undefined so callers refuse instead of inventing a column. The two resolvers disagree on that one case. I used each per its own contract rather than papering over it; merging them is already an open follow-up in the source.

## The remaining 49, with what each needs

- **`to`/`from` move-effect parameters** (`3455`, `3479`, `3530`, `3540`, `15882`, `14565`, `4060`) — these compare a *move's* endpoints, not a card's resting column, and the move effects are trait-hook territory. **Flagged, not guessed.**
- **wip-lane liveness guards** (`2409`, `3340`, `4254`, `4456`, `5777`, `12356`, `12365`, `12373`, `14122`, `20131`, `20907`, `16869`) — mechanical, same `resolveResumeLanes` pattern; the only cost is one IR read per guard on hot paths, which wants a per-poll memo rather than a per-guard resolution.
- **hold/intake guards** (`4395`, `14589`, `16856`, `13316`, `15276`, `15328`) — same, plus `13316`/`15276`/`15328` mix wip **and** hold in one expression, so they need the snapshot form.
- **review-lane guards** (`2339`, `4355`, `4611`, `4635`, `5504`, `11796`) — `11796` is a three-literal expression across review/hold and is the highest-risk single site left in the file.
- **complete-column guards** (`6401`, `7881`, `9029`, `5501`, `5502`) — same decision as the finalize guard above, so the same union-vs-complete distinction applies.
- **`12406`, the dependency guard** (`dep.column !== "done" && !== "in-review" && !== "archived"`) — asks "is this dependency satisfied?", which is a **different** question from any lane role and reads as complete-or-review-or-archived. **Flagged**: it wants a deliberate answer about what "satisfied" means on a board with no review lane, not a mechanical swap.

## Verification

`pnpm test:gate` **10 / 487 / 71 green** · `pnpm verify:fast` **PASS (15 steps, live boot smoke)** · `tsc -p packages/engine` clean · `pnpm lint` clean · census `--strict` exit 0 · 53/53 across the four suites covering these paths (including `executor-paused-abort-todo-benign`, which drives the hold-lane arm).

No changeset: `@fusion/engine` is private and this is internal behaviour on renamed boards only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
