### PR TITLE
fleet: TaskDetailModal.tsx 30 → 10 (20 converted; 10 flagged with reasons, incl. a census misclassification)

### DIFF
--- a/packages/dashboard/app/components/TaskDetailModal.tsx
+++ b/packages/dashboard/app/components/TaskDetailModal.tsx
@@ -24,7 +24,13 @@ import { resolveEffectivePlannerOversightLevel } from "../../../core/src/workflo
 import { resolveTaskSessionAdvisorEnabled } from "../../../core/src/session-advisor";
 import { isNearDuplicateCanonicalInactive } from "../../../core/src/near-duplicate-canonical";
 import { getRevertOfId, findOpenUndoTaskForSource } from "../utils/taskRevert";
-import { isFieldEditableColumnRole } from "../utils/columnRoles";
+import {
+  isArchivedColumnRole,
+  isCompleteColumnRole,
+  isFieldEditableColumnRole,
+  isReviewColumnRole,
+  isWipColumnRole,
+} from "../utils/columnRoles";
 import { resolveEffectiveAutoMerge } from "../../../core/src/task-merge";
 import { uploadAttachment, deleteAttachment, updateTask, repairOverlapBlocker, pauseTask, unpauseTask, fetchTaskDetail, fetchTaskVerificationRequest, fetchSettings, fetchTaskEffectiveSettings, fetchGlobalSettings, requestSpecRevision, rebuildTaskSpec, approvePlan, rejectPlan, refineTask, fetchWorkflowResults, assignTask, fetchAgents, fetchAgent, refreshPrStatus, fetchBoardWorkflows, updateTaskCustomFields, summarizeTitle, fetchWorkflowSettingValues, nudgeOverseer, stopOverseer, explainOverseer, fetchModels, fetchNodes, api } from "../api";
 import type { RevertTaskOptions, RevertTaskResult, ModelInfo, NodeInfo } from "../api";
@@ -997,6 +1003,13 @@ export function TaskDetailContent({
   */
   const [taskWorkflowBadge, setTaskWorkflowBadge] = useState<{ id: string; name: string; icon?: string } | null>(null);
   const [workflowMoveMetadata, setWorkflowMoveMetadata] = useState<Pick<TaskWorkflowMetadata, "moveColumns" | "currentColumnFlags"> | null>(null);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-21:30 (fleet: TaskDetailModal.tsx):
+  ONE alias for this task's resolved column traits, so the role helpers below read the same
+  metadata the modal already fetches. No new abstraction: `currentColumnFlags` is produced by
+  the board-workflows payload and was already consumed at `canEdit`.
+  */
+  const taskColumnRoleFlags = workflowMoveMetadata?.currentColumnFlags;
   // Custom field definitions (U13/KTD-14). Resolved for this task's workflow
   // from the board-workflows payload; absent when the workflow declares none,
   // in which case the fields section renders nothing (today's UI byte-identical).
@@ -1335,7 +1348,7 @@ export function TaskDetailContent({
   const [workflowResults, setWorkflowResults] = useState<WorkflowStepResult[]>([]);
   const [workflowResultsLoading, setWorkflowResultsLoading] = useState(false);
   const [workflowEnabledSteps, setWorkflowEnabledSteps] = useState<string[] | undefined>(task.enabledWorkflowSteps);
-  const isNodeOverrideLocked = task.column === "in-progress" || ACTIVE_STATUSES.has(task.status as string);
+  const isNodeOverrideLocked = isWipColumnRole(taskColumnRoleFlags, task.column) || ACTIVE_STATUSES.has(task.status as string);
 
   // Reset edit state when task changes
   useEffect(() => {
@@ -2597,7 +2610,7 @@ export function TaskDetailContent({
       deleteCloseRequested = true;
     };
 
-    if (task.column !== "archived" && onArchiveTask) {
+    if (!isArchivedColumnRole(taskColumnRoleFlags, task.column) && onArchiveTask) {
       const deleteChoice = await confirmWithChoice({
         title: t("taskDetail.delete.title", "Delete Task"),
         message: t("taskDetail.delete.message", "Delete {{id}}?", { id: task.id }),
@@ -2980,7 +2993,7 @@ export function TaskDetailContent({
   AI-undo task on conflict/unsupported. The source task's column is never
   mutated as a side effect.
   */
-  const isRevertable = (task.column === "done" || task.column === "archived")
+  const isRevertable = (isCompleteColumnRole(taskColumnRoleFlags, task.column) || isArchivedColumnRole(taskColumnRoleFlags, task.column))
     && Boolean(task.mergeDetails?.commitSha);
 
   const handleRevertTask = useCallback(async () => {
@@ -3605,8 +3618,8 @@ export function TaskDetailContent({
   */
   const overseerSnapshot = workingTask.plannerOverseerState ?? null;
   const overseerActive = Boolean(overseerSnapshot);
-  const isDoneOrArchivedColumn = task.column === "done" || task.column === "archived";
-  const isOverseerHumanReviewTerminal = task.column === "in-review" && !effectiveAutoMerge;
+  const isDoneOrArchivedColumn = isCompleteColumnRole(taskColumnRoleFlags, task.column) || isArchivedColumnRole(taskColumnRoleFlags, task.column);
+  const isOverseerHumanReviewTerminal = isReviewColumnRole(taskColumnRoleFlags, task.column) && !effectiveAutoMerge;
   const overseerHumanControlSuppressed = Boolean(isTaskPaused) || isDoneOrArchivedColumn || isOverseerHumanReviewTerminal;
   const oversightIsOff = effectiveOversightLevel === "off";
   /*
@@ -4371,7 +4384,7 @@ export function TaskDetailContent({
                   customFields={customFieldValues}
                   onSave={handleSaveCustomFields}
                   error={customFieldError}
-                  readOnly={Boolean(task.column === "archived")}
+                  readOnly={Boolean(isArchivedColumnRole(taskColumnRoleFlags, task.column))}
                 />
               ) : null}
               {showNearDuplicateWarning && (
@@ -5083,7 +5096,7 @@ export function TaskDetailContent({
                 </button>
               </>
             )}
-            {task.column === "done" && (
+            {isCompleteColumnRole(taskColumnRoleFlags, task.column) && (
               <button
                 className={`detail-tab${activeTab === "summary" ? " detail-tab-active" : ""}`}
                 onClick={() => setActiveTab("summary")}
@@ -5097,7 +5110,7 @@ export function TaskDetailContent({
             >
               {t("taskDetail.tabs.definition", "Plan")}
             </button>
-            {(task.column === "in-progress" || task.column === "in-review" || task.column === "done") && (
+            {(isWipColumnRole(taskColumnRoleFlags, task.column) || isReviewColumnRole(taskColumnRoleFlags, task.column) || isCompleteColumnRole(taskColumnRoleFlags, task.column)) && (
               <button
                 className={`detail-tab${activeTab === "changes" ? " detail-tab-active" : ""}`}
                 onClick={() => setActiveTab("changes")}
@@ -5111,7 +5124,7 @@ export function TaskDetailContent({
             >
               {t("taskDetail.tabs.review", "Review")}
             </button>
-            {task.column === "in-review" && (
+            {isReviewColumnRole(taskColumnRoleFlags, task.column) && (
               <button
                 className={`detail-tab${activeTab === "pr" ? " detail-tab-active" : ""}`}
                 onClick={() => setActiveTab("pr")}
@@ -5203,7 +5216,7 @@ export function TaskDetailContent({
                 canEdit={canEdit}
                 projectId={projectId}
                 isTaskInProgress={
-                  task.column === "in-progress"
+                  isWipColumnRole(taskColumnRoleFlags, task.column)
                   && !task.paused
                   && !task.userPaused
                   && task.status !== "paused"
@@ -5230,7 +5243,7 @@ export function TaskDetailContent({
                 projectId={projectId}
               />
             </div>
-          ) : activeTab === "summary" && task.column === "done" ? (
+          ) : activeTab === "summary" && isCompleteColumnRole(taskColumnRoleFlags, task.column) ? (
             <div className="detail-section detail-section--summary">
               <TaskSummaryTab task={workingTask} pricingOverrides={globalSettings?.modelPricingOverrides} />
             </div>
@@ -5382,7 +5395,7 @@ export function TaskDetailContent({
             />
           ) : activeTab === "pr" ? (
             <div className="detail-section detail-pr-tab">
-              {task.column === "in-review" && (
+              {isReviewColumnRole(taskColumnRoleFlags, task.column) && (
                 <>
                   {shouldShowInReviewStallBadge(workingTask) && workingTask.inReviewStall && (() => {
                     const copy = getInReviewStallCopy(workingTask.inReviewStall, {
@@ -6375,7 +6388,7 @@ export function TaskDetailContent({
           </>
           )}
         </div>
-        {task.column === "in-review" && (
+        {isReviewColumnRole(taskColumnRoleFlags, task.column) && (
           <PrCreateModal
             open={prCreateOpen}
             taskId={task.id}
@@ -6461,7 +6474,7 @@ export function TaskDetailContent({
               completed task's outcome. Omitted — not disabled — when the task has
               no landed commit to revert, avoiding an empty button shell.
               */}
-              {(task.column === "done" || task.column === "archived") && onRevertTask && isRevertable && (
+              {(isCompleteColumnRole(taskColumnRoleFlags, task.column) || isArchivedColumnRole(taskColumnRoleFlags, task.column)) && onRevertTask && isRevertable && (
                 <button
                   className="btn btn-sm"
                   onClick={() => void handleRevertTask()}
@@ -6515,7 +6528,7 @@ export function TaskDetailContent({
 
               {/* Move dropdown — column transitions and merge actions */}
               <div className="detail-move-dropdown" ref={moveMenuRef}>
-                {task.column === "in-review" ? (
+                {isReviewColumnRole(taskColumnRoleFlags, task.column) ? (
                   <div className="detail-move-actions-in-review">
                     <div>
                       <button

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -17,7 +17,7 @@
     "packages/engine/src/self-healing.ts": 110,
     "packages/engine/src/executor.ts": 57,
     "packages/dashboard/app/components/TaskCard.tsx": 3,
-    "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
+    "packages/dashboard/app/components/TaskDetailModal.tsx": 10,
     "packages/engine/src/scheduler.ts": 26,
     "packages/core/src/store.ts": 12,
     "packages/engine/src/mission-execution-loop.ts": 10,


### PR DESCRIPTION
Claiming **`packages/dashboard/app/components/TaskDetailModal.tsx`** — the largest unclaimed cluster (self-healing, executor, TaskCard and scheduler were already taken).

## Census before/after

| | before | after |
|---|---:|---:|
| `TaskDetailModal.tsx` column guards | **30** | **10** |
| repo backlog | 722 | **702** |

Baseline re-recorded to 10 — shrinks by exactly the converted count. `--strict` exits 0.

## Converted: 20, existing helpers only

`isCompleteColumnRole`, `isArchivedColumnRole`, `isWipColumnRole`, `isReviewColumnRole` from `utils/columnRoles`, alongside the `isFieldEditableColumnRole` this file already imported. No new abstractions, no new helper.

6× `=== "done"` · 4× `=== "archived"` · 1× `!== "archived"` · 3× `=== "in-progress"` · 6× `=== "in-review"`

One alias — `taskColumnRoleFlags = workflowMoveMetadata?.currentColumnFlags` — so every site reads metadata the modal **already fetches**: `canEdit` was consuming it at line 1725 before this change, so there is no new data flow and no new request.

**Behaviour-preserving by construction.** Each helper is `flags ? <trait> : <legacy id>`, and flags are absent precisely when the modal has not yet loaded its workflow metadata — so with no flags the legacy comparison is exactly what ran before.

## The 10 remaining, each with a reason — flagged, not guessed

**Already-converted fallback, miscounted (2 sites, one line)**
- `560` — `return column === "todo" || column === "in-progress";` is the documented legacy fallback *inside* a helper that already takes `flags` and checks `flags.hold || flags.countsTowardWip` first. It is the fallback arm, not an unconverted guard. It needs a `DELIBERATE-LITERAL` marker rather than conversion; I have not added one because the marker changes the tracked deliberate count and I would rather that be a deliberate call by whoever owns the ratchet than a side effect of my batch.

**Not a column at all — census misclassification (1 site)**
- `346` — `session.agentState === "done"`. Receiver is `agentState`; `done` is an agent state, not a column. The classifier keys on receiver name, and `agentState` matches neither the role-token list nor `/status/i`, so it falls through to `column`. Converting it would ask "which column has the complete trait" about an agent's state. **Worth fixing in the classifier** — `agentState` belongs in its token list.

**Module scope, no flags available (5 sites)**
- `277` (`resolveDefaultTab`), `869`, `870`, `918`, `924` — module-level functions taking a bare `column: ColumnId`. Converting means threading `flags` through their signatures and every call site. That is a real refactor with its own blast radius, not a mechanical substitution, so it is out of scope for this batch by the fleet rules.

**Another task's column (2 sites)**
- `3536` — `overlapBlockerTask.column === "in-progress" || … === "in-review"`. `currentColumnFlags` describes *this* task's column, not the blocker's. Passing it would be wrong, and passing `undefined` would silently use legacy ids for that card while looking converted. Correct fix is a per-task flag lookup from `moveColumns`, which this component does not currently build.

## Verification

`pnpm lint` clean · dashboard app `tsc` clean · `--strict` exits 0.

`TaskDetailModal.test.tsx` 45 passed / 6 failed and the wider `app/components/__tests__` 9883 passed / 209 failed — **both byte-identical on clean `origin/main`**, confirmed by stashing these changes and re-running. None of those failures is from this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task detail behavior by consistently recognizing workflow column roles.
  * Updated editing, deletion, archiving, reverting, oversight, and review controls to reflect each task’s workflow status.
  * Corrected tab visibility, custom-field editing, pull request, and move-menu behavior for archived and review-related tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->