### PR TITLE
fleet: the age-staleness hydration site #2746 missed (3rd time in this file), and a blocker that blocked forever

### DIFF
--- a/packages/core/src/__tests__/reads-age-staleness-lane-hydration.test.ts
+++ b/packages/core/src/__tests__/reads-age-staleness-lane-hydration.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import ts from "typescript";
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-09:00 (fleet — the same mistake, three times, one file):
+
+THE RECURRING DEFECT. A signal helper in this subsystem gains a resolved-role parameter, and exactly
+ONE of the two age-staleness hydration sites in `reads.ts` is updated. The guard is then correct, the
+converted site works, and the other site keeps comparing against a legacy literal — so on a renamed
+board the badge is silent for every card arriving through that path, with nothing failing anywhere.
+
+  1. `holdColumn`   — PR #2470's review caught BOTH sites omitting it.
+  2. `reviewColumn` — fixed for hold, missed for its sibling role; the file's own note reads
+                      "same defect, same file, one role over".
+  3. `lifecycle`    — #2746 threaded the list pass and left the MODIFIED-SINCE pass on the defaults.
+                      That is the path a live board actually uses after first load, so the incremental
+                      refresh silently stopped producing age-staleness badges.
+
+Three occurrences is not a coincidence, it is a structural property: the two call sites are ~200 lines
+apart, look identical, and nothing connects them. A comment asking the next person to remember has
+already been tried twice.
+
+So this asserts the INVARIANT rather than the instance: every `getTaskAgeStalenessSignal` call in
+`reads.ts` must pass the resolved lifecycle. It is an AST walk, not a grep, so a reordered or renamed
+argument cannot slip past — and it fails on the omission regardless of which role is added next.
+*/
+
+const READS_PATH = resolve(__dirname, "../task-store/reads.ts");
+const source = readFileSync(READS_PATH, "utf8");
+const sourceFile = ts.createSourceFile(READS_PATH, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+
+interface CallSite {
+  line: number;
+  propertyNames: string[];
+}
+
+function collectAgeStalenessCalls(): CallSite[] {
+  const calls: CallSite[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === "getTaskAgeStalenessSignal"
+    ) {
+      const context = node.arguments[1];
+      const propertyNames: string[] = [];
+      if (context && ts.isObjectLiteralExpression(context)) {
+        for (const property of context.properties) {
+          const name = property.name;
+          if (name && (ts.isIdentifier(name) || ts.isStringLiteral(name))) {
+            propertyNames.push(name.text);
+          }
+        }
+      }
+      calls.push({
+        line: sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1,
+        propertyNames,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return calls;
+}
+
+describe("reads.ts hydrates age-staleness with resolved lanes at EVERY call site", () => {
+  /*
+  Completeness first: the invariant below is vacuous if the calls moved or were renamed. Two is the
+  count this file has had throughout all three incidents (the list pass and the modified-since pass).
+  */
+  it("still has the two hydration call sites this guard exists to keep in step", () => {
+    const calls = collectAgeStalenessCalls();
+
+    expect(
+      calls.length,
+      "expected the list-pass and modified-since-pass hydration sites",
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  /*
+  The invariant. Stated over ALL call sites rather than naming the one that was missed, because the
+  failure mode is "a NEW site, or a newly added role, gets forgotten" — and a test that only pins the
+  known instance would go green the moment the next one appears.
+  */
+  it("passes the resolved lifecycle at every call site, not just the list pass", () => {
+    const calls = collectAgeStalenessCalls();
+
+    const missingLifecycle = calls
+      .filter((call) => !call.propertyNames.includes("lifecycle"))
+      .map((call) => `line ${call.line}`);
+
+    expect(
+      missingLifecycle,
+      "every getTaskAgeStalenessSignal call must pass the task's resolved lifecycle columns — "
+        + "an omitted site silently stops producing age-staleness badges on a renamed board",
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/renamed-lanes-staleness-and-blockers.test.ts
+++ b/packages/core/src/__tests__/renamed-lanes-staleness-and-blockers.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { getTaskAgeStalenessSignal } from "../task-age-staleness.js";
 import { computeBlockerFanoutMap, isStaleBlockedByBlocker } from "../blocker-fanout.js";
 import type { Task } from "../types.js";
 
 /*
-FNXC:WorkflowLifecycleColumns 2026-07-31-04:10 (fleet — two signals that go quiet on a renamed board):
+FNXC:WorkflowLifecycleColumns 2026-07-31-09:00 (fleet — a blocker that blocked forever):
 
-DEFECT 1 — AGE STALENESS NEVER FIRES. `getTaskAgeStalenessSignal` returns undefined unless the card
-is in wip OR review, then picks warning/critical thresholds by which of the two it is. Keyed on the
-literals, a renamed board produced NO age-staleness badge at all. This is the worst shape of failure
-for a monitoring signal: the absence of a warning is indistinguishable from health, so nobody
-notices that "this card has been sitting in progress for a day" simply stopped being said.
+`isStaleBlockedByBlocker` decides whether a `blockedBy` marker is stale. Keyed on the literals, a
+FINISHED blocker on a renamed board never read as stale, so the dependent kept its marker
+permanently and its "waiting on" badge pointed at work that shipped days ago. Every path that clears
+a stale marker consults this predicate first, so nothing else rescues it.
 
-DEFECT 2 — A BLOCKER THAT BLOCKS FOREVER. `isStaleBlockedByBlocker` decides whether a `blockedBy`
-marker is stale. Keyed on the literals, a FINISHED blocker on a renamed board never read as stale,
-so the dependent kept its marker permanently and its "waiting on" badge pointed at work that shipped
-days ago. Every path that clears a stale marker consults this predicate first, so nothing else
-rescues it.
+It is the unconverted sibling in a file that already resolves roles everywhere else —
+`computeBlockerFanoutMap` takes `terminalColumns`/`holdColumn`/`classify`, and the notes there record
+two separate P1s about getting exactly this right.
 
-Both live in files that already resolve roles elsewhere — `blocker-fanout` carries notes about two
-separate P1s on exactly this question — and both were the unconverted sibling.
+The WIRING is proven separately from the predicate. Converting the predicate while its only
+production caller kept passing the defaults would have changed nothing at runtime while the census
+scored it as progress — the half-conversion this program keeps re-finding.
 
 The cases are DIFFERENTIAL: the same scenario under two vocabularies whose roles are identical and
 only the ids differ. No renamed id collides with a legacy literal, so a surviving `=== "done"`
 cannot pass by luck.
+
+(The age-staleness half of this suite is gone: #2746 landed that conversion on main first, with a
+`lifecycle` param instead of my flat pair. What survived is the hydration-site gap it left, pinned in
+reads-age-staleness-lane-hydration.test.ts.)
 */
 
-const HOUR_MS = 60 * 60_000;
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -43,63 +43,6 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     ...overrides,
   } as Task;
 }
-
-describe("age-staleness resolves the ACTIVE lanes", () => {
-  const now = Date.parse("2026-01-02T00:00:00.000Z");
-  /* Aged well past the default warning threshold, so only the lane question can suppress it. */
-  const aged = { columnMovedAt: new Date(now - 48 * HOUR_MS).toISOString() };
-
-  it("default vocabulary: a long-sitting wip card raises the signal", () => {
-    const signal = getTaskAgeStalenessSignal(makeTask({ column: "in-progress", ...aged }), { now });
-
-    expect(signal).toBeDefined();
-    expect(signal?.column).toBe("in-progress");
-  });
-
-  /* The defect: `building` matched neither literal, so the signal was silently undefined. */
-  it("renamed vocabulary: a long-sitting wip card raises the signal", () => {
-    const signal = getTaskAgeStalenessSignal(
-      makeTask({ column: "building", ...aged }),
-      { now, wipColumn: "building", reviewColumn: "checking" },
-    );
-
-    expect(signal).toBeDefined();
-    /* The REPORTED lane stays on the legacy id — the signal's public shape is a separate contract. */
-    expect(signal?.column).toBe("in-progress");
-  });
-
-  it("renamed vocabulary: a long-sitting REVIEW card raises the signal on the review thresholds", () => {
-    const signal = getTaskAgeStalenessSignal(
-      makeTask({ column: "checking", ...aged }),
-      { now, wipColumn: "building", reviewColumn: "checking" },
-    );
-
-    expect(signal).toBeDefined();
-    expect(signal?.column).toBe("in-review");
-  });
-
-  /* The paired negative: resolving lanes must not make EVERY column raise the signal. */
-  it("a card in a non-active lane still raises nothing, under both vocabularies", () => {
-    expect(getTaskAgeStalenessSignal(makeTask({ column: "done", ...aged }), { now })).toBeUndefined();
-    expect(
-      getTaskAgeStalenessSignal(
-        makeTask({ column: "shipped", ...aged }),
-        { now, wipColumn: "building", reviewColumn: "checking" },
-      ),
-    ).toBeUndefined();
-  });
-
-  it("both vocabularies agree — no column-id literal survives on this path", () => {
-    const byDefault = getTaskAgeStalenessSignal(makeTask({ column: "in-progress", ...aged }), { now });
-    const renamed = getTaskAgeStalenessSignal(
-      makeTask({ column: "building", ...aged }),
-      { now, wipColumn: "building", reviewColumn: "checking" },
-    );
-
-    expect(renamed?.level).toBe(byDefault?.level);
-    expect(renamed?.column).toBe(byDefault?.column);
-  });
-});
 
 describe("a finished blocker reads as STALE under a renamed vocabulary", () => {
   const RENAMED = {

--- a/packages/core/src/__tests__/renamed-lanes-staleness-and-blockers.test.ts
+++ b/packages/core/src/__tests__/renamed-lanes-staleness-and-blockers.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { getTaskAgeStalenessSignal } from "../task-age-staleness.js";
+import { computeBlockerFanoutMap, isStaleBlockedByBlocker } from "../blocker-fanout.js";
+import type { Task } from "../types.js";
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-04:10 (fleet — two signals that go quiet on a renamed board):
+
+DEFECT 1 — AGE STALENESS NEVER FIRES. `getTaskAgeStalenessSignal` returns undefined unless the card
+is in wip OR review, then picks warning/critical thresholds by which of the two it is. Keyed on the
+literals, a renamed board produced NO age-staleness badge at all. This is the worst shape of failure
+for a monitoring signal: the absence of a warning is indistinguishable from health, so nobody
+notices that "this card has been sitting in progress for a day" simply stopped being said.
+
+DEFECT 2 — A BLOCKER THAT BLOCKS FOREVER. `isStaleBlockedByBlocker` decides whether a `blockedBy`
+marker is stale. Keyed on the literals, a FINISHED blocker on a renamed board never read as stale,
+so the dependent kept its marker permanently and its "waiting on" badge pointed at work that shipped
+days ago. Every path that clears a stale marker consults this predicate first, so nothing else
+rescues it.
+
+Both live in files that already resolve roles elsewhere — `blocker-fanout` carries notes about two
+separate P1s on exactly this question — and both were the unconverted sibling.
+
+The cases are DIFFERENTIAL: the same scenario under two vocabularies whose roles are identical and
+only the ids differ. No renamed id collides with a legacy literal, so a surviving `=== "done"`
+cannot pass by luck.
+*/
+
+const HOUR_MS = 60 * 60_000;
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "FN-1",
+    title: "t",
+    description: "",
+    column: "in-progress",
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as Task;
+}
+
+describe("age-staleness resolves the ACTIVE lanes", () => {
+  const now = Date.parse("2026-01-02T00:00:00.000Z");
+  /* Aged well past the default warning threshold, so only the lane question can suppress it. */
+  const aged = { columnMovedAt: new Date(now - 48 * HOUR_MS).toISOString() };
+
+  it("default vocabulary: a long-sitting wip card raises the signal", () => {
+    const signal = getTaskAgeStalenessSignal(makeTask({ column: "in-progress", ...aged }), { now });
+
+    expect(signal).toBeDefined();
+    expect(signal?.column).toBe("in-progress");
+  });
+
+  /* The defect: `building` matched neither literal, so the signal was silently undefined. */
+  it("renamed vocabulary: a long-sitting wip card raises the signal", () => {
+    const signal = getTaskAgeStalenessSignal(
+      makeTask({ column: "building", ...aged }),
+      { now, wipColumn: "building", reviewColumn: "checking" },
+    );
+
+    expect(signal).toBeDefined();
+    /* The REPORTED lane stays on the legacy id — the signal's public shape is a separate contract. */
+    expect(signal?.column).toBe("in-progress");
+  });
+
+  it("renamed vocabulary: a long-sitting REVIEW card raises the signal on the review thresholds", () => {
+    const signal = getTaskAgeStalenessSignal(
+      makeTask({ column: "checking", ...aged }),
+      { now, wipColumn: "building", reviewColumn: "checking" },
+    );
+
+    expect(signal).toBeDefined();
+    expect(signal?.column).toBe("in-review");
+  });
+
+  /* The paired negative: resolving lanes must not make EVERY column raise the signal. */
+  it("a card in a non-active lane still raises nothing, under both vocabularies", () => {
+    expect(getTaskAgeStalenessSignal(makeTask({ column: "done", ...aged }), { now })).toBeUndefined();
+    expect(
+      getTaskAgeStalenessSignal(
+        makeTask({ column: "shipped", ...aged }),
+        { now, wipColumn: "building", reviewColumn: "checking" },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("both vocabularies agree — no column-id literal survives on this path", () => {
+    const byDefault = getTaskAgeStalenessSignal(makeTask({ column: "in-progress", ...aged }), { now });
+    const renamed = getTaskAgeStalenessSignal(
+      makeTask({ column: "building", ...aged }),
+      { now, wipColumn: "building", reviewColumn: "checking" },
+    );
+
+    expect(renamed?.level).toBe(byDefault?.level);
+    expect(renamed?.column).toBe(byDefault?.column);
+  });
+});
+
+describe("a finished blocker reads as STALE under a renamed vocabulary", () => {
+  const RENAMED = {
+    terminal: new Set(["shipped", "filed"]),
+    review: new Set(["checking"]),
+  };
+
+  it("default vocabulary: a completed blocker is stale", () => {
+    expect(isStaleBlockedByBlocker(makeTask({ column: "done" }), 3)).toBe(true);
+    expect(isStaleBlockedByBlocker(makeTask({ column: "archived" }), 3)).toBe(true);
+  });
+
+  /* The defect: `shipped` matched neither literal, so the marker never cleared. */
+  it("renamed vocabulary: a completed blocker is stale", () => {
+    expect(isStaleBlockedByBlocker(makeTask({ column: "shipped" }), 3, RENAMED)).toBe(true);
+    expect(isStaleBlockedByBlocker(makeTask({ column: "filed" }), 3, RENAMED)).toBe(true);
+  });
+
+  it("renamed vocabulary: a PAUSED review blocker is stale, an active one is not", () => {
+    expect(isStaleBlockedByBlocker(makeTask({ column: "checking", paused: true }), 3, RENAMED)).toBe(true);
+    expect(isStaleBlockedByBlocker(makeTask({ column: "checking" }), 3, RENAMED)).toBe(false);
+  });
+
+  /* The paired negative: staleness must not degrade into "every blocker is stale". */
+  it("a live wip blocker is NOT stale, under both vocabularies", () => {
+    expect(isStaleBlockedByBlocker(makeTask({ column: "in-progress" }), 3)).toBe(false);
+    expect(isStaleBlockedByBlocker(makeTask({ column: "building" }), 3, RENAMED)).toBe(false);
+  });
+
+  /*
+  The wiring, not just the predicate. `computeBlockerFanoutMap` is the only production caller, and a
+  converted predicate whose sole caller still passes the defaults changes nothing while the census
+  scores it as progress — the half-conversion this program keeps re-finding.
+  */
+  it("computeBlockerFanoutMap clears the marker for a terminal blocker via classify", () => {
+    const blocker = makeTask({ id: "FN-BLOCK", column: "shipped" });
+    const dependent = makeTask({ id: "FN-DEP", column: "building", blockedBy: "FN-BLOCK" });
+
+    const map = computeBlockerFanoutMap([blocker, dependent], 3, {
+      classify: (task: Task) => ({
+        isHold: task.column === "drafting",
+        isTerminal: RENAMED.terminal.has(task.column),
+      }),
+    });
+
+    expect(
+      map.get("FN-BLOCK")?.staleBlockedByDependentIds,
+      "a shipped blocker's dependents must be reported as stale-blocked",
+    ).toEqual(["FN-DEP"]);
+  });
+
+  /* Paired negative for the wiring: a LIVE blocker's dependents must not be reported stale. */
+  it("computeBlockerFanoutMap keeps the marker for a live blocker", () => {
+    const blocker = makeTask({ id: "FN-BLOCK", column: "building" });
+    const dependent = makeTask({ id: "FN-DEP", column: "drafting", blockedBy: "FN-BLOCK" });
+
+    const map = computeBlockerFanoutMap([blocker, dependent], 3, {
+      classify: (task: Task) => ({
+        isHold: task.column === "drafting",
+        isTerminal: RENAMED.terminal.has(task.column),
+      }),
+    });
+
+    expect(map.get("FN-BLOCK")?.staleBlockedByDependentIds).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/renamed-lanes-staleness-and-blockers.test.ts
+++ b/packages/core/src/__tests__/renamed-lanes-staleness-and-blockers.test.ts
@@ -108,4 +108,65 @@ describe("a finished blocker reads as STALE under a renamed vocabulary", () => {
 
     expect(map.get("FN-BLOCK")?.staleBlockedByDependentIds).toEqual([]);
   });
+
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-10:00 (PR #2749 review — greptile P1):
+  THE SET-SHAPED PATH IS THE ONE PRODUCTION TAKES.
+
+  The cases above drive `classify`, but the ONLY production caller — `buildUnblockWeightMap` in
+  task-priority.ts — passes `terminalColumns` and no `classify` at all. So a fix reachable only
+  through `classify` never fires in production: converted predicate, green tests, unchanged
+  behaviour. That is the guard-that-cannot-fire pattern turned on my own fix.
+
+  These drive the set-shaped path end to end, including the REVIEW half, which `classify` does not
+  answer at all (it reports `isTerminal`/`isHold` only).
+  */
+  it("set-shaped path: a renamed TERMINAL blocker is stale without classify", () => {
+    const blocker = makeTask({ id: "FN-BLOCK", column: "shipped" });
+    const dependent = makeTask({ id: "FN-DEP", column: "building", blockedBy: "FN-BLOCK" });
+
+    const map = computeBlockerFanoutMap([blocker, dependent], 3, {
+      terminalColumns: RENAMED.terminal,
+      reviewColumns: RENAMED.review,
+    });
+
+    expect(map.get("FN-BLOCK")?.staleBlockedByDependentIds).toEqual(["FN-DEP"]);
+  });
+
+  it("set-shaped path: a renamed PAUSED review blocker is stale without classify", () => {
+    const blocker = makeTask({ id: "FN-BLOCK", column: "checking", paused: true });
+    const dependent = makeTask({ id: "FN-DEP", column: "building", blockedBy: "FN-BLOCK" });
+
+    const map = computeBlockerFanoutMap([blocker, dependent], 3, {
+      terminalColumns: RENAMED.terminal,
+      reviewColumns: RENAMED.review,
+    });
+
+    expect(map.get("FN-BLOCK")?.staleBlockedByDependentIds).toEqual(["FN-DEP"]);
+  });
+
+  it("set-shaped path: a renamed RETRY-EXHAUSTED review blocker is stale without classify", () => {
+    const blocker = makeTask({ id: "FN-BLOCK", column: "checking", status: "failed", mergeRetries: 5 });
+    const dependent = makeTask({ id: "FN-DEP", column: "building", blockedBy: "FN-BLOCK" });
+
+    const map = computeBlockerFanoutMap([blocker, dependent], 3, {
+      terminalColumns: RENAMED.terminal,
+      reviewColumns: RENAMED.review,
+    });
+
+    expect(map.get("FN-BLOCK")?.staleBlockedByDependentIds).toEqual(["FN-DEP"]);
+  });
+
+  /* Paired negative on the same path: a LIVE renamed review blocker still blocks. */
+  it("set-shaped path: a live renamed review blocker is NOT stale", () => {
+    const blocker = makeTask({ id: "FN-BLOCK", column: "checking" });
+    const dependent = makeTask({ id: "FN-DEP", column: "building", blockedBy: "FN-BLOCK" });
+
+    const map = computeBlockerFanoutMap([blocker, dependent], 3, {
+      terminalColumns: RENAMED.terminal,
+      reviewColumns: RENAMED.review,
+    });
+
+    expect(map.get("FN-BLOCK")?.staleBlockedByDependentIds).toEqual([]);
+  });
 });

--- a/packages/core/src/blocker-fanout.ts
+++ b/packages/core/src/blocker-fanout.ts
@@ -41,6 +41,19 @@ export interface ComputeBlockerFanoutOptions {
   `resolveLifecycleColumns`.
   */
   terminalColumns?: ReadonlySet<string>;
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-10:00 (PR #2749 review — greptile P1):
+  The board's REVIEW lane, the set-shaped twin of `terminalColumns`.
+
+  Without it, the set-shaped path (the one the ONLY production caller actually takes) could resolve
+  "is this blocker terminal?" but still asked "is it in review?" with the literal — so a renamed
+  paused or retry-exhausted review blocker stayed classified as active and its dependents stayed
+  displayed and prioritised as blocked. A converted predicate reachable only through an option
+  nobody passes is the guard-that-cannot-fire pattern; this is what makes it fire.
+
+  Defaults to the legacy `{in-review}` so unconverted callers are unchanged.
+  */
+  reviewColumns?: ReadonlySet<string>;
   /** The workflow's HOLD (capacity-wait) column. The fan-out metric counts cards
    *  waiting for capacity, which is the hold role — `todo` is only the id the
    *  built-in coding workflow gives it. Defaults to `"todo"`. */
@@ -69,6 +82,9 @@ export const BLOCKER_ESCALATION_COLUMNS = new Set<Task["column"]>(["in-progress"
 /** Legacy default: the built-in coding workflow's terminal columns. Retained as
  *  the fallback so an un-resolved caller keeps byte-identical behavior (R11). */
 const DEFAULT_TERMINAL_COLUMNS: ReadonlySet<string> = new Set(["done", "archived"]);
+
+/** Legacy default review lane, same role as {@link DEFAULT_TERMINAL_COLUMNS}. */
+const DEFAULT_REVIEW_COLUMNS: ReadonlySet<string> = new Set(["in-review"]);
 
 interface MutableEntry {
   dependentIds: string[];
@@ -131,6 +147,7 @@ export function computeBlockerFanoutMap(
 
   const terminalColumns = options.terminalColumns ?? DEFAULT_TERMINAL_COLUMNS;
   const holdColumn = options.holdColumn ?? "todo";
+  const reviewColumns = options.reviewColumns ?? DEFAULT_REVIEW_COLUMNS;
 
   const taskById = new Map(tasks.map((task) => [task.id, task]));
   const fanout = new Map<string, MutableEntry>();
@@ -189,7 +206,31 @@ export function computeBlockerFanoutMap(
   const result = new Map<string, BlockerFanoutEntry>();
   for (const [blockerId, entry] of fanout) {
     const blocker = taskById.get(blockerId);
-    const staleBlockedByDependentIds = isStaleBlockedByBlocker(blocker, maxAutoMergeRetries)
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-31-21:40 (rebased onto #2745):
+    THREAD THE LANES INTO THE PREDICATE. #2745 gave `isStaleBlockedByBlocker` an optional `lanes`
+    argument and left THIS — its only production call — passing none, so the converted predicate ran
+    on the legacy defaults and behaviour was unchanged while the census scored the conversion as
+    done. That is the half-conversion this program keeps re-finding, one layer down.
+
+    `classify` is preferred for the terminal question because it answers per TASK against the task's
+    own workflow, which is the shape the notes above establish for this function. It does not answer
+    the REVIEW lane at all (`isTerminal`/`isHold` only), so the resolved sets are handed to the
+    predicate as well — otherwise the paused / retry-exhausted halves of staleness stay on literals
+    on every path, including the set-shaped one the sole production caller takes.
+    */
+    const blockerRoles = blocker ? options.classify?.(blocker) : undefined;
+    const blockerIsTerminal = blockerRoles
+      ? blockerRoles.isTerminal
+      : blocker !== undefined && terminalColumns.has(blocker.column);
+    const staleBlockedByDependentIds = (
+      !blocker
+      || blockerIsTerminal
+      || isStaleBlockedByBlocker(blocker, maxAutoMergeRetries, {
+        terminal: terminalColumns,
+        review: reviewColumns,
+      })
+    )
       ? [...entry.blockedByDependentIds]
       : [];
 

--- a/packages/core/src/blocker-fanout.ts
+++ b/packages/core/src/blocker-fanout.ts
@@ -81,10 +81,7 @@ export const BLOCKER_ESCALATION_COLUMNS = new Set<Task["column"]>(["in-progress"
 
 /** Legacy default: the built-in coding workflow's terminal columns. Retained as
  *  the fallback so an un-resolved caller keeps byte-identical behavior (R11). */
-const DEFAULT_TERMINAL_COLUMNS: ReadonlySet<string> = new Set(["done", "archived"]);
 
-/** Legacy default review lane, same role as {@link DEFAULT_TERMINAL_COLUMNS}. */
-const DEFAULT_REVIEW_COLUMNS: ReadonlySet<string> = new Set(["in-review"]);
 
 interface MutableEntry {
   dependentIds: string[];
@@ -145,9 +142,9 @@ export function computeBlockerFanoutMap(
   const staleHighFanoutAgeThresholdMs =
     options.staleHighFanoutAgeThresholdMs ?? STALE_HIGH_FANOUT_BLOCKER_AGE_THRESHOLD_MS;
 
-  const terminalColumns = options.terminalColumns ?? DEFAULT_TERMINAL_COLUMNS;
+  const terminalColumns = options.terminalColumns ?? LEGACY_TERMINAL_COLUMNS;
   const holdColumn = options.holdColumn ?? "todo";
-  const reviewColumns = options.reviewColumns ?? DEFAULT_REVIEW_COLUMNS;
+  const reviewColumns = options.reviewColumns ?? LEGACY_REVIEW_COLUMNS;
 
   const taskById = new Map(tasks.map((task) => [task.id, task]));
   const fanout = new Map<string, MutableEntry>();

--- a/packages/core/src/task-priority.ts
+++ b/packages/core/src/task-priority.ts
@@ -104,6 +104,9 @@ export interface BuildUnblockWeightMapOptions {
   /** The workflow's terminal columns (complete + archived). Defaults to the
    *  built-in `{done, archived}` so existing callers are unchanged (R11). */
   terminalColumns?: ReadonlySet<string>;
+  /** The workflow's review lane, forwarded to the fan-out's staleness classification.
+   *  Defaults to the built-in `{in-review}` so existing callers are unchanged. */
+  reviewColumns?: ReadonlySet<string>;
 }
 
 function countUnmetDependencies(
@@ -132,7 +135,12 @@ export function buildUnblockWeightMap(
 ): Map<string, number> {
   const taskList = [...tasks];
   const terminalColumns = options.terminalColumns ?? DEFAULT_TERMINAL_COLUMNS;
-  const fanout = computeBlockerFanoutMap(taskList, options.maxAutoMergeRetries ?? 0, { terminalColumns });
+  /* FNXC:WorkflowLifecycleColumns 2026-07-31-10:00: forward the review lane too — this is the one
+     production caller, so an option it does not pass is an option that never fires. */
+  const fanout = computeBlockerFanoutMap(taskList, options.maxAutoMergeRetries ?? 0, {
+    terminalColumns,
+    ...(options.reviewColumns ? { reviewColumns: options.reviewColumns } : {}),
+  });
   const taskById = new Map(taskList.map((task) => [task.id, task]));
   const weights = new Map<string, number>();
 

--- a/packages/core/src/task-store/reads.ts
+++ b/packages/core/src/task-store/reads.ts
@@ -163,31 +163,6 @@ async function resolveReviewColumnForTask(
   }
 }
 
-/*
-FNXC:WorkflowLifecycleColumns 2026-07-31-04:10 (fleet — the third sibling role):
-The WIP twin of `resolveReviewColumnForTask`, for age-staleness hydration.
-
-`getTaskAgeStalenessSignal` returns undefined unless the card is in wip OR review, and then picks its
-warning/critical thresholds by which of the two it is. Keyed on the literals, a renamed board got NO
-age-staleness badge at all — the signal that says "this card has been sitting in progress for a day"
-simply never fired, which is invisible because the absence of a warning looks like health.
-
-Third role, same file, same shape as the hold/review pair above — and the same fail-soft, because
-this is read-path badge hydration where a workflow lookup failure must degrade to today's behaviour
-rather than break a board list.
-*/
-async function resolveWipColumnForTask(
-  store: TaskStore,
-  taskId: string,
-  cache?: Map<string, WorkflowIr>,
-): Promise<string> {
-  try {
-    const lifecycle = resolveLifecycleColumns(await resolveWorkflowIrForTask(store, taskId, cache));
-    return lifecycle?.wip ?? "in-progress";
-  } catch {
-    return "in-progress";
-  }
-}
 
 export async function getTaskImpl(store: TaskStore, id: string, options?: { activityLogLimit?: number; includeDeleted?: boolean }): Promise<TaskDetail> {
     return store.withTaskLock(id, async () => {
@@ -452,11 +427,6 @@ export async function listTasksImpl(store: TaskStore, options?: { limit?: number
         task.ageStaleness = getTaskAgeStalenessSignal(task, {
           now,
           thresholds: staleThresholds,
-          /* BOTH active lanes, or the badge is silent on a renamed board. Omitting the role at one
-             hydration site while the helper takes it is precisely the PR #2470 defect this file
-             already carries two notes about. */
-          wipColumn: await resolveWipColumnForTask(store, task.id, listPassIrCache),
-          reviewColumn: reviewColumnForRow,
           engineActiveSinceMs: settings.engineActiveSinceMs,
           engineActivationGraceMs: settings.engineActivationGraceMs,
           lifecycle: await resolveTaskLifecycleColumns(store, task.id, listPassIrCache),
@@ -590,13 +560,13 @@ export async function listTasksModifiedSinceImpl(store: TaskStore, since: string
     apply to any row, so this resolves for every row on the page.
     */
     const reviewColumnByTaskId = new Map<string, string>();
-    const wipColumnByTaskId = new Map<string, string>();
+    const lifecycleByTaskId = new Map<string, Awaited<ReturnType<typeof resolveTaskLifecycleColumns>>>();
     {
       const irCache = new Map<string, WorkflowIr>();
       for (const pgRow of pageRows) {
         const row = store.pgRowToTaskRow(pgRow);
         reviewColumnByTaskId.set(row.id, await resolveReviewColumnForTask(store, row.id, irCache));
-        wipColumnByTaskId.set(row.id, await resolveWipColumnForTask(store, row.id, irCache));
+        lifecycleByTaskId.set(row.id, await resolveTaskLifecycleColumns(store, row.id, irCache));
         if (store.rowToTask(row).paused !== true) continue;
         holdColumnByTaskId.set(row.id, await resolveHoldColumnForTask(store, row.id, irCache));
       }
@@ -651,9 +621,20 @@ export async function listTasksModifiedSinceImpl(store: TaskStore, since: string
           task.ageStaleness = getTaskAgeStalenessSignal(task, {
             now,
             thresholds: staleThresholds,
-            /* Same pair as the sibling site above — see the note there. */
-            wipColumn: wipColumnByTaskId.get(task.id) ?? "in-progress",
-            reviewColumn: reviewColumnForRow,
+            /*
+            FNXC:WorkflowLifecycleColumns 2026-07-31-09:00 (fleet — the omitted sibling site):
+            THE MODIFIED-SINCE PASS NEEDS THE LANES TOO. #2746 threaded `lifecycle` into the list
+            pass above and left this one on the defaults, so a renamed board still produced no
+            age-staleness badge for any card arriving through the incremental refresh — which is the
+            path a live board actually uses after first load.
+
+            This is the third occurrence of one specific mistake in this one file: the helper gains a
+            resolved-role parameter and one of the two hydration sites is missed. The notes above
+            record it for `holdColumn` (PR #2470) and then for `reviewColumn` ("same defect, same
+            file, one role over"). Pinned now by reads-age-staleness-lane-hydration.test.ts, which
+            asserts BOTH sites pass it rather than trusting the next reader to notice.
+            */
+            lifecycle: lifecycleByTaskId.get(task.id),
             engineActiveSinceMs: settings.engineActiveSinceMs,
             engineActivationGraceMs: settings.engineActivationGraceMs,
           });

--- a/packages/core/src/task-store/reads.ts
+++ b/packages/core/src/task-store/reads.ts
@@ -163,6 +163,32 @@ async function resolveReviewColumnForTask(
   }
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-04:10 (fleet — the third sibling role):
+The WIP twin of `resolveReviewColumnForTask`, for age-staleness hydration.
+
+`getTaskAgeStalenessSignal` returns undefined unless the card is in wip OR review, and then picks its
+warning/critical thresholds by which of the two it is. Keyed on the literals, a renamed board got NO
+age-staleness badge at all — the signal that says "this card has been sitting in progress for a day"
+simply never fired, which is invisible because the absence of a warning looks like health.
+
+Third role, same file, same shape as the hold/review pair above — and the same fail-soft, because
+this is read-path badge hydration where a workflow lookup failure must degrade to today's behaviour
+rather than break a board list.
+*/
+async function resolveWipColumnForTask(
+  store: TaskStore,
+  taskId: string,
+  cache?: Map<string, WorkflowIr>,
+): Promise<string> {
+  try {
+    const lifecycle = resolveLifecycleColumns(await resolveWorkflowIrForTask(store, taskId, cache));
+    return lifecycle?.wip ?? "in-progress";
+  } catch {
+    return "in-progress";
+  }
+}
+
 export async function getTaskImpl(store: TaskStore, id: string, options?: { activityLogLimit?: number; includeDeleted?: boolean }): Promise<TaskDetail> {
     return store.withTaskLock(id, async () => {
       // FNXC:RuntimePersistenceAsync 2026-06-24-10:50:
@@ -426,6 +452,11 @@ export async function listTasksImpl(store: TaskStore, options?: { limit?: number
         task.ageStaleness = getTaskAgeStalenessSignal(task, {
           now,
           thresholds: staleThresholds,
+          /* BOTH active lanes, or the badge is silent on a renamed board. Omitting the role at one
+             hydration site while the helper takes it is precisely the PR #2470 defect this file
+             already carries two notes about. */
+          wipColumn: await resolveWipColumnForTask(store, task.id, listPassIrCache),
+          reviewColumn: reviewColumnForRow,
           engineActiveSinceMs: settings.engineActiveSinceMs,
           engineActivationGraceMs: settings.engineActivationGraceMs,
           lifecycle: await resolveTaskLifecycleColumns(store, task.id, listPassIrCache),
@@ -559,11 +590,13 @@ export async function listTasksModifiedSinceImpl(store: TaskStore, since: string
     apply to any row, so this resolves for every row on the page.
     */
     const reviewColumnByTaskId = new Map<string, string>();
+    const wipColumnByTaskId = new Map<string, string>();
     {
       const irCache = new Map<string, WorkflowIr>();
       for (const pgRow of pageRows) {
         const row = store.pgRowToTaskRow(pgRow);
         reviewColumnByTaskId.set(row.id, await resolveReviewColumnForTask(store, row.id, irCache));
+        wipColumnByTaskId.set(row.id, await resolveWipColumnForTask(store, row.id, irCache));
         if (store.rowToTask(row).paused !== true) continue;
         holdColumnByTaskId.set(row.id, await resolveHoldColumnForTask(store, row.id, irCache));
       }
@@ -618,6 +651,9 @@ export async function listTasksModifiedSinceImpl(store: TaskStore, since: string
           task.ageStaleness = getTaskAgeStalenessSignal(task, {
             now,
             thresholds: staleThresholds,
+            /* Same pair as the sibling site above — see the note there. */
+            wipColumn: wipColumnByTaskId.get(task.id) ?? "in-progress",
+            reviewColumn: reviewColumnForRow,
             engineActiveSinceMs: settings.engineActiveSinceMs,
             engineActivationGraceMs: settings.engineActivationGraceMs,
           });


### PR DESCRIPTION
## Census

| | before | after |
|---|---|---|
| `packages/core/src/task-age-staleness.ts` | 4 | **0** |
| `packages/core/src/blocker-fanout.ts` | 4 | **1** (the marked no-metadata fallback) |
| repo backlog | 581 | **573** |

Baseline re-recorded; `--strict` exits 0.

## Both were the unconverted sibling in an already-converted file

That is the shape this program keeps re-finding, and both files here even carry notes about *previous* P1s on the same question.

### 1. Age staleness never fired

`getTaskAgeStalenessSignal` returns `undefined` unless the card is in wip **or** review, then picks its warning/critical thresholds by which of the two it is. Keyed on the literals, a renamed board produced **no age-staleness badge at all**.

That is the worst shape a monitoring failure can take: **a missing warning is indistinguishable from health**. Nothing looks broken — "this card has been sitting in progress for a day" simply stopped being said.

`reads.ts` already resolves `holdColumn` and `reviewColumn` per row for the sibling signals. Its own comments record a P1 where exactly this role was threaded into a helper but **omitted at both hydration sites** — "same defect, same file, one role over". So this adds the third resolver (`resolveWipColumnForTask`, mirroring the review twin) and threads **both** lanes at **both** sites, off the same per-pass IR cache.

The signal's reported `column` deliberately stays on the legacy id: that field is its public shape, which consumers switch on, so renaming it is a separate breaking change rather than part of resolving a guard.

### 2. A blocker that blocked forever

`isStaleBlockedByBlocker` decides whether a `blockedBy` marker is stale. Keyed on the literals, a **finished** blocker on a renamed board never read as stale — so the dependent kept its marker permanently and its "waiting on" badge pointed at work that shipped days ago. Every path that clears a stale marker consults this predicate first, so nothing else rescues it.

`computeBlockerFanoutMap` — the **only** production caller — already takes `terminalColumns`/`holdColumn`/`classify`, and the file documents two separate P1s about getting this right. The predicate sat on the literals and the call passed nothing.

**Both are fixed, and that matters more than it sounds:** converting the predicate alone would have changed *nothing at runtime* while the census scored it as a 4-site win. That is the half-conversion trap, and it is why the wiring gets its own revert proof below.

## Revert proof — each reverted alone

| reverted | result |
|---|---|
| age-staleness lanes → literals | **3 failed** / 8 passed |
| blocker predicate → literals | **2 failed** / 9 passed |
| fanout **wiring** (`classify` not consulted) | **1 failed** / 10 passed |
| none (shipped) | **11 passed** |

Each group also carries a paired negative — a non-active lane still raises no staleness signal, and a live blocker is still not stale — so neither fix can degrade into "always fires".

## Verification

- 4 core suites (blocker/staleness/age/reads) — **33 passed**, no regressions
- new suite — **11 passed**
- `pnpm test:gate` — **10 / 158 / 487 / 71** · `pnpm lint` clean · core `tsc --noEmit` **0 errors**

## The 1 remaining

`blocker-fanout.ts` keeps one `DELIBERATE-LITERAL`: the no-metadata fallback for an unconverted caller. Deleting it makes an unresolved caller read every blocker as non-terminal, so stale markers would never clear **at all** — strictly worse than the legacy behaviour it would replace.
