### PR TITLE
fix(test): #2728 landed a red test — a Set was passed where a boolean is expected

### DIFF
--- a/packages/cli/src/__tests__/cli-active-count-lanes.test.ts
+++ b/packages/cli/src/__tests__/cli-active-count-lanes.test.ts
@@ -137,19 +137,33 @@ site that accepts the parameter and does not pass it is the failure mode a unit 
 describe("the shared missing-worktree classifier takes the caller's review lane", () => {
   const FAILURE = "Refusing to start coding agent in missing worktree: /gone";
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-11:30:
+  The second parameter is a RESOLVED BOOLEAN (`isReviewColumn?: boolean`), not a lane Set. These two
+  cases passed `new Set([...])`, and a non-empty Set is TRUTHY — so `isReviewColumn ?? ...` short-
+  circuited to the Set and the classifier answered `true` for every column. The negative case failed
+  on main, and the positive case was passing for the wrong reason: any truthy second argument
+  satisfies it, including `new Set(["nothing-relevant"])`.
+
+  Both now derive the boolean the way the real caller does — `commands/task.ts:1396` passes
+  `retryReviewColumns.has(task.column)` — so the lane set is still what decides, and the cases
+  exercise the resolution rather than a hand-picked literal.
+  */
+  const reviewLanes = new Set(["signoff"]);
+
   it("recognises a renamed review lane when the caller supplies it", async () => {
     const { isInReviewMissingWorktreeSessionStartFailure } = await import("@fusion/engine");
     const task = { id: "FN-1", column: "signoff", error: FAILURE } as never;
 
     // Pre-fix: `signoff` !== "in-review", so the retry bypass this classifier exists for never applied.
-    expect(isInReviewMissingWorktreeSessionStartFailure(task, new Set(["signoff"]))).toBe(true);
+    expect(isInReviewMissingWorktreeSessionStartFailure(task, reviewLanes.has(task.column))).toBe(true);
   });
 
   it("still refuses a column outside the supplied set", async () => {
     const { isInReviewMissingWorktreeSessionStartFailure } = await import("@fusion/engine");
     const task = { id: "FN-2", column: "building", error: FAILURE } as never;
 
-    expect(isInReviewMissingWorktreeSessionStartFailure(task, new Set(["signoff"]))).toBe(false);
+    expect(isInReviewMissingWorktreeSessionStartFailure(task, reviewLanes.has(task.column))).toBe(false);
   });
 
   it("keeps the legacy literal when no set is supplied", async () => {


### PR DESCRIPTION
## What happened

`cli-active-count-lanes.test.ts` arrived with **#2728** (merged minutes ago) and one of its own cases fails on `main`.

The signature is:

```ts
isInReviewMissingWorktreeSessionStartFailure(task, isReviewColumn?: boolean)
```

A **resolved boolean** — not a lane `Set`. Two cases passed `new Set(["signoff"])`.

**A non-empty `Set` is truthy**, so `isReviewColumn ?? task.column === "in-review"` short-circuits to the Set and the classifier answers `true` for *every* column:

| Case | On main |
|---|---|
| *"still refuses a column outside the supplied set"* | **FAILED** — column `"building"` → `true` |
| *"recognises a renamed review lane when the caller supplies it"* | passed **for the wrong reason** — any truthy second argument satisfies it, including `new Set(["nothing-relevant"])` |

So the file shipped one red case and one vacuous case, both from the same misread of the parameter. The vacuous one is the more dangerous of the two: it would have kept passing if the resolved-answer support were reverted entirely.

## The fix

Both cases now derive the boolean the way production does — `commands/task.ts:1396` passes `retryReviewColumns.has(task.column)`. The lane set still decides, and the cases exercise the **resolution** rather than a hand-picked literal, which is what the test names claim to be testing.

## Measured, both directions

| mutation | result |
|---|---|
| ignore the resolved answer (revert to the bare `task.column === "in-review"`) | **1 failed** / 8 passed |
| always accept (drop the column check entirely) | **2 failed** / 7 passed |

So the positive case is no longer satisfiable by any truthy value, and the negative case genuinely pins refusal. Neither was true before.

## Verification

| Check | Result |
|---|---|
| this file | 1 failed → **9 passed** |
| whole CLI package | 6 failed / 2 files → **5 failed / 1 file** |
| `pnpm typecheck` | exit 0 |
| `pnpm lint` | clean |

The remaining 5 are `task.test.ts`'s GitHub-import cases, owned by `feature/tool-permission-gates` — untouched.

## Note for the fleet

This is worth flagging beyond the one-line fix: the converted signature takes a **boolean**, and passing a `Set` produces a silently-permissive classifier rather than a type error, because the parameter is optional and `??` accepts any non-nullish value. #2728's own PR body describes the conversion correctly; only the test's call shape was wrong. Any other caller adopting `isReviewColumn` should pass `laneSet.has(task.column)`, not the set.