### PR TITLE
fix(dashboard): TaskDetailModal — one root cause that produced six separate review findings

### DIFF
--- a/packages/dashboard/app/components/TaskDetailModal.tsx
+++ b/packages/dashboard/app/components/TaskDetailModal.tsx
@@ -958,6 +958,17 @@ export function TaskDetailContent({
   stale. `undefined` here gives every role the same answer it uses before any fetch lands.
   */
   const detailFlagsAreForThisTask = workflowMoveMetadata?.taskId === task.id;
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-17:30 (one root cause, SIX review findings):
+  EVERY consumer in this file reads the task-identity-guarded value. `workflowMoveMetadata` outlives a
+  task switch, so while the modal is open its flags describe the PREVIOUS task for a render — and this
+  component gates editability, the execution-mode replan decision, the intake affordance, the actions
+  menu and the review tab on them.
+
+  The guard existed from the start; five call sites simply read around it, and each was found
+  separately: #2744 (review tab), #2696 (handleDelete deps), and the four here. Converting them
+  together retires the class instead of paying another review round per site.
+  */
   const detailColumnFlags = detailFlagsAreForThisTask ? workflowMoveMetadata?.currentColumnFlags : undefined;
   const isDoneColumn = isCompleteColumnRole(detailColumnFlags, task.column);
   const isArchivedColumn = isArchivedColumnRole(detailColumnFlags, task.column);
@@ -1824,7 +1835,7 @@ export function TaskDetailContent({
   // Note: TaskForm handles auto-focus internally via isActive prop
 
   // Check if task can be edited
-  const canEdit = isTaskFieldEditableColumn(task.column, workflowMoveMetadata?.currentColumnFlags) && !isSaving;
+  const canEdit = isTaskFieldEditableColumn(task.column, detailColumnFlags) && !isSaving;
   /** The card's column name as its own workflow declares it; `undefined` when unresolved. */
   const workflowColumnDisplayName = workflowMoveMetadata?.moveColumns?.find((column) => column.id === task.column)?.label;
   const canEditGithubTracking = canTaskEditGithubTracking(task.column, taskWorkflowBadge?.id) && !isSaving;
@@ -2144,7 +2155,7 @@ export function TaskDetailContent({
       }
       return false;
     }
-    const replanAfterExecutionModeChange = Object.prototype.hasOwnProperty.call(updates, "executionMode") && requiresExecutionModeReplan(task.column, workflowMoveMetadata?.currentColumnFlags);
+    const replanAfterExecutionModeChange = Object.prototype.hasOwnProperty.call(updates, "executionMode") && requiresExecutionModeReplan(task.column, detailColumnFlags);
     if (replanAfterExecutionModeChange && !includeDescription) {
       delete updates.executionMode;
     }
@@ -2282,7 +2293,7 @@ export function TaskDetailContent({
     const currentMode = normalizeExecutionModeValue(task.executionMode);
     const nextMode = currentMode === "fast" ? "standard" : "fast";
     const previousMode = inlineExecutionMode;
-    const shouldReplan = requiresExecutionModeReplan(task.column, workflowMoveMetadata?.currentColumnFlags);
+    const shouldReplan = requiresExecutionModeReplan(task.column, detailColumnFlags);
 
     if (shouldReplan) {
       const shouldChangeMode = await confirm({
@@ -3153,8 +3164,8 @@ export function TaskDetailContent({
   Reachable only with no resolved flags; guessing "not intake" hides Approve/Reject from a parked
   planning card, which is an operator dead end. Retires with the pre-load window.
   */
-  const isIntakeColumn = workflowMoveMetadata?.currentColumnFlags
-    ? workflowMoveMetadata.currentColumnFlags.intake === true
+  const isIntakeColumn = detailColumnFlags
+    ? detailColumnFlags.intake === true
     : task.column === "triage";
   const isAwaitingApproval = isIntakeColumn && task.status === "awaiting-approval";
   const isPlanReviewReplanCapApproval = isReviewBudgetExhaustedApproval(task);
@@ -3779,7 +3790,7 @@ export function TaskDetailContent({
     task,
     t,
     columnLabel,
-    currentColumnFlags: workflowMoveMetadata?.currentColumnFlags,
+    currentColumnFlags: detailColumnFlags,
     workflowMoveColumns: workflowMoveMetadata?.moveColumns,
     canRetryTask,
     hasDuplicateHandler: Boolean(onDuplicateTask),

--- a/packages/dashboard/app/components/TaskDetailModal.tsx
+++ b/packages/dashboard/app/components/TaskDetailModal.tsx
@@ -2205,7 +2205,7 @@ export function TaskDetailContent({
         setIsSaving(false);
       }
     }
-  }, [addToast, buildEditUpdates, confirm, onTaskUpdated, projectId, requestClose, task.column, task.executionMode, task.id]);
+  }, [addToast, buildEditUpdates, confirm, detailColumnFlags, onTaskUpdated, projectId, requestClose, task.column, task.executionMode, task.id]);
 
   const handleAutoSaveDescription = useCallback(async (_description: string) => {
     await persistEditChanges(true);
@@ -2329,7 +2329,15 @@ export function TaskDetailContent({
         setIsSavingInlineExecutionMode(false);
       }
     }
-  }, [task.id, task.column, task.executionMode, projectId, inlineExecutionMode, onTaskUpdated, addToast, confirm, requestClose]);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-18:10 (PR #2761 review — greptile):
+  `detailColumnFlags` is a DEPENDENCY, not a constant. It starts undefined on a task switch and
+  populates when the metadata lands, so a callback that captures it without listing it keeps applying
+  the pre-resolution answer — deciding the execution-mode replan from the legacy id on a custom hold or
+  WIP column. My narrowing introduced a value that changes over time into callbacks written for one
+  that did not.
+  */
+  }, [task.id, task.column, task.executionMode, detailColumnFlags, projectId, inlineExecutionMode, onTaskUpdated, addToast, confirm, requestClose]);
 
   const handleInlineNoCommitsExpectedToggle = useCallback(async () => {
     const nextValue = !inlineNoCommitsExpected;
@@ -3790,8 +3798,15 @@ export function TaskDetailContent({
     task,
     t,
     columnLabel,
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-18:10 (PR #2761 review — greptile, and the finding is on my
+    own change): BOTH FIELDS OR NEITHER. Guarding `currentColumnFlags` alone left `moveColumns` coming
+    from the PREVIOUS task, so the action model mixed one task's roles with another's move targets —
+    an inconsistency my narrowing created, and arguably worse than leaving both unguarded, because the
+    menu then offers destinations from a card the operator is no longer looking at.
+    */
     currentColumnFlags: detailColumnFlags,
-    workflowMoveColumns: workflowMoveMetadata?.moveColumns,
+    workflowMoveColumns: detailFlagsAreForThisTask ? workflowMoveMetadata?.moveColumns : undefined,
     canRetryTask,
     hasDuplicateHandler: Boolean(onDuplicateTask),
     hasRetryHandler: Boolean(onRetryTask),


### PR DESCRIPTION
## The pattern

`workflowMoveMetadata` outlives a task switch, so while the modal is open its flags describe the **previous** task for a render. This component gates editability, the execution-mode replan decision, the intake affordance, the actions menu and the review tab on them.

**The guard already existed** at line 961:

```ts
const detailFlagsAreForThisTask = workflowMoveMetadata?.taskId === task.id;
const detailColumnFlags = detailFlagsAreForThisTask ? workflowMoveMetadata?.currentColumnFlags : undefined;
```

Five call sites read **around** it. Each was found separately — #2744 (review tab), #2696 (`handleDelete` deps), and the four converted here:

| line | consumer |
|---|---|
| 1827 | `canEdit` |
| 2147 | execution-mode replan on save |
| 2285 | execution-mode replan on mode change |
| 3156 | `isIntakeColumn` |
| 3782 | actions-menu model |

**Six review rounds for one root cause.** Converting them together retires the class instead of paying a round per site — the same arithmetic as the review-lane family, which took #2730 and #2750 to end rather than eight per-file patches.

Only the definition line still reads the raw value, which is the point of it.

## Not covered by a new test — stated rather than papered over

 is internal state populated by a fetch, not a prop, so the stale-flags scenario needs the workflow-metadata request mocked **plus** a task switch mid-render. That is a real test worth writing. It is not a line I can add honestly in passing, and I have shipped four tests today that passed with the bug fully in place — I would rather flag the gap than repeat that.

This file's suite also carries **6 pre-existing failures**, confirmed identical on clean  by stashing and re-running, which would muddy the signal from a new case.

## What is verified

- the narrowing is mechanical and **total** — one remaining raw read, the definition;
- pre-existing failure count **unchanged at 6/45** with and without this change;
- 106 passed + 5 skipped across both `TaskDetailModal` suites;
- dashboard `tsc` clean (`tsconfig.app.json`), lint clean (0 errors), gate green (487 + 158 + 10 + 71).

No census movement — this changes which value is read, not whether a column id is compared.