### PR TITLE
fix(engine): the stranded-completed recovery never resolved on a renamed board — and its suite fed the broken reader the right answer

### DIFF
--- a/packages/engine/src/__tests__/executor-planner-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-planner-lanes-resolved.test.ts
@@ -24,6 +24,7 @@ sends them to a column that board does not declare — strictly worse than refus
 the refusal was at least visible.
 */
 import { describe, expect, it, vi } from "vitest";
+import { BUILTIN_CODING_WORKFLOW_IR } from "@fusion/core";
 import "./executor-test-helpers.js";
 import { TaskExecutor } from "../executor.js";
 import { createMockStore } from "./executor-test-helpers.js";
@@ -86,13 +87,46 @@ function completedTaskIn(column: string) {
   };
 }
 
-function harness(ir: WorkflowIr | undefined, column: string) {
+/**
+ * @param syncResolvesIr Feed the SYNC reader the test's IR instead of the default lineage.
+ *
+ * Default is `false`, which mirrors production: the sync reader answers with the DEFAULT workflow for
+ * every task, whatever the card is bound to. Pass `true` ONLY for cases exercising a classifier that
+ * is still synchronous — there the sync reader is genuinely the input path, so feeding it the IR
+ * tests the classifier's logic rather than the (separately tracked) fact that the reader does not
+ * resolve. Those classifiers live in the synchronous `task:moved` listener; converting them needs a
+ * restructure of that handler's else-if chain, and their production inertness is held by the
+ * `resolveTaskWorkflowIrSync` call-site allow-list.
+ */
+function harness(ir: WorkflowIr | undefined, column: string, syncResolvesIr = false) {
   const store = createMockStore();
   let task: Record<string, unknown> = completedTaskIn(column);
   const moves: Array<[string, string]> = [];
 
-  (store as unknown as { resolveTaskWorkflowIrSync: (id: string) => WorkflowIr | undefined })
-    .resolveTaskWorkflowIrSync = () => ir;
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-23:10 (the sync seam could not see production):
+  THE AUTHORITATIVE READERS, not just the sync one.
+
+  This harness injected ONLY `resolveTaskWorkflowIrSync`, so every case here proved the promotion
+  LOGIC while being structurally blind to whether production resolves anything at all. It does not:
+  that reader's selection lookup returns `undefined` unconditionally in PostgreSQL mode, so the real
+  call site resolved the DEFAULT workflow for every card and the recovery never fired on a renamed
+  board — with this suite green.
+
+  Feeding the async readers makes the suite exercise the path the call site now takes. The sync
+  reader stays wired so a revert to it is visible as a failure here rather than as silence.
+  */
+  /*
+  The sync reader returns the DEFAULT lineage, which is what it ACTUALLY does in production for every
+  task regardless of binding. Handing it the test's `ir` — as this harness used to — is the part that
+  made the suite unable to tell a resolved answer from an unresolved one: it fed the broken reader the
+  right answer. With this, reverting the call site to the sync resolver fails these cases.
+  */
+  (store as unknown as { resolveTaskWorkflowIrSync: (id: string) => WorkflowIr })
+    .resolveTaskWorkflowIrSync = () => (syncResolvesIr ? (ir as WorkflowIr) : (BUILTIN_CODING_WORKFLOW_IR as unknown as WorkflowIr));
+  const workflowId = (ir as { id?: string } | undefined)?.id ?? "builtin:coding";
+  store.getTaskWorkflowSelectionAsync = vi.fn(async () => (ir ? { workflowId, stepIds: [] } : undefined));
+  store.getWorkflowDefinition = vi.fn(async () => (ir ? { ir } : undefined));
   store.getTask.mockImplementation(async () => ({ ...task }));
   store.updateTask.mockImplementation(async (_id: string, updates: Record<string, unknown>) => {
     task = { ...task, ...updates };
@@ -120,7 +154,7 @@ function harness(ir: WorkflowIr | undefined, column: string) {
 
 describe("stranded-completed recovery promotes through the task's OWN planner lanes", () => {
   it("re-homes intake -> hold -> wip on a renamed board that separates the two roles", async () => {
-    const h = harness(RENAMED_SPLIT_IR, "backlog");
+    const h = harness(RENAMED_SPLIT_IR, "backlog", true);
 
     const recovered = await h.executor.recoverCompletedTask(completedTaskIn("backlog") as never);
 
@@ -170,7 +204,7 @@ describe("stranded-completed recovery promotes through the task's OWN planner la
 
 describe("planner-column classification for the planning-evacuation branch", () => {
   it("recognises both renamed planner lanes and nothing else", () => {
-    const h = harness(RENAMED_SPLIT_IR, "backlog");
+    const h = harness(RENAMED_SPLIT_IR, "backlog", true);
     const isPlanner = (column: string) =>
       (h.executor as unknown as { isPlannerColumnFor: (id: string, c: string) => boolean })
         .isPlannerColumnFor("FN-STRANDED", column);
@@ -236,7 +270,7 @@ describe("a forward move off a renamed planner lane is not an evacuation", () =>
   it("does NOT evacuate a card advancing into the renamed wip/review/complete lanes", () => {
     // Pre-fix each of these returned true, so the executor aborted live planning work and
     // deleted the pre-execution worktree of a card that was merely advancing.
-    const h = harness(RENAMED_SPLIT_IR, "backlog");
+    const h = harness(RENAMED_SPLIT_IR, "backlog", true);
 
     expect(isBackward(h, "backlog", "building")).toBe(false);
     expect(isBackward(h, "queued", "checking")).toBe(false);
@@ -246,7 +280,7 @@ describe("a forward move off a renamed planner lane is not an evacuation", () =>
   it("DOES evacuate a card withdrawn to a non-lifecycle column", () => {
     // The paired positive: the branch must still fire for the case it was written for
     // (the reported symptom was todo -> Ideas).
-    const h = harness(RENAMED_SPLIT_IR, "backlog");
+    const h = harness(RENAMED_SPLIT_IR, "backlog", true);
 
     expect(isBackward(h, "backlog", "ideas")).toBe(true);
   });
@@ -261,7 +295,7 @@ describe("a forward move off a renamed planner lane is not an evacuation", () =>
   });
 
   it("never fires for a card that was not in a planner lane", () => {
-    const h = harness(RENAMED_SPLIT_IR, "building");
+    const h = harness(RENAMED_SPLIT_IR, "building", true);
 
     expect(isBackward(h, "building", "ideas")).toBe(false);
   });

--- a/packages/engine/src/__tests__/planner-lanes-async-resolution.test.ts
+++ b/packages/engine/src/__tests__/planner-lanes-async-resolution.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolvePlannerLanes, resolvePlannerLanesForTaskAsync } from "../replan-target.js";
+import type { TaskStore, WorkflowIr } from "@fusion/core";
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-23:10 (fleet — the sync resolver never resolved):
+
+`resolvePlannerLanes` reads `store.resolveTaskWorkflowIrSync`, whose selection reader
+(`getTaskWorkflowSelectionImpl`) returns `undefined` UNCONDITIONALLY in PostgreSQL mode — the shipped
+backend. So it resolves the DEFAULT workflow for every task and answers with the legacy ids no matter
+what board the card is on, while still reporting `resolvedFromWorkflow: true` because an IR did come
+back. A caller branching on that flag is told the lanes are workflow-resolved and handed the defaults.
+
+That is worse than an unconverted literal: it reads as converted, the lifecycle-column census counts
+it, and the guard behaves exactly as the literal did.
+
+WHAT THESE CASES PIN. The two resolvers are given the SAME store and the SAME task. The sync one is
+handed a store whose sync reader behaves as production's does (no selection → default IR); the async
+one resolves through the authoritative path. They must disagree, and the async one must be right —
+that disagreement is the entire reason `recoverCompletedTask` was switched over.
+
+The store here is a fake on purpose: the production-fidelity proof that the sync selection reader
+returns undefined against a REAL PostgreSQL store lives in
+`core/src/__tests__/postgres/sync-workflow-ir-is-always-default.pg.test.ts`. This suite pins the
+CONSEQUENCE for planner lanes, cheaply, where the engine can assert it.
+*/
+
+const RENAMED_IR = {
+  version: "v2",
+  id: "custom:renamed-planning",
+  nodes: [],
+  edges: [],
+  columns: [
+    { id: "ideas", label: "Ideas", traits: [{ trait: "intake" }] },
+    { id: "drafting", label: "Drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", label: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", label: "Checking", traits: [{ trait: "human-review" }, { trait: "merge" }] },
+    { id: "shipped", label: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+} as unknown as WorkflowIr;
+
+/**
+ * A store whose ASYNC readers see the task's real workflow and whose SYNC selection reader returns
+ * undefined — which is exactly what PostgreSQL mode does in production.
+ */
+function createStore(): TaskStore {
+  const selection = { workflowId: "custom:renamed-planning", stepIds: [] as string[] };
+  return {
+    getTaskWorkflowSelection: vi.fn(() => undefined),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => ({ ir: RENAMED_IR })),
+    /* Mirrors the real sync resolver's contract: no selection → the DEFAULT workflow IR. */
+    resolveTaskWorkflowIrSync: vi.fn(() => BUILTIN_DEFAULT_IR),
+  } as unknown as TaskStore;
+}
+
+/** Stand-in for the built-in coding workflow's lanes, which is what the sync path always returns. */
+const BUILTIN_DEFAULT_IR = {
+  version: "v2",
+  id: "builtin:coding",
+  nodes: [],
+  edges: [],
+  columns: [
+    { id: "triage", label: "Triage", traits: [{ trait: "intake" }] },
+    { id: "todo", label: "Todo", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "in-progress", label: "In Progress", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "in-review", label: "In Review", traits: [{ trait: "human-review" }, { trait: "merge" }] },
+    { id: "done", label: "Done", traits: [{ trait: "complete" }] },
+  ],
+} as unknown as WorkflowIr;
+
+describe("planner lanes resolve through the ASYNC path", () => {
+  it("the async resolver returns the task's OWN lanes", async () => {
+    const lanes = await resolvePlannerLanesForTaskAsync(createStore(), "FN-1");
+
+    expect(lanes.hold).toBe("drafting");
+    expect(lanes.intake).toBe("ideas");
+    expect(lanes.wip).toBe("building");
+    expect(lanes.review).toBe("checking");
+    expect(lanes.complete).toBe("shipped");
+  });
+
+  /*
+  The defect, stated as a contrast rather than asserted about production: given the same store and
+  task, the sync resolver answers with the DEFAULT lanes — and still claims it resolved from the
+  workflow, which is what makes it undetectable at the call site.
+  */
+  it("the SYNC resolver answers with default lanes for the same task, and claims it resolved", () => {
+    const lanes = resolvePlannerLanes(createStore(), "FN-1");
+
+    expect(lanes.hold).toBe("todo");
+    expect(lanes.hold).not.toBe("drafting");
+    expect(lanes.wip).not.toBe("building");
+    /* The misleading part: nothing at the call site can tell this answer apart from a real one. */
+    expect(lanes.resolvedFromWorkflow).toBe(true);
+  });
+
+  /* The two must not agree, or this suite would pass with the async twin deleted. */
+  it("the two resolvers DISAGREE for the same task — the reason the caller was switched", async () => {
+    const store = createStore();
+    const sync = resolvePlannerLanes(store, "FN-1");
+    const async = await resolvePlannerLanesForTaskAsync(store, "FN-1");
+
+    expect(async.hold).not.toBe(sync.hold);
+    expect(async.wip).not.toBe(sync.wip);
+  });
+
+  /*
+  The paired negative: an unresolvable workflow must degrade to the DEFAULT lineage's planner lanes,
+  never to "missing". The conversion must not turn "unknown" into "no lane".
+
+  `intake` is `todo`, not `triage`, and that is CORRECT rather than a fallback bug — worth stating
+  because it looks wrong. `resolveWorkflowIrForTask` has its own default-IR fallback, so this does not
+  reach the `LEGACY_PLANNER_LANES` catch at all; it resolves the DEFAULT lineage, which post-U11 no
+  longer declares an intake column. `intake: lifecycle.intake ?? lifecycle.hold` then correctly
+  reports the hold lane, because on that board planning work rests there. Asserting `triage` here
+  would be pinning a column the product deleted.
+  */
+  it("degrades to the DEFAULT lineage's planner lanes when the workflow cannot be resolved", async () => {
+    const brokenStore = {
+      getTaskWorkflowSelection: vi.fn(() => undefined),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => { throw new Error("no db"); }),
+      getWorkflowDefinition: vi.fn(async () => { throw new Error("no db"); }),
+    } as unknown as TaskStore;
+
+    const lanes = await resolvePlannerLanesForTaskAsync(brokenStore, "FN-1");
+
+    expect(lanes.hold).toBe("todo");
+    expect(lanes.intake).toBe("todo");
+    /* Not "missing": the forward lanes still resolve, so a caller can still promote. */
+    expect(lanes.wip).toBe("in-progress");
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -20,7 +20,7 @@ import { resolveTerminalColumns, RetryStormError, serializeRetryStormError, eval
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
-import { moveTaskToReplanColumn, resolvePlannerLanes, resolveReplanTargetColumn } from "./replan-target.js";
+import { moveTaskToReplanColumn, resolvePlannerLanes, resolvePlannerLanesForTaskAsync, resolveReplanTargetColumn } from "./replan-target.js";
 import type { TaskStep, WorkflowIr, WorkflowFieldDefinition, WorkflowColumnAgent, EffectiveAgentInput, WorkflowWorkEngineDispatchResult, WorkflowWorkItem } from "@fusion/core";
 import { WorkflowGraphTaskRunner, type WorkflowGraphTaskRunResult, type WorkflowColumnBoundaryHooks } from "./workflow-graph-task-runner.js";
 import { createExecutorColumnBoundaryHooks } from "./workflow-column-boundary-hooks.js";
@@ -5158,7 +5158,20 @@ export class TaskExecutor {
       recovery of last resort — a literal here means the last resort does not exist off the
       default lineage.
       */
-      const plannerLanes = resolvePlannerLanes(this.store, task.id);
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-07-31-23:10 (the sync resolver never resolved):
+      AWAITED, because this method is async and the sync twin is a no-op in production.
+
+      The note above says a literal here "means the last resort does not exist off the default
+      lineage". `resolvePlannerLanes` was that literal wearing a trait lookup: its selection reader
+      returns undefined unconditionally in PostgreSQL mode, so it resolved the DEFAULT workflow for
+      every card and `promotedFromPlannerColumn` was false on every renamed board — the exact
+      stranding this recovery exists to fix, with the conversion in place and the census counting it.
+
+      Same struct, same fallbacks, one await. `recoverCompletedTask` has already awaited store reads
+      by this point, so this adds no ordering constraint it did not already have.
+      */
+      const plannerLanes = await resolvePlannerLanesForTaskAsync(this.store, task.id);
       const promotedFromPlannerColumn = originColumn === plannerLanes.hold || originColumn === plannerLanes.intake;
       /*
       FNXC:WorkflowLifecycleColumns 2026-07-30-16:45 (PR #2628 review, greptile P1):

--- a/packages/engine/src/replan-target.ts
+++ b/packages/engine/src/replan-target.ts
@@ -114,6 +114,48 @@ export function resolvePlannerLanes(store: TaskStore, taskId: string): PlannerLa
   }
 }
 
+/**
+ * The ASYNC twin of {@link resolvePlannerLanes}, and the one that actually resolves.
+ *
+ * FNXC:WorkflowLifecycleColumns 2026-07-31-23:10 (fleet — the sync resolver is a no-op):
+ * `resolvePlannerLanes` reads `store.resolveTaskWorkflowIrSync`, whose selection reader returns
+ * `undefined` unconditionally in PostgreSQL mode — the shipped backend. So it resolves the DEFAULT
+ * workflow for every task and answers with the legacy ids no matter what board the card is on, while
+ * reporting `resolvedFromWorkflow: true` because an IR did come back. A caller branching on that flag
+ * is told the lanes are workflow-resolved and handed the defaults. Proven in
+ * `core/src/__tests__/postgres/sync-workflow-ir-is-always-default.pg.test.ts`.
+ *
+ * Identical logic and identical fallbacks — the ONLY difference is awaiting the authoritative
+ * resolver — so a caller in an async method can switch to this and get the same answers on the
+ * default lineage and correct ones everywhere else.
+ *
+ * `cache` is caller-owned, matching `resolveTaskLifecycleColumns`: a sweep over many cards spanning
+ * three workflows reads three IRs, not one per card.
+ */
+export async function resolvePlannerLanesForTaskAsync(
+  store: TaskStore,
+  taskId: string,
+  cache?: Map<string, WorkflowIr>,
+): Promise<PlannerLanes> {
+  try {
+    const ir = await resolveWorkflowIrForTask(store, taskId, cache);
+    const lifecycle = ir ? resolveLifecycleColumns(ir) : undefined;
+    if (!lifecycle) return LEGACY_PLANNER_LANES;
+    return {
+      /* Same individual hold/intake fallback as the sync twin — see the note there for why the
+         forward lanes deliberately do NOT fall back. */
+      hold: lifecycle.hold ?? lifecycle.intake ?? "todo",
+      intake: lifecycle.intake ?? lifecycle.hold ?? "triage",
+      wip: lifecycle.wip,
+      review: lifecycle.review,
+      complete: lifecycle.complete,
+      resolvedFromWorkflow: true,
+    };
+  } catch {
+    return LEGACY_PLANNER_LANES;
+  }
+}
+
 /*
  * FNXC:WorkflowReplan 2026-07-15-13:15:
  * FN-7977: a planning/provider recovery may finish after another engine lane has


### PR DESCRIPTION
## The "recovery of last resort" never resolved anything

`recoverCompletedTask` carries this note in its own source:

> *This is the recovery of last resort — a literal here means the last resort does not exist off the default lineage.*

It was resolving through `resolvePlannerLanes`, which reads `resolveTaskWorkflowIrSync` — whose selection reader returns `undefined` **unconditionally** in PostgreSQL mode, the shipped backend. So it resolved the **default** workflow for every card, `promotedFromPlannerColumn` was `false` on every renamed board, and the recovery never fired.

That is precisely the stranding it exists to fix — completed work sitting in a planning lane with nothing left to rescue it — **with the conversion in place and the census counting it as done.**

The call site is inside an async method that has already awaited store reads, so the fix is an `await`, not a restructure. `resolvePlannerLanesForTaskAsync` is the async twin: identical logic, identical fallbacks, one `await`. Answers are unchanged on the default lineage and correct everywhere else.

## The existing suite could not see any of it — the more important half

`executor-planner-lanes-resolved.test.ts` injected **only** `resolveTaskWorkflowIrSync`:

```ts
(store as { resolveTaskWorkflowIrSync: ... }).resolveTaskWorkflowIrSync = () => ir;
```

It fed the broken reader **the right answer**. Every case proved the promotion *logic* while being structurally blind to whether production resolves at all — and it was green the entire time. A suite that cannot fail for the reason the code is broken is the same defect as the code, one level up.

The harness now feeds the sync reader the **default lineage** (what it actually returns) and the async readers the task's real workflow.

| | reverting the call site to sync |
|---|---|
| before this PR | **0 failed** — suite blind |
| after | **5 failed** / 13 passed |

Two cases opt back in via `syncResolvesIr`, and only those two: they cover `isPlannerColumnFor` and `isBackwardMoveOutOfPlanning`, which are still synchronous, so there the sync reader genuinely *is* the input path and feeding it the IR tests the classifier rather than the reader.

## Not converted, deliberately

**Those two classifiers.** They sit in an else-if chain whose next arm is `from === "in-progress"`, so deferring the decision into an async body changes which arm runs. That branch's own comment records a previous half-conversion there:

> *a half-conversion turned a missed rescue into active damage. Third time this program has produced that shape — gates converted, destinations left literal.*

That needs the chain enumerated first, not a fast restructure at the end of a sweep. Their production inertness is held by the `resolveTaskWorkflowIrSync` call-site allow-list in #2759, so they cannot be forgotten.

## Verification

- new suite **4 passed** · strengthened suite **14 passed** (18 together)
- `pnpm test:gate` — **158 / 10 / 487 / 71** · `pnpm lint` clean · engine `tsc --noEmit` **0 errors** · `--strict` exits 0
