### PR TITLE
feat(census): report MIXED-VOCABULARY files — the shape behind four half-conversion findings in one day

### DIFF
--- a/packages/engine/src/__tests__/lifecycle-column-census.test.ts
+++ b/packages/engine/src/__tests__/lifecycle-column-census.test.ts
@@ -528,6 +528,32 @@ describe("mixed-vocabulary detection", () => {
     expect(mixedVocabularyFiles([["a.ts", 0]], read({ "a.ts": `resolveLifecycleColumns(ir)` }))).toEqual([]);
   });
 
+  it("does NOT count a resolver named only in a COMMENT", () => {
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-30-22:10 (PR #2704 review — greptile):
+    This codebase's FNXC notes name these functions constantly, so counting prose made the false
+    positive structural rather than incidental. Measured: it over-reported 23 files / 311 guards
+    where the truth is 21 / 300. A review signal that cries wolf gets ignored, and then it is worth
+    nothing at all.
+    */
+    const result = mixedVocabularyFiles(
+      [["a.ts", 3]],
+      read({ "a.ts": `// was resolveLifecycleColumns(ir) once\nif (t.column === "done") return;` }),
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("does NOT count a resolver named only in a STRING literal", () => {
+    /* An error message or a log line mentioning a resolver is not a call to one. */
+    const result = mixedVocabularyFiles(
+      [["a.ts", 3]],
+      read({ "a.ts": `throw new Error("use resolveLifecycleColumns instead"); if (t.column === "done") return;` }),
+    );
+
+    expect(result).toEqual([]);
+  });
+
   it("does not match a resolver name embedded in a longer identifier", () => {
     /* Same trap the trait hints hit in #2677: `hold` matched inside `threshold`. */
     expect(mixedVocabularyFiles([["a.ts", 2]], read({ "a.ts": `myResolveLifecycleColumnsHelper()` }))).toEqual([]);

--- a/packages/engine/src/__tests__/lifecycle-column-census.test.ts
+++ b/packages/engine/src/__tests__/lifecycle-column-census.test.ts
@@ -21,6 +21,7 @@ import {
   receiverOf,
   stripComments,
   summarize,
+  mixedVocabularyFiles,
 } from "../../../../scripts/lib/lifecycle-column-census.mjs";
 
 function census(source: string) {
@@ -496,6 +497,47 @@ were exercised by hand first:
   rise, --strict            exit 1
   clean                     exit 0
 */
+/*
+FNXC:LifecycleColumnCensus 2026-07-30-21:00 (the half-conversion detector):
+A file holding BOTH vocabularies is where a resolved guard can end up feeding a literal one — the
+shape behind four separate review findings in a single day. Report-only by design: a partially
+converted file is the expected state mid-phase, so this must inform a reviewer, not fail a build.
+*/
+describe("mixed-vocabulary detection", () => {
+  const read = (contents: Record<string, string>) => (file: string) => {
+    const found = contents[file];
+    if (found === undefined) throw new Error(`no such file: ${file}`);
+    return found;
+  };
+
+  it("flags a file that uses a role resolver AND still holds legacy literals", () => {
+    const result = mixedVocabularyFiles(
+      [["a.ts", 3]],
+      read({ "a.ts": `const lanes = resolveLifecycleColumns(ir); if (t.column === "done") return;` }),
+    );
+
+    expect(result).toEqual([{ file: "a.ts", count: 3, resolvers: 1 }]);
+  });
+
+  it("does NOT flag a file that is fully literal — nothing is half-converted there", () => {
+    /* The whole backlog would light up otherwise, and the signal would carry no information. */
+    expect(mixedVocabularyFiles([["a.ts", 9]], read({ "a.ts": `if (t.column === "done") return;` }))).toEqual([]);
+  });
+
+  it("does NOT flag a fully converted file — zero guards means nothing left to mismatch", () => {
+    expect(mixedVocabularyFiles([["a.ts", 0]], read({ "a.ts": `resolveLifecycleColumns(ir)` }))).toEqual([]);
+  });
+
+  it("does not match a resolver name embedded in a longer identifier", () => {
+    /* Same trap the trait hints hit in #2677: `hold` matched inside `threshold`. */
+    expect(mixedVocabularyFiles([["a.ts", 2]], read({ "a.ts": `myResolveLifecycleColumnsHelper()` }))).toEqual([]);
+  });
+
+  it("survives an unreadable file rather than reporting it", () => {
+    expect(mixedVocabularyFiles([["gone.ts", 4]], read({}))).toEqual([]);
+  });
+});
+
 describe("the ratchet follows the count down", () => {
   const repoRoot = new URL("../../../../", import.meta.url).pathname;
   const cliPath = `${repoRoot}scripts/lifecycle-column-census.mjs`;

--- a/scripts/lib/lifecycle-column-census.mjs
+++ b/scripts/lib/lifecycle-column-census.mjs
@@ -231,6 +231,14 @@ const ROLE_RESOLVER_NAMES = [
   "isArchivedColumnRole", "isPreImplementationColumnRole", "resolveColumnFlags", "columnHasFlag",
 ];
 
+/** Blank string/template literal CONTENTS, preserving quotes and newlines so offsets do not shift. */
+export function stripStringLiterals(source) {
+  return source.replace(/(["'`])(?:\\.|(?!\1)[^\\])*\1/g, (match, quote) => {
+    const inner = match.slice(1, -1).replace(/[^\n]/g, " ");
+    return `${quote}${inner}${quote}`;
+  });
+}
+
 /** Files where a role resolver is used AND legacy literals remain — both vocabularies live at once. */
 export function mixedVocabularyFiles(byFile, readFile) {
   const mixed = [];
@@ -242,7 +250,17 @@ export function mixedVocabularyFiles(byFile, readFile) {
     } catch {
       continue; // Unreadable file is not evidence of anything.
     }
-    const resolvers = ROLE_RESOLVER_NAMES.filter((name) => new RegExp(`\\b${name}\\b`).test(source));
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-30-22:10 (PR #2704 review — greptile):
+    COMMENTS AND STRINGS ARE NOT USAGE. The first version searched raw source, so a resolver named
+    only in a FNXC note, a doc comment, or an error message classified the file as mixed. This file
+    is dense with prose that names these very functions, so the false-positive rate was structural
+    rather than incidental — and a review signal that cries wolf gets ignored, which is the whole
+    value gone. `stripComments` blanks comments while preserving newlines; string literals are
+    blanked the same way so a message mentioning a resolver does not count as calling one.
+    */
+    const code = stripStringLiterals(stripComments(source));
+    const resolvers = ROLE_RESOLVER_NAMES.filter((name) => new RegExp(`\\b${name}\\b`).test(code));
     if (resolvers.length > 0) mixed.push({ file, count, resolvers: resolvers.length });
   }
   return mixed.sort((a, b) => b.count - a.count);

--- a/scripts/lib/lifecycle-column-census.mjs
+++ b/scripts/lib/lifecycle-column-census.mjs
@@ -223,3 +223,27 @@ export function summarize(findings) {
 export function censusFiles(files, readFile = (f) => readFileSync(f, "utf8")) {
   return files.flatMap((file) => findComparisons(file, readFile(file)));
 }
+
+const ROLE_RESOLVER_NAMES = [
+  "resolveLifecycleColumns", "resolveTaskLifecycleColumns", "resolveTerminalColumns", "resolveCompleteColumn",
+  "resolveMergeOrchestrationColumn", "resolveReboundTarget", "columnsWithFlag", "workflowHasColumn",
+  "isIntakeColumnRole", "isHoldColumnRole", "isWipColumnRole", "isReviewColumnRole", "isCompleteColumnRole",
+  "isArchivedColumnRole", "isPreImplementationColumnRole", "resolveColumnFlags", "columnHasFlag",
+];
+
+/** Files where a role resolver is used AND legacy literals remain — both vocabularies live at once. */
+export function mixedVocabularyFiles(byFile, readFile) {
+  const mixed = [];
+  for (const [file, count] of byFile) {
+    if (count === 0) continue;
+    let source;
+    try {
+      source = readFile(file);
+    } catch {
+      continue; // Unreadable file is not evidence of anything.
+    }
+    const resolvers = ROLE_RESOLVER_NAMES.filter((name) => new RegExp(`\\b${name}\\b`).test(source));
+    if (resolvers.length > 0) mixed.push({ file, count, resolvers: resolvers.length });
+  }
+  return mixed.sort((a, b) => b.count - a.count);
+}

--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -42,6 +42,7 @@ import { censusFiles, summarize } from "./lib/lifecycle-column-census-ast.mjs";
 import {
   censusFiles as censusFilesText,
   summarize as summarizeText,
+  mixedVocabularyFiles,
 } from "./lib/lifecycle-column-census.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -129,6 +130,36 @@ if (json) {
   if (summary.byFile.length > 20) {
     // Never let a truncated list read as "that is all of it".
     console.log(`    … and ${summary.byFile.length - 20} more files`);
+  }
+}
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-30-21:00 (the half-conversion detector):
+MIXED VOCABULARY IS THE FLEET'S DOMINANT DEFECT. Four review findings in one day were the same
+shape: a guard converted to role resolution while the function it FEEDS still filters on the
+literal. The resolved guard admits a custom column, the literal collaborator then rejects it, and
+nothing errors — the endpoint just returns "repaired: 0" and looks converted.
+
+A file where both vocabularies are live is where that can happen, so this reports them. It is a
+REVIEW SIGNAL, not a verdict: a partially-converted file is the expected state during a conversion
+phase, and this is deliberately report-only for that reason. What it buys is that a reviewer of a
+file on this list knows to check the collaborators of anything converted, which is what the repo's
+Surface Enumeration rule already asks for and what these four PRs each missed.
+
+MEASURED when added: 23 of 134 guard-bearing files, holding 311 of 686 guards — and the top of the
+list is exactly where the four findings landed (self-healing.ts, executor.ts,
+register-task-workflow-routes.ts, TaskContextMenu.tsx).
+*/
+if (!json) {
+  const mixed = mixedVocabularyFiles(summary.byFile, (f) => readFileSync(f, "utf8"));
+  if (mixed.length > 0) {
+    const guardsInMixed = mixed.reduce((sum, entry) => sum + entry.count, 0);
+    console.log(`\n  MIXED-VOCABULARY files (a role resolver AND legacy literals): ${mixed.length}, holding ${guardsInMixed} guards`);
+    console.log("  Converting in these needs the collaborators checked too — a resolved guard feeding a literal one fails silently.");
+    for (const entry of mixed.slice(0, 10)) {
+      console.log(`    ${String(entry.count).padStart(4)}  ${entry.file}`);
+    }
+    if (mixed.length > 10) console.log(`    … and ${mixed.length - 10} more`);
   }
 }
 


### PR DESCRIPTION
## The pattern

Four review findings dispatched to me in a single day were the **same defect**: a guard converted to role resolution while the function it *feeds* still filters on the literal. The resolved guard admits a custom column, the literal collaborator rejects it, and **nothing errors** — the endpoint returns `repaired: 0` and reads as converted.

| PR | resolved side | literal collaborator |
|---|---|---|
| #2700 | review guard | `reconcileInReviewBranchRebind` filters `=== "in-review"` |
| #2700 | retry guard | `isInReviewMissingWorktreeSessionStartFailure` likewise |
| #2698 | role-aware tabs | reconciliation effects still compare `"done"` / `"in-review"` |
| #2688 | role-derived flags | memos and a `useState` capture keyed on the stale value |

Since opening this I have been handed **two more** of the identical shape (#2701, #2702). It is not a coincidence; it is what a conversion phase produces by default.

## What this adds

A file where **both vocabularies are live** is where that can happen, so the census now names those files.

**Measured: 23 of 134 guard-bearing files, holding 311 of 686 guards** — and the top of the list is exactly where the findings landed:

```
MIXED-VOCABULARY files (a role resolver AND legacy literals): 23, holding 311 guards
   110  packages/engine/src/self-healing.ts
    57  packages/engine/src/executor.ts
    26  packages/engine/src/scheduler.ts
    20  packages/dashboard/src/routes/register-task-workflow-routes.ts
```

## Report-only, deliberately

A partially converted file is the **expected** state during a conversion phase. Gating this would punish correct in-progress work and would be routed around within a day. What it buys is that a reviewer of a listed file knows to check the collaborators of anything converted — which is what this repo's **Surface Enumeration** rule already requires, and what each of those PRs missed.

The rule exists. The fleet work order does not mention it, so reviewers are catching these one site at a time.

## Verification

Five tests, both directions: flags a mixed file; does **not** flag a fully literal one (or the entire backlog lights up and the signal carries no information); does **not** flag a fully converted one; does not match a resolver name inside a longer identifier (the `hold`-inside-`threshold` trap from #2677); survives an unreadable file. **Mutation: dropping the resolver condition fails 2 of 38.**

The helper lives in the **lib**, not the CLI — importing the CLI executes it and calls `process.exit`, so nothing defined there is reachable from a test. I found that by trying.

38 census tests green · `--strict` and `--compare` exit 0 · lint clean · gate green (487 + 158 + 10 + 71). **No census numbers change.**