### PR TITLE
fleet: project-engine.ts 12 → 5 — auto-merge silently declined every card on a renamed board

### DIFF
--- a/packages/engine/src/__tests__/project-engine-merge-lane-resolved.test.ts
+++ b/packages/engine/src/__tests__/project-engine-merge-lane-resolved.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-19:50 (fleet: project-engine.ts merge lane):
+
+THE INVARIANT: the merge machinery recognises the task's OWN merge lane.
+
+Every merge guard in `project-engine.ts` spelled it `in-review`. The consequence on a renamed board is
+not an error anywhere — it is auto-merge DECLINING every card:
+
+  - `requestInterpreterMerge` returns `noOp: true` ("parked cleanly in review, awaiting human merge")
+    for a card that was in review and fully eligible;
+  - the merge-queue snapshot returns an EMPTY list for a queue full of review cards, so the
+    coordinator sees nothing to admit;
+  - the taskMoved handoff never fires, so nothing is handed to auto-merge in the first place.
+
+That is why this class has no error signature to search for: the operator sees cards resting in review
+with auto-merge on, and every log line says the system did the right thing.
+
+HOW THIS DRIVES THE REAL METHOD. `ProjectEngine`'s constructor builds a whole runtime, which a unit
+test has no business standing up — so the method is invoked with `.call()` on a minimal `this`
+providing exactly what it touches: `runtime.getTaskStore()`, `allowInReviewMergeProcessing`, and
+`onMerge`. The body under test is the shipped one, not a copy. `onMerge` is stubbed because reaching it
+IS the assertion: eligible routes to the serialized merge path, ineligible returns the `noOp` result.
+
+REVERT PROOF, measured: restore the literal and the renamed-board case returns `noOp: true` instead of
+routing to `onMerge`.
+*/
+import { describe, expect, it, vi } from "vitest";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+import { ProjectEngine } from "../project-engine.js";
+
+/** A board whose merge lane is `signoff`, sharing no lifecycle id with the default lineage. */
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "signoff", name: "Sign-off", traits: [{ trait: "merge" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+} as unknown as WorkflowIr;
+
+function harness(column: string, ir: WorkflowIr | undefined) {
+  const task = { id: "FN-1", column, branch: "fusion/FN-1", dependencies: [], steps: [] } as unknown as Task;
+  const settings = { autoMerge: true, globalPause: false, enginePaused: false } as unknown as Settings;
+  const selection = { workflowId: "wf-renamed", stepIds: [] as string[] };
+
+  const store = {
+    getTask: vi.fn(async () => task),
+    getSettings: vi.fn(async () => settings),
+    getTaskWorkflowSelection: () => (ir ? selection : undefined),
+    getTaskWorkflowSelectionAsync: async () => (ir ? selection : undefined),
+    getWorkflowDefinition: async () => (ir ? { ir } : undefined),
+  } as unknown as TaskStore;
+
+  const onMerge = vi.fn(async () => ({ task, branch: task.branch ?? "", merged: true } as never));
+  const self = {
+    runtime: { getTaskStore: () => store },
+    allowInReviewMergeProcessing: vi.fn(async () => true),
+    onMerge,
+  };
+
+  const call = () =>
+    (ProjectEngine.prototype as unknown as {
+      requestInterpreterMerge: (this: unknown, id: string, o?: unknown) => Promise<{ noOp?: boolean; merged?: boolean }>;
+    }).requestInterpreterMerge.call(self, "FN-1", {});
+
+  return { call, onMerge, task };
+}
+
+describe("project-engine merge eligibility resolves the board's own merge lane", () => {
+  it("routes a RENAMED board's review card to the merge path instead of declining it", async () => {
+    // Pre-fix: `signoff` !== "in-review", so this returned noOp:true and the card sat in review with
+    // auto-merge on and a log line saying manual merge was required.
+    const { call, onMerge } = harness("signoff", RENAMED_IR);
+
+    const result = await call();
+
+    expect(onMerge).toHaveBeenCalledTimes(1);
+    expect(result.noOp).toBeUndefined();
+  });
+
+  it("still declines a card that is NOT in the merge lane", async () => {
+    // The paired negative: a card mid-implementation must not be merged.
+    const { call, onMerge } = harness("building", RENAMED_IR);
+
+    const result = await call();
+
+    expect(onMerge).not.toHaveBeenCalled();
+    expect(result.noOp).toBe(true);
+    expect(result.merged).toBe(false);
+  });
+
+  it("behaves identically on the DEFAULT board", async () => {
+    // No workflow selection: resolution falls back to `in-review`, unchanged behaviour. This case
+    // passes either way by design and is here as no-change evidence, not as coverage.
+    const { call, onMerge } = harness("in-review", undefined);
+
+    await call();
+
+    expect(onMerge).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/engine/src/__tests__/project-engine-merge-lane-resolved.test.ts
+++ b/packages/engine/src/__tests__/project-engine-merge-lane-resolved.test.ts
@@ -102,3 +102,93 @@ describe("project-engine merge eligibility resolves the board's own merge lane",
     expect(onMerge).toHaveBeenCalledTimes(1);
   });
 });
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-08-01-22:10 (PR #2706 review — greptile P2, and the project's own
+Surface Enumeration rule says the same thing):
+
+The first block covered `requestInterpreterMerge` only, while the change also touches the merge-queue
+snapshot, the queue drain, the `taskMoved` handoff, the pause-interruption tracker and the
+session-advisor WIP guard. A suite that covers one of six surfaces can stay green while renamed-board
+cards disappear from admission or pause tracking again.
+
+Two more surfaces are covered here, chosen because they are the ones with STATE an assertion can see:
+
+  - THE PAUSE-INTERRUPTION TRACKER, because it has state an assertion can see. On a renamed board its
+    first branch DELETED every card from `pausedReviewTaskIds` and returned, so pausing an active merge
+    never interrupted it.
+
+NOT COVERED, and named rather than implied — I tried each of these before dropping it:
+
+  - THE MERGE-QUEUE SNAPSHOT. Its failure is the quietest in the file (an EMPTY array for a queue full of
+    review cards, with no log line saying why), so it is the one I most wanted. The admission provider is
+    registered in the CONSTRUCTOR, which builds a whole runtime, so reaching its `refresh` needs a booted
+    ProjectEngine. My first attempt looked the method up dynamically on the prototype and would have
+    silently skipped — a case that cannot fail is worse than an absent one, so it is gone.
+  - THE `taskMoved` HANDOFF and THE QUEUE DRAIN schedule real timers and recurse into the merge machinery.
+  - THE SESSION-ADVISOR guard needs a live advisor.
+
+Those four are covered by the census and by review only. Padding the suite with cases that assert nothing
+would make the gap invisible, which is the failure this file already documents twice.
+*/
+describe("the other merge-lane surfaces on a renamed board", () => {
+  function storeFor(column: string, ir: WorkflowIr | undefined) {
+    const task = { id: "FN-Q", column, dependencies: [], steps: [] } as unknown as Task;
+    const selection = { workflowId: "wf-renamed", stepIds: [] as string[] };
+    return {
+      task,
+      store: {
+        getTask: vi.fn(async () => task),
+        getSettings: vi.fn(async () => ({ autoMerge: true }) as unknown as Settings),
+        getTaskWorkflowSelection: () => (ir ? selection : undefined),
+        getTaskWorkflowSelectionAsync: async () => (ir ? selection : undefined),
+        getWorkflowDefinition: async () => (ir ? { ir } : undefined),
+        /* `wireTaskPauseMergeInterruption` also subscribes to store events; the stub must accept that. */
+        on: vi.fn(),
+      } as unknown as TaskStore,
+    };
+  }
+
+  it("keeps a renamed board's review card in the paused-review set", async () => {
+    // Pre-fix: `signoff` !== "in-review", so the first branch DELETED the card and returned — pausing an
+    // active merge never interrupted it.
+    const { store, task } = storeFor("signoff", RENAMED_IR);
+    const self = {
+      pausedReviewTaskIds: new Set<string>(),
+      mergeQueue: [] as string[],
+      mergeActive: new Set<string>(),
+      activeMergeTaskId: null as string | null,
+      taskUpdatedHandler: undefined as unknown,
+      abortActiveMerge: vi.fn(),
+    };
+
+    (ProjectEngine.prototype as unknown as {
+      wireTaskPauseMergeInterruption: (this: unknown, s: TaskStore) => void;
+    }).wireTaskPauseMergeInterruption.call(self, store);
+
+    await (self.taskUpdatedHandler as (t: Task) => Promise<void>)({ ...task, paused: true } as Task);
+
+    expect([...self.pausedReviewTaskIds]).toEqual([task.id]);
+  });
+
+  it("still drops a NON-review card from the paused-review set", async () => {
+    // The paired negative: the set must not accumulate cards that are not in the merge lane.
+    const { store, task } = storeFor("building", RENAMED_IR);
+    const self = {
+      pausedReviewTaskIds: new Set<string>([task.id]),
+      mergeQueue: [] as string[],
+      mergeActive: new Set<string>(),
+      activeMergeTaskId: null as string | null,
+      taskUpdatedHandler: undefined as unknown,
+      abortActiveMerge: vi.fn(),
+    };
+
+    (ProjectEngine.prototype as unknown as {
+      wireTaskPauseMergeInterruption: (this: unknown, s: TaskStore) => void;
+    }).wireTaskPauseMergeInterruption.call(self, store);
+
+    await (self.taskUpdatedHandler as (t: Task) => Promise<void>)({ ...task, paused: true } as Task);
+
+    expect([...self.pausedReviewTaskIds]).toEqual([]);
+  });
+});

--- a/packages/engine/src/project-engine.ts
+++ b/packages/engine/src/project-engine.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
+  WorkflowIr,
   TaskStore,
   Task,
   CentralCore,
@@ -33,6 +34,7 @@ import {
   resolveEffectivePlannerOversightLevel,
   resolveEffectiveSettings,
   resolveMaxAutoMergeRetries,
+  resolveTaskLifecycleColumns,
   resolveTaskSessionAdvisorEnabled,
   sortTasksByPriorityThenAgeAndId,
 } from "@fusion/core";
@@ -641,8 +643,26 @@ export class ProjectEngine {
         const store = this.runtime.getTaskStore();
         const queuedTaskIds = [...this.mergeQueue];
         const tasks = await Promise.all(queuedTaskIds.map(async (taskId) => await store.getTask(taskId).catch(() => null)));
+        /*
+        FNXC:WorkflowLifecycleColumns 2026-08-01-19:10 (fleet: project-engine.ts merge lane):
+        THE MERGE LANE IS THE TASK'S OWN, resolved through core's `resolveTaskLifecycleColumns` — the
+        canonical helper, so no new abstraction here. Every guard in this file spelled it `in-review`, and
+        on a renamed board that means the merge machinery does not recognise its own queue: this snapshot
+        returned an EMPTY list for a queue full of review cards, so the coordinator saw nothing to admit.
+
+        Resolved per task rather than once, because a merge queue can hold cards from different workflows;
+        the shared `irCache` keeps that to one IR read per workflow, not per card.
+        */
+        const irCache = new Map<string, WorkflowIr>();
+        const lifecycleByTaskId = new Map<string, string>();
+        for (const task of tasks) {
+          if (!task) continue;
+          const lifecycle = await resolveTaskLifecycleColumns(store, task.id, irCache);
+          lifecycleByTaskId.set(task.id, lifecycle?.review ?? "in-review");
+        }
         return tasks.flatMap((task) => {
-          if (!task || task.paused || task.userPaused || task.column !== "in-review") return [];
+          if (!task || task.paused || task.userPaused
+            || task.column !== (lifecycleByTaskId.get(task.id) ?? "in-review")) return [];
           return [{
             taskId: task.id,
             projectId,
@@ -2283,8 +2303,14 @@ export class ProjectEngine {
     } catch {
       // Fall through to the not-eligible response below.
     }
+    /* FNXC:WorkflowLifecycleColumns 2026-08-01-19:15 (fleet): merge eligibility asks whether the card is in
+       ITS board's merge lane. With the literal, no card on a renamed board was ever eligible — auto-merge
+       did not fail, it declined every card, which is why this class of defect has no error signature. */
+    const eligibleReviewColumn = task
+      ? (await resolveTaskLifecycleColumns(store, task.id))?.review ?? "in-review"
+      : "in-review";
     const eligible = !!task && !!settings
-      && task.column === "in-review"
+      && task.column === eligibleReviewColumn
       && !settings.globalPause && !settings.enginePaused
       && (await this.allowInReviewMergeProcessing(task, settings, store))
       && !(task.paused && !task.mergeDetails?.mergeConfirmed);
@@ -2954,7 +2980,10 @@ export class ProjectEngine {
           Session-advisor log feed when effective enable resolves true for the task
           (task override → project default → workflow flag → off). Still needs model.
           */
-          if (task.column === "in-progress" && this.sessionAdvisor) {
+          /* FNXC:WorkflowLifecycleColumns 2026-08-01-19:30 (fleet): the wip lane — the advisor feed exists
+             for cards that are executing, and the literal silenced it on every renamed board. */
+          if (task.column === ((await resolveTaskLifecycleColumns(store, task.id))?.wip ?? "in-progress")
+            && this.sessionAdvisor) {
             const advisorEnabled = resolveTaskSessionAdvisorEnabled(
               task,
               engineSettings,
@@ -3240,7 +3269,7 @@ export class ProjectEngine {
               continue;
             }
             const task = await store.getTask(taskId);
-            if (!task || task.column !== "in-review") {
+            if (!task || task.column !== ((await resolveTaskLifecycleColumns(store, taskId))?.review ?? "in-review")) {
               continue;
             }
             if (!(await this.allowInReviewMergeProcessing(task, settings, store))) {
@@ -4722,7 +4751,14 @@ export class ProjectEngine {
 
   private wireAutoMerge(store: TaskStore, _cwd: string): void {
     this.taskMovedHandler = async ({ task, to }: { task: Task; to: string }) => {
-      if (to !== "in-review") return;
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-08-01-19:20 (fleet): ONE snapshot for the handoff and its
+      post-grace recheck below. The two are halves of one decision — "did this card just enter the merge
+      lane, and is it still there?" — and with the literal neither half fired on a renamed board, so
+      auto-merge was never handed a card at all.
+      */
+      const handoffReviewColumn = (await resolveTaskLifecycleColumns(store, task.id))?.review ?? "in-review";
+      if (to !== handoffReviewColumn) return;
       if (task.paused) return;
       if (this.options.getTaskMergeBlocker?.(task)) return;
 
@@ -4743,7 +4779,7 @@ export class ProjectEngine {
             runtimeLog.warn(`Auto-merge handoff (${task.id}): task disappeared during grace period`);
             return;
           }
-          if (latestTask.column !== "in-review") {
+          if (latestTask.column !== handoffReviewColumn) {
             runtimeLog.log(`Auto-merge handoff (${task.id}) skipped: column changed to ${latestTask.column}`);
             return;
           }
@@ -4854,7 +4890,9 @@ export class ProjectEngine {
 
   private wireTaskPauseMergeInterruption(store: TaskStore): void {
     this.taskUpdatedHandler = async (task: Task) => {
-      if (task.column !== "in-review") {
+      /* FNXC:WorkflowLifecycleColumns 2026-08-01-19:25 (fleet): on a renamed board this dropped EVERY card
+         from the paused-review set on its next update, so a merge paused mid-flight was never interrupted. */
+      if (task.column !== ((await resolveTaskLifecycleColumns(store, task.id))?.review ?? "in-review")) {
         this.pausedReviewTaskIds.delete(task.id);
         return;
       }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,5 +1,18 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
+  "totals": {
+    "column": 685,
+    "role": 5,
+    "status": 186,
+    "deliberate": 20
+  },
+  "byColumnId": {
+    "done": 182,
+    "in-progress": 134,
+    "in-review": 193,
+    "archived": 138,
+    "todo": 38
+  },
   "byFile": {
     "packages/engine/src/self-healing.ts": 110,
     "packages/engine/src/executor.ts": 57,
@@ -9,7 +22,6 @@
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 20,
     "packages/core/src/task-store/moves.ts": 15,
     "packages/core/src/store.ts": 12,
-    "packages/engine/src/project-engine.ts": 12,
     "packages/engine/src/mission-execution-loop.ts": 10,
     "packages/core/src/task-store/async-comments-attachments.ts": 9,
     "packages/dashboard/app/components/TaskContextMenu.tsx": 9,
@@ -33,6 +45,7 @@
     "packages/dashboard/app/hooks/useTaskDiffStats.ts": 5,
     "packages/engine/src/agent-tools.ts": 5,
     "packages/engine/src/merger.ts": 5,
+    "packages/engine/src/project-engine.ts": 5,
     "packages/engine/src/restart-recovery-coordinator.ts": 5,
     "packages/core/src/agent-store.ts": 4,
     "packages/core/src/blocker-fanout.ts": 4,
@@ -159,6 +172,18 @@
     "packages/engine/src/hold-release.ts\u0000done": 1,
     "packages/engine/src/hold-release.ts\u0000in-review": 1,
     "packages/engine/src/triage.ts\u0000triage": 1
+  },
+  "properties": {
+    "query": 83,
+    "definition": 43
+  },
+  "queryByColumnId": {
+    "todo": 10,
+    "archived": 7,
+    "done": 10,
+    "in-progress": 19,
+    "in-review": 35,
+    "triage": 2
   },
   "queryByFile": {
     "packages/engine/src/self-healing.ts": 48,


### PR DESCRIPTION
**Claim announced before the work** (on #2689, alongside `register-task-workflow-routes.ts`): `packages/engine/src/project-engine.ts`.

**12 → 5.** Repo backlog → **685**.

## The failure mode here has no error signature

Every merge guard in this file spelled the lane `in-review`. On a renamed board nothing throws, nothing logs a warning — **auto-merge simply declines every card**:

| guard | what a renamed board gets |
|---|---|
| `requestInterpreterMerge` | returns `noOp: true` — *"parked cleanly in review, awaiting human merge"* — for a card that was in review and fully eligible |
| the merge-queue snapshot | returns an **empty list** for a queue full of review cards, so the coordinator sees nothing to admit |
| the `taskMoved` auto-merge handoff | never fires, so nothing reaches auto-merge in the first place |
| the pause-interruption tracker | drops every card from its paused-review set on the next update, so a merge paused mid-flight is never interrupted |

The operator sees cards resting in review with auto-merge **on**, and every log line says the system did the right thing. There is no string to search for — which is the argument for the census being a parse rather than a grep over error messages.

## Implementation notes

- **Core's `resolveTaskLifecycleColumns` directly** — the canonical helper, so no new abstraction and no fourth local resolver in a file that had none.
- **The merge-queue snapshot resolves per task through a shared `irCache`**, because a merge queue can hold cards from *different* workflows. Per-workflow, not per-card: one IR read each.
- **The handoff and its post-grace recheck share one snapshot.** They are halves of one decision — "did this card just enter the merge lane, and is it still there?" — and that is exactly the split that produced the defects in `executor.ts`.

## Revert proof

**1 of 3 cases reddens** with the literal restored.

The suite invokes the real `requestInterpreterMerge` via `.call()` on a minimal `this` (`runtime.getTaskStore`, `allowInReviewMergeProcessing`, `onMerge`) instead of standing up a whole `ProjectEngine` runtime. The body under test is the shipped one, and *reaching* `onMerge` is the assertion. I would rather explain that seam than either skip the proof or spend the test budget booting a runtime. The default-board case is labelled in the file as no-change evidence, not counted as coverage.

## The remaining 5, flagged not guessed

All five are `column === "done"` **merge-confirmation reads** — "did the merge land?". That is a different question from any lane role, and it shares its answer with the dependency guards I flagged in `executor.ts` (`12325`) and `register-task-workflow-routes.ts` (`3995`). Three files, one open question: **what does "landed / satisfied" mean on a board whose terminal column is not named `done`, and is it the complete column or the terminal union?** Deciding it once and applying it to all three is right; swapping it three times independently is how the resolver choice ends up inconsistent — which already happened once inside `executor.ts`, where the correct resolver inverts between two guards a few lines apart.

## Verification

`pnpm test:gate` **158 / 10 / 487 / 71** · **56/56** across the six auto-merge / project-engine suites · 3/3 in the new suite · `tsc -p packages/engine` clean · `pnpm lint` clean · census `--strict` exit 0.

No changeset: `@fusion/engine` is private, and the behaviour change is confined to renamed boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
