### PR TITLE
docs(solutions): the optional-flags seam kept four green suites blind to their own conversion — and why I did not ship a ratchet for it

### DIFF
--- a/docs/solutions/test-failures/optional-flags-seam-hides-unconverted-column-guards.md
+++ b/docs/solutions/test-failures/optional-flags-seam-hides-unconverted-column-guards.md
@@ -116,8 +116,11 @@ version of the automated attempt is recorded above so it is not re-attempted fro
   documented fallback and the test is right about the wrong configuration. A reader debugging "my branch
   never ran" wants that entry; a reviewer asking "would this suite have noticed?" wants this one.
 - `scripts/lifecycle-column-census.mjs` — the authoritative count of remaining literals.
-- `packages/core/src/__tests__/archived-column-gate-parity.test.ts` — the archived gate is enforced in
-  three encodings (TypeScript, Drizzle, raw SQL); converting one alone is a split brain.
+- The archived gate is enforced in THREE encodings — TypeScript comparisons, Drizzle `eq`/`ne`
+  predicates, and raw `sql` templates — so converting one alone is a split brain. The guard that pins
+  all three inventories is `packages/core/src/__tests__/archived-column-gate-parity.test.ts`, added by
+  PR #2724; if that path does not resolve, #2724 has not landed yet and the measurement above (50 sites)
+  is the standalone record.
 - `packages/dashboard/app/components/__tests__/column-role-id-invariance.test.tsx` — the renaming
   property, and a note on why it is only half the invariant.
 - `packages/dashboard/app/utils/columnRoles.ts` — why the id fallback exists and must not be deleted.

--- a/docs/solutions/test-failures/optional-flags-seam-hides-unconverted-column-guards.md
+++ b/docs/solutions/test-failures/optional-flags-seam-hides-unconverted-column-guards.md
@@ -1,0 +1,123 @@
+---
+category: test-failures
+module: workflow-resolved-columns
+date: 2026-07-31
+problem_type: test_blind_spot
+component: testing
+severity: high
+applies_when:
+  - "Converting a lifecycle-column literal to a resolved role (the column-census backlog)"
+  - "Reviewing a conversion PR whose existing suite stayed green"
+  - "Adding an optional parameter that changes behaviour only when supplied"
+tags:
+  - workflow-resolved-columns
+  - column-census
+  - optional-parameter
+  - revert-proof
+  - fleet
+---
+
+# An optional-flags seam keeps the whole existing suite green — through the conversion AND through a broken one
+
+## The problem, measured
+
+Every conversion in the workflow-resolved-columns program uses the same seam: a caller passes resolved
+trait flags (or a `LifecycleColumns`), and the helper falls back to the legacy column id when they are
+absent.
+
+```ts
+export function isCompleteColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return flags ? flags.complete === true : columnId === LEGACY_COMPLETE_COLUMN_ID;
+}
+```
+
+The fallback is correct and must stay — flags are legitimately absent during first paint and for a card
+in a column its workflow no longer declares. But it has a consequence that bit four consecutive files:
+
+**every pre-existing test omits the flags, so every pre-existing test asserts the fallback.** The suite
+therefore passes:
+
+- before the conversion (the literal is the answer),
+- after a correct conversion (the fallback returns the same answer), and
+- after a *wrong* conversion, as long as the fallback is intact.
+
+Measured instances, all in files whose suites were fully green at conversion time:
+
+| file | pre-existing cases that could not detect the conversion |
+| --- | --- |
+| `github-tracking-reconciler.ts` | 33 (fake store had no workflow reader) |
+| `TaskReviewTab.tsx` | 45 (`columnFlags` omitted everywhere) |
+| `task-age-staleness.ts` | 12 (`context.lifecycle` omitted everywhere) |
+| `plan-approval-hold-invariant` (drain) | 25 (`opts.lifecycle` omitted everywhere) |
+
+In each case the conversion was verified only because a NEW case supplied flags. Without that, "the
+suite is green" carried no information about the change at all.
+
+## Why the usual instinct — a renaming test — is not enough either
+
+The natural property is "hold the traits fixed, change the id, behaviour is identical". That catches a
+site still reading the id **only when the id no longer matches anything**. It does not catch the
+commonest real shape:
+
+```ts
+// Not a fallback — an override. The id wins even when traits disagree.
+return column === "in-review" || flags?.mergeBlocker === true;
+```
+
+Renaming `in-review` to `checking` leaves this correct, because the trait arm answers. The defect
+appears in the *converse* direction: a column that still **carries** a lifecycle name while its traits
+say otherwise — which is what a project gets by repurposing a default column rather than renaming one.
+That direction found a live "Merge & Close" offered on a mid-implementation card
+(`TaskContextMenu`, PR #2718).
+
+## What to require
+
+For any conversion in this program, at least one test must **supply flags/lifecycle**, and the PR must
+state the measured revert result. Concretely:
+
+1. **A flags-supplying case.** If every case in the file omits the new parameter, the conversion is
+   untested in both directions.
+2. **Both directions where both are reachable.** Traits-say-role-but-id-differs (renamed lane), and
+   id-says-role-but-traits-differ (repurposed column). The second is the one an unconditional `||`
+   gets wrong.
+3. **A non-vacuous companion.** Assert something the widened predicate must still *exclude*, or a
+   predicate matching every column satisfies the new cases. (`TaskReviewTab` and the dispatch filters
+   both needed this; without it a filter returning `true` everywhere passed.)
+4. **Run the revert.** Restore the literal, run the new case, record the failure text in the PR. Twice
+   in this program a new case passed with the change reverted — once because the branch was gated behind
+   an unwired handler (`refine` needs `onOpenRefine`), once because the hook was dispatched by trait and
+   the test IR did not declare that trait, so the hook never ran at all.
+
+## Why this is documentation and not a ratchet
+
+I tried to automate it: AST-scan for role-helper call sites (sound — 31 consumer files, 66 call sites),
+then match each against a test file containing a "renamed vocabulary".
+
+**The detection half is unsound and I did not ship it.** The renamed ids used across this program —
+`building`, `checking`, `converted`, `published`, `backlog` — are ordinary English words that appear in
+unrelated test prose, and a test merely *importing* the module under test does not prove it exercises
+the role path. The scan reported `TaskCard.tsx` as covered by `Column.test.tsx` on a filename
+coincidence. A guard built on that reports coverage that does not exist, which is worse than no guard.
+
+A sound alternative — pin the consumer-file set and require each new one to declare its status — was
+also rejected: a 31-entry status inventory conflicts with every concurrent fleet PR that adds coverage,
+which is the same churn already removed from the census baseline by dropping its derived aggregates
+(see `scripts/lifecycle-column-census.mjs`).
+
+So the requirement lives here, as a review criterion, until someone finds a sound signal. The honest
+version of the automated attempt is recorded above so it is not re-attempted from scratch.
+
+## Related
+
+- `docs/solutions/test-failures/store-fake-defects-that-masquerade-as-production-bugs.md` — the adjacent
+  failure, and the reason the two are separate entries. There, a hand-rolled fake is MISSING a method the
+  production path needs, so a branch silently does not run and the production code looks wrong. Here the
+  fake is complete and the test is correct; the *parameter* is absent, so the production path runs its
+  documented fallback and the test is right about the wrong configuration. A reader debugging "my branch
+  never ran" wants that entry; a reviewer asking "would this suite have noticed?" wants this one.
+- `scripts/lifecycle-column-census.mjs` — the authoritative count of remaining literals.
+- `packages/core/src/__tests__/archived-column-gate-parity.test.ts` — the archived gate is enforced in
+  three encodings (TypeScript, Drizzle, raw SQL); converting one alone is a split brain.
+- `packages/dashboard/app/components/__tests__/column-role-id-invariance.test.tsx` — the renaming
+  property, and a note on why it is only half the invariant.
+- `packages/dashboard/app/utils/columnRoles.ts` — why the id fallback exists and must not be deleted.

--- a/docs/solutions/test-failures/store-fake-defects-that-masquerade-as-production-bugs.md
+++ b/docs/solutions/test-failures/store-fake-defects-that-masquerade-as-production-bugs.md
@@ -175,3 +175,8 @@ build it instead and link it here.
 - `docs/testing.md` — testing lanes and the taxonomy for trim-vs-keep.
 - AGENTS.md → "Standing Rule: Fix the Invariant, Not the Repro" — the same
   discipline applied to regression coverage.
+- `docs/solutions/test-failures/optional-flags-seam-hides-unconverted-column-guards.md` — the mirror
+  image of this entry. HERE a fake is MISSING a method, so a branch silently does not run. THERE the
+  fake is complete and the test is correct, but an OPTIONAL parameter is omitted, so the production path
+  takes its documented legacy fallback and the suite stays green through a conversion AND through a
+  broken one.


### PR DESCRIPTION
Docs only. No code, no census movement.

## The finding, measured

Four consecutive files in this program had **fully green suites at conversion time** that could not have detected the conversion — correct or broken:

| file | pre-existing cases blind to the change |
| --- | --- |
| `github-tracking-reconciler.ts` | **33** (fake store had no workflow reader) |
| `TaskReviewTab.tsx` | **45** (`columnFlags` omitted everywhere) |
| `plan-approval-hold-invariant` drain | **25** (`opts.lifecycle` omitted everywhere) |
| `task-age-staleness.ts` | **12** (`context.lifecycle` omitted everywhere) |

The cause is structural. Every conversion here uses the same seam — the caller passes resolved flags, the helper falls back to the legacy id when they are absent — and every pre-existing test omits the flags. So the suite passes **before** the conversion, **after a correct one**, and **after a wrong one**, as long as the fallback is intact. "The suite is green" carries no information about the change.

I reported this observation four times in PR bodies. Restating it a fifth time is worth less than writing it where the next worker will actually find it.

## It also corrects the obvious test

The natural property is "hold the traits fixed, change the id, behaviour is identical". That is only half the invariant. It does not catch:

```ts
// Not a fallback — an OVERRIDE. The id wins even when traits disagree.
return column === "in-review" || flags?.mergeBlocker === true;
```

Renaming `in-review` → `checking` leaves that correct, because the trait arm answers. The defect appears in the **converse** direction — a column that still *carries* a lifecycle name while its traits say otherwise, which is what you get by repurposing a default column rather than renaming one. That is the direction that found a live **"Merge & Close" offered on a mid-implementation card** in #2718.

## Why this is not a ratchet — a negative result, recorded

I tried to automate it, and I am shipping the reason it failed rather than a guard I do not trust.

The **consumer scan is sound**: AST-based, 31 files, 66 role-helper call sites. The **coverage half is not**. The renamed ids this program uses — `building`, `checking`, `converted`, `published`, `backlog` — are ordinary English words that appear in unrelated test prose, and a test merely *importing* the module under test does not prove it exercises the role path. My scan reported `TaskCard.tsx` as covered by `Column.test.tsx` on a **filename coincidence**.

A guard built on that reports coverage that does not exist, which is worse than no guard, so it is not shipped.

A sound alternative — pin the consumer set and make each new file declare its status — was also rejected: a 31-entry status inventory would conflict with every concurrent fleet PR that adds coverage. That is the same churn already removed from the census baseline by dropping its derived aggregates.

The attempt is written down so the next person does not repeat it from scratch, and the requirement lives as a review criterion until someone finds a sound signal.

## What it asks for

1. **A flags-supplying case** — if every case omits the new parameter, the conversion is untested in both directions.
2. **Both directions where both are reachable** — renamed lane, and repurposed column.
3. **A non-vacuous companion** — assert what the widened predicate must still *exclude*, or a predicate matching every column satisfies your new cases. (Both `TaskReviewTab` and the dispatch filters needed this.)
4. **Run the revert and record the failure text.** Twice in this program a new case passed with the change reverted: once because the branch was gated behind an unwired handler (`refine` needs `onOpenRefine`), once because the hook was dispatched by trait and the test IR did not declare that trait, so it never ran at all.

Cross-linked both ways with the adjacent `store-fake-defects` entry, with the distinction stated so the two are not confused: **there** a fake is missing a method so a branch never runs and production looks wrong; **here** the fake is complete and the test is correct, but a parameter is absent so production takes its documented fallback.

## Verification

`pnpm lint` clean · census `--strict` exits 0 (unmoved — this PR changes no code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)