### PR TITLE
test(engine): 11 reds from two intended product changes the tests still pinned

### DIFF
--- a/packages/engine/src/__tests__/agent-tools-intake-column.test.ts
+++ b/packages/engine/src/__tests__/agent-tools-intake-column.test.ts
@@ -101,7 +101,7 @@ async function seedApprovedLineage(store: TaskStore): Promise<{ mission_id: stri
     expect(task.column).toBe("inbox");
   });
 
-  it("keeps a task with no workflow_id landing in triage (byte-identical default)", async () => {
+  it("keeps a task with no workflow_id landing in the merged Planning column (byte-identical default)", async () => {
     const tool = createTaskCreateTool(store);
     const result = await tool.execute(
       "call-2",
@@ -113,10 +113,19 @@ async function seedApprovedLineage(store: TaskStore): Promise<{ mission_id: stri
 
     expect((result as { isError?: boolean }).isError).toBeFalsy();
     const task = await store.getTask((result.details as { taskId: string }).taskId);
-    expect(task.column).toBe("triage");
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-01:20:
+    RE-PINNED, not deleted. These two guards exist to hold the DEFAULT workflow's landing column
+    stable, and they fired on an intended change: U11 merged the two pre-implementation columns, so
+    `builtin:coding`'s intake column is now `todo` (the merged Planning column, carrying
+    intake+hold+resetOnEntry) and no `triage` column is declared at all. Leaving them on `triage`
+    pinned a column the product no longer has; deleting them would drop the only check that the
+    landing column stays put.
+    */
+    expect(task.column).toBe("todo");
   });
 
-  it("lands a task explicitly selecting builtin:coding in triage even when the project default is the custom intake workflow", async () => {
+  it("lands a task explicitly selecting builtin:coding in the merged Planning column even when the project default is the custom intake workflow", async () => {
     const created = await store.createWorkflowDefinition({
       name: "Inbox-intake workflow 2",
       ir: inboxWorkflowIr("Inbox-intake workflow 2"),
@@ -134,7 +143,8 @@ async function seedApprovedLineage(store: TaskStore): Promise<{ mission_id: stri
 
     expect((result as { isError?: boolean }).isError).toBeFalsy();
     const task = await store.getTask((result.details as { taskId: string }).taskId);
-    expect(task.column).toBe("triage");
+    // Same U11 re-pin as above: `builtin:coding`'s intake column is the merged Planning column.
+    expect(task.column).toBe("todo");
   });
 
   it("writes a bootstrap PROMPT.md (unplanned) for the inbox-landed task, matching the store's intake gate", async () => {

--- a/packages/engine/src/__tests__/builtin-workflows-lifecycle.test.ts
+++ b/packages/engine/src/__tests__/builtin-workflows-lifecycle.test.ts
@@ -294,11 +294,17 @@ interface BuiltinExpectation {
 const EXPECTATIONS: BuiltinExpectation[] = [
   {
     id: "builtin:coding",
-    entryColumn: "triage",
+        /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-01:35:
+    U11 merged the two pre-implementation columns for this lineage: its declared columns are now
+    `todo,in-progress,in-review,done,archived` with NO `triage`. So the card ENTERS at `todo` and the
+    former `triage -> todo` graph hop does not exist — there is no longer a boundary to cross.
+    Verified by resolving the built-in IR and reading its column ids, not inferred from the failure.
+    */
+    entryColumn: "todo",
     trail: [
       // FNXC:PlanReviewStep 2026-07-26-17:10: plan-in-place — specification (plan + plan review) runs
       // in the planning lane, so the card crosses into implementation once, via the scheduler.
-      ["triage", "todo", "graph"],
       ["todo", "in-progress", "scheduler"],
       ["in-progress", "in-review", "graph"],
       ["in-review", "done", "graph"],
@@ -338,11 +344,17 @@ const EXPECTATIONS: BuiltinExpectation[] = [
   },
   {
     id: "builtin:stepwise-coding",
-    entryColumn: "triage",
+        /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-01:35:
+    U11 merged the two pre-implementation columns for this lineage: its declared columns are now
+    `todo,in-progress,in-review,done,archived` with NO `triage`. So the card ENTERS at `todo` and the
+    former `triage -> todo` graph hop does not exist — there is no longer a boundary to cross.
+    Verified by resolving the built-in IR and reading its column ids, not inferred from the failure.
+    */
+    entryColumn: "todo",
     trail: [
       // FNXC:PlanReviewStep 2026-07-26-17:10: plan-in-place — specification (plan + plan review) runs
       // in the planning lane, so the card crosses into implementation once, via the scheduler.
-      ["triage", "todo", "graph"],
       ["todo", "in-progress", "scheduler"],
       ["in-progress", "in-review", "graph"],
       ["in-review", "done", "graph"],
@@ -454,11 +466,17 @@ const EXPECTATIONS: BuiltinExpectation[] = [
     /* The brainstorm loop only exits once the user's answer carries the approval
        phrase; after that it is the stepwise-final-review pipeline. */
     id: "builtin:brainstorming",
-    entryColumn: "triage",
+        /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-01:35:
+    U11 merged the two pre-implementation columns for this lineage: its declared columns are now
+    `todo,in-progress,in-review,done,archived` with NO `triage`. So the card ENTERS at `todo` and the
+    former `triage -> todo` graph hop does not exist — there is no longer a boundary to cross.
+    Verified by resolving the built-in IR and reading its column ids, not inferred from the failure.
+    */
+    entryColumn: "todo",
     trail: [
       // FNXC:PlanReviewStep 2026-07-26-17:10: plan-in-place — specification (plan + plan review) runs
       // in the planning lane, so the card crosses into implementation once, via the scheduler.
-      ["triage", "todo", "graph"],
       ["todo", "in-progress", "scheduler"],
       ["in-progress", "in-review", "graph"],
       ["in-review", "done", "graph"],

--- a/packages/engine/src/__tests__/workflow-graph-optional-step-fix.test.ts
+++ b/packages/engine/src/__tests__/workflow-graph-optional-step-fix.test.ts
@@ -1,4 +1,5 @@
 import "./executor-test-helpers.js";
+import { DEFAULT_MAX_POST_REVIEW_FIXES } from "@fusion/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -68,7 +69,16 @@ describe("TaskExecutor pre-merge optional-step fix seam", () => {
     });
 
     expect(scheduled).toBe(true);
-    expect(store.moveTask).toHaveBeenCalledWith(liveTask.id, "triage", { preserveWorktree: true });
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-01:50:
+    The replan rebound target is RESOLVED, not literal: executor.ts:4392 moves to
+    `resolveReboundColumnFor(store, taskId)`, which for the default lineage is now `todo` — U11 merged
+    the two pre-implementation columns, so `builtin:coding` declares no `triage`.
+
+    Kept as the expected column id rather than calling the resolver here: asserting the product's own
+    resolver against itself would pass no matter which column it returned.
+    */
+    expect(store.moveTask).toHaveBeenCalledWith(liveTask.id, "todo", { preserveWorktree: true });
     expect(store.updateTask).toHaveBeenCalledWith(liveTask.id, expect.objectContaining({
       status: "needs-replan",
       recoveryRetryCount: 1,
@@ -315,11 +325,20 @@ describe("TaskExecutor pre-merge optional-step fix seam", () => {
     );
     expect(store.logEntry).toHaveBeenCalledWith(
       "FN-7066",
-      "Plan Review failed — moved to triage for automatic replan (attempt 1/unbounded)",
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-02:00:
+      The message INTERPOLATES the resolved column (executor.ts:5366 uses `${replanColumn}`), so a
+      hard-coded id here re-pins a column name inside prose every time the vocabulary moves. Matching
+      the shape plus the attempt counter keeps what this case owns — that a Plan Review failure logs a
+      replan with the right attempt/budget — while the destination column stays pinned by the
+      `moveTask` assertion in this same test.
+      */
+      expect.stringMatching(/^Plan Review failed — moved to \S+ for automatic replan \(attempt 1\/unbounded\)$/),
       expect.stringContaining("PROMPT.md is missing the new workflow-order requirement"),
       undefined,
     );
-    expect(store.moveTask).toHaveBeenCalledWith("FN-7066", "triage", { preserveWorktree: true });
+    // Resolved rebound column for the default lineage — see the note above.
+    expect(store.moveTask).toHaveBeenCalledWith("FN-7066", "todo", { preserveWorktree: true });
     expect(store.updateTask).toHaveBeenCalledWith("FN-7066", { postReviewFixCount: 1 }, undefined);
     expect(store.updateTask).toHaveBeenCalledWith("FN-7066", {
       status: "needs-replan",
@@ -361,7 +380,7 @@ describe("TaskExecutor pre-merge optional-step fix seam", () => {
         nodeId: "plan-review",
       });
 
-      expect(store.moveTask).toHaveBeenCalledWith(liveTask.id, "triage", { preserveWorktree: true });
+      expect(store.moveTask).toHaveBeenCalledWith(liveTask.id, "todo", { preserveWorktree: true });
       expect(abortSpy).not.toHaveBeenCalled();
       expect((executor as any).pausedAborted.has(liveTask.id)).toBe(false);
     } finally {
@@ -447,10 +466,12 @@ describe("TaskExecutor pre-merge optional-step fix seam", () => {
       maxRevisions: "unbounded",
     })).resolves.toBe(true);
 
-    expect(store.moveTask).toHaveBeenCalledWith("FN-7066", "triage", { preserveWorktree: true });
+    // Resolved rebound column for the default lineage — see the note above.
+    expect(store.moveTask).toHaveBeenCalledWith("FN-7066", "todo", { preserveWorktree: true });
     expect(store.logEntry).toHaveBeenCalledWith(
       "FN-7066",
-      "Plan Review failed — moved to triage for automatic replan (attempt 15/unbounded)",
+      // Same interpolated-column reason as above; the attempt counter is what matters here.
+      expect.stringMatching(/^Plan Review failed — moved to \S+ for automatic replan \(attempt 15\/unbounded\)$/),
       expect.anything(),
       undefined,
     );
@@ -611,10 +632,18 @@ describe("TaskExecutor pre-merge optional-step fix seam", () => {
     }
   });
 
-  it("uses the default budget of 3 for repeated fix passes and then declines when exhausted", async () => {
+  /*
+  FNXC:WorkflowOptionalStepCycle 2026-07-31-02:10:
+  The generic optional-gate budget is `DEFAULT_MAX_POST_REVIEW_FIXES`, raised 3 -> 10
+  (builtin-workflow-settings.ts:555). Driven off the imported constant rather than a re-inlined
+  number, because that constant exists precisely BECAUSE the declaration default and two inline
+  literal 3s had already drifted apart once — a third copy here would be the same mistake.
+  */
+  it("uses the default post-review-fix budget for repeated fix passes and then declines when exhausted", async () => {
     const sendBackCalls: number[] = [];
+    const BUDGET = DEFAULT_MAX_POST_REVIEW_FIXES;
 
-    for (const count of [0, 1, 2, 3]) {
+    for (const count of [BUDGET - 3, BUDGET - 2, BUDGET - 1, BUDGET]) {
       const store = createMockStore();
       const liveTask = task({
         postReviewFixCount: count,
@@ -629,24 +658,25 @@ describe("TaskExecutor pre-merge optional-step fix seam", () => {
 
       const scheduled = await (executor as any).requestPreMergeOptionalStepFix(liveTask.id, liveTask, reviseInfo);
 
-      if (count < 3) {
+      if (count < BUDGET) {
         expect(scheduled).toBe(true);
         expect(store.updateTask).toHaveBeenCalledWith("FN-7066", { postReviewFixCount: count + 1 }, undefined);
         expect(store.logEntry).toHaveBeenCalledWith(
           "FN-7066",
-          expect.stringContaining(`attempt ${count + 1}/3`),
+          expect.stringContaining(`attempt ${count + 1}/${BUDGET}`),
           expect.any(String),
           undefined,
         );
         expect(sendBack).toHaveBeenCalledOnce();
       } else {
         expect(scheduled).toBe(false);
-        expect(store.updateTask).not.toHaveBeenCalledWith("FN-7066", expect.objectContaining({ postReviewFixCount: 4 }), undefined);
+        expect(store.updateTask).not.toHaveBeenCalledWith("FN-7066", expect.objectContaining({ postReviewFixCount: BUDGET + 1 }), undefined);
         expect(sendBack).not.toHaveBeenCalled();
       }
     }
 
-    expect(sendBackCalls).toEqual([0, 1, 2]);
+    // The three passes below the cap are scheduled; the pass AT the cap declines.
+    expect(sendBackCalls).toEqual([BUDGET - 3, BUDGET - 2, BUDGET - 1]);
   });
 
   it("keeps graph-owned Code Review remediation unbounded past the legacy three-pass display cap", async () => {

--- a/packages/engine/src/__tests__/workflow-settings-fallback-alignment.test.ts
+++ b/packages/engine/src/__tests__/workflow-settings-fallback-alignment.test.ts
@@ -94,7 +94,18 @@ describe("workflow-settings fallback alignment (KTD-3, item 4)", () => {
       maxParallelSteps: 2, // executor.ts / step-session-executor.ts: ?? 2
       buildRetryCount: 0, // merger.ts: ?? 0
       verificationFixRetries: 3, // executor.ts: ?? 3; merger.ts aligned to ?? 3 (was ?? 2, dead)
-      maxPostReviewFixes: 3, // self-healing.ts + executor.ts: ?? 3
+      /*
+      FNXC:WorkflowOptionalStepCycle 2026-07-31-01:10:
+      Raised 3 -> 10 deliberately, and the read sites no longer inline a literal at all: they import
+      `DEFAULT_MAX_POST_REVIEW_FIXES` from core (builtin-workflow-settings.ts:555), whose own comment
+      records that the declaration default and two inline `?? 3`s had drifted apart — "raising the
+      declaration alone would have left every unset-settings path on the old value".
+
+      Case (b) above already passed because it scans for literal `?? <n>` fallbacks and there are none
+      left for this key; only this human-readable audit table lagged. Updating it keeps the drift
+      detector honest rather than pinning a value the product abandoned.
+      */
+      maxPostReviewFixes: 10, // executor.ts / self-healing.ts: ?? DEFAULT_MAX_POST_REVIEW_FIXES
       requirePrApproval: false, // no engine read; default-false elsewhere
       requirePlanApproval: false, // triage.ts: truthy check → false
       reviewHandoffPolicy: "disabled", // executor.ts: === "comment-triggered" → "disabled"


### PR DESCRIPTION
## The 11 failures, two causes

Four files, all confirmed red on clean `origin/main`, all unowned. Neither cause is a product defect.

**A. U11 merged the two pre-implementation columns.** `builtin:coding`, `builtin:stepwise-coding` and `builtin:brainstorming` now declare `todo,in-progress,in-review,done,archived` — **no `triage`**. So the entry column is `todo`, the former `triage → todo` graph hop no longer exists (there is no boundary to cross), and the replan rebound (`executor.ts:4392`, via `resolveReboundColumnFor`) targets `todo`.

Verified by resolving each built-in IR and printing its column ids, not inferred from the failure text.

**B. `maxPostReviewFixes` was raised 3 → 10** via `DEFAULT_MAX_POST_REVIEW_FIXES` (`builtin-workflow-settings.ts:555`). Two files still pinned 3.

| File | Before | After |
|---|---:|---:|
| `workflow-graph-optional-step-fix` | 5 failed | **39 passed** |
| `builtin-workflows-lifecycle` | 3 failed | **94 passed** |
| `agent-tools-intake-column` | 2 failed | **4 passed** |
| `workflow-settings-fallback-alignment` | 1 failed | **3 passed** |

`pnpm test:gate` **726 passed**; lint clean; census unchanged (test files only).

## Three choices so these don't re-break on the next rename

Swapping `"triage"` for `"todo"` everywhere would have worked and been wrong in three places:

1. **The replan log assertion no longer embeds a column id.** `executor.ts:5366` *interpolates* the resolved column into the message, so a literal there pins a column name inside prose — guaranteed to break again. It now matches the message shape plus the attempt/budget counter, while the destination column stays pinned by the `moveTask` assertion in the same test.
2. **The budget case drives off the imported `DEFAULT_MAX_POST_REVIEW_FIXES`.** That constant exists *because* the declaration default and two inline literal `3`s had already drifted apart once — its own comment says raising the declaration alone "would have left every unset-settings path on the old value". A third copy in a test would repeat exactly that mistake.
3. **`agent-tools-intake-column`'s two guards are RE-PINNED, not deleted.** They hold the default workflow's landing column stable and fired on an intended change, so they still have a job. Deleting them removes the only check; leaving them on `triage` pinned a column that no longer exists.

## What I deliberately did not touch

`builtin-workflows-lifecycle` has **18** expectations and only **3** were failing. I changed only those three: the other 15 pass unchanged, which proves those workflows genuinely still declare `triage`. A blanket rename across the file would have broken them — the same trap that bit me earlier in `starved-refinement`, where renaming a shared fixture default broke a test that had been passing.

Similarly in `workflow-settings-fallback-alignment`: case (b), which scans engine source for literal `?? <n>` fallbacks, **already passed** — there are no literal fallbacks left for that key because the read sites import the constant. Only the human-readable audit table had lagged. That table is the drift detector, so updating it keeps it honest rather than pinning a value the product abandoned.

## Still red in this area, not in this PR

`executor-fast-mode-workflows` (1) and `executor-prompt` (3) remain. They are not column- or budget-drift; `executor-prompt`'s three call `execute()` directly and raise a real design question (whether `execute()` should carry its own pause guard, or whether those direct-call assertions should retire) that I am not answering silently in a test-repair PR.