### PR TITLE
test(fleet): prove resolved traits beat a matching legacy id

### DIFF
--- a/packages/dashboard/app/__tests__/columnRoles.test.ts
+++ b/packages/dashboard/app/__tests__/columnRoles.test.ts
@@ -125,6 +125,25 @@ Each case asserts BOTH directions, because a helper that returns false unconditi
 a one-sided test while converting every site to a dead guard.
 */
 describe("terminal and mid-flight column roles", () => {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-22:40 (PR #2688 review — greptile, and it is right):
+  RESOLVED METADATA WINS, asserted against a MATCHING legacy id.
+
+  My other false cases pass a non-matching id (`isCompleteColumnRole(undefined, "shipped")`), which a
+  broken `trait || legacyId` implementation satisfies just as well — no trait AND no id match, so
+  false either way. They prove the fallback fires; they do not prove precedence.
+
+  These do: the trait says false while the id says true. Flags-first returns false; an OR returns
+  true. That is the only shape that separates the two implementations, and it is the one that
+  matters — a resolved column whose trait is explicitly off must not be overridden by its name.
+  */
+  it("lets a resolved FALSE trait beat a matching legacy id", () => {
+    expect(isCompleteColumnRole({ complete: false }, "done")).toBe(false);
+    expect(isArchivedColumnRole({ archived: false }, "archived")).toBe(false);
+    expect(isWipColumnRole({ countsTowardWip: false }, "in-progress")).toBe(false);
+    expect(isReviewColumnRole({ mergeBlocker: false, humanReview: false }, "in-review")).toBe(false);
+  });
+
   it("isCompleteColumnRole reads the complete trait, and does NOT count archived", () => {
     expect(isCompleteColumnRole({ complete: true }, "shipped")).toBe(true);
     /*


### PR DESCRIPTION
Review finding on #2688, landing separately because the helper set merged in #2685 (so the test file is on `main`) and #2688's branch is checked out in another worktree.

## The gap

My false cases for the four new role helpers all passed a **non-matching** id:

```ts
expect(isCompleteColumnRole(undefined, "shipped")).toBe(false);
```

A broken `trait || legacyId` implementation satisfies that just as well — no trait **and** no id match, so `false` either way. Those cases prove the fallback fires. They do not prove **precedence**.

## The discriminating shape

Trait says `false`, id says `true`:

```ts
expect(isCompleteColumnRole({ complete: false }, "done")).toBe(false);
expect(isArchivedColumnRole({ archived: false }, "archived")).toBe(false);
expect(isWipColumnRole({ countsTowardWip: false }, "in-progress")).toBe(false);
expect(isReviewColumnRole({ mergeBlocker: false, humanReview: false }, "in-review")).toBe(false);
```

Flags-first returns `false`; an OR returns `true`. That is the only shape separating the two implementations, and it is the one that matters in production — **a resolved column whose trait is explicitly off must not be overridden by its name.**

**Mutation-verified:** rewriting `isCompleteColumnRole` as `flags?.complete === true || columnId === LEGACY_COMPLETE_COLUMN_ID` now fails with `expected true to be false`. Under the previous cases it passed.

## Worth naming

This is the same one-sided-test defect I have been flagging in other people's work, in mine. The helpers were already correct — only the evidence was weak, which is the harder version to catch, because everything is green and the assertion *looks* thorough.

It generalises to the fleet: any converted site tested only with "no flags, non-matching id" proves the fallback and nothing about precedence.

## Verification

`columnRoles.test.ts` **14 → 15**. `pnpm test:gate` green (10 / 158 / 487 / 71). `pnpm check:lifecycle-columns` exits 0. `pnpm lint` clean.

Test-only; no changeset.