### PR TITLE
fix(test): two dashboard-api reds — conversions changed the log CHANNEL and the error MESSAGE

### DIFF
--- a/packages/dashboard/src/__tests__/sse.test.ts
+++ b/packages/dashboard/src/__tests__/sse.test.ts
@@ -432,6 +432,16 @@ describe("createSSE connection log severity", () => {
   afterEach(() => {
     if (originalDebug === undefined) delete process.env.FUSION_DEBUG;
     else process.env.FUSION_DEBUG = originalDebug;
+    /*
+    FNXC:EngineDiagnostics 2026-07-30-17:40 (PR review — greptile P2):
+    Restore console spies HERE, not at the end of each test. A failing assertion skips the trailing
+    `mockRestore()`, leaving the console mocked for every later test in the file — and since these
+    spy `console.error`, which is where the shared logger writes ALL diagnostics, the leak silences
+    the output you would need to debug the very failure that caused it.
+
+    Both cases in this describe had that shape; the hook covers them and any case added later.
+    */
+    vi.restoreAllMocks();
   });
 
   it("does not console.log +/- connection when FUSION_DEBUG is unset", () => {
@@ -453,7 +463,6 @@ describe("createSSE connection log severity", () => {
       .map((call) => String(call[0] ?? ""))
       .filter((line) => line.includes("[sse] + connection") || line.includes("[sse] - connection"));
     expect(spam).toEqual([]);
-    errorSpy.mockRestore();
     connection.req.emit("close");
   });
 
@@ -472,7 +481,6 @@ describe("createSSE connection log severity", () => {
     const lines = errorSpy.mock.calls.map((call) => String(call[0] ?? ""));
     expect(lines.some((line) => line.includes("[sse] + connection"))).toBe(true);
     expect(lines.some((line) => line.includes("[sse] - connection"))).toBe(true);
-    errorSpy.mockRestore();
   });
 });
 

--- a/packages/dashboard/src/__tests__/sse.test.ts
+++ b/packages/dashboard/src/__tests__/sse.test.ts
@@ -459,6 +459,13 @@ describe("createSSE connection log severity", () => {
 
   it("emits +/- connection when FUSION_DEBUG=sse", () => {
     process.env.FUSION_DEBUG = "sse";
+    /*
+    FNXC:EngineDiagnostics 2026-07-30-17:10:
+    `sseDebug` routes through `createLogger("sse").debug` (sse.ts:50-53), and the shared logger writes
+    debug lines to console.ERROR carrying a `\0fnlvl=info\0` severity marker — that is the whole point
+    of FN-8603's adapter. Spying `console.log` saw nothing once the bare console call was replaced, and
+    failed with "expected false to be true" rather than anything naming the channel.
+    */
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     openSseConnection("client-severity-debug");
     disconnectSSEClient("client-severity-debug");


### PR DESCRIPTION
Both red on main. `api:curated` goes **2 failed → 34 files / 1599 passed**. Neither is a product defect — both are conversions the tests had not followed.

## 1. The log channel moved

`sse.test.ts` spied `console.log`. `sseDebug` routes through `createLogger("sse").debug` (`sse.ts:50-53`), and the shared logger writes debug lines to **`console.error`** carrying a `\0fnlvl=info\0` severity marker — that is the point of FN-8603's adapter.

So the spy saw nothing, and the failure read `expected false to be true`, naming neither the channel nor the logger. The stderr in the run output showed the lines being emitted the whole time:

```
fnlvl=info [sse] [sse] + connection (active=1, hwm=2)
fnlvl=info [sse] [sse] - connection (active=0)
```

## 2. The error message is now built from resolved lanes

`routes-tasks` asserted the substring `"in-review or in-progress"`. The message is now:

```ts
const allowed = [...prFeedbackReviewColumns, prFeedbackWipColumn]
  .map((column) => `'${column}'`).join(" or ");
throw badRequest(`PR feedback can only be addressed for tasks in ${allowed}`);
```

so it reads `'in-review' or 'in-progress'` — quoted, and derived from the resolved columns.

**Asserted each lane separately rather than re-pinning the joined string.** The join order and separator are presentation; the lanes being the resolved review + wip columns is the fact this case owns. Re-pinning the punctuation would break again on the next formatting change *and* would not have caught a wrong lane — which is the failure this test exists to catch on a renamed board.

## Verification

| check | result |
|---|---|
| `test:quality:api:curated` | 2 failed → **34 files / 1599 passed** |
| `sse.test.ts` | **24 passed** |
| `routes-tasks.test.ts` | **99 passed** |
| `pnpm lint`, dashboard `tsc` | clean |

## Scope

Fix-forward only, per the u9 lane. Found by re-scanning the packages after #2739 / #2744 / #2754 merged, rather than by waiting for a report.

For the record on the other groups at the same commit: `components-a` **1195 passed**, core is **2 failed** — both already accounted for (`archived-column-gate-parity` is #2768's target, `agent-logs-and-monitor.pg` is the deferred funnel/analytics decision on #2669).