### PR TITLE
test(engine): isolate the fast-mode red — v1 seam→column normalization skips `start` (1 → 0) + an unanswered pause-guard question

### DIFF
--- a/packages/engine/src/__tests__/executor-fast-mode-workflows.test.ts
+++ b/packages/engine/src/__tests__/executor-fast-mode-workflows.test.ts
@@ -536,7 +536,26 @@ describe("fast mode workflow/runtime invariants", () => {
     const result = await runner.run(task({ executionMode: "fast" }), { experimentalFeatures: { workflowGraphExecutor: true } });
 
     expect(result.disposition).toBe("completed");
-    expect(result.visitedNodeIds).toEqual(["start", "review"]);
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-02:40:
+    `start` is NOT traversed here, and that is the graph-entry contract working.
+
+    v1 normalization places nodes into synthesized default columns BY SEAM (workflow-ir.ts:150):
+    `seam: "review"` -> `in-review`, seam-less nodes -> `todo`. This card rests in `in-progress`,
+    which this three-node graph has no node for, so `resolveColumnResumeNode`
+    (workflow-graph-executor.ts:473) resumes at the next node FORWARD — the review node — rather than
+    re-entering at `start`. Its `>=` comparison is commented for exactly this case: "a card can rest
+    in a column the pipeline has no node for ... and must then resume at the next node forward."
+
+    Why the sibling skill-executor case two tests up still expects `["start", "skill-review"]`: its
+    node carries no `seam`, so it normalizes into `todo`, which is BEHIND `in-progress` — no forward
+    match, so entry falls back to `start`. That contrast is an accident of the seam-less config rather
+    than a deliberate difference, so do not "align" the two expectations.
+
+    This mechanism is why the failure resisted diagnosis: nothing about the assertion, the fast-mode
+    flag, or the node kind points at column normalization of a v1 IR.
+    */
+    expect(result.visitedNodeIds).toEqual(["review"]);
     expect(review).toHaveBeenCalledTimes(1);
     expect(runCustomNode).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## The fast-mode failure, finally isolated

```
expected [ 'review' ] to deeply equal [ 'start', 'review' ]
```

This resisted **three earlier diagnosis attempts** because nothing about the assertion, the fast-mode flag, or the node kind points at the real mechanism: **column normalization of a v1 IR.**

**Isolated by mutation, not by reading.** Swapping the node's `config: { seam: "review" }` for the sibling test's `config: { executor: "skill", ... }` makes `start` reappear in `visitedNodeIds`. So `config.seam` is the trigger — which is not a thing the failure text suggests looking at.

The chain:

1. v1 normalization places nodes into synthesized default columns **by seam** (`workflow-ir.ts:150` — `review` → `in-review`, seam-less → `todo`).
2. The card rests in `in-progress`, which this three-node graph has **no node for**.
3. `resolveColumnResumeNode` (`workflow-graph-executor.ts:473`) therefore resumes at the next node **forward** — the review node — instead of re-entering at `start`.

That resolver's `>=` comparison is commented for exactly this case: *"a card can rest in a column the pipeline has no node for … and must then resume at the next node forward."*

**So the product is right and the expectation was stale.** Visited is `["review"]`. `pnpm test:gate` **726 passed**, lint clean, census unchanged.

I also recorded in-file *why the sibling skill-executor case legitimately still expects `start`*: its seam-less node normalizes into `todo`, which is **behind** `in-progress`, so there is no forward match and entry falls back to `start`. That contrast is an accident of config rather than a deliberate difference — so the two expectations must **not** be "aligned", which is the obvious-looking wrong move for the next person here.

## Flagged, NOT fixed: `executor-prompt`'s 3 failures are a real design question

These assert that `execute()` refuses to dispatch a user-paused row during a global pause:

```
expect(mockedCreateFnAgent).not.toHaveBeenCalled();   // actually called 1 time
```

The test's own comment (from #2371) states the behaviour as "a paused todo task is no longer dispatched at all". **The guard lives in the scheduler, not in `execute()`** — `scheduler.ts:1515` is the `globalPause` gate, and it is a hard stop that never reaches `.execute(`. These three tests call `executor.execute(task)` **directly**, so no guard fires.

That is not merely a test-layer mismatch, which is why I am not "fixing" the assertions. `execute()` has **five call sites outside the scheduler**:

- `executor.ts:3333`, `:3495`, `:5702`, `:5858` — internal re-dispatch paths
- `runtimes/in-process-runtime.ts:2255` — `void this.executor.execute(task)`

Whether each of those is separately gated determines whether work can be dispatched on a user-paused row, or during a global pause, by a path that never consults the scheduler. Two legitimate resolutions exist and they differ in behaviour:

1. give `execute()` its own pause guard (defence-in-depth — but must not break legitimate internal re-dispatch), or
2. retire the direct-`execute()` assertions and cover the invariant at the scheduler layer.

Picking either silently inside a test-repair PR would either change lifecycle behaviour around **user pause** — a safeguard this program has re-ratified and told me not to narrow — or delete coverage of it. So it stays flagged with the call-site evidence for whoever owns the pause contract.

This is the same file and question I flagged much earlier in the program; it is now backed by the specific line numbers rather than a suspicion.