### PR TITLE
fleet: reliability-metrics.ts 6 → 0 — historical log values, marked not converted

### DIFF
--- a/packages/dashboard/src/reliability-metrics.ts
+++ b/packages/dashboard/src/reliability-metrics.ts
@@ -61,6 +61,21 @@ function incrementDayCount(counts: Record<string, number>, day: string): void {
   counts[day] = (counts[day] ?? 0) + 1;
 }
 
+/*
+FNXC:ReliabilityMetrics 2026-07-30-03:10 DELIBERATE-LITERAL: historical log values, not live columns.
+These ids come from `metadataColumn(entry, ...)` — the `from`/`to` recorded ON A PAST MOVE EVENT in
+the activity log. They are not a question about a task's current column, so there is no workflow to
+resolve them against: the event was written under whatever the board looked like at the time, and a
+column renamed since leaves every older entry carrying the OLD id forever.
+
+Converting these to a trait read would ask "what role does the column named X play TODAY?" about a
+record written months ago, possibly under a different workflow — which is a different question with
+a different answer, and it would silently drop history from the metric rather than improve it.
+
+The correct fix for renamed boards is at the WRITER (record a role alongside the id when the event is
+emitted), not at this reader. Until events carry that, matching the recorded literal is the only
+answer that keeps old data in the series.
+*/
 export function tasksEnteredInReviewPerDay(activity: ActivityLogEntry[], startMs: number, endMs: number): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const entry of collectTaskMovedEvents(activity, startMs, endMs)) {
@@ -71,6 +86,9 @@ export function tasksEnteredInReviewPerDay(activity: ActivityLogEntry[], startMs
   return counts;
 }
 
+/* FNXC:ReliabilityMetrics 2026-07-30-03:10 DELIBERATE-LITERAL: historical log values — `from`/`to`
+   as RECORDED on a past move event, matched as recorded. Full reasoning above
+   `tasksEnteredInReviewPerDay`. */
 export function tasksBouncedToInProgressPerDay(activity: ActivityLogEntry[], startMs: number, endMs: number): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const entry of collectTaskMovedEvents(activity, startMs, endMs)) {
@@ -101,6 +119,9 @@ function percentile(sortedValues: number[], p: number): number {
   return sortedValues[Math.min(sortedValues.length - 1, Math.max(0, index))] ?? 0;
 }
 
+/* FNXC:ReliabilityMetrics 2026-07-30-03:10 DELIBERATE-LITERAL: historical log values — `from`/`to`
+   as RECORDED on a past move event, matched as recorded. Full reasoning above
+   `tasksEnteredInReviewPerDay`. */
 export function inReviewDurationMetrics(activity: ActivityLogEntry[], startMs: number, endMs: number): InReviewDurationMetric {
   const moved = activity
     .filter((entry) => entry.type === "task:moved")

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -17,7 +17,6 @@
     "packages/core/src/task-store/branch-group-ops.ts": 6,
     "packages/core/src/task-store/task-artifacts-ops.ts": 6,
     "packages/dashboard/app/components/ListView.tsx": 6,
-    "packages/dashboard/src/reliability-metrics.ts": 6,
     "packages/engine/src/runtimes/in-process-runtime.ts": 6,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 5,
     "packages/dashboard/app/components/TaskDetailModal.tsx": 5,
@@ -137,6 +136,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts": 1
   },
   "deliberateByFile": {
+    "packages/dashboard/src/reliability-metrics.ts\u0000in-review": 4,
     "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 2,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000triage": 2,
     "packages/engine/src/scheduler.ts\u0000in-progress": 2,
@@ -155,6 +155,8 @@
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000triage": 1,
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000todo": 1,
     "packages/dashboard/app/utils/columnRoles.ts\u0000todo": 1,
+    "packages/dashboard/src/reliability-metrics.ts\u0000done": 1,
+    "packages/dashboard/src/reliability-metrics.ts\u0000in-progress": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000todo": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts\u0000triage": 1,
     "packages/engine/src/hold-release.ts\u0000archived": 1,


### PR DESCRIPTION
Unclaimed file, no overlap with any open fleet PR — deliberately picked to avoid adding conflicts to the queue.

## Census

| | before | after |
|---|---|---|
| backlog | 539 | **533** |
| reviewed (DELIBERATE-LITERAL) | 31 | 36 |
| this file | 6 | **0** |

`--strict` exit 0, baseline re-recorded in the same commit.

## Why these are marked, not converted

All six ids come from `metadataColumn(entry, "from"|"to")` — the columns **recorded on a past move event** in the activity log, not a task's current column.

There is no workflow to resolve them against. The event was written under whatever the board looked like at the time, and **a column renamed since leaves every older entry carrying the old id forever.** Converting them to a trait read would ask *"what role does the column named X play today?"* about a record written months ago, possibly under a different workflow — a different question with a different answer.

The failure mode matters: a trait-converted reader on a renamed board would **zero the series** rather than fix it, silently dropping history out of `tasksEnteredInReviewPerDay`, `tasksBouncedToInProgressPerDay`, and `inReviewDurationMetrics`. That is worse than the literal, which at least keeps matching the data that exists.

**The real fix for renamed boards is at the WRITER** — emit a role alongside the id when the move event is recorded — not at this reader. Noted at the site so whoever does that work finds it.

## A rule this generalises to

**Any reader of activity-log or run-audit metadata is a mark, not a convert.** The census cannot distinguish `task.column === "in-review"` (a live question, convert it) from `metadataColumn(entry, "to") === "in-review"` (a historical record, match it as recorded) — both are just literals to the AST. Other fleet workers hitting log/audit readers should expect the same call.

## Placement trap, third occurrence

My first pass marked the `const from`/`const to` declarations and moved the count by **1 of 6** — the census excuses the construct a marker is attached to, and the guards live in **sibling `if` statements**. Moved the markers to the enclosing functions.

This has now caught #2645's author, me on `TaskContextMenu`, and me again here. **Verify a marker by the count moving, not by the comment existing** — and until every worker does, a batch reporting "N → 0" can be off by most of N.

## Verification

Dashboard typecheck clean · reliability suites green (11 passed) · `--strict` exit 0 · no behavior change (comments only).