### PR TITLE
fleet: register-task-workflow-routes.ts 20 → 13 — the review lane, incl. three 400s naming a column the board doesn't have

### DIFF
--- a/packages/dashboard/src/routes/__tests__/register-task-workflow-routes.resolved-review-column.test.ts
+++ b/packages/dashboard/src/routes/__tests__/register-task-workflow-routes.resolved-review-column.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-15:00 (fleet: register-task-workflow-routes.ts review lane):
+
+THE INVARIANT: the task routes decide "is this card in review?" from the task's OWN workflow.
+
+Ten route guards spelled it as `in-review`. Two of them are operator-visible in a way that is worse
+than an inert guard, because the wrong answer is REPORTED as a fact about the operator's own board:
+
+  - the user-comment re-engagement returns `suppressedReason: "not-in-review"` for a review card on a
+    renamed board, so a comment on a card plainly sitting in review is dropped and the API says the
+    card is not in review;
+  - the branch-binding recovery and PR-feedback routes reject with 400 messages naming `in-review` —
+    a column the operator's board does not have. Both messages now name the resolved columns.
+
+WHICH ROUTE THIS DRIVES, and why the assertions are on the MESSAGE rather than the status: the
+branch-binding route's success path continues into the self-healing manager, which a partial store mock
+cannot provide, so a passing card also ends in a 400 ("Self-healing manager unavailable"). Asserting
+`status !== 400` would therefore be asserting nothing. The discriminator is WHICH 400 comes back — the
+column refusal or the manager one — which is exactly the guard under test. My first version drove
+`/address-pr-feedback`, a path that does not exist (it is `/pr/address-feedback`), and all five cases
+hung for 15s each on the unmatched route: a test that never reached the code it named.
+
+THE ROUTE IS THE SURFACE, not the resolver. A unit test on `resolveReviewColumnForTask` would pass with
+every call site still comparing against the literal, which is precisely the gap this file exists to
+close.
+
+REVERT PROOF, measured below. The default-board cases pass either way by design — `builtin:coding`'s
+review column IS `in-review` — and they are here to prove the conversion did not change the shipped
+board's behaviour, not as evidence for it.
+*/
+import { describe, it, expect, vi } from "vitest";
+import type { TaskStore } from "@fusion/core";
+import express from "express";
+import { createApiRoutes } from "../../routes.js";
+import { request as REQUEST } from "../../test-request.js";
+
+/** Default lifecycle SHAPE, renamed ids — `signoff` carries the merge-orchestration traits. */
+const RENAMED_IR = {
+  version: "v2",
+  id: "wf-renamed",
+  name: "Renamed Flow",
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "staging", name: "Staging", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "signoff", name: "Sign-off", traits: [{ trait: "merge" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+  nodes: [{ id: "start", kind: "start", column: "backlog" }],
+  edges: [],
+};
+
+function buildStore(options: { taskColumn: string; workflowId?: string }) {
+  const task = {
+    id: "FN-001",
+    column: options.taskColumn,
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    prInfo: { number: 7, url: "https://example.invalid/pr/7", state: "open" },
+  };
+  const recoverBranchBinding = vi.fn(async () => ({ recovered: true, branch: "fusion/FN-001" }));
+
+  const store = {
+    getRootDir: vi.fn(() => process.cwd()),
+    getProjectScopedPluginMcpServers: vi.fn(async () => []),
+    getTask: vi.fn(async () => task),
+    getSettings: vi.fn(async () => ({})),
+    listTasks: vi.fn(async () => [task]),
+    getTaskWorkflowSelection: vi.fn(() => (options.workflowId ? { workflowId: options.workflowId } : undefined)),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => (options.workflowId ? { workflowId: options.workflowId } : undefined)),
+    getWorkflowDefinition: vi.fn(async (id: string) =>
+      id === "wf-renamed" ? { id, name: "Renamed Flow", kind: "workflow", ir: RENAMED_IR } : null,
+    ),
+    updateTask: vi.fn(async () => task),
+    logEntry: vi.fn(async () => undefined),
+    recordRunAuditEvent: vi.fn(async () => undefined),
+    recoverBranchBinding,
+  } as unknown as TaskStore;
+
+  return { store, recoverBranchBinding };
+}
+
+async function post(store: TaskStore, path: string, body: unknown = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", createApiRoutes(store));
+  return REQUEST(app, "POST", `/api/tasks/FN-001${path}`, JSON.stringify(body), {
+    "content-type": "application/json",
+  });
+}
+
+describe("the task routes resolve the board's own review column", () => {
+  const COLUMN_REFUSAL = "column to recover branch binding";
+
+  async function refusal(store: TaskStore): Promise<string> {
+    const res = await post(store, "/recover-branch-binding");
+    const payload = res.body as { error?: string } | undefined;
+    return payload?.error ?? JSON.stringify(res.body ?? {});
+  }
+
+  it("does not refuse a RENAMED board's review card as being in the wrong column", async () => {
+    // Pre-fix: `signoff` !== "in-review", so the route rejected with a message naming a column this
+    // board does not have. The card was in review the whole time.
+    const { store } = buildStore({ taskColumn: "signoff", workflowId: "wf-renamed" });
+
+    expect(await refusal(store)).not.toContain(COLUMN_REFUSAL);
+  });
+
+  it("still refuses a card outside the review lane, naming the board's OWN column", async () => {
+    // The paired negative, plus the message fix: an operator must be told `signoff`, not `in-review`.
+    const { store } = buildStore({ taskColumn: "building", workflowId: "wf-renamed" });
+
+    const message = await refusal(store);
+    expect(message).toContain(COLUMN_REFUSAL);
+    expect(message).toContain("signoff");
+    expect(message).not.toContain("in-review");
+  });
+
+  it("behaves identically on the DEFAULT board, where the literal was already correct", async () => {
+    // No workflow selection: the resolver falls back to `in-review`. Passes either way by design.
+    const { store } = buildStore({ taskColumn: "in-review" });
+
+    expect(await refusal(store)).not.toContain(COLUMN_REFUSAL);
+  });
+
+  it("still refuses an intake-lane card on the DEFAULT board", async () => {
+    const { store } = buildStore({ taskColumn: "todo" });
+
+    expect(await refusal(store)).toContain(COLUMN_REFUSAL);
+  });
+});

--- a/packages/dashboard/src/routes/__tests__/register-task-workflow-routes.resolved-review-column.test.ts
+++ b/packages/dashboard/src/routes/__tests__/register-task-workflow-routes.resolved-review-column.test.ts
@@ -131,3 +131,101 @@ describe("the task routes resolve the board's own review column", () => {
     expect(await refusal(store)).toContain(COLUMN_REFUSAL);
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-21:40 (PR #2701 review — greptile P1):
+
+THE INVARIANT: an open PR blocks the in-review user-comment re-engagement on ANY board.
+
+THE THIRD FORM OF THIS PROGRAM'S DEFECT, and the most interesting one. The guard was deliberately left
+on the legacy `COLUMNS.indexOf` enum, with a comment justifying it: "this whole function is gated on the
+literal `task.column !== "in-review"` above and re-engages to the literal `"in-progress"`, so both
+endpoints are legacy ids by construction". That was TRUE when written.
+
+Then U5 converted the re-engage target to `resolveWipColumnForTask`, and this PR converted the entry gate
+to the resolved review lane. Both halves of the premise are now false, so on a renamed board the enum
+scores -1 for both endpoints — and `isBackwardMoveBlockedByOpenPr` treats a negative index as "cannot
+tell -> allow". A user comment on a review card with an OPEN PR resumed execution behind that PR.
+
+Nobody edited the guard or the comment. The comment's correctness argument depended on literals
+elsewhere, and someone else converted them. When you convert a lane, grep for comments justifying a
+nearby legacy path by "the surrounding literals" — they are load-bearing.
+
+REVERT PROOF, measured: restore `COLUMNS.indexOf` and the renamed-board case fails — the task is moved
+to the wip lane despite the open PR.
+*/
+describe("the re-engage open-PR guard survives a renamed board", () => {
+  function buildReengageStore(column: string, workflowId: string | undefined, prState: string | null) {
+    const task = {
+      id: "FN-002", column, dependencies: [], steps: [], currentStep: 0, sessionFile: null,
+    };
+    const moveTask = vi.fn(async (_id: string, to: string) => ({ ...task, column: to }));
+    const logEntry = vi.fn(async () => undefined);
+
+    const store = {
+      getRootDir: vi.fn(() => process.cwd()),
+      getProjectScopedPluginMcpServers: vi.fn(async () => []),
+      getTask: vi.fn(async () => task),
+      getSettings: vi.fn(async () => ({})),
+      getTaskWorkflowSelection: vi.fn(() => (workflowId ? { workflowId } : undefined)),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => (workflowId ? { workflowId } : undefined)),
+      getWorkflowDefinition: vi.fn(async (id: string) =>
+        id === "wf-renamed" ? { id, name: "Renamed Flow", kind: "workflow", ir: RENAMED_IR } : null,
+      ),
+      getActivePrEntityBySource: vi.fn(async () =>
+        prState ? { id: "PR-1", state: prState, sourceType: "task", sourceId: "FN-002" } : null,
+      ),
+      /* The route calls `addTaskComment` and re-engages the TASK IT RETURNS, so the mock must return the
+         task row — returning a bare comment made the whole block vacuous: the route threw before reaching
+         the guard, `moveTask` was never called, and both negative cases "passed" for the wrong reason.
+         Caught it because the paired POSITIVE case failed; without that case this suite would have looked
+         green and proven nothing. */
+      addTaskComment: vi.fn(async () => ({ ...task, comments: [{ id: "c1", text: "please fix", author: "user" }] })),
+      updateTask: vi.fn(async () => task),
+      updateStep: vi.fn(async () => undefined),
+      logEntry,
+      moveTask,
+      recordRunAuditEvent: vi.fn(async () => undefined),
+    } as unknown as TaskStore;
+
+    return { store, moveTask, logEntry };
+  }
+
+  async function comment(store: TaskStore) {
+    const app = express();
+    app.use(express.json());
+    app.use("/api", createApiRoutes(store));
+    return REQUEST(app, "POST", "/api/tasks/FN-002/comments", JSON.stringify({ text: "please fix", author: "user" }), {
+      "content-type": "application/json",
+    });
+  }
+
+  it("does NOT re-engage a renamed board's review card while a PR is open", async () => {
+    // Pre-fix: both endpoints scored -1 on the legacy enum, a negative index means "allow", and the card
+    // was moved into the wip lane behind an open PR.
+    const { store, moveTask } = buildReengageStore("signoff", "wf-renamed", "open");
+
+    await comment(store);
+
+    expect(moveTask).not.toHaveBeenCalled();
+  });
+
+  it("DOES re-engage a renamed board's review card once no PR is active", async () => {
+    // The paired positive: the guard must not block re-engagement outright.
+    const { store, moveTask } = buildReengageStore("signoff", "wf-renamed", null);
+
+    await comment(store);
+
+    expect(moveTask).toHaveBeenCalledTimes(1);
+    expect(moveTask.mock.calls[0]?.[1]).toBe("building");
+  });
+
+  it("still blocks on the DEFAULT board with an open PR", async () => {
+    // The case the legacy enum already handled; it must keep working.
+    const { store, moveTask } = buildReengageStore("in-review", undefined, "open");
+
+    await comment(store);
+
+    expect(moveTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -2690,6 +2690,17 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       card. Scoped to pre-WIP columns otherwise, so no in-progress/in-review status gains a retry path
       it did not have.
       */
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-08-01-16:35 (fleet: register-task-workflow-routes.ts):
+      RESOLVED UNCONDITIONALLY, and my first version got this wrong in a way worth recording: I reused the
+      resolution that lives inside the `retrySpecificationStatus` branch below, so on every request that
+      did NOT take that branch the review checks silently fell back to the legacy `in-review` — a
+      conversion that reads as done and answers from the default lineage in the common path. The snapshot
+      has to be owned by the scope that uses it, not borrowed from a conditional.
+
+      `workflowIr` is already in scope, so this is a pure read with no extra I/O.
+      */
+      const reviewLifecycle = resolveLifecycleColumns(workflowIr);
       let strandedSpecificationRetry = false;
       if (retrySpecificationStatus && !retrySpecification) {
         if (!workflowDeclaresColumnModel(workflowIr)) {
@@ -2717,13 +2728,23 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
           */
           strandedSpecificationRetry = task.column === "triage" || task.column === "todo";
         } else {
-          const lifecycle = resolveLifecycleColumns(workflowIr);
-          strandedSpecificationRetry = lifecycle !== undefined
-            && (task.column === lifecycle.intake || task.column === lifecycle.hold);
+          strandedSpecificationRetry = reviewLifecycle !== undefined
+            && (task.column === reviewLifecycle.intake || task.column === reviewLifecycle.hold);
         }
       }
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-08-01-16:10 (fleet: register-task-workflow-routes.ts):
+      THE SNAPSHOT WAS ALREADY IN SCOPE. `strandedSpecificationRetry` twelve lines up resolves
+      `lifecycle` from this task's own workflow and compares against `lifecycle.intake`/`.hold`, while
+      these three review checks compared against the literal — one aggregation, two boards. Threading the
+      same snapshot is both the fix and the cheaper option: no second IR read.
+
+      `lifecycle` is undefined for a column-less (v1) IR, which is the documented no-basis signal, so the
+      legacy `in-review` remains the answer there rather than inventing one.
+      */
+      const reviewLane = reviewLifecycle?.review ?? "in-review";
       const isInReviewStatusNone =
-        task.column === "in-review" && (task.status === null || task.status === undefined);
+        task.column === reviewLane && (task.status === null || task.status === undefined);
       const hasIncompleteSteps = task.steps.some(
         (s: { status: string }) => s.status === "pending" || s.status === "in-progress",
       );
@@ -2756,7 +2777,7 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       */
       const selfHealingManager = _resolveSelfHealingManager(scopedStore);
       const isStaleMergeActiveRetry =
-        task.column === "in-review" &&
+        task.column === reviewLane &&
         isStaleMergeActiveStatus(task, {
           activeMergeTaskId: selfHealingManager?.getActiveMergeTaskId?.() ?? null,
           minAgeMs: selfHealingManager?.getStaleMergingStatusMinAgeMs?.(),
@@ -4828,7 +4849,13 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       const currentColumn = "columns" in workflowIr
         ? workflowIr.columns.find((column) => column.id === task.column)
         : undefined;
-      const isArchived = task.column === "archived" || (currentColumn != null && resolveColumnFlags(currentColumn).archived);
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-16:20 (fleet): the trait check was already here; the
+         literal beside it only covers a row still stored in a column the workflow no longer declares
+         (`currentColumn` is then undefined). Kept for exactly that case and marked, because on a board
+         that renames its archive lane the TRAIT half is what answers — the literal is the leftover-row
+         fallback, not the primary. DELIBERATE-LITERAL: an undeclared column cannot be resolved by trait. */
+      const isArchived = (currentColumn != null && resolveColumnFlags(currentColumn).archived)
+        || (currentColumn == null && task.column === "archived");
       if (isArchived) {
         throw badRequest("Respecify is not available for archived tasks; unarchive first.");
       }
@@ -5800,7 +5827,8 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
         })).task;
       } else {
         const hasActiveSession = Boolean(updatedTask.sessionFile);
-        if (steeringCommentId && updatedTask.column === "in-progress" && updatedTask.assignedAgentId && !hasActiveSession) {
+        if (steeringCommentId && updatedTask.column === await resolveWipColumnForTask(scopedStore, updatedTask.id)
+          && updatedTask.assignedAgentId && !hasActiveSession) {
           await triggerCommentWakeForAssignedAgent(scopedStore, updatedTask, {
             triggeringCommentType: "steering",
             triggeringCommentIds: [steeringCommentId],
@@ -5855,7 +5883,7 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
 
       let updatedTask: Task = await scopedStore.getTask(task.id);
 
-      if (task.column === "in-review") {
+      if (task.column === await resolveReviewColumnForTask(scopedStore, task.id)) {
         await scopedStore.updateTask(task.id, {
           status: null,
           error: null,
@@ -5873,7 +5901,8 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       }
 
       const hasActiveSession = Boolean(updatedTask.sessionFile);
-      if (updatedTask.column === "in-progress" && updatedTask.assignedAgentId && !hasActiveSession) {
+      if (updatedTask.column === await resolveWipColumnForTask(scopedStore, updatedTask.id)
+        && updatedTask.assignedAgentId && !hasActiveSession) {
         await triggerCommentWakeForAssignedAgent(scopedStore, updatedTask, {
           triggeringCommentType: "steering",
           triggeringCommentIds: [steeringCommentId],

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -833,19 +833,35 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
         ? await scopedStore.getActivePrEntityBySource?.("branch-group", task.branchContext.groupId)
         : null);
     /*
-    FNXC:WorkflowResolvedColumns 2026-07-27-16:20 (U10 / R8):
-    Deliberately still on the legacy enum, unlike the move route's copy of this guard. This whole
-    function is gated on the literal `task.column !== "in-review"` above and re-engages to the
-    literal `"in-progress"`, so both endpoints are legacy ids by construction and the enum resolves
-    them correctly. Swapping in the task's workflow order here would make the guard WEAKER, not
-    stronger: a workflow declaring `in-review` but not `in-progress` would score -1 for the target
-    and disable the guard entirely. Convert this site when its surrounding literals are converted
-    (U5 owns the re-engage lane), not before.
+    FNXC:WorkflowResolvedColumns 2026-07-27-16:20 (U10 / R8) — SUPERSEDED, kept for the reasoning:
+    this guard stayed on the legacy enum because "this whole function is gated on the literal
+    `task.column !== "in-review"` above and re-engages to the literal `"in-progress"`, so both endpoints
+    are legacy ids by construction". That premise held when it was written.
+
+    FNXC:WorkflowLifecycleColumns 2026-08-01-21:20 (PR #2701 review — greptile P1):
+    BOTH HALVES OF THAT PREMISE ARE NOW FALSE, and the guard silently stopped existing. U5 converted the
+    re-engage TARGET to `resolveWipColumnForTask`, and this PR converted the entry GATE to the resolved
+    review lane — so on a renamed board the enum scores -1 for both endpoints, and
+    `isBackwardMoveBlockedByOpenPr` treats a negative index as "cannot tell -> allow". A user comment on a
+    review card with an OPEN PR resumed execution behind that PR.
+
+    This is the third form of the same defect this program keeps finding: not a literal answering wrongly,
+    but a guard whose CORRECTNESS ARGUMENT depended on literals elsewhere that someone else has since
+    converted. The comment was accurate and became false without being touched. When you convert a lane,
+    grep for comments that justify a nearby legacy path by "the surrounding literals" — they are load-bearing.
+
+    Ordering now comes from the same `resolveMoveOrderIndices` the move route uses, with the workflow
+    authoritative only when it can place BOTH endpoints (U10/R8's rule), and the target is the SAME value
+    the move below uses rather than a second resolution.
     */
+    const reengageColumn = await resolveWipColumnForTask(scopedStore, task.id);
+    const reengageIr = await resolveWorkflowIrForTask(scopedStore, task.id).catch(() => undefined);
+    const { fromIndex: reengageFromIndex, toIndex: reengageToIndex } =
+      resolveMoveOrderIndices(reengageIr, task.column, reengageColumn);
     if (
       isBackwardMoveBlockedByOpenPr({
-        fromIndex: COLUMNS.indexOf(task.column as Column),
-        toIndex: COLUMNS.indexOf("in-progress"),
+        fromIndex: reengageFromIndex,
+        toIndex: reengageToIndex,
         activePrEntity,
       })
     ) {
@@ -870,7 +886,6 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       await scopedStore.updateStep(task.id, lastDoneStep.index, "pending");
     }
 
-    const reengageColumn = await resolveWipColumnForTask(scopedStore, task.id);
     const reengagedTask = await scopedStore.moveTask(task.id, reengageColumn, { preserveProgress: true });
     await triggerCommentWakeForAssignedAgent(scopedStore, reengagedTask, wake);
     return { task: reengagedTask, reengaged: true };
@@ -2782,8 +2797,14 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
           activeMergeTaskId: selfHealingManager?.getActiveMergeTaskId?.() ?? null,
           minAgeMs: selfHealingManager?.getStaleMergingStatusMinAgeMs?.(),
         });
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-21:10 (PR #2701 review — greptile P1, and it is right):
+         `isInReviewStatusNone` and `isStaleMergeActiveRetry` above already read the RESOLVED lane, so
+         leaving this one literal made the retry decision internally inconsistent: every input said the
+         card was in review, and the combining gate said it was not. On a renamed board
+         `POST /tasks/:id/retry` rejected a legitimate failed/stalled review card with "Task is not in a
+         retryable state". One decision, one lane. */
       const isInReviewRetry =
-        task.column === "in-review" &&
+        task.column === reviewLane &&
         (task.status === "failed" ||
           task.status === "stuck-killed" ||
           isInReviewExecutionStall ||

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -220,6 +220,26 @@ function resolveMoveOrderIndices(
   };
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-14:30 (fleet: register-task-workflow-routes.ts):
+THE REVIEW-LANE SIBLING of the three resolvers above, and it completes this file's OWN pattern rather
+than adding an abstraction: `resolveReboundColumnForTask` (hold), `resolveIntakeColumnForTask` (intake)
+and `resolveWipColumnForTask` (wip) already exist in exactly this shape, and ten route guards needed the
+fourth. Adding it beside its siblings is what stops the fourth role being inlined ten times — the
+copy-paste drift the first three were extracted to remove.
+
+`mergeOrchestration` is the trait, matching core's `resolveLifecycleColumns().review`, and the legacy
+`in-review` stays the fallback for an unresolvable or column-less IR, so `builtin:coding` is unchanged.
+*/
+async function resolveReviewColumnForTask(store: TaskStore, taskId: string): Promise<string> {
+  try {
+    const ir = await resolveWorkflowIrForTask(store, taskId);
+    return columnsWithFlag(ir, "mergeOrchestration")[0] ?? "in-review";
+  } catch {
+    return "in-review";
+  }
+}
+
 async function resolveWipColumnForTask(store: TaskStore, taskId: string): Promise<string> {
   try {
     const ir = await resolveWorkflowIrForTask(store, taskId);
@@ -797,7 +817,10 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
     task: Task,
     wake: InReviewUserCommentReengagementInput,
   ): Promise<InReviewUserCommentReengagementResult> {
-    if (task.column !== "in-review") {
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-14:35 (fleet): the board's review lane. With the literal, a
+       user comment on a review card of a renamed board was suppressed as "not-in-review" — and that string
+       is returned by the API, so the operator was told their own review card was not in review. */
+    if (task.column !== await resolveReviewColumnForTask(scopedStore, task.id)) {
       return { task, reengaged: false, suppressedReason: "not-in-review" };
     }
     if (task.sessionFile) {
@@ -3780,8 +3803,9 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       if (!task) {
         throw notFound(`Task ${req.params.id} not found`);
       }
-      if (task.column !== "in-review") {
-        throw badRequest("Task must be in 'in-review' column to recover branch binding");
+      const reviewColumn = await resolveReviewColumnForTask(scopedStore, task.id);
+      if (task.column !== reviewColumn) {
+        throw badRequest(`Task must be in the '${reviewColumn}' column to recover branch binding`);
       }
 
       const selfHealingManager = _resolveSelfHealingManager(scopedStore);
@@ -4098,7 +4122,7 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
         triggerDetail: "task-comment",
       };
       if (normalizedAuthor === "user") {
-        if (task.column === "in-review" && !task.sessionFile) {
+        if (task.column === await resolveReviewColumnForTask(scopedStore, task.id) && !task.sessionFile) {
           const { task: reengagedTask } = await reengageInReviewTaskForUserComment(scopedStore, task, wake);
           res.json(reengagedTask);
           return;
@@ -4665,7 +4689,7 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
         triggeringCommentIds: newSteeringCommentId ? [newSteeringCommentId] : undefined,
         triggerDetail: "steering-comment",
       };
-      if (task.column === "in-review" && !task.sessionFile) {
+      if (task.column === await resolveReviewColumnForTask(scopedStore, task.id) && !task.sessionFile) {
         const { task: reengagedTask } = await reengageInReviewTaskForUserComment(scopedStore, task, wake);
         res.json(reengagedTask);
         return;
@@ -5768,7 +5792,7 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
 
       let updatedTask: Task = await scopedStore.getTask(task.id);
 
-      if (task.column === "in-review") {
+      if (task.column === await resolveReviewColumnForTask(scopedStore, task.id)) {
         updatedTask = (await reengageInReviewTaskForUserComment(scopedStore, updatedTask, {
           triggeringCommentType: "steering",
           triggeringCommentIds: steeringCommentId ? [steeringCommentId] : undefined,
@@ -5803,8 +5827,13 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       if (!prInfo) {
         throw badRequest("Task must have a linked pull request before PR feedback can be addressed");
       }
-      if (task.column !== "in-review" && task.column !== "in-progress") {
-        throw badRequest("PR feedback can only be addressed for in-review or in-progress tasks");
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-14:40 (fleet): both lanes resolved, and the 400 message
+         now names the board's actual columns — telling an operator their card must be "in-review" on a
+         board with no such column is a worse failure than the guard being wrong. */
+      const feedbackReviewColumn = await resolveReviewColumnForTask(scopedStore, task.id);
+      const feedbackWipColumn = await resolveWipColumnForTask(scopedStore, task.id);
+      if (task.column !== feedbackReviewColumn && task.column !== feedbackWipColumn) {
+        throw badRequest(`PR feedback can only be addressed for ${feedbackReviewColumn} or ${feedbackWipColumn} tasks`);
       }
 
       /*

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,21 +1,21 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 707,
+    "column": 679,
     "role": 5,
     "status": 186,
     "deliberate": 21
   },
   "byColumnId": {
-    "done": 196,
+    "done": 182,
     "in-progress": 132,
     "in-review": 190,
-    "archived": 147,
-    "todo": 42
+    "archived": 137,
+    "todo": 38
   },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 85,
+    "packages/engine/src/executor.ts": 57,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 26,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 679,
+    "column": 678,
     "role": 5,
     "status": 186,
     "deliberate": 21
@@ -9,7 +9,7 @@
   "byColumnId": {
     "done": 182,
     "in-progress": 132,
-    "in-review": 190,
+    "in-review": 189,
     "archived": 137,
     "todo": 38
   },
@@ -33,13 +33,13 @@
     "packages/core/src/default-workflow-hooks.ts": 7,
     "packages/core/src/task-store/update-task-deps.ts": 7,
     "packages/dashboard/app/components/Column.tsx": 7,
-    "packages/dashboard/src/routes/register-task-workflow-routes.ts": 7,
     "packages/core/src/live-agent-count.ts": 6,
     "packages/core/src/task-merge.ts": 6,
     "packages/core/src/task-store/branch-group-ops.ts": 6,
     "packages/core/src/task-store/task-artifacts-ops.ts": 6,
     "packages/dashboard/app/components/ListView.tsx": 6,
     "packages/dashboard/src/reliability-metrics.ts": 6,
+    "packages/dashboard/src/routes/register-task-workflow-routes.ts": 6,
     "packages/engine/src/runtimes/in-process-runtime.ts": 6,
     "packages/cli/src/extension.ts": 5,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 5,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,16 +1,16 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "totals": {
-    "column": 713,
+    "column": 707,
     "role": 5,
     "status": 186,
-    "deliberate": 20
+    "deliberate": 21
   },
   "byColumnId": {
     "done": 196,
-    "in-progress": 134,
-    "in-review": 193,
-    "archived": 148,
+    "in-progress": 132,
+    "in-review": 190,
+    "archived": 147,
     "todo": 42
   },
   "byFile": {
@@ -20,7 +20,6 @@
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 26,
     "packages/core/src/task-store/moves.ts": 15,
-    "packages/dashboard/src/routes/register-task-workflow-routes.ts": 13,
     "packages/core/src/store.ts": 12,
     "packages/engine/src/project-engine.ts": 12,
     "packages/engine/src/mission-execution-loop.ts": 10,
@@ -34,6 +33,7 @@
     "packages/core/src/default-workflow-hooks.ts": 7,
     "packages/core/src/task-store/update-task-deps.ts": 7,
     "packages/dashboard/app/components/Column.tsx": 7,
+    "packages/dashboard/src/routes/register-task-workflow-routes.ts": 7,
     "packages/core/src/live-agent-count.ts": 6,
     "packages/core/src/task-merge.ts": 6,
     "packages/core/src/task-store/branch-group-ops.ts": 6,
@@ -166,6 +166,7 @@
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000triage": 1,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000todo": 1,
     "packages/dashboard/app/utils/columnRoles.ts\u0000todo": 1,
+    "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000archived": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000todo": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000triage": 1,
     "packages/engine/src/hold-release.ts\u0000archived": 1,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,13 +1,26 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
+  "totals": {
+    "column": 713,
+    "role": 5,
+    "status": 186,
+    "deliberate": 20
+  },
+  "byColumnId": {
+    "done": 196,
+    "in-progress": 134,
+    "in-review": 193,
+    "archived": 148,
+    "todo": 42
+  },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
-    "packages/engine/src/executor.ts": 57,
+    "packages/engine/src/executor.ts": 85,
     "packages/dashboard/app/components/TaskCard.tsx": 42,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 30,
     "packages/engine/src/scheduler.ts": 26,
-    "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
     "packages/core/src/task-store/moves.ts": 15,
+    "packages/dashboard/src/routes/register-task-workflow-routes.ts": 13,
     "packages/core/src/store.ts": 12,
     "packages/engine/src/project-engine.ts": 12,
     "packages/engine/src/mission-execution-loop.ts": 10,
@@ -159,6 +172,18 @@
     "packages/engine/src/hold-release.ts\u0000done": 1,
     "packages/engine/src/hold-release.ts\u0000in-review": 1,
     "packages/engine/src/triage.ts\u0000triage": 1
+  },
+  "properties": {
+    "query": 83,
+    "definition": 43
+  },
+  "queryByColumnId": {
+    "todo": 10,
+    "archived": 7,
+    "done": 10,
+    "in-progress": 19,
+    "in-review": 35,
+    "triage": 2
   },
   "queryByFile": {
     "packages/engine/src/self-healing.ts": 48,


### PR DESCRIPTION
**Claim announced before the work this time** (on #2689, after colliding with another worker on `executor.ts`): `packages/dashboard/src/routes/register-task-workflow-routes.ts`.

**20 → 13**, seven guards, the review-lane cluster.

## Why these seven are worse than an inert guard

In three of the seven the wrong answer is **reported to the operator as a fact about their own board**:

- the user-comment re-engagement returns `suppressedReason: "not-in-review"` — so a comment on a card **plainly sitting in review** is dropped, and the API tells the operator the card is not in review;
- the branch-binding recovery and PR-feedback routes reject with 400s naming `in-review`, **a column the board does not have**.

Both messages now name the resolved columns. Telling an operator their card must be `in-review` on a board with no such column is a worse failure than the guard being wrong quietly — it sends them looking for a column that does not exist.

## `resolveReviewColumnForTask` completes this file's own family

`resolveReboundColumnForTask` (hold), `resolveIntakeColumnForTask` (intake) and `resolveWipColumnForTask` (wip) already exist in exactly this shape. The fourth role was needed in seven places, so this is the same abstraction applied to the role it did not yet cover — the alternative is inlining a resolve-plus-fallback expression seven times, which is the copy-paste drift the first three were extracted to remove. Trait is `mergeOrchestration`, matching core's `resolveLifecycleColumns().review`; the legacy `in-review` stays the fallback, so `builtin:coding` is byte-identical.

## Revert proof

**2 of 4 cases redden** with the literal restored. The two default-board cases pass either way by design — `builtin:coding`'s review column *is* `in-review` — and they are labelled in the file as no-change evidence rather than counted as coverage.

**Two of my own mistakes are recorded in the test file**, because both are the same failure — an assertion that never touched the code it named:

1. My first version drove `/address-pr-feedback`. That path does not exist (it is `/pr/address-feedback`), and all five cases **hung for 15s each** on the unmatched route.
2. The assertions are on **which 400** comes back, not on the status. The success path continues into a self-healing manager a partial store mock cannot provide, so a passing card also ends in a 400 — `expect(status).not.toBe(400)` would have asserted nothing.

## Remaining 13 in this file

- **`1149`, `1882`, `4798`** — `todoRows` filtering, a `column === "in-progress"` inside a rendering helper, and an `isArchived` check that already reads trait flags beside the literal. Convertible; next batch.
- **`2066`, `3962`** — terminal pairs; `3962` is a **dependency** `done` check, the same "what does satisfied mean" question I flagged in `executor.ts` at `12456`. Same answer needed for both, so they should be decided together rather than swapped twice.
- **`2694`, `2727`, `2733`** — review-status classifiers inside the awaiting-planning aggregation; these read `lifecycle` from a resolution already in scope a few lines above, so they want that snapshot threaded rather than a new resolve per site.
- **`5770`, `5838`** — wip-lane steering checks, mechanical.

## Verification

`pnpm test:gate` **158 / 10 / 487 / 71** · 10/10 across the two resolved-column route suites · `tsc -p packages/dashboard` clean · `pnpm lint` clean · census `--strict` exit 0.

Baseline re-recorded; it also picked up another worker's landed `scheduler.ts` drop, which is the #2679 auto-tighten doing its job rather than reddening this PR for an unrelated change.

No changeset: `@fusion/dashboard` is private, and the operator-visible part is a 400 message naming the right column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
