### PR TITLE
fix(engine): the revert route admitted and the service refused — a dead end on any renamed board

### DIFF
--- a/packages/dashboard/src/__tests__/task-revert-route.test.ts
+++ b/packages/dashboard/src/__tests__/task-revert-route.test.ts
@@ -158,6 +158,14 @@ function createMockStore(
     autoMerge?: boolean;
     aiUndoTaskWorkflowId?: string;
     knownWorkflowIds?: string[];
+    /*
+    FNXC:TaskRevert 2026-07-30-18:05 (PR #2766 review — greptile "cover every changed revert surface"):
+    Opt-in renamed board for the route. Supplying this stubs the two selection readers
+    `resolveWorkflowIrForTask` consults, so `resolveTerminalColumnsForTask` resolves the task's OWN
+    lanes instead of taking the `["done","archived"]` legacy fallback every other test in this file
+    rides on. Only the forwarding tests below pass it, so no existing expectation moves.
+    */
+    workflowIr?: unknown;
     rootDir?: string;
   },
 ): TaskStore {
@@ -180,10 +188,18 @@ function createMockStore(
   // FN-7556: `getWorkflowDefinition` backs the route's validation of a
   // configured (non-builtin) `aiUndoTaskWorkflowId`; default to "unknown" so
   // tests must explicitly declare a custom id as known via `knownWorkflowIds`.
-  const getWorkflowDefinition = vi.fn().mockImplementation(async (id: string) =>
-    (opts?.knownWorkflowIds ?? []).includes(id) ? { id, name: id, ir: {} } : undefined,
-  );
+  const getWorkflowDefinition = vi.fn().mockImplementation(async (id: string) => {
+    if (opts?.workflowIr && id === "wf-renamed") return { id, name: id, ir: opts.workflowIr };
+    return (opts?.knownWorkflowIds ?? []).includes(id) ? { id, name: id, ir: {} } : undefined;
+  });
+  const selectionReaders = opts?.workflowIr
+    ? {
+        getTaskWorkflowSelection: () => ({ workflowId: "wf-renamed", stepIds: [] }),
+        getTaskWorkflowSelectionAsync: async () => ({ workflowId: "wf-renamed", stepIds: [] }),
+      }
+    : {};
   return {
+    ...selectionReaders,
     getSettings: vi.fn().mockResolvedValue({}),
     getSettingsFast: vi.fn().mockResolvedValue({
       autoMerge: opts?.autoMerge ?? true,
@@ -334,6 +350,80 @@ describe("POST /tasks/:id/revert", () => {
     expect(res.status).toBe(409);
     expect((res.body as { details?: { code?: string } }).details?.code ?? (res.body as { error?: string }).error).toBeTruthy();
     expect(performTaskRevertMock).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:TaskRevert 2026-07-30-18:05 (PR #2766 review — greptile "cover every changed revert surface"):
+
+  THE ROUTE MUST HAND ITS RESOLVED TERMINAL LANES TO THE SERVICE.
+
+  This change made the route resolve terminal lanes by role AND forward that set to the service so
+  the service's defence-in-depth guard answers the same question. Before it, the route admitted a
+  revert on a renamed board and the service refused it with its own hardcoded `done`/`archived` —
+  a dead end reached from an affordance both the UI and the route offer.
+
+  WHY THESE TESTS EXIST. The engine-side tests drive `performTaskRevert`/`revertWorkspaceTask`
+  directly, so they pass their own `revertableColumns` and can never observe whether the ROUTE
+  supplies it. Deleting `revertableColumns: terminalColumns` from either call site left all 26
+  engine tests green and `tsc` clean — measured, not assumed. These are the tests that fail.
+
+  Both call sites are covered because they are separate literals in separate branches: the
+  single-repo one and the workspace one can regress independently.
+  */
+  const RENAMED_TERMINAL_IR = {
+    version: "v2",
+    id: "wf-renamed",
+    name: "renamed",
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+      { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+      { id: "attic", name: "Attic", traits: [{ trait: "archived" }] },
+    ],
+  };
+
+  it("forwards the route's RESOLVED terminal lanes to performTaskRevert (single-repo, renamed board)", async () => {
+    const task = makeTask({ column: "shipped" });
+    const store = createMockStore(task, { workflowIr: RENAMED_TERMINAL_IR });
+    performTaskRevertMock.mockResolvedValue({ mode: "git", clean: true, revertCommitSha: "abc123" });
+
+    const res = await REQUEST(createApp(store), "POST", `/api/tasks/${task.id}/revert`);
+
+    expect(res.status).toBe(200);
+    expect(performTaskRevertMock).toHaveBeenCalledTimes(1);
+    const forwarded = (performTaskRevertMock.mock.calls[0] as unknown[]).find(
+      (arg): arg is { revertableColumns?: Iterable<string> } =>
+        typeof arg === "object" && arg !== null && "revertableColumns" in arg,
+    );
+    /*
+    The set itself, not merely its presence: a forwarding that hands over the legacy pair would
+    still refuse this card, which is the bug. `shipped` and `attic` must both be in it, since the
+    roles resolve independently and can fail independently.
+    */
+    expect(forwarded).toBeDefined();
+    expect([...(forwarded?.revertableColumns ?? [])].sort()).toEqual(["attic", "shipped"]);
+  });
+
+  it("forwards the route's RESOLVED terminal lanes to revertWorkspaceTask (workspace, renamed board)", async () => {
+    const task = makeWorkspaceTask({ column: "shipped" });
+    const store = createMockStore(task, { workflowIr: RENAMED_TERMINAL_IR });
+    revertWorkspaceTaskMock.mockResolvedValue({
+      mode: "git",
+      clean: true,
+      workspace: { repos: [{ repo: "repo-a", classification: "clean", revertCommitSha: "rev-a" }] },
+    });
+
+    const res = await REQUEST(createApp(store), "POST", `/api/tasks/${task.id}/revert`);
+
+    expect(res.status).toBe(200);
+    expect(revertWorkspaceTaskMock).toHaveBeenCalledTimes(1);
+    const forwarded = (revertWorkspaceTaskMock.mock.calls[0] as unknown[]).find(
+      (arg): arg is { revertableColumns?: Iterable<string> } =>
+        typeof arg === "object" && arg !== null && "revertableColumns" in arg,
+    );
+    expect(forwarded).toBeDefined();
+    expect([...(forwarded?.revertableColumns ?? [])].sort()).toEqual(["attic", "shipped"]);
   });
 
   it("dispatches a done workspace task to revertWorkspaceTask and returns the per-repo breakdown (clean)", async () => {

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -2454,6 +2454,15 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
 
         const workspaceResult = await revertWorkspaceTask({
           task,
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-30-17:20:
+          The SAME set this route already gated on a few lines up, handed to the service so its
+          defence-in-depth check answers the same question. Before this the route resolved terminal lanes
+          while the service compared to hardcoded `done`/`archived`, so on a renamed board the route
+          admitted the revert and the service refused it — a dead end from an affordance both the UI and
+          the route offered.
+          */
+          revertableColumns: terminalColumns,
           workspaceRootDir: rootDir,
           settings,
           commitAssociationSource: {
@@ -2689,6 +2698,15 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
 
       const result = await performTaskRevert({
         task,
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-30-17:20:
+        The SAME set this route already gated on a few lines up, handed to the service so its
+        defence-in-depth check answers the same question. Before this the route resolved terminal lanes
+        while the service compared to hardcoded `done`/`archived`, so on a renamed board the route
+        admitted the revert and the service refused it — a dead end from an affordance both the UI and
+        the route offered.
+        */
+        revertableColumns: terminalColumns,
         worktreePath: rootDir,
         baseBranch,
         commitAssociationSource: {

--- a/packages/engine/src/__tests__/task-revert.real-git.test.ts
+++ b/packages/engine/src/__tests__/task-revert.real-git.test.ts
@@ -1,5 +1,5 @@
 import { execSync, spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -259,7 +259,13 @@ describeIfGit("task-revert real-git scenarios", { timeout: 30_000 }, () => {
       revertableColumns: new Set(["shipped", "attic"]),
     });
 
-    expect(result).not.toMatchObject({ needsHuman: true, reason: expect.stringContaining("revertable") });
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-18:10 (#2766 review — a negative assertion proved too little):
+    `not.toMatchObject({ needsHuman })` passes for ANY other outcome, including a failed revert. It proved
+    the guard did not refuse, not that the revert happened. Asserting the clean-revert result proves both.
+    */
+    expect(result).toMatchObject({ mode: "git", clean: true });
+    expect(readFileSync(join(repo, "foo.ts"), "utf8")).toBe("line1\n");
   });
 
   it("resolved columns still REFUSE a live lane, so the gate is not simply widened", async () => {

--- a/packages/engine/src/__tests__/task-revert.real-git.test.ts
+++ b/packages/engine/src/__tests__/task-revert.real-git.test.ts
@@ -233,6 +233,53 @@ describeIfGit("task-revert real-git scenarios", { timeout: 30_000 }, () => {
     expect(task.column).toBe("in-progress");
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-17:35:
+  The service's revertable check used a hardcoded {done, archived} while `POST /tasks/:id/revert` already
+  gated on `resolveTerminalColumnsForTask` — resolved membership over the task's own workflow. On a renamed
+  board the two halves DISAGREED: the route admitted the request and the service refused it, so the operator
+  got a dead end from an affordance the UI and the route both offered.
+
+  REVERT CHECK, measured: dropping `revertableColumns` back to the literal pair makes the first case fail —
+  a card in `shipped` is refused with "only done/archived tasks are revertable". The second case is the
+  non-vacuous half: the set must still REFUSE a live lane, or a check that admits everything would satisfy
+  the first.
+  */
+  it("a renamed terminal lane is revertable when the caller supplies resolved columns", async () => {
+    const repo = repoFixture();
+    writeFileSync(join(repo, "foo.ts"), "line1\nfeature-a\n");
+    git(repo, "git add foo.ts && git commit -m 'feat(FN-901): add feature a'");
+    const sha = git(repo, "git rev-parse HEAD");
+
+    const task = makeTask({ column: "shipped" as never, mergeDetails: { commitSha: sha, mergeTargetBranch: "main" } });
+    const result = await performTaskRevert({
+      task,
+      worktreePath: repo,
+      baseBranch: "main",
+      revertableColumns: new Set(["shipped", "attic"]),
+    });
+
+    expect(result).not.toMatchObject({ needsHuman: true, reason: expect.stringContaining("revertable") });
+  });
+
+  it("resolved columns still REFUSE a live lane, so the gate is not simply widened", async () => {
+    const repo = repoFixture();
+    writeFileSync(join(repo, "foo.ts"), "line1\nfeature-a\n");
+    git(repo, "git add foo.ts && git commit -m 'feat(FN-902): add feature a'");
+    const sha = git(repo, "git rev-parse HEAD");
+
+    const task = makeTask({ column: "building" as never, mergeDetails: { commitSha: sha, mergeTargetBranch: "main" } });
+    const result = await performTaskRevert({
+      task,
+      worktreePath: repo,
+      baseBranch: "main",
+      revertableColumns: new Set(["shipped", "attic"]),
+    });
+
+    expect(result).toMatchObject({ mode: "git", needsHuman: true });
+    expect(String((result as { reason?: string }).reason)).toContain("revertable");
+  });
+
   it("guard rails: autoMerge:false returns a needsHuman result instead of force-writing", async () => {
     const repo = repoFixture();
     writeFileSync(join(repo, "foo.ts"), "line1\nfeature-a\n");

--- a/packages/engine/src/__tests__/task-revert.workspace.real-git.test.ts
+++ b/packages/engine/src/__tests__/task-revert.workspace.real-git.test.ts
@@ -133,6 +133,50 @@ describeIfGit("task-revert workspace real-git scenarios", { timeout: 30_000 }, (
     expect(attribution["repo-b"]).toEqual({ commits: [shaBUnrecorded], source: "lineage" });
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-18:20 (#2766 review — the SECOND changed surface):
+  `revertWorkspaceTask` has the same terminal guard as `performTaskRevert` and I changed both, but the
+  regression case covered only the single-repo path. AGENTS' Surface Enumeration rule is explicit that a
+  fix must assert the invariant across every surface, not the one reproduction — and the two entry points
+  are exactly "different branches of the same failure" it names. Covering one would have let the workspace
+  path regress to refusing renamed terminal lanes while the suite stayed green.
+
+  REVERT CHECK, measured: making this service ignore `revertableColumns` fails here with the workspace task
+  refused as non-revertable.
+  */
+  it("a renamed terminal lane is revertable on the WORKSPACE path too", async () => {
+    const { workspaceRoot, repoA, repoB } = workspaceFixture();
+    const shaA = landTaskCommit(repoA, "a.ts", "line1\nfeature-a\n", "feat(FN-A): add feature in repo-a");
+    const shaB = landTaskCommit(repoB, "b.ts", "line1\nfeature-a\n", "feat(FN-A): add feature in repo-b");
+
+    const task = makeWorkspaceTask(shaA, shaB, { column: "shipped" as never });
+    const result = await revertWorkspaceTask({
+      task,
+      workspaceRootDir: workspaceRoot,
+      settings: {},
+      revertableColumns: new Set(["shipped", "attic"]),
+    });
+
+    expect(result.mode).toBe("git");
+    expect(result.clean).toBe(true);
+  });
+
+  it("the workspace guard still REFUSES a live lane under a resolved set", async () => {
+    const { workspaceRoot, repoA, repoB } = workspaceFixture();
+    const shaA = landTaskCommit(repoA, "a.ts", "line1\nfeature-a\n", "feat(FN-A): add feature in repo-a");
+    const shaB = landTaskCommit(repoB, "b.ts", "line1\nfeature-a\n", "feat(FN-A): add feature in repo-b");
+
+    const task = makeWorkspaceTask(shaA, shaB, { column: "building" as never });
+    const result = await revertWorkspaceTask({
+      task,
+      workspaceRootDir: workspaceRoot,
+      settings: {},
+      revertableColumns: new Set(["shipped", "attic"]),
+    });
+
+    expect(result).toMatchObject({ mode: "git", needsHuman: true });
+  });
+
   it("clean all-or-nothing: reverts both sub-repos with a Fusion-Task-Id-trailered commit on each (Symptom Verification)", async () => {
     const { workspaceRoot, repoA, repoB } = workspaceFixture();
     const shaA = landTaskCommit(repoA, "a.ts", "line1\nfeature-a\n", "feat(FN-A): add feature in repo-a");

--- a/packages/engine/src/__tests__/task-revert.workspace.real-git.test.ts
+++ b/packages/engine/src/__tests__/task-revert.workspace.real-git.test.ts
@@ -159,6 +159,17 @@ describeIfGit("task-revert workspace real-git scenarios", { timeout: 30_000 }, (
 
     expect(result.mode).toBe("git");
     expect(result.clean).toBe(true);
+    /*
+    FNXC:TaskRevert 2026-07-30-18:20 (PR #2766 review — coderabbit):
+    `clean: true` is a SHAPE check: an implementation that admits the renamed lane and then reverts
+    nothing reports exactly that. The point of admitting the card is that the work comes back out,
+    and on the workspace path it must come out of EVERY sub-repo — a per-repo loop that admits the
+    task once and then reverts only the first repo is a real failure this shape cannot see. Assert
+    the landed content is gone from both, matching the single-repo regression test's post-revert
+    assertion.
+    */
+    expect(git(repoA, "git show HEAD:a.ts")).toBe("line1");
+    expect(git(repoB, "git show HEAD:b.ts")).toBe("line1");
   });
 
   it("the workspace guard still REFUSES a live lane under a resolved set", async () => {

--- a/packages/engine/src/task-revert.ts
+++ b/packages/engine/src/task-revert.ts
@@ -463,6 +463,19 @@ export type TaskRevertResult =
 export type TaskRevertGranularity = "squash" | "per-sha";
 
 export interface PerformTaskRevertOptions {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-17:20:
+  The task's resolved TERMINAL lanes, as membership. Optional: without it the legacy `done`/`archived`
+  pair answers, so any caller that cannot resolve a workflow is unchanged. The dashboard revert route
+  already computes this via `resolveTerminalColumnsForTask` for its own gate and now passes the same set
+  down, so the route and the service cannot disagree about which cards are revertable.
+
+  MEMBERSHIP, not a single id — a workflow may declare more than one complete or archived lane, and
+  first-per-role would refuse a revert on the second. That arity trap has now been hit three times in this
+  program (routes review lane, the FN-7720 bypass guard, dependency satisfaction), so it is the default
+  shape here rather than a later correction.
+  */
+  revertableColumns?: ReadonlySet<string>;
   task: Pick<Task, "id" | "lineageId" | "column" | "mergeDetails" | "autoMerge" | "userPaused" | "paused" | "workspaceWorktrees">;
   worktreePath: string;
   baseBranch: string;
@@ -474,9 +487,22 @@ export interface PerformTaskRevertOptions {
   granularity?: TaskRevertGranularity;
 }
 
-// FNXC:TaskRevert 2026-07-04-00:00 (guard rails, enforced in BOTH the service
-// and the route per PROMPT Step 3): only done/archived tasks are revertable.
-const REVERTABLE_COLUMNS = new Set(["done", "archived"]);
+/*
+FNXC:TaskRevert 2026-07-04-00:00 (guard rails, enforced in BOTH the service and the route per PROMPT
+Step 3): only terminal tasks are revertable.
+
+FNXC:WorkflowResolvedColumns 2026-07-30-17:20 (the two halves had drifted apart):
+This is the DEGRADED default now, not the answer. `POST /tasks/:id/revert` already gates on
+`resolveTerminalColumnsForTask(...)` — resolved membership over the task's own workflow — while this
+service kept the literal pair. On a board whose terminal lanes are renamed the two halves DISAGREED: the
+route admitted the request and the service then refused it with "only done/archived tasks are revertable",
+so the operator got a dead end from an affordance the UI and the route both offered.
+
+Defence-in-depth is the point of having the check twice, but only if both halves answer the same question.
+Callers pass `revertableColumns`; without it the legacy pair keeps today's behaviour for any caller that
+cannot resolve a workflow.
+*/
+const LEGACY_REVERTABLE_COLUMNS: ReadonlySet<string> = new Set(["done", "archived"]);
 
 /**
  * FNXC:TaskRevert 2026-07-04-00:00 (commit message/trailer contract):
@@ -517,8 +543,10 @@ export async function performTaskRevert(opts: PerformTaskRevertOptions): Promise
     return { mode: "git", unsupported: true, reason: "workspace-task-revert-unsupported-by-single-repo-path; use revertWorkspaceTask" };
   }
 
-  if (!REVERTABLE_COLUMNS.has(task.column)) {
-    return { mode: "git", needsHuman: true, reason: `task is in column "${task.column}"; only done/archived tasks are revertable` };
+  const revertableColumns = opts.revertableColumns ?? LEGACY_REVERTABLE_COLUMNS;
+  if (!revertableColumns.has(task.column)) {
+    const named = [...revertableColumns].map((c) => `"${c}"`).join(" or ");
+    return { mode: "git", needsHuman: true, reason: `task is in column "${task.column}"; only ${named} tasks are revertable` };
   }
 
   const effectiveAutoMerge = task.autoMerge ?? opts.effectiveAutoMerge ?? true;
@@ -1041,6 +1069,19 @@ export type WorkspaceTaskRevertResult =
   | { mode: "git"; needsHuman: true; reason: string };
 
 export interface RevertWorkspaceTaskOptions {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-17:20:
+  The task's resolved TERMINAL lanes, as membership. Optional: without it the legacy `done`/`archived`
+  pair answers, so any caller that cannot resolve a workflow is unchanged. The dashboard revert route
+  already computes this via `resolveTerminalColumnsForTask` for its own gate and now passes the same set
+  down, so the route and the service cannot disagree about which cards are revertable.
+
+  MEMBERSHIP, not a single id — a workflow may declare more than one complete or archived lane, and
+  first-per-role would refuse a revert on the second. That arity trap has now been hit three times in this
+  program (routes review lane, the FN-7720 bypass guard, dependency satisfaction), so it is the default
+  shape here rather than a later correction.
+  */
+  revertableColumns?: ReadonlySet<string>;
   task: Pick<Task, "id" | "lineageId" | "column" | "mergeDetails" | "workspaceWorktrees" | "autoMerge" | "userPaused" | "paused">;
   /** Project root dir; each sub-repo lives at `join(workspaceRootDir, repoRel)` (mirrors `landWorkspaceTask`). */
   workspaceRootDir: string;
@@ -1096,8 +1137,10 @@ export async function revertWorkspaceTask(opts: RevertWorkspaceTaskOptions): Pro
   const { task, workspaceRootDir } = opts;
   const execImpl = opts.execAsyncImpl ?? defaultExecAsync;
 
-  if (!REVERTABLE_COLUMNS.has(task.column)) {
-    return { mode: "git", needsHuman: true, reason: `task is in column "${task.column}"; only done/archived tasks are revertable` };
+  const revertableColumns = opts.revertableColumns ?? LEGACY_REVERTABLE_COLUMNS;
+  if (!revertableColumns.has(task.column)) {
+    const named = [...revertableColumns].map((c) => `"${c}"`).join(" or ");
+    return { mode: "git", needsHuman: true, reason: `task is in column "${task.column}"; only ${named} tasks are revertable` };
   }
 
   const effectiveAutoMerge = task.autoMerge ?? opts.effectiveAutoMerge ?? true;


### PR DESCRIPTION
First conversion from the **census-invisible** class measured in #2763 — a `Set.has(task.column)` membership predicate that no comparison-based scan counts.

## Two halves of one guard, disagreeing

The revert guard is deliberately enforced **twice** (FN-7525: "guard rails, enforced in BOTH the service and the route"). They had drifted:

- **Route** — `resolveTerminalColumnsForTask(scopedStore, task.id)`, resolved membership over the task's own workflow. **Admits.**
- **Service** — `REVERTABLE_COLUMNS = new Set(["done", "archived"])`, hardcoded. **Refuses.**

So on a board with renamed terminal lanes the route lets the request through and the service rejects it with *"only done/archived tasks are revertable"* — a **dead end from an affordance the UI and the route both offered**. Defence-in-depth is only defence if both halves answer the same question.

`revertableColumns` is now an optional opt on both entry points, and the route passes the **same set it already gated on**. Without it the legacy pair answers, so any caller that cannot resolve a workflow is unchanged. The refusal message now names the lanes actually used instead of hardcoding two.

## Membership by default, not as a later correction

This takes a `ReadonlySet`, not a single id. The first-per-role arity trap has now been hit **three times** in this program — the routes review lane (#2700), the FN-7720 bypass guard (#2718), and dependency satisfaction (#2739) — and each time the version already on main was the membership one and mine was the narrower one. A workflow may declare more than one complete or archived lane; first-per-role would refuse a revert on the second.

## Revert proof

| reverted | result |
|---|---|
| service ignores the caller's set | renamed-lane case fails: `expected { needsHuman: true } to not match` |

The companion case is the non-vacuous half — a resolved set must still **refuse** a live lane, or a check that admits everything would satisfy the first. Both run against the real-git fixture, so the guard is exercised through the actual service path rather than a stub.

## Why this file, and why it was invisible

It came out of the audit in #2763: the census scans `===`/`!==` against a column, so a `Set.has(task.column)` predicate is structurally uncounted. This is one of **~16 genuine unconverted guards** in that class — none of them visible in the backlog number the fleet measures against.

## Verification

`pnpm test:gate` **GREEN** (158 + 10 + 487 + 71) · `task-revert` suites **47/47** · engine and dashboard `tsc` clean · `pnpm lint` clean · census `--strict` exits 0 (unmoved — it does not count this class, which is the point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed task reversion for boards with renamed or customized terminal lanes by aligning reversion eligibility across workspace and single-repository flows.
  - Route-driven terminal-lane rules are now consistently applied to engine reversion checks, preventing mismatches.
  - Added/updated real-git regression coverage to confirm reverted results for renamed terminal lanes and rejection for active non-terminal lanes.
  - Route tests now verify the correct “revertable columns” are forwarded to the engine services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->