### PR TITLE
fix(census): stop the baseline serialising the fleet — every fleet PR conflicted with every other one

### DIFF
--- a/packages/engine/src/__tests__/lifecycle-column-census.test.ts
+++ b/packages/engine/src/__tests__/lifecycle-column-census.test.ts
@@ -451,7 +451,14 @@ describe("the baseline can always be re-recorded", () => {
       const r = runCli(["--strict", "--update-baseline"], stale) as unknown as { status: number; stdout: string; baselinePath: string };
       expect(r.status).toBe(0);
       const written = JSON.parse(fs.readFileSync(r.baselinePath, "utf8"));
-      expect(written.totals.column).toBeGreaterThan(1);
+      /*
+      FNXC:LifecycleColumnCensus 2026-07-30-19:10:
+      Asserted on the per-file entry rather than `totals`, which the pin no longer stores — the
+      derived aggregates were the only lines every conversion PR rewrote, and so the sole cause of
+      fleet-wide conflicts in this file. The claim is unchanged and still specific: the stale pin
+      said 1, and the rewritten pin must carry the tree's real (higher) count for that same file.
+      */
+      expect(written.byFile["packages/engine/src/self-healing.ts"]).toBeGreaterThan(1);
       expect(r.stdout).toContain("ACCEPTED RISES");
     });
 

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,24 +1,11 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
-  "totals": {
-    "column": 693,
-    "role": 5,
-    "status": 186,
-    "deliberate": 17
-  },
-  "byColumnId": {
-    "done": 182,
-    "in-progress": 136,
-    "in-review": 199,
-    "archived": 138,
-    "todo": 38
-  },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/engine/src/executor.ts": 57,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
-    "packages/engine/src/scheduler.ts": 27,
+    "packages/engine/src/scheduler.ts": 26,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
     "packages/core/src/task-store/moves.ts": 15,
     "packages/core/src/store.ts": 12,
@@ -156,15 +143,15 @@
   "deliberateByFile": {
     "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 2,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000triage": 2,
-    "packages/dashboard/app/components/RoutineEditor.tsx": 1,
-    "packages/dashboard/app/components/ScheduleForm.tsx": 1,
-    "packages/dashboard/app/components/ScheduleStepsEditor.tsx": 1,
-    "packages/dashboard/app/components/TaskCard.tsx\u0000todo": 1,
-    "packages/dashboard/app/components/TaskContextMenu.tsx\u0000triage": 1,
-    "packages/dashboard/app/components/TaskDetailModal.tsx\u0000todo": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000done": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000in-review": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000todo": 1,
+    "packages/dashboard/app/components/RoutineEditor.tsx\u0000triage": 1,
+    "packages/dashboard/app/components/ScheduleForm.tsx\u0000triage": 1,
+    "packages/dashboard/app/components/ScheduleStepsEditor.tsx\u0000triage": 1,
+    "packages/dashboard/app/components/TaskCard.tsx\u0000todo": 1,
+    "packages/dashboard/app/components/TaskContextMenu.tsx\u0000triage": 1,
+    "packages/dashboard/app/components/TaskDetailModal.tsx\u0000todo": 1,
     "packages/dashboard/app/utils/columnRoles.ts\u0000todo": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000todo": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000triage": 1,
@@ -172,18 +159,6 @@
     "packages/engine/src/hold-release.ts\u0000done": 1,
     "packages/engine/src/hold-release.ts\u0000in-review": 1,
     "packages/engine/src/triage.ts\u0000triage": 1
-  },
-  "properties": {
-    "query": 83,
-    "definition": 43
-  },
-  "queryByColumnId": {
-    "todo": 10,
-    "archived": 7,
-    "done": 10,
-    "in-progress": 19,
-    "in-review": 35,
-    "triage": 2
   },
   "queryByFile": {
     "packages/engine/src/self-healing.ts": 48,

--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -364,17 +364,30 @@ The flag is an explicit operator action, so it re-records unconditionally and PR
 under `ACCEPTED RISES`. Silently swallowing a rise is the real danger; refusing to let anyone re-record is
 the same danger one step later, wearing a red check nobody trusts.
 */
+/*
+FNXC:LifecycleColumnCensus 2026-07-30-19:10 (fleet — the baseline was serialising the fleet):
+NO DERIVED AGGREGATES IN THE PIN. `totals`, `byColumnId`, `properties` and `queryByColumnId` are all
+recomputable from the per-file maps, and `--strict` never read any of them — it compares `byFile`,
+`deliberateByFile` and `queryByFile` and nothing else.
+
+They were not free. Every conversion PR changes at least one aggregate line, so EVERY fleet PR
+conflicted with EVERY other fleet PR in this file even when they converted different files. Six of my
+own branches were rebased for nothing but this, and the resolution was always "take main's, re-run
+--update-baseline" — never a real merge. Two PRs converting different files now touch disjoint lines.
+
+TRADE-OFF, stated because it undoes a deliberate choice: an earlier note kept the totals here so the
+new number would appear in the diff where a reviewer sees it. That signal is preserved elsewhere —
+the CLI prints the totals on every run, `--update-baseline` prints each tightened entry, and the
+fleet rules already require a census before/after in the PR body. Reversible if the diff-visible
+number turns out to matter more than the conflicts.
+*/
 function writeBaseline() {
   writeFileSync(
     BASELINE_PATH,
     `${JSON.stringify({
       generatedFrom: "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
-      totals: summary.totals,
-      byColumnId: summary.byColumnId,
       byFile: Object.fromEntries(summary.byFile),
       deliberateByFile: Object.fromEntries(summary.deliberateByFile ?? []),
-      properties: summary.properties,
-      queryByColumnId: summary.queryByColumnId,
       queryByFile: Object.fromEntries(summary.queryByFile),
     }, null, 2)}\n`,
   );


### PR DESCRIPTION
## The problem

Every fleet PR conflicts with every other fleet PR in `lifecycle-column-census-baseline.json` — **even when they convert entirely different files**. I have rebased **six** of my own branches for nothing but this file, and the resolution was *always* "take main's, re-run `--update-baseline`". Never once a real merge.

That makes a generated artifact the serialisation point for the whole fleet phase.

## The cause

`totals`, `byColumnId`, `properties` and `queryByColumnId` are **derived** — recomputable from the per-file maps — and **`--strict` never reads any of them**. It compares `byFile`, `deliberateByFile` and `queryByFile`, and nothing else.

But every conversion changes at least one aggregate line. So those lines were a **shared write on a file whose real content is per-file and disjoint**. Removing them, two PRs converting different files touch no common lines.

## Trade-off, stated because it undoes a deliberate choice

An earlier note kept the totals in the pin *"so the new number lands in the diff where a reviewer sees it"*. That was a good reason. The signal survives elsewhere:

- the CLI prints the totals on every run;
- `--update-baseline` prints each tightened entry by name;
- the fleet rules already require a census before/after **in the PR body**.

Reversible if the diff-visible number proves to matter more than the conflicts.

## Cost, stated too

Merging this makes every in-flight fleet PR re-record once. That is one more instance of an operation they are already performing on every rebase — a one-time cost against a recurring one.

## Verification

The end-to-end test that asserted the write via `totals.column` now asserts the same claim via the per-file entry: the stale pin says 1, the rewritten pin must carry the tree's real higher count for that file. **Mutation: suppressing the `--update-baseline` write still fails it**, so the assertion did not weaken.

71 census tests green · `--strict` and `--strict --exact` exit 0 · lint clean · gate green (487 + 158 + 10 + 71).

## Not done

A merge driver. `.gitattributes` can name one, but registering it needs `git config` per clone and this repo has no `postinstall`/`prepare` hook to do that — so it would silently not apply for most people. Removing the shared lines fixes the conflicts without needing any local setup.