### PR TITLE
fix(engine): follow-up dedup treated a finished card as open forever on a renamed board (both copies)

### DIFF
--- a/packages/engine/src/__tests__/eval-followups.test.ts
+++ b/packages/engine/src/__tests__/eval-followups.test.ts
@@ -4,13 +4,42 @@ import { materializeEvalFollowUps, normalizeEvalFollowUps, resolveEvalFollowUpPo
 
 function makeStore(params: {
   openTasks?: Array<Record<string, unknown>>;
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-19:30:
+  Per-task terminal lanes, so a case can put a prior follow-up in a lane this board calls terminal.
+  Absent, the fake declares no workflow and `resolveTerminalColumnsFor` falls back to the legacy pair —
+  which is why every existing case is unaffected.
+  */
+  terminalColumnsByTaskId?: Record<string, string[]>;
   priorDedupeKeys?: string[];
   taskLogsById?: Record<string, Array<{ action: string; timestamp: string }>>;
 }) {
   const openTasks = params.openTasks ?? [];
   const priorDedupeKeys = params.priorDedupeKeys ?? [];
   const taskLogsById = params.taskLogsById ?? {};
+  const terminalColumnsByTaskId = params.terminalColumnsByTaskId ?? {};
   return {
+    getTaskWorkflowSelection: (taskId: string) =>
+      terminalColumnsByTaskId[taskId] ? { workflowId: `wf-${taskId}`, stepIds: [] } : undefined,
+    getWorkflowDefinition: async (workflowId: string) => {
+      const taskId = workflowId.replace(/^wf-/, "");
+      const lanes = terminalColumnsByTaskId[taskId];
+      if (!lanes) return undefined;
+      return {
+        ir: {
+          version: "v2",
+          id: workflowId,
+          name: workflowId,
+          nodes: [],
+          edges: [],
+          columns: [
+            { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+            { id: lanes[0], name: "Complete", traits: [{ trait: "complete" }] },
+            ...(lanes[1] ? [{ id: lanes[1], name: "Archived", traits: [{ trait: "archived" }] }] : []),
+          ],
+        },
+      };
+    },
     listTasks: async () => openTasks,
     createTask: vi.fn(async () => ({ id: "FN-created" })),
     getTask: vi.fn(async (id: string) => ({ id, log: taskLogsById[id] ?? [] })),
@@ -122,6 +151,55 @@ describe("normalizeEvalFollowUps", () => {
     });
     expect(created?.state).toBe("created");
     expect(created?.createdTaskId).toBe("FN-created");
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-19:30 (the dedup blocked NEW follow-ups forever on a renamed board):
+  The dedup deliberately excludes closed columns "so a re-run after the follow-up is finished can
+  legitimately file a fresh card". Keyed on the literal {done, archived}, a finished follow-up in a RENAMED
+  complete lane still read as OPEN — so the dedup matched it forever and the fresh card was never filed.
+
+  The existing reuse case above uses `todo`, which is open under both the old and new logic, so it cannot
+  tell them apart. This one puts the prior follow-up in a renamed COMPLETE lane, where the two disagree.
+
+  REVERT CHECK, measured: restoring `CLOSED_FOLLOWUP_COLUMNS` fails this — `createTask` is never called
+  because the finished card is treated as an open duplicate.
+  */
+  it("files a fresh card when the prior follow-up finished in a RENAMED complete lane", async () => {
+    const store = makeStore({
+      openTasks: [{
+        id: "FN-finished",
+        column: "shipped",
+        description: "finished eval follow-up",
+        sourceParentTaskId: "FN-parent",
+        sourceMetadata: { suggestionId: "efs-1" },
+      }],
+      terminalColumnsByTaskId: { "FN-finished": ["shipped", "attic"] },
+    });
+
+    const [created] = await materializeEvalFollowUps({
+      parentTaskId: "FN-parent",
+      runId: "ER-6",
+      policyMode: "create_all_non_duplicates",
+      overallScore: 42,
+      store,
+      followUps: [{
+        suggestionId: "efs-1",
+        dedupeKey: "k",
+        title: "Investigate issue",
+        description: "Investigate issue found by eval.",
+        priority: "high",
+        severity: "weak",
+        rationale: "Signals showed repeated failures.",
+        evidenceRefs: [{ evidenceId: "workflow-1", source: "other" }],
+        recommendation: { shouldCreate: true, reason: "qualified", policyQualified: true },
+        state: "suggested",
+        policyMode: "create_all_non_duplicates",
+      }],
+    });
+
+    expect(store.createTask).toHaveBeenCalled();
+    expect(created?.createdTaskId).not.toBe("FN-finished");
   });
 
   it("reuses an existing task when the suggestion id already has an open follow-up", async () => {

--- a/packages/engine/src/__tests__/pr-comment-handler.test.ts
+++ b/packages/engine/src/__tests__/pr-comment-handler.test.ts
@@ -11,6 +11,13 @@ const mockStore = {
   logEntry: vi.fn<(id: string, action: string, outcome?: string) => Promise<Task>>().mockResolvedValue({ id: "FN-001" } as Task),
   recordRunAuditEvent: vi.fn<(event: unknown) => Promise<void>>().mockResolvedValue(),
   moveTask: vi.fn<(id: string, column: Task["column"]) => Promise<Task>>().mockResolvedValue({ id: "FN-001", column: "in-progress" } as Task),
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-20:10:
+  The workflow readers `resolveTerminalColumnsFor` needs. Default to "no workflow" so every existing case
+  keeps the legacy-pair fallback unchanged; the renamed case overrides them per test.
+  */
+  getTaskWorkflowSelection: vi.fn<(id: string) => unknown>().mockReturnValue(undefined),
+  getWorkflowDefinition: vi.fn<(id: string) => Promise<unknown>>().mockResolvedValue(undefined),
 } as unknown as TaskStore;
 
 describe("PrCommentHandler", () => {
@@ -306,6 +313,56 @@ describe("PrCommentHandler", () => {
       expect(description).toContain("@reviewer2");
       expect(description).toContain("First issue");
       expect(description).toContain("Second issue");
+    });
+
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-20:10 (#2770 review — the SECOND copy, which I converted and did not cover):
+    `PrCommentHandler` carries the same dedup as `eval-followups.ts` and I converted both in one commit,
+    then wrote a regression case for only one of them. That is the Surface Enumeration rule I had just
+    accepted on #2766 and repeated in the very next PR, which is why this case exists rather than an
+    argument that the other file's coverage generalises.
+
+    The reuse case below uses `todo` — open under both the old literal and the resolved answer, so it
+    cannot tell them apart. This one puts the prior follow-up in a RENAMED complete lane, where they
+    disagree: keyed on {done, archived} the finished card reads as open and blocks the new one forever.
+
+    REVERT CHECK, measured: restoring the literal pair here fails this with `createTask` never called.
+    */
+    it("files a fresh PR follow-up when the prior one finished in a RENAMED complete lane", async () => {
+      (mockStore.listTasks as ReturnType<typeof vi.fn>).mockResolvedValue([{
+        id: "FN-finished",
+        column: "shipped",
+        description: "finished pr follow-up",
+        sourceParentTaskId: "FN-001",
+        sourceMetadata: { prNumber: 42 },
+      }]);
+      (mockStore.getTaskWorkflowSelection as ReturnType<typeof vi.fn>).mockReturnValue({ workflowId: "wf-renamed", stepIds: [] });
+      (mockStore.getWorkflowDefinition as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ir: {
+          version: "v2",
+          id: "wf-renamed",
+          name: "renamed",
+          nodes: [],
+          edges: [],
+          columns: [
+            { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+            { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+          ],
+        },
+      });
+
+      await handler.createFollowUpTask("FN-001", mockPrInfo, [
+        {
+          id: 1,
+          body: "This needs fixing",
+          user: { login: "reviewer" },
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          html_url: "https://github.com/owner/repo/pull/42#issuecomment-1",
+        },
+      ]);
+
+      expect(mockStore.createTask).toHaveBeenCalled();
     });
 
     it("reuses an existing PR follow-up when the same parent/prNumber is still open", async () => {

--- a/packages/engine/src/eval-followups.ts
+++ b/packages/engine/src/eval-followups.ts
@@ -7,13 +7,24 @@ import {
   type FollowUpDraft,
   type TaskStore,
 } from "@fusion/core";
+import { resolveTerminalColumnsFor } from "./executor.js";
 
 const OPEN_COLUMNS = new Set(["triage", "todo", "in-progress", "in-review"]);
 /*
 FNXC:Evals 2026-07-26-00:00:
 Eval follow-ups are a real product feature, but they used to borrow the shared automated-recovery follow-up engine (`createAutomatedFollowup` in verification-followup-dedup.ts) purely for its dedup pass. That engine was deleted along with the recovery follow-up cards it existed to file, so the one dedup rule this feature actually needs is inlined here: never create a second card for the same `suggestionId` under the same parent while one is still open. Closed columns (done/archived) are excluded so a re-run after the follow-up is finished can legitimately file a fresh card.
 */
-const CLOSED_FOLLOWUP_COLUMNS = new Set(["done", "archived"]);
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-19:10 (the dedup blocked new follow-ups forever on a renamed board):
+The comment above states the intent exactly — "closed columns (done/archived) are excluded so a re-run
+after the follow-up is finished can legitimately file a fresh card". Keyed on the literal pair, a finished
+follow-up in a RENAMED complete lane still read as OPEN, so the dedup matched it forever and the fresh card
+was never filed. The feature silently stopped working on any board that renamed its terminals.
+
+Resolved per candidate through the shared `resolveTerminalColumnsFor`, which unions the task's real
+terminals with the legacy pair — see its note: a missing custom workflow silently yields the BUILT-IN IR,
+so the union is what keeps a renamed board's own terminal recognised.
+*/
 const GENERIC_TITLE_PATTERNS = [/^follow\s*-?up$/i, /^todo$/i, /^fix\s+issue$/i, /^improve\s+task$/i, /^investigate$/i];
 
 export interface NormalizeEvalFollowUpsInput {
@@ -198,14 +209,21 @@ async function findOpenEvalFollowUpTaskId(
   suggestionId: string,
 ): Promise<string | undefined> {
   const tasks = await store.listTasks({ slim: true }).catch(() => []);
-  const match = tasks.find(
+  /*
+  Cheap identity filters FIRST, so only genuine candidates for this parent+suggestion pay a workflow
+  resolution — usually zero or one card rather than the whole board.
+  */
+  const candidates = tasks.filter(
     (task) =>
       task.id !== parentTaskId &&
-      !CLOSED_FOLLOWUP_COLUMNS.has(task.column) &&
       task.sourceParentTaskId === parentTaskId &&
       task.sourceMetadata?.suggestionId === suggestionId,
   );
-  return match?.id;
+  for (const task of candidates) {
+    const terminal = await resolveTerminalColumnsFor(store, task.id);
+    if (!terminal.includes(task.column)) return task.id;
+  }
+  return undefined;
 }
 
 export async function materializeEvalFollowUps(input: MaterializeEvalFollowUpsInput): Promise<EvalFollowUpSuggestion[]> {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -1782,7 +1782,14 @@ not see it. Each site now resolves once and uses the same value for both.
 /** The terminal ids from before workflows owned the vocabulary. */
 const LEGACY_TERMINAL_COLUMNS: readonly string[] = ["done", "archived"];
 
-async function resolveTerminalColumnsFor(store: TaskStore, taskId: string): Promise<readonly string[]> {
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-19:10 (exported for the follow-up dedup paths):
+EXPORTED rather than copied. `eval-followups.ts` and `pr-comment-handler.ts` each carried their own
+`CLOSED_FOLLOWUP_COLUMNS = new Set(["done", "archived"])` for the same question this answers, and a third
+and fourth copy of the union-with-legacy reasoning is exactly the drift this program exists to remove.
+Nothing else about the function changes.
+*/
+export async function resolveTerminalColumnsFor(store: TaskStore, taskId: string): Promise<readonly string[]> {
   /*
   FNXC:WorkflowLifecycleColumns 2026-07-31-12:20 (PR #2568 review — greptile):
   THE UNION IS DELIBERATE, and the `catch` alone was not enough.

--- a/packages/engine/src/pr-comment-handler.ts
+++ b/packages/engine/src/pr-comment-handler.ts
@@ -1,12 +1,21 @@
 import type { TaskStore } from "@fusion/core";
 import type { PrInfo } from "@fusion/core";
 import { prMonitorLog } from "./logger.js";
+import { resolveTerminalColumnsFor } from "./executor.js";
 
 /*
 FNXC:PullRequestReview 2026-07-26-00:00:
 The PR-feedback follow-up card is a real product feature, but it used to borrow the shared automated-recovery follow-up engine (`createAutomatedFollowup` in verification-followup-dedup.ts) purely for its dedup pass. That engine was deleted along with the recovery follow-up cards it existed to file, so the one dedup rule this feature needs is inlined below: never file a second card for the same PR number under the same parent while one is still open. Closed columns (done/archived) are excluded so a later close/reopen of the same PR can legitimately file a fresh card.
 */
-const CLOSED_FOLLOWUP_COLUMNS = new Set(["done", "archived"]);
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-19:15 (the SECOND copy of the same dedup, converted with the first):
+Byte-identical to `eval-followups.ts`'s constant and used for the same question — "is an earlier follow-up
+for this parent still open?" — so it had the same defect: on a renamed board a FINISHED follow-up read as
+open, the dedup matched it forever, and no fresh PR-feedback card was ever filed.
+
+Converting one and leaving the other is the FN-6115 -> FN-6118 -> FN-6123 shape, so both move together and
+both now call the shared `resolveTerminalColumnsFor` instead of carrying a private copy of the pair.
+*/
 
 interface PrComment {
   id: number;
@@ -235,13 +244,18 @@ Please review the PR comments and address any remaining issues.`;
 
     try {
       const openTasks = await this.store.listTasks({ slim: true }).catch(() => []);
-      const existing = openTasks.find(
+      /* Cheap identity filters first; only real candidates pay a workflow resolution. */
+      const candidates = openTasks.filter(
         (task) =>
           task.id !== originalTaskId &&
-          !CLOSED_FOLLOWUP_COLUMNS.has(task.column) &&
           task.sourceParentTaskId === originalTaskId &&
           task.sourceMetadata?.prNumber === prInfo.number,
       );
+      let existing: (typeof candidates)[number] | undefined;
+      for (const task of candidates) {
+        const terminal = await resolveTerminalColumnsFor(this.store, task.id);
+        if (!terminal.includes(task.column)) { existing = task; break; }
+      }
 
       if (existing) {
         prMonitorLog.log(`Reused follow-up task ${existing.id} for PR #${prInfo.number}`);


### PR DESCRIPTION
Second conversion from the **census-invisible** class measured in #2763 — `Set.has(task.column)` membership, which no comparison-based scan counts.

## The code stated its own intent, and the literal defeated it

`eval-followups.ts` documents exactly what the exclusion is for:

> "Closed columns (done/archived) are excluded so a re-run after the follow-up is finished can legitimately file a fresh card."

Keyed on a literal `{done, archived}`, a finished follow-up sitting in a **renamed** complete lane still read as **open** — so the dedup matched it forever and the fresh card was **never filed**. The feature silently stopped working on any board that renamed its terminals.

## Both copies, together

`pr-comment-handler.ts` carried a **byte-identical** `CLOSED_FOLLOWUP_COLUMNS` for the same question, so PR-feedback follow-ups had the same defect. Converting one and leaving the other is the FN-6115 → FN-6118 → FN-6123 shape, so both move in one commit.

**Reused, not copied:** `resolveTerminalColumnsFor` is now exported from `executor.ts` rather than gaining a third and fourth private copy of the union-with-legacy reasoning. That union is load-bearing here — its own note explains that a missing custom workflow silently yields the **built-in** IR, so unioning with the legacy pair is what keeps a renamed board's terminal recognised rather than answering "not terminal".

Cheap identity filters run **first** at both sites, so only genuine candidates for the parent pay a workflow resolution — usually zero or one card, not the whole board.

## Revert proof

Restoring the literal pair fails the new case with `expected "vi.fn()" to be called at least once` — no fresh card is filed, because the finished one is treated as an open duplicate.

Worth noting **why a new case was needed**: the existing reuse test puts the prior follow-up in `todo`, which is open under both the old and new logic, so it cannot tell them apart. The new case puts it in a renamed **complete** lane, which is the only place the two disagree. That is the optional-flags blind spot from the merged solutions entry, one more time — the suite was green before and after, and would have stayed green through a broken conversion.

The store fake gains optional per-task terminal lanes; without them it declares no workflow and the resolver falls back to the legacy pair, which is why the other 7 cases are untouched.

## Verification

`pnpm test:gate` **GREEN** (158 + 10 + 487 + 71) · `eval-followups` + `pr-comment-handler` **39/39** · engine `tsc` clean · `pnpm lint` clean · census `--strict` exits 0 (unmoved — it does not count this class, which is the point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)