### PR TITLE
fix(test): two engine reds from fleet churn — and stop the shellout guard breaking on line drift

### DIFF
--- a/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
+++ b/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
@@ -104,15 +104,45 @@ function scanEngineSource(): ShelloutSite[] {
   return listProductionSource(root).flatMap((path) => scanSource(relative(process.cwd(), path), readFileSync(path, "utf-8")));
 }
 
+/*
+FNXC:EngineProcessRules 2026-07-30-12:20:
+Identity is file + primitive + SIGNATURE, with a per-key COUNT. The line number is documentation.
+
+The key used to include `entry.line`, so ANY edit above an audited call site broke this guard even
+though the call itself was untouched. That is not a hypothetical: it has now produced three false
+failures and been re-pinned twice by hand, most recently when unrelated fleet conversions shifted
+`executor.ts` and `self-healing.ts` (5 sites drifted at once). A guard that fails on edits it does not
+care about trains people to re-pin it without reading it, which is how a real new shellout would slip
+through in the same commit.
+
+The count preserves what the line number was actually buying: a SECOND identical shellout added to the
+same file is still unmatched, because the allowlist declares how many of that exact call it audits.
+What is deliberately given up is distinguishing "the audited call moved" from "the audited call stayed
+put" — which this guard has no reason to care about.
+*/
+function keyOf(entry: { file: string; primitive: string; signature: string }): string {
+  return `${entry.file}:${entry.primitive}:${entry.signature}`;
+}
+
 function classifySites(sites: ShelloutSite[]): { unmatched: ShelloutSite[]; stale: AllowlistEntry[] } {
-  const remaining = new Set(allowlist.map((entry) => `${entry.file}:${entry.line}:${entry.primitive}:${entry.signature}`));
+  const budget = new Map<string, number>();
+  for (const entry of allowlist) budget.set(keyOf(entry), (budget.get(keyOf(entry)) ?? 0) + 1);
+
   const unmatched = sites.filter((site) => {
-    const key = `${site.file}:${site.line}:${site.primitive}:${site.signature}`;
-    if (!remaining.has(key)) return true;
-    remaining.delete(key);
+    const remainingForKey = budget.get(keyOf(site)) ?? 0;
+    if (remainingForKey === 0) return true;
+    budget.set(keyOf(site), remainingForKey - 1);
     return false;
   });
-  return { unmatched, stale: allowlist.filter((entry) => remaining.has(`${entry.file}:${entry.line}:${entry.primitive}:${entry.signature}`)) };
+
+  // Anything still holding budget is an allowlist entry with no matching call site left in source.
+  const stale = allowlist.filter((entry) => {
+    const left = budget.get(keyOf(entry)) ?? 0;
+    if (left === 0) return false;
+    budget.set(keyOf(entry), left - 1);
+    return true;
+  });
+  return { unmatched, stale };
 }
 
 describe("engine blocking-shellout static guard", () => {

--- a/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
+++ b/packages/engine/src/__tests__/engine-no-blocking-shellout.test.ts
@@ -124,9 +124,12 @@ function keyOf(entry: { file: string; primitive: string; signature: string }): s
   return `${entry.file}:${entry.primitive}:${entry.signature}`;
 }
 
-function classifySites(sites: ShelloutSite[]): { unmatched: ShelloutSite[]; stale: AllowlistEntry[] } {
+function classifySites(
+  sites: ShelloutSite[],
+  entries: AllowlistEntry[] = allowlist,
+): { unmatched: ShelloutSite[]; stale: AllowlistEntry[] } {
   const budget = new Map<string, number>();
-  for (const entry of allowlist) budget.set(keyOf(entry), (budget.get(keyOf(entry)) ?? 0) + 1);
+  for (const entry of entries) budget.set(keyOf(entry), (budget.get(keyOf(entry)) ?? 0) + 1);
 
   const unmatched = sites.filter((site) => {
     const remainingForKey = budget.get(keyOf(site)) ?? 0;
@@ -136,7 +139,7 @@ function classifySites(sites: ShelloutSite[]): { unmatched: ShelloutSite[]; stal
   });
 
   // Anything still holding budget is an allowlist entry with no matching call site left in source.
-  const stale = allowlist.filter((entry) => {
+  const stale = entries.filter((entry) => {
     const left = budget.get(keyOf(entry)) ?? 0;
     if (left === 0) return false;
     budget.set(keyOf(entry), left - 1);
@@ -144,6 +147,59 @@ function classifySites(sites: ShelloutSite[]): { unmatched: ShelloutSite[]; stal
   });
   return { unmatched, stale };
 }
+
+/*
+FNXC:EngineProcessRules 2026-07-30-13:20 (greptile P2 — the count semantics had no direct coverage):
+The two invariants that replaced line coupling were verified by MUTATION while writing the change,
+which proves nothing once the mutation is reverted. Pinned here directly, so a later edit cannot
+restore line coupling or weaken duplicate detection without a red test.
+*/
+describe("shellout allowlist matching semantics", () => {
+  const AUDITED: AllowlistEntry = {
+    file: "src/example.ts",
+    line: 10,
+    primitive: "execSync",
+    signature: 'execSync("git worktree prune", {',
+    reason: "test fixture",
+  };
+  const siteAt = (line: number): ShelloutSite => ({
+    file: AUDITED.file,
+    line,
+    primitive: AUDITED.primitive,
+    signature: AUDITED.signature,
+  });
+
+  it("accepts an audited call that has MOVED — line drift alone is not a violation", () => {
+    // The false failure this replaced: an edit ABOVE the call site broke the guard three times.
+    const { unmatched, stale } = classifySites([siteAt(9_999)], [AUDITED]);
+
+    expect(unmatched).toEqual([]);
+    expect(stale).toEqual([]);
+  });
+
+  it("rejects a SECOND identical shellout — the count is what line numbers were buying", () => {
+    // One audited entry, two identical calls: the extra one is unmatched even though its
+    // file+primitive+signature match, because the allowlist audits exactly one of them.
+    const { unmatched } = classifySites([siteAt(10), siteAt(40)], [AUDITED]);
+
+    expect(unmatched).toHaveLength(1);
+    expect(unmatched[0]).toMatchObject({ file: AUDITED.file, signature: AUDITED.signature });
+  });
+
+  it("reports an audited entry with no call site left as STALE", () => {
+    const { unmatched, stale } = classifySites([], [AUDITED]);
+
+    expect(unmatched).toEqual([]);
+    expect(stale).toEqual([AUDITED]);
+  });
+
+  it("still distinguishes a DIFFERENT shellout in the same file", () => {
+    const other: ShelloutSite = { ...siteAt(12), signature: 'execSync("git gc --prune=now", {' };
+    const { unmatched } = classifySites([siteAt(10), other], [AUDITED]);
+
+    expect(unmatched).toEqual([other]);
+  });
+});
 
 describe("engine blocking-shellout static guard", () => {
   it("confines every production synchronous shellout to an audited call-site allowlist", () => {

--- a/packages/engine/src/__tests__/executor-execution-policy-renamed-columns.test.ts
+++ b/packages/engine/src/__tests__/executor-execution-policy-renamed-columns.test.ts
@@ -426,9 +426,21 @@ describe("a resolved workflow is never given a column it does not declare", () =
     encode the wrong contract; what this case pins is that the DISPATCH-LOOP gate did not claim
     it, and that the run reached a real classifier rather than falling off the end.
 
-    Noted while writing this: the resume router's log says "moved back to todo" and its
-    already-there check is another `"todo"` literal — one of the 20 sites in this method left to
-    U5's executor slice. It is why the card stays put here rather than being rehomed to `inbox`.
+    Noted while writing this: the resume router's log said "moved back to todo" and its
+    already-there check was another `"todo"` literal — one of the 20 sites in this method left to
+    U5's executor slice. It is why the card USED TO stay put here rather than being rehomed to
+    `inbox`.
+
+    FNXC:WorkflowExecutionOwnership 2026-07-30-12:40:
+    That literal is now converted, and this case flipped to the outcome the paragraph above
+    predicted: the resume router rehomes the card to `inbox`, this workflow's declared intake column
+    (`noHoldIr`), instead of leaving it parked in a `todo` the workflow does not declare. The
+    prediction landing is the evidence the conversion is right, so this asserts the rehome rather
+    than the absence of a move.
+
+    What the case still owns is unchanged: the DISPATCH-LOOP gate did not claim the card (no
+    "executor recovery preserved" log), and the run reached a real classifier rather than falling off
+    the end.
     */
     expect(store.logEntry).toHaveBeenCalledWith(
       task.id,
@@ -436,7 +448,13 @@ describe("a resolved workflow is never given a column it does not declare", () =
       undefined,
       undefined,
     );
-    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(store.moveTask).toHaveBeenCalledWith(
+      task.id,
+      "inbox",
+      expect.objectContaining({ recoveryRehome: true, preserveProgress: true }),
+    );
+    // Still never the literal the workflow does not declare.
+    expect(store.moveTask).not.toHaveBeenCalledWith(task.id, "todo", expect.anything());
     expect(task.status).not.toBe("failed");
   });
 


### PR DESCRIPTION
Both failures are fleet-churn fallout on `main`, not defects in the conversions. Engine goes **5 failed / 3 files → 3 failed / 1 file**; the remaining 3 are `executor-prompt`'s pause-guard question, documented in #2747.

## 1. The shellout guard was coupled to line numbers — third time

Its match key was `file:LINE:primitive:signature`, so **any edit above an audited call site** broke it while the call itself was untouched. Recent fleet conversions shifted `executor.ts` and `self-healing.ts`, and 5 sites drifted at once.

**This is the third time it has gone red this way, and the third hand re-pin.** A guard that fails on edits it does not care about trains people to re-pin it without reading it — which is exactly how a real new shellout slips through in the same commit as a drift fix.

So this removes the coupling rather than updating the numbers again. Identity is now **file + primitive + signature**, with a **per-key count**; `line` stays as documentation.

The count preserves what `line` was actually buying: a *second identical* shellout in the same file is still unmatched, because the allowlist declares how many of that exact call it audits. What is deliberately given up is distinguishing "the audited call moved" from "it stayed put" — which this guard has no reason to care about.

**Measured, all three directions:**

| mutation | result |
|---|---|
| add a NEW, different shellout | **2 failed** / 1 passed |
| **duplicate** an already-audited shellout | **2 failed** / 1 passed — what `line` used to catch |
| pure line drift above an audited call | **3 passed** — previously the false failure |

## 2. A test that predicted its own flip

`executor-execution-policy-renamed-columns` asserted `moveTask` was never called. It now rehomes the card to `inbox`.

That is not a surprise — **the test's own comment called it**:

> *"the resume router's log says 'moved back to todo' and its already-there check is another `"todo"` literal — one of the 20 sites in this method left to U5's executor slice. It is why the card stays put here rather than being rehomed to `inbox`."*

A fleet PR converted that literal, and the router now rehomes to `inbox` — the declared intake column of `noHoldIr`, the workflow under test. **The prediction landing is the evidence the conversion is right**, so the case asserts the rehome instead of the absence of a move, and additionally pins that the card is never moved to the `todo` this workflow does not declare.

What the case owns is unchanged: the dispatch-loop gate did not claim the card (no *"executor recovery preserved"* log), and the run reached a real classifier rather than falling off the end.

## Verification

`pnpm test:gate` **726**, `pnpm lint` clean, engine `tsc --noEmit` clean.

## Note on PR count

This is my fourth open PR against the one-per-worker rule, opened because it clears **red on main** — the stated priority-one exception. My other three (#2753, #2747, #2743) are rebased onto current main, green, with zero unresolved threads, waiting only on CI. I am opening nothing further until they land.