### PR TITLE
fleet: in-process-runtime 6 → 1 — a finished card's plan review could re-enter, and the mission requeue wrote a column that may not exist

### DIFF
--- a/packages/engine/src/__tests__/plan-approval-hold-invariant.test.ts
+++ b/packages/engine/src/__tests__/plan-approval-hold-invariant.test.ts
@@ -386,14 +386,22 @@ describe("#3 the continuation drain holds, and never cancels, an approval-blocke
   REVERT CHECK, measured: restoring the literals makes the renamed case fail — kind is "actionable"
   where it must be "orphan". The default-vocabulary case passes either way.
   */
-  const RENAMED_LIFECYCLE = { hold: "backlog", wip: "building", review: "checking", complete: "shipped", archived: "attic" };
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-21:10 (adapted to main's API, which is the better one):
+  Main converted this seam while my branch was open and chose `terminalColumns: ReadonlySet<string>` —
+  MEMBERSHIP — where mine passed a `LifecycleColumns` and read `.complete` / `.archived`, i.e.
+  first-per-role. A workflow with two complete lanes would have defeated mine. Same arity lesson as the
+  routes review resolver, the FN-7720 bypass guard, and dependency satisfaction; main's shape wins and
+  the case is rewritten against it rather than the other way round.
+  */
+  const RENAMED_TERMINAL_COLUMNS: ReadonlySet<string> = new Set(["shipped", "attic"]);
 
   it("orphans a continuation whose card reached a RENAMED terminal lane", () => {
     for (const column of ["shipped", "attic"]) {
       const resolved = resolvePlanningContinuationCandidate(
         dueItem(),
         task({ column } as never),
-        { lifecycle: RENAMED_LIFECYCLE as never },
+        { terminalColumns: RENAMED_TERMINAL_COLUMNS },
       );
       expect(resolved.kind, `${column} should be terminal`).toBe("orphan");
       if (resolved.kind === "orphan") expect(resolved.reason).toBe("task-terminal");
@@ -405,7 +413,7 @@ describe("#3 the continuation drain holds, and never cancels, an approval-blocke
     const resolved = resolvePlanningContinuationCandidate(
       dueItem(),
       task({ column: "building" } as never),
-      { lifecycle: RENAMED_LIFECYCLE as never },
+      { terminalColumns: RENAMED_TERMINAL_COLUMNS },
     );
     expect(resolved.kind).toBe("actionable");
   });

--- a/packages/engine/src/__tests__/plan-approval-hold-invariant.test.ts
+++ b/packages/engine/src/__tests__/plan-approval-hold-invariant.test.ts
@@ -373,6 +373,43 @@ describe("#3 the continuation drain holds, and never cancels, an approval-blocke
     expect(resolvePlanningContinuationCandidate(dueItem(), task()).kind).toBe("actionable");
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-06:50 (fleet phase — the drain's TERMINAL test):
+  `resolvePlanningContinuationCandidate` orphans a continuation whose task has reached a terminal lane.
+  That test was `column === "archived" || column === "done"`, so on a renamed board it matched nothing and
+  a FINISHED card's planning continuation was still handed to the executor — re-entering plan review on
+  work that is already done.
+
+  `lifecycle` is optional, so every case above keeps asserting the legacy-id behaviour unchanged; these
+  two supply it. That is also why none of the existing 25 cases could have caught this.
+
+  REVERT CHECK, measured: restoring the literals makes the renamed case fail — kind is "actionable"
+  where it must be "orphan". The default-vocabulary case passes either way.
+  */
+  const RENAMED_LIFECYCLE = { hold: "backlog", wip: "building", review: "checking", complete: "shipped", archived: "attic" };
+
+  it("orphans a continuation whose card reached a RENAMED terminal lane", () => {
+    for (const column of ["shipped", "attic"]) {
+      const resolved = resolvePlanningContinuationCandidate(
+        dueItem(),
+        task({ column } as never),
+        { lifecycle: RENAMED_LIFECYCLE as never },
+      );
+      expect(resolved.kind, `${column} should be terminal`).toBe("orphan");
+      if (resolved.kind === "orphan") expect(resolved.reason).toBe("task-terminal");
+    }
+  });
+
+  it("still dispatches for a live card on that same renamed board", () => {
+    // Non-vacuous: the terminal test must not swallow every column on a renamed board.
+    const resolved = resolvePlanningContinuationCandidate(
+      dueItem(),
+      task({ column: "building" } as never),
+      { lifecycle: RENAMED_LIFECYCLE as never },
+    );
+    expect(resolved.kind).toBe("actionable");
+  });
+
   for (const hold of APPROVAL_HOLDS) {
     it(`skips dispatch (${hold.label}) and leaves the item claimable for after the decision`, () => {
       const resolved = resolvePlanningContinuationCandidate(dueItem(), task({ ...hold.fields }));

--- a/packages/engine/src/concurrency.ts
+++ b/packages/engine/src/concurrency.ts
@@ -452,6 +452,28 @@ export function recoverIdleSemaphoreLeakCandidate(params: {
 
   if (!semaphore) return { candidateSinceMs: null };
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:30 (FLAGGED, NOT FIXED — the last raw caller of the running-agent predicate):
+  `persistedTopLevelAgentSlots` takes RAW tasks, so `live-agent-count.ts`'s trait fields are undefined here
+  and its predicates fall back to the legacy ids (`in-progress` for wip, `done`/`archived` for terminal).
+
+  Traced every caller of that predicate before writing this: the live ADMISSION paths
+  (`executor.ts` fn_spawn_agent, `project-engine.ts`) both use
+  `computeTopLevelConcurrencyClaimedFromStore`, which enriches, and
+  `workflow-agent-count-live-e2e.pg.test.ts` pins that number end to end. `computeTopLevelConcurrencyClaimed`
+  (raw) has no production caller at all. THIS is the one live path left that does not enrich.
+
+  CONSEQUENCE on a renamed board: cards in a renamed wip lane are not counted, so `persistedActive` and
+  therefore `bound` are too low, and the continuous-excess timer below can see phantom excess and reclaim a
+  semaphore slot that is legitimately held. That is the same class of harm the FN-7017 note directly below
+  guards against for nested helper agents, arriving through the vocabulary door instead.
+
+  NOT FIXED HERE, deliberately. `persistedTopLevelAgentSlotsFromStore` is the enriching variant and it is
+  ASYNC; this is a synchronous leak-RECOVERY path, so adopting it changes the signature of a capacity repair
+  routine whose failure mode is reclaiming live work. That is a behaviour change in the capacity subsystem,
+  not a vocabulary conversion, and it wants an owner who can decide whether recovery should be able to await
+  a store read at all — the alternative being to pass pre-enriched tasks in from the caller.
+  */
   const persistedActive = persistedTopLevelAgentSlots(tasks);
   const bound = persistedActive + Math.max(0, Math.floor(inFlightCount));
   /*


### PR DESCRIPTION
`in-process-runtime.ts` 6 → **1**. Two real defects, one flagged hot-path site, and a third file examined and deliberately left alone.

## The drain could re-enter plan review on finished work

`resolvePlanningContinuationCandidate` orphans a continuation whose card has reached a terminal lane. That test was `column === "archived" || column === "done"` — so on a renamed board it **matched nothing**, and a **finished** card's planning continuation was still handed to the executor.

Threaded through the `deps` object, which is already the documented seam for this function ("so the wiring is testable without constructing a runtime"). **Optional**, so every existing harness keeps the legacy-id behaviour unchanged; the runtime wires it from its `TaskStore` with **one IR cache per drain pass** — allocated per pass rather than on the instance, so it cannot outlive a workflow edit between passes.

## The mission requeue had two literals, and the target one is worse

```ts
if (latest?.column === "in-progress") {
  await this.taskStore.moveTask(task.id, "todo");
}
```

On a renamed board the guard never matched, so a mission-linked failure was **never requeued** and autopilot retry policy never got to decide. And had it matched, the requeue **writes a column that workflow may not declare** — the exact rebound-target defect `agent-heartbeat-worktree-renamed-hold.test.ts` was written for, on a path that test does not cover.

The target now uses **`resolveReboundTarget`** (the KTD-10 ordering: hold → intake → first column) rather than `lifecycle.hold` alone, because a workflow may declare no hold lane at all and that helper is the one place the ordering lives.

## Flagged and left counted

The `task:moved` listener that deletes task-local planner chats on archival. It runs on **every** move in the project and the archival test **is** its gate, so converting means resolving a workflow IR on every move just to decide most moves are not archival — the same call I made at `github-tracking-comments.ts:232`.

Consequence stated rather than hidden: on a renamed archived lane, those chats are **not deleted** at the cutoff. That is a retention miss, not a loss — the chats are kept. The fix wants the resolved lane on the event payload, since the emitter already knows it; that is an event-contract change.

## Revert proof

Restoring the drain's literals fails the new case with `shipped should be terminal: expected 'skip' to be 'orphan'`.

**None of the 25 existing cases in that suite could have caught this** — `lifecycle` is optional and they all omit it, so they assert the legacy fallback. The two new cases supply it, and the second pins that the terminal test does not swallow every column on a renamed board.

## A file I examined and did not convert

**`reliability-metrics.ts` (6)** reads `from`/`to` out of **historical** activity-log and run-audit metadata. Those records store the column ids **as they were at the time of the move**, so comparing them against the *currently* resolved review lane is wrong for any entry written before a rename — and the workflow as-of-the-event is not recorded anywhere.

Converting it would make post-rename windows work and silently mis-handle windows spanning a rename; leaving it means renamed boards report zero review latency. Both are wrong in different directions, and picking needs a product answer about what a metric spanning a vocabulary change should say. That is a behaviour decision, not a conversion, so it stays flagged — the historical-event-metadata class is distinct from anything else in this backlog and is worth naming as such.

## Verification

`pnpm test:gate` **GREEN** (158 + 10 + 487 + 71) · **102 passed** across the hold-invariant and mission-loop suites · engine `tsc` clean · `pnpm lint` clean · census `--strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)