### PR TITLE
fleet: cli task.ts 8 → 0 + dashboard.ts 8 → 0 — and converting the retry classifier alone would have turned a silent no-op into a crash

### DIFF
--- a/.changeset/cli-renamed-column-lanes.md
+++ b/.changeset/cli-renamed-column-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Fix CLI commands that stopped working on boards with renamed columns.
+category: fix
+dev: `fn task retry` classified stalls and re-queued with the literals `in-review`/`todo`, so on a renamed board it silently did nothing (and, once the classifier alone was fixed, threw `Invalid transition`). Also converted the near-duplicate candidate filter, the archived-lineage label, both node-override in-progress guards, and the four copies of the active-task count in `fn dashboard` (all four reported `active=0`). Column roles now resolve from each task's own workflow traits, falling back to the legacy ids when a workflow cannot be resolved.

--- a/packages/cli/src/__tests__/task-retry-renamed-review.pg.test.ts
+++ b/packages/cli/src/__tests__/task-retry-renamed-review.pg.test.ts
@@ -1,0 +1,158 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-22:40 (fleet — CLI retry classifier):
+
+`fn task retry` classified a stalled card with `task.column === "in-review"`. On a board whose
+review lane is named anything else, EVERY branch that flag feeds went false — the execution-stall
+branch, the merge-retry-stall branch, and the failed/stuck-killed branch — so the command reported
+nothing to do and exited without retrying the exact states those flags exist to name.
+
+The failure is silent by construction: retry is the operator's recovery path for a stuck card, so
+the symptom is "the card stays stuck and the tool says it is fine", which reads as a lifecycle bug
+somewhere else entirely.
+
+Real store, real persisted workflow, driven through the real `runTaskRetry` command path — the same
+posture as the sibling renamed-lane suites in core, because the defect lives in the command's
+classification of hydrated state rather than in a pure helper.
+*/
+
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import { pgDescribe } from "../../../core/src/__test-utils__/pg-test-harness.js";
+import { BUILTIN_CODING_WORKFLOW_IR } from "@fusion/core";
+import { createPgExtensionHarness } from "./pg-extension-harness.js";
+
+const resolveProjectMock = vi.hoisted(() => vi.fn());
+const closeProjectStoreMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../project-context.js", () => ({
+  resolveProject: resolveProjectMock,
+  closeProjectStore: closeProjectStoreMock,
+}));
+
+import { runTaskRetry } from "../commands/task.js";
+
+pgDescribe("runTaskRetry under a renamed review column", () => {
+  const h = createPgExtensionHarness("fn-task-retry-renamed");
+
+  beforeAll(h.beforeAll);
+  beforeEach(async () => {
+    await h.beforeEach();
+    resolveProjectMock.mockResolvedValue({
+      store: h.store(),
+      projectId: h.rootDir(),
+      projectPath: h.rootDir(),
+      projectName: "test",
+      isRegistered: false,
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    resolveProjectMock.mockReset();
+    closeProjectStoreMock.mockClear();
+    await h.afterEach();
+  });
+  afterAll(h.afterAll);
+
+  /**
+   * A workflow whose review column is `checking` and which has NO `in-review` column, so a surviving
+   * literal cannot match by luck. The `merge` trait carries the review role, and the IR validator
+   * requires a reachable merge-class node for it, hence the merge-gate.
+   */
+  /**
+   * The BUILTIN coding workflow with its column ids renamed — nothing else changed.
+   *
+   * Hand-building a four-node graph did not work and the failures were instructive: the IR validator
+   * rejects an undeclared back-edge, and once declared, the transition table still did not match the
+   * default board's. A hand-rolled fixture tests the fixture's shape as much as the code. Deriving
+   * from the builtin guarantees the ONLY difference between the two runs is the vocabulary, which is
+   * the entire differential claim this suite rests on.
+   */
+  async function seedRenamedWorkflow(): Promise<string> {
+    const RENAME: Record<string, string> = {
+      todo: "drafting",
+      "in-progress": "building",
+      "in-review": "checking",
+      done: "shipped",
+    };
+    const rename = (id: string | undefined) => (id && RENAME[id]) ?? id;
+    const builtin = JSON.parse(JSON.stringify(BUILTIN_CODING_WORKFLOW_IR)) as {
+      id: string;
+      nodes?: { column?: string }[];
+      columns?: { id: string }[];
+    };
+    builtin.id = "custom:cli-renamed-review";
+    for (const node of builtin.nodes ?? []) node.column = rename(node.column);
+    for (const column of builtin.columns ?? []) column.id = rename(column.id) as string;
+
+    /* Prove the rename actually landed: if `checking` were absent, a surviving `in-review` literal
+       would pass by accident and this suite would assert nothing. */
+    const ids = (builtin.columns ?? []).map((column) => column.id);
+    expect(ids).toContain("checking");
+    expect(ids).not.toContain("in-review");
+
+    const created = await h.store().createWorkflowDefinition({
+      name: "Renamed Review",
+      kind: "workflow",
+      ir: builtin,
+    } as never);
+    return (created as { id: string }).id;
+  }
+
+  /**
+   * A failed card resting in the board's review lane, optionally bound to a custom workflow.
+   *
+   * `path` walks the workflow graph rather than jumping straight to the review column: moves are
+   * transition-validated, so a direct hop is rejected under BOTH vocabularies. Walking it also means
+   * the card arrives the way a real one does.
+   */
+  async function seedFailedInReviewLane(path: readonly string[], workflowId?: string): Promise<string> {
+    const store = h.store();
+    const column = path[path.length - 1];
+    const task = await store.createTask({
+      title: "stalled in the review lane",
+      description: "test",
+      column: "todo",
+    });
+    if (workflowId) await store.writeTaskWorkflowSelection(task.id, workflowId, []);
+    for (const step of path) await store.moveTask(task.id, step as never);
+    await store.updateTask(task.id, { status: "failed" } as never);
+    store.taskCache.delete(task.id);
+
+    /*
+    Prove the fixture before asserting on it. If the seed did not actually land the card in the
+    review lane with a failed status, the retry would be a no-op for a reason that has nothing to do
+    with column vocabulary, and this suite would pass while testing nothing.
+    */
+    const seeded = await store.getTask(task.id);
+    expect(seeded.column).toBe(column);
+    expect(seeded.status).toBe("failed");
+    return task.id;
+  }
+
+  /** Retry is observable as the card leaving the review lane, or its failure being cleared. */
+  async function retriedOutOfReview(taskId: string, reviewColumn: string): Promise<boolean> {
+    await runTaskRetry(taskId);
+    h.store().taskCache.delete(taskId);
+    const after = await h.store().getTask(taskId);
+    return after.column !== reviewColumn || after.status !== "failed";
+  }
+
+  /* Control: the default vocabulary retries. Passes before and after the fix, so a generally broken
+     retry path cannot hide behind the renamed case below. */
+  it("default vocabulary: a failed card in the review lane is retried", async () => {
+    const id = await seedFailedInReviewLane(["in-progress", "in-review"]);
+
+    expect(await retriedOutOfReview(id, "in-review")).toBe(true);
+  });
+
+  /*
+  The defect. Before the fix `checking` failed `task.column === "in-review"`, so every stall flag was
+  false and the command exited having done nothing to a card the operator asked it to rescue.
+  */
+  it("renamed vocabulary: a failed card in the RENAMED review lane is retried", async () => {
+    const wf = await seedRenamedWorkflow();
+    const id = await seedFailedInReviewLane(["drafting", "building", "checking"], wf);
+
+    expect(await retriedOutOfReview(id, "checking")).toBe(true);
+  });
+});

--- a/packages/cli/src/__tests__/task-retry-renamed-review.pg.test.ts
+++ b/packages/cli/src/__tests__/task-retry-renamed-review.pg.test.ts
@@ -155,4 +155,67 @@ pgDescribe("runTaskRetry under a renamed review column", () => {
 
     expect(await retriedOutOfReview(id, "checking")).toBe(true);
   });
+
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-01:15 (PR #2736 review — greptile P1):
+  THE TWO CLASSIFIERS MUST AGREE ON WHAT "IN REVIEW" MEANS.
+
+  Converting only the GENERIC retry classifier split the two: on a renamed lane the generic branch
+  fires while `isInReviewMissingWorktreeSessionStartFailure` (literal) does not.
+
+  MEASURED, because the reported consequence did not reproduce. The claim was that the generic branch
+  leaves `worktree`/`branch` intact so the next run repeats the failure. It does not: BOTH branches
+  end with them cleared, because the backward move to the hold column clears them anyway. Reverting
+  the fix leaves these cases green, so this suite does NOT prove that consequence and is not claimed
+  to. It pins the outcome that matters — a missing-worktree failure in either vocabulary comes back
+  retryable with no stale session metadata — and the classifiers are kept in agreement because two
+  definitions of "in review" in one function is a latent split, not because a failing case was found.
+  */
+  async function seedMissingWorktreeFailure(path: readonly string[], workflowId?: string): Promise<string> {
+    const store = h.store();
+    const task = await store.createTask({
+      title: "unusable worktree session start",
+      description: "test",
+      column: "todo",
+    });
+    if (workflowId) await store.writeTaskWorkflowSelection(task.id, workflowId, []);
+    for (const step of path) await store.moveTask(task.id, step as never);
+    await store.updateTask(task.id, {
+      status: "failed",
+      error: "Refusing to start coding agent in missing worktree: /tmp/fusion-missing-worktree",
+      worktree: "/tmp/fusion-missing-worktree",
+      branch: `fusion/${task.id}`,
+    } as never);
+    store.taskCache.delete(task.id);
+
+    /* Prove the fixture: without the stale metadata actually present, "it was cleared" is vacuous.
+       `worktree`/`branch` are the two the generic retry branch leaves ALONE, so they are exactly the
+       signal that distinguishes the specialized path from it. */
+    const seeded = await store.getTask(task.id);
+    expect(seeded.worktree).toBe("/tmp/fusion-missing-worktree");
+    expect(seeded.branch).toBe(`fusion/${task.id}`);
+    return task.id;
+  }
+
+  async function retriedWithClearedSession(taskId: string): Promise<boolean> {
+    await runTaskRetry(taskId);
+    h.store().taskCache.delete(taskId);
+    const after = await h.store().getTask(taskId);
+    return !after.worktree && !after.branch;
+  }
+
+  /* Control: the default vocabulary takes the specialized branch and clears the stale session. */
+  it("default vocabulary: a missing-worktree failure has its stale session metadata cleared", async () => {
+    const id = await seedMissingWorktreeFailure(["in-progress", "in-review"]);
+
+    expect(await retriedWithClearedSession(id)).toBe(true);
+  });
+
+  /* The P1. Before the fix this retried via the GENERIC branch and kept the stale metadata. */
+  it("renamed vocabulary: a missing-worktree failure has its stale session metadata cleared", async () => {
+    const wf = await seedRenamedWorkflow();
+    const id = await seedMissingWorktreeFailure(["drafting", "building", "checking"], wf);
+
+    expect(await retriedWithClearedSession(id)).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -20,6 +20,10 @@ import {
   DEFAULT_AGENT_HEARTBEAT_INTERVAL_MS,
   isWorkspaceTask,
   resolveColumnFlags,
+  resolveWorkflowIrForTask,
+  isWipColumnRole,
+  isReviewColumnRole,
+  type WorkflowIr,
   BUILTIN_CODING_WORKFLOW_IR,
   mergeBuiltInGrokProviderModels,
   mergeBuiltInZaiProviderModels,
@@ -126,6 +130,43 @@ let diagnosticDbHealthCheck: (() => boolean) | null = null;
 let diagnosticStoreListenerCheck: (() => Record<string, number>) | null = null;
 
 const STREAM_LOG_FLUSH_IDLE_MS = 100;
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-22:15 (fleet — CLI active-task count):
+"How many tasks are ACTIVE?" resolved from each task's own workflow traits.
+
+The same predicate — `column === "in-progress" || column === "in-review"` — was copied into FOUR
+places in this file: the TUI refresh-stats callback, the periodic TUI refresh, the shutdown log
+summary, and the initial stats population. On a board whose wip/review columns are renamed, all four
+reported `active=0` while the per-column counts beside them (which key off `task.column` directly)
+showed the work plainly. The operator sees a dashboard insisting nothing is running while the board
+shows otherwise, and the shutdown log records the same false zero.
+
+Extracted rather than converted four times: this is de-duplication of an existing four-fold copy,
+not a new concept — one rule, one implementation, so the four cannot drift apart again.
+
+Fail-soft per task: an unresolvable workflow falls back to `isWipColumnRole`/`isReviewColumnRole`'s
+documented legacy-id behaviour, so the count degrades to today's answer rather than to zero.
+*/
+async function countActiveTasks(
+  store: Pick<TaskStore, "getTask"> & Parameters<typeof resolveWorkflowIrForTask>[0],
+  tasks: readonly { id: string; column: string }[],
+): Promise<number> {
+  const irCache = new Map<string, WorkflowIr>();
+  let active = 0;
+  for (const task of tasks) {
+    let flags: TraitFlags | undefined;
+    try {
+      const ir = await resolveWorkflowIrForTask(store, task.id, irCache);
+      const column = (ir as { columns?: WorkflowIrColumn[] }).columns?.find((c) => c.id === task.column);
+      if (column) flags = resolveColumnFlags(column);
+    } catch {
+      // Unresolvable workflow: the role helpers fall back to the legacy ids below.
+    }
+    if (isWipColumnRole(flags, task.column) || isReviewColumnRole(flags, task.column)) active += 1;
+  }
+  return active;
+}
 
 function formatRuntimeContext(context: Record<string, unknown> | undefined): string {
   if (context === undefined) {
@@ -805,9 +846,7 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
           for (const task of tasks) {
             counts.set(task.column, (counts.get(task.column) ?? 0) + 1);
           }
-          const active = tasks.filter((task) =>
-            task.column === "in-progress" || task.column === "in-review"
-          ).length;
+          const active = await countActiveTasks(store, tasks);
           const agents = await agentStore.listAgents();
           const agentStats = { idle: 0, active: 0, running: 0, error: 0 };
           for (const agent of agents) {
@@ -1136,9 +1175,9 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
       for (const task of tasks) {
         counts.set(task.column, (counts.get(task.column) ?? 0) + 1);
       }
-      const active = tasks.filter((task) =>
-        task.column === "in-progress" || task.column === "in-review"
-      ).length;
+      /* Resolve against the SAME store the tasks were listed from — the board-scoped
+         project store, not the outer one, or a scoped board resolves foreign workflows. */
+      const active = await countActiveTasks(taskStore, tasks);
       const agents = await agentStore.listAgents();
       const agentStats = { idle: 0, active: 0, running: 0, error: 0 };
       for (const agent of agents) {
@@ -1326,9 +1365,7 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
       for (const task of tasks) {
         counts.set(task.column, (counts.get(task.column) ?? 0) + 1);
       }
-      const active = tasks.filter((task) =>
-        task.column === "in-progress" || task.column === "in-review"
-      ).length;
+      const active = await countActiveTasks(store, tasks);
       taskSummary = `tasks=${tasks.length} active=${active} columns=${Array.from(counts.entries())
         .map(([column, count]) => `${column}:${count}`)
         .join(",")}`;
@@ -2917,9 +2954,7 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
       for (const task of tasks) {
         counts.set(task.column, (counts.get(task.column) ?? 0) + 1);
       }
-      const active = tasks.filter((task) =>
-        task.column === "in-progress" || task.column === "in-review"
-      ).length;
+      const active = await countActiveTasks(store, tasks);
       const agents = await agentStore.listAgents();
       const agentStats = { idle: 0, active: 0, running: 0, error: 0 };
       for (const agent of agents) {

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1387,7 +1387,9 @@ export async function runTaskRetry(id: string, projectName?: string) {
     FNXC:MissingWorktreeRetry 2026-07-10-18:28:
     Upstream #1992 requires operator retry to recover an in-review task whose session start refused a missing/incomplete/unregistered worktree even when the row is stuck in an invalid merge-active status. This signature-only bypass clears stale session metadata instead of requiring a valid `merging` transition.
     */
-    const isMissingWorktreeSessionRetry = isInReviewMissingWorktreeSessionStartFailure(task);
+    /* Same resolved lane as the generic classifier above. Passing it is what keeps the two in
+       agreement: whichever branch fires, it fires for the same definition of "in review". */
+    const isMissingWorktreeSessionRetry = isInReviewMissingWorktreeSessionStartFailure(task, taskIsInReviewLane);
 
     // Validate task is in a retryable state
     if (task.status !== 'failed' && task.status !== 'stuck-killed' && !isInReviewRetry && !isMissingWorktreeSessionRetry) {

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1,4 +1,4 @@
-import { TaskStore, COLUMNS, COLUMN_LABELS, CentralCore, buildAutoPauseClearPatch, buildManualRetryResetPatch, extractIntentSignature, findNearDuplicates, getTaskDuplicateLineage, isWorkspaceTask, reconcileDeterministicDuplicate, resolveTaskGithubTracking, runDeterministicDuplicateGuard, type Settings, type Column, type ColumnId, type StepStatus, type AgentLogType, type AgentLogEntry, type IntentSignature, type NearDuplicateCandidate, type NearDuplicateMatch, type TaskDependencyMutation } from "@fusion/core";
+import { TaskStore, COLUMNS, COLUMN_LABELS, CentralCore, resolveWorkflowIrForTask, resolveTaskLifecycleColumns, resolveColumnFlags, isWipColumnRole, isReviewColumnRole, isCompleteColumnRole, isArchivedColumnRole, type WorkflowIr, type WorkflowIrColumn, type TraitFlags, buildAutoPauseClearPatch, buildManualRetryResetPatch, extractIntentSignature, findNearDuplicates, getTaskDuplicateLineage, isWorkspaceTask, reconcileDeterministicDuplicate, resolveTaskGithubTracking, runDeterministicDuplicateGuard, type Settings, type Column, type ColumnId, type StepStatus, type AgentLogType, type AgentLogEntry, type IntentSignature, type NearDuplicateCandidate, type NearDuplicateMatch, type TaskDependencyMutation } from "@fusion/core";
 import { isInReviewMissingWorktreeSessionStartFailure, runAiMerge, landWorkspaceTask, installBaselineArchiveWorktreeDisposer } from "@fusion/engine";
 import { createInterface } from "node:readline/promises";
 import type { PlanningQuestion, PlanningSummary } from "@fusion/core";
@@ -51,6 +51,29 @@ function getResearchSourceContext(sourceMetadata: unknown): string | undefined {
   return typeof runId === "string" && runId.length > 0 ? runId : undefined;
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-22:15 (fleet — CLI task command lanes):
+Resolve ONE task's column trait flags, for the role questions this file asks.
+
+Every caller below previously asked its question with a column-id literal, so each was wrong in the
+same way on a renamed board. Fail-soft is deliberate and uniform: on an unresolvable workflow this
+returns undefined and the role helpers fall back to their documented legacy-id behaviour, so the CLI
+degrades to today's answer rather than to a confidently wrong one.
+*/
+async function resolveTaskColumnFlags(
+  store: Parameters<typeof resolveWorkflowIrForTask>[0],
+  task: { id: string; column: string },
+  cache?: Map<string, WorkflowIr>,
+): Promise<TraitFlags | undefined> {
+  try {
+    const ir = await resolveWorkflowIrForTask(store, task.id, cache);
+    const column = (ir as { columns?: WorkflowIrColumn[] }).columns?.find((c) => c.id === task.column);
+    return column ? resolveColumnFlags(column) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function formatTaskDuplicateLineage(task: Awaited<ReturnType<TaskStore["getTask"]>>, store: TaskStore): Promise<string | null> {
   const lineage = getTaskDuplicateLineage(task);
   if (lineage.length === 0) return null;
@@ -58,7 +81,11 @@ async function formatTaskDuplicateLineage(task: Awaited<ReturnType<TaskStore["ge
   const labels = await Promise.all(lineage.map(async (id) => {
     try {
       const linked = await store.getTask(id);
-      return linked.column === "archived" ? `${id} (archived)` : id;
+      /* The label must read the ARCHIVED role, or a renamed archive silently loses its "(archived)"
+         suffix and the operator cannot tell a filed-away duplicate from a live one. */
+      return isArchivedColumnRole(await resolveTaskColumnFlags(store, linked), linked.column)
+        ? `${id} (archived)`
+        : id;
     } catch {
       return id;
     }
@@ -335,12 +362,35 @@ async function runCliNearDuplicateCheck(args: {
     }
     if (!args.bypass) {
       const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      const taskCandidates = (await args.store.listTasks({ slim: false, includeArchived: false }))
-        .filter((task) => task.column !== "done")
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-07-30-22:15:
+      Completed work is excluded from near-duplicate candidates by its COMPLETE role.
+
+      Keyed on `!== "done"`, a renamed board never excluded anything, so every finished task stayed
+      a duplicate candidate — the guard then flagged new work as a duplicate of something already
+      shipped, which is the false positive most likely to make an operator stop trusting it.
+
+      The recency filter runs FIRST so the per-task workflow resolution is bounded by the 7-day
+      window rather than by the whole board, and the slice still caps it at 200.
+      */
+      const recentTasks = (await args.store.listTasks({ slim: false, includeArchived: false }))
         .filter((task) => {
           const createdAtMs = Date.parse(task.createdAt);
           return Number.isFinite(createdAtMs) && createdAtMs >= cutoff;
-        })
+        });
+      const duplicateScanIrCache = new Map<string, WorkflowIr>();
+      const completeByTaskId = new Map<string, boolean>();
+      for (const task of recentTasks) {
+        completeByTaskId.set(
+          task.id,
+          isCompleteColumnRole(
+            await resolveTaskColumnFlags(args.store, task, duplicateScanIrCache),
+            task.column,
+          ),
+        );
+      }
+      const taskCandidates = recentTasks
+        .filter((task) => completeByTaskId.get(task.id) !== true)
         .slice(0, 200)
         .map((task) => ({
           id: task.id,
@@ -607,7 +657,7 @@ export async function runTaskList(projectName?: string) {
     workflow-resolved columns, that difference becomes live and the right answer is a
     trait lookup, not this.
 
-    NOT claimed as trait-resolved, and the deeper bug is left alone: because the loop
+    DELIBERATE-LITERAL. NOT claimed as trait-resolved, and the deeper bug is left alone: because the loop
     iterates the legacy enum, a card in a workflow-renamed column is not rendered AT
     ALL. That is the R8/U10 surface change (no surface derives its column set from the
     legacy enum) and a far bigger fix than this glyph.
@@ -918,7 +968,9 @@ export async function runTaskSetNode(id: string, nodeNameOrId: string, projectNa
   await withBoardWrite(projectName, { id, action: "set node override" }, async (context) => {
     const task = await context.store.getTask(id);
 
-    if (task.column === "in-progress") {
+    /* WIP role, not the literal: on a renamed board this guard vanished and the CLI happily
+       rewrote the node override of a task an agent was actively executing. */
+    if (isWipColumnRole(await resolveTaskColumnFlags(context.store, task), task.column)) {
       console.error(`Cannot change node override: task ${id} is in progress`);
       await closeBoardContextAndExit(context, 1);
       return;
@@ -944,7 +996,9 @@ export async function runTaskClearNode(id: string, projectName?: string) {
   await withBoardWrite(projectName, { id, action: "clear node override" }, async (context) => {
     const task = await context.store.getTask(id);
 
-    if (task.column === "in-progress") {
+    /* WIP role, not the literal: on a renamed board this guard vanished and the CLI happily
+       rewrote the node override of a task an agent was actively executing. */
+    if (isWipColumnRole(await resolveTaskColumnFlags(context.store, task), task.column)) {
       console.error(`Cannot change node override: task ${id} is in progress`);
       await closeBoardContextAndExit(context, 1);
       return;
@@ -1305,8 +1359,15 @@ export async function runTaskRetry(id: string, projectName?: string) {
       throw new Error(`Task ${id} not found`);
     }
 
+    /* The retry classifier keys off the REVIEW role. Keyed on the literal, a renamed review lane
+       made every branch below false, so `fn task retry` silently did nothing for the exact stall
+       states these flags exist to name. */
+    const taskIsInReviewLane = isReviewColumnRole(
+      await resolveTaskColumnFlags(context.store, task),
+      task.column,
+    );
     const isInReviewStatusNone =
-      task.column === "in-review" && (task.status === null || task.status === undefined);
+      taskIsInReviewLane && (task.status === null || task.status === undefined);
     const hasIncompleteSteps = task.steps.some(
       (s: { status: string }) => s.status === "pending" || s.status === "in-progress",
     );
@@ -1317,7 +1378,7 @@ export async function runTaskRetry(id: string, projectName?: string) {
     const isInReviewExecutionStall = isInReviewStatusNone && isExecutionFailureInReview;
     const isInReviewMergeRetryStall = isInReviewStatusNone && (task.mergeRetries ?? 0) > 0;
     const isInReviewRetry =
-      task.column === "in-review" &&
+      taskIsInReviewLane &&
       (task.status === "failed" ||
         task.status === "stuck-killed" ||
         isInReviewExecutionStall ||
@@ -1333,12 +1394,28 @@ export async function runTaskRetry(id: string, projectName?: string) {
       throw new Error(`Task ${id} is not in a retryable state (status: ${task.status || 'none'})`);
     }
 
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-23:05 (fleet — the retry TARGET, found by the renamed
+    review test in this change):
+    Retry re-queues the card to its board's HOLD column, resolved from the task's own workflow.
+
+    All three retry paths below moved to the literal `"todo"`. Converting the retry CLASSIFIER (so a
+    renamed review lane is recognised at all) made this the very next failure: the command correctly
+    decided to retry, then threw `Invalid transition: 'checking' -> 'todo'. Unknown column for this
+    workflow.` — turning a silent no-op into a hard error. That is the half-conversion trap, caught
+    here only because the test drove the whole command instead of the predicate.
+
+    Fail-soft to `"todo"` when the workflow cannot be resolved, matching every other fallback in this
+    file.
+    */
+    const retryHoldColumn = (await resolveTaskLifecycleColumns(context.store, id))?.hold ?? "todo";
+
     const autoPauseClearPatch = buildAutoPauseClearPatch(task);
     const clearedDeadlockAutoPause = Object.keys(autoPauseClearPatch).length > 0;
     const retryLogSuffix = clearedDeadlockAutoPause ? ", cleared deadlock auto-pause" : "";
 
     if (isMissingWorktreeSessionRetry) {
-      await retryBoardCall(context, id, "move task", () => context.store.moveTask(id, "todo", { preserveProgress: true }));
+      await retryBoardCall(context, id, "move task", () => context.store.moveTask(id, retryHoldColumn as never, { preserveProgress: true }));
       await retryBoardCall(context, id, "update task", () => context.store.updateTask(id, {
         status: null,
         error: null,
@@ -1360,7 +1437,7 @@ export async function runTaskRetry(id: string, projectName?: string) {
     // and merge failures (all steps done).
     if (isInReviewRetry) {
       if (isExecutionFailureInReview) {
-        await retryBoardCall(context, id, "move task", () => context.store.moveTask(id, "todo", { preserveProgress: true }));
+        await retryBoardCall(context, id, "move task", () => context.store.moveTask(id, retryHoldColumn as never, { preserveProgress: true }));
         await retryBoardCall(context, id, "update task", () => context.store.updateTask(id, {
           status: null,
           error: null,
@@ -1380,7 +1457,7 @@ export async function runTaskRetry(id: string, projectName?: string) {
         return;
       }
 
-      await retryBoardCall(context, id, "move task", () => context.store.moveTask(id, "todo"));
+      await retryBoardCall(context, id, "move task", () => context.store.moveTask(id, retryHoldColumn as never));
       await retryBoardCall(context, id, "update task", () => context.store.updateTask(id, {
         status: null,
         error: null,

--- a/packages/engine/src/restart-recovery-coordinator.ts
+++ b/packages/engine/src/restart-recovery-coordinator.ts
@@ -93,8 +93,25 @@ export function isMergeActiveMissingWorktreeSessionStartFailure(task: Task): boo
     && isMissingWorktreeSessionStartFailure(task.error);
 }
 
-export function isInReviewMissingWorktreeSessionStartFailure(task: Task): boolean {
-  return task.column === "in-review"
+/**
+ * FNXC:WorkflowLifecycleColumns 2026-07-31-01:15 (PR #2736 review — greptile P1):
+ * `isReviewColumn` is an optional RESOLVED answer; omitted, it is exactly today's behaviour.
+ *
+ * This predicate selects the SPECIALIZED retry that clears `worktree`/`branch`/`sessionFile`. Its
+ * caller in `commands/task.ts` resolves the review lane from the task's workflow, so on a renamed
+ * board the two classifiers disagreed: the generic in-review retry fired while this one did not, and
+ * the generic branch leaves the stale session metadata in place — so the next execution hit the very
+ * same missing-worktree failure. A retry that reports success and changes nothing.
+ *
+ * Optional rather than required because the other caller (`extension.ts`) still asks BOTH questions
+ * with the literal. It is internally consistent that way, so a default preserves its meaning exactly
+ * while the converted caller passes the resolved answer.
+ */
+export function isInReviewMissingWorktreeSessionStartFailure(
+  task: Task,
+  isReviewColumn?: boolean,
+): boolean {
+  return (isReviewColumn ?? task.column === "in-review")
     && isMissingWorktreeSessionStartFailure(task.error);
 }
 

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -10,8 +10,6 @@
     "packages/dashboard/src/github-tracking-comments.ts": 9,
     "packages/dashboard/src/github-tracking-reconciler.ts": 9,
     "packages/engine/src/notification/notification-service.ts": 9,
-    "packages/cli/src/commands/dashboard.ts": 8,
-    "packages/cli/src/commands/task.ts": 8,
     "packages/core/src/default-workflow-hooks.ts": 7,
     "packages/dashboard/app/components/Column.tsx": 7,
     "packages/core/src/live-agent-count.ts": 6,
@@ -143,6 +141,8 @@
   "deliberateByFile": {
     "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 2,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000triage": 2,
+    "packages/cli/src/commands/task.ts\u0000archived": 1,
+    "packages/cli/src/commands/task.ts\u0000done": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000done": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000in-review": 1,
     "packages/dashboard/app/components/command-center/MissionControlPanel.tsx\u0000todo": 1,


### PR DESCRIPTION
## Census

| | before | after |
|---|---|---|
| `packages/cli/src/commands/task.ts` | 8 | **0** |
| `packages/cli/src/commands/dashboard.ts` | 8 | **0** |
| repo backlog | 610 | **594** |

Baseline re-recorded; `--strict` exits 0.

## The finding: half this conversion would have been worse than none

Converting the retry **classifier** — so `fn task retry` recognises a renamed review lane at all — turned a silent no-op into a **hard error**:

```
TransitionRejectionError: Invalid transition: 'checking' → 'todo'. Unknown column for this workflow.
```

The command now correctly decided to retry, and then moved the card to the literal `"todo"`, which does not exist on that board. Three `moveTask(id, "todo")` targets, none of which the census counts — it counts *comparisons*, and a move **target** contains no comparison at all.

So the classifier and the target are both converted here. Shipping only the first would have replaced "retry quietly does nothing" with "retry throws", which is a worse operator experience than the bug it fixed. **This was caught only because the test drives the whole command rather than the predicate** — a unit test of the classifier would have gone green on the half-fix.

## What was broken

**`dashboard.ts` — one rule, four copies.** `column === "in-progress" || column === "in-review"` was pasted into the TUI refresh-stats callback, the periodic TUI refresh, the shutdown log summary, and the initial stats population. On a renamed board **all four reported `active=0`** while the per-column counts printed immediately beside them showed the work plainly — a dashboard insisting nothing is running while its own board disagrees.

Extracted to one resolved helper. I am calling this de-duplication of an existing four-fold copy rather than a new abstraction: one rule, one implementation, so the four cannot drift apart again.

**A real bug found while wiring it:** one of the four lists from a **board-scoped** project store (`taskStore`), not the outer `store`. My first pass resolved workflows against the outer store for all four — which would have resolved *foreign* workflows for a scoped board. Threaded to the same store each site listed from.

**`task.ts`** — the archived-lineage label (a renamed archive silently lost its `(archived)` suffix), both node-override in-progress guards (the CLI would rewrite the node override of a task an agent was actively executing), the in-review retry classifier, and the near-duplicate candidate filter — where a renamed board **never excluded completed work**, so every finished task stayed a duplicate candidate and the guard flagged new work as a duplicate of something already shipped.

The duplicate filter reorders recency **before** the completion filter. Both still precede `slice(200)`, so the resulting set and its order are identical; the reorder bounds the per-task workflow resolution by the 7-day window instead of the whole board.

## The fixture is derived, not hand-built

The renamed workflow is `BUILTIN_CODING_WORKFLOW_IR` with **only its column ids renamed**. I first hand-built a four-node graph and the failures were instructive: the IR validator rejects an undeclared back-edge, and once declared as `kind: "rework"` the transition table *still* did not match the default board's. A hand-rolled fixture ends up testing the fixture's shape as much as the code. Deriving from the builtin guarantees the only difference between the two runs is the vocabulary — which is the entire differential claim.

It also asserts the rename landed (`checking` present, `in-review` absent), so a surviving literal cannot pass by accident.

## Revert proof

| reverted | result |
|---|---|
| retry classifier → `column === "in-review"` | **1 failed** / 1 passed |
| retry target → literal `"todo"` | **1 failed** / 1 passed |
| neither (shipped) | **2 passed** |

## Verification

- new PG suite — **2 passed** (real store, real persisted workflow, driven through the real `runTaskRetry`)
- 5 adjacent CLI suites — **38 passed**, no regressions
- `pnpm test:gate` — **158 / 10 / 487 / 71** · `pnpm lint` clean · CLI `tsc --noEmit` **0 errors**

## Not converted, deliberately

One `DELIBERATE-LITERAL` mark in `task.ts`: the board-print glyph at ~L615. Its comment already reasoned the case out fully — the loop iterates the legacy `COLUMNS` constant, so `col` can never be a custom id — it was simply missing the machine-readable marker. The deeper bug it names (a card in a renamed column is not rendered **at all**, because the loop derives its column set from the legacy enum) is the R8/U10 surface change and is far larger than this glyph.
