### PR TITLE
batch-cli-plugins: 7 guards — 3 were a foreign enum, and `fn pr create` refused every card on a renamed board

### DIFF
--- a/packages/cli/src/__tests__/pr-create-review-lane-resolved.test.ts
+++ b/packages/cli/src/__tests__/pr-create-review-lane-resolved.test.ts
@@ -160,6 +160,27 @@ describe("fn pr create resolves the board's own review lane", () => {
     expect(refusal).not.toContain("in-review");
   });
 
+  it("refuses WITHOUT naming a phantom lane when the workflow declares no review lane", async () => {
+    /*
+    #2775 review (greptile P2). My first pass fell back to `'in-review'` for BOTH the unresolvable
+    workflow and the resolved-but-empty case, so the refusal named a column this board does not have
+    — the very defect this change exists to fix, reintroduced one branch over. A resolved workflow
+    with no review-trait column is an ANSWER; only an unreadable workflow is a missing one.
+    */
+    const noReviewIr = {
+      ...RENAMED_IR,
+      columns: RENAMED_IR.columns.filter((c) => c.id !== "signoff" && c.id !== "waiting-on-a-human"),
+    };
+    const store = mockBoard("building", noReviewIr);
+
+    await expect(runPrCreate("FN-001", { ai: false })).rejects.toThrow("process.exit:1");
+
+    expect(store.updatePrInfo).not.toHaveBeenCalled();
+    const refusal = errors.find((e) => e.includes("no review lane"));
+    expect(refusal).toBeDefined();
+    expect(refusal).not.toContain("in-review");
+  });
+
   it("keeps the legacy literal when the workflow cannot be resolved", async () => {
     // The unresolvable-board fallback: today's behaviour, not "refuse everything".
     const store = mockBoard("in-review", undefined);

--- a/packages/cli/src/__tests__/pr-create-review-lane-resolved.test.ts
+++ b/packages/cli/src/__tests__/pr-create-review-lane-resolved.test.ts
@@ -1,0 +1,171 @@
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-22:30 (batch-cli-plugins: packages/cli/src/commands/pr.ts 1 → 0):
+
+THE INVARIANT: `fn pr create` accepts a card sitting in ITS OWN review lane.
+
+Gated on the literal `in-review`, the command refused every card on a renamed board and printed an
+error naming a column that board does not have — the operator is told to move the task somewhere that
+cannot exist. There is no way to satisfy it short of renaming the workflow back.
+
+Two lanes are asserted, not one: `resolveReviewColumns` unions `mergeOrchestration`, `mergeBlocker`
+and `humanReview`, and a card parked in a human-review-only lane is still a card you can open a PR
+from. Resolving `lifecycle.review` instead would answer with a single id and keep refusing those —
+the exact narrowing PR #2728's review caught in the CLI retry gate, which is why this file pins the
+SET rather than one id.
+
+REVERT PROOF, measured: restore `if (task.column !== "in-review")` and the two renamed-lane cases
+fail with `process.exit:1`, while the default-board and wrong-column cases keep passing — so the
+negative cases alone do not pin the fix, and all four are required.
+*/
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../project-context.js", () => ({
+  resolveProject: vi.fn(),
+  closeProjectStore: vi.fn(async () => undefined),
+  asLocalProjectContext: vi.fn((store: unknown) => ({
+    projectId: process.cwd(),
+    projectPath: process.cwd(),
+    projectName: "current-project",
+    isRegistered: false,
+    store,
+  })),
+}));
+
+vi.mock("@fusion/engine", () => ({ releaseHeldTaskByEvent: vi.fn() }));
+
+const createPr = vi.fn();
+vi.mock("@fusion/dashboard", () => ({
+  GitHubClient: class {
+    createPr(...args: unknown[]) {
+      return createPr(...args);
+    }
+  },
+  generatePrMetadata: vi.fn(),
+}));
+
+vi.mock("@fusion/core/gh-cli", () => ({
+  classifyGhError: vi.fn(() => ({ message: "err" })),
+  getGhErrorMessage: vi.fn(() => "err"),
+  getCurrentRepo: vi.fn(() => ({ owner: "owner", repo: "repo" })),
+  isGhAuthenticated: vi.fn(() => true),
+  isGhAvailable: vi.fn(() => true),
+}));
+
+const { resolveProject } = await import("../project-context.js");
+const { runPrCreate } = await import("../commands/pr.js");
+
+/** A board with TWO review lanes and no id shared with the default lineage. */
+const RENAMED_IR = {
+  version: "v2",
+  id: "wf-renamed",
+  name: "renamed",
+  nodes: [],
+  edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "signoff", name: "Sign-off", traits: [{ trait: "merge" }] },
+    { id: "waiting-on-a-human", name: "Waiting on a human", traits: [{ trait: "human-review" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+};
+
+function mockBoard(column: string, ir: unknown) {
+  const selection = { workflowId: "wf-renamed", stepIds: [] as string[] };
+  const store = {
+    getTask: vi.fn().mockResolvedValue({
+      id: "FN-001",
+      title: "Task one",
+      description: "do a thing",
+      column,
+      branch: "fusion/fn-001",
+      prInfo: undefined,
+    }),
+    getTaskWorkflowSelection: () => (ir ? selection : undefined),
+    getTaskWorkflowSelectionAsync: async () => (ir ? selection : undefined),
+    getWorkflowDefinition: async () => (ir ? { ir } : undefined),
+    updatePrInfo: vi.fn(),
+    ensurePrEntityForSource: vi.fn().mockReturnValue({ id: "PR-NEW" }),
+    updatePrEntity: vi.fn().mockReturnValue({ id: "PR-NEW" }),
+    logEntry: vi.fn(),
+    close: vi.fn(),
+  };
+  vi.mocked(resolveProject).mockResolvedValue({
+    store: store as never,
+    projectPath: "/tmp/project",
+    projectName: "proj",
+  } as never);
+  return store;
+}
+
+describe("fn pr create resolves the board's own review lane", () => {
+  const originalExit = process.exit;
+  let errors: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    errors = [];
+    delete process.env.GITHUB_REPOSITORY;
+    createPr.mockResolvedValue({
+      url: "https://github.com/owner/repo/pull/7",
+      number: 7,
+      status: "open",
+      title: "T",
+      headBranch: "fusion/fn-001",
+      baseBranch: "main",
+      commentCount: 0,
+    });
+    process.exit = vi.fn(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as typeof process.exit);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a card in a RENAMED merge lane", async () => {
+    // Pre-fix: `signoff` !== "in-review" → refused with exit 1.
+    const store = mockBoard("signoff", RENAMED_IR);
+
+    await runPrCreate("FN-001", { ai: false });
+
+    expect(store.updatePrInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a card in a human-review-only lane (the union, not a single id)", async () => {
+    // Resolving `lifecycle.review` alone would answer `signoff` and refuse this card.
+    const store = mockBoard("waiting-on-a-human", RENAMED_IR);
+
+    await runPrCreate("FN-001", { ai: false });
+
+    expect(store.updatePrInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refuses a card that is in no review lane, naming the resolved lanes", async () => {
+    // The gate must still be a gate — and the message must not name a column this board lacks.
+    const store = mockBoard("building", RENAMED_IR);
+
+    await expect(runPrCreate("FN-001", { ai: false })).rejects.toThrow("process.exit:1");
+
+    expect(store.updatePrInfo).not.toHaveBeenCalled();
+    const refusal = errors.find((e) => e.includes("must be in"));
+    expect(refusal).toContain("'signoff'");
+    expect(refusal).toContain("'waiting-on-a-human'");
+    expect(refusal).not.toContain("in-review");
+  });
+
+  it("keeps the legacy literal when the workflow cannot be resolved", async () => {
+    // The unresolvable-board fallback: today's behaviour, not "refuse everything".
+    const store = mockBoard("in-review", undefined);
+
+    await runPrCreate("FN-001", { ai: false });
+
+    expect(store.updatePrInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/commands/__tests__/task.test.ts
+++ b/packages/cli/src/commands/__tests__/task.test.ts
@@ -3331,6 +3331,56 @@ describe("runTaskPrCreate", () => {
     vi.restoreAllMocks();
   });
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-22:05 (#2775 review — "legacy review lane rejected"):
+
+  A V1 WORKFLOW MUST STILL BE ABLE TO OPEN A PR FROM ITS `in-review` COLUMN.
+
+  `synthesizeDefaultColumns` (workflow-ir.ts:158-159) upgrades a v1 graph by emitting every default
+  column id with `traits: []`. So a v1-upgraded workflow resolves to an EMPTY review set while its
+  `in-review` column plainly exists and is where its cards live. A guard that reads empty as "this
+  board declares no review lane" refuses `fn pr create` on every pre-v2 project.
+
+  This is the ratchet for that: the store resolves a real v1-shaped workflow, and the command must get
+  past the review guard rather than refusing. No v2 fixture can catch this — a v2 board expresses its
+  traits, so its set is never empty.
+  */
+  it("does NOT refuse a v1-upgraded workflow whose synthesized columns carry no traits", async () => {
+    const v1UpgradedIr = {
+      version: "v2",
+      id: "wf-v1-upgraded",
+      name: "legacy",
+      nodes: [],
+      edges: [],
+      // Exactly what synthesizeDefaultColumns emits: every column, NO traits.
+      columns: ["todo", "in-progress", "in-review", "done", "archived"].map((id) => ({ id, name: id, traits: [] })),
+    };
+    const selection = { workflowId: "wf-v1-upgraded", stepIds: [] };
+    (TaskStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      init: vi.fn(),
+      getTask: mockGetTask,
+      updatePrInfo: mockUpdatePrInfo,
+      ensurePrEntityForSource: vi.fn(() => ({ id: "pr-entity-1" })),
+      updatePrEntity: vi.fn(),
+      logEntry: mockLogEntry,
+      getTaskWorkflowSelection: () => selection,
+      getTaskWorkflowSelectionAsync: async () => selection,
+      getWorkflowDefinition: async () => ({ id: "wf-v1-upgraded", ir: v1UpgradedIr }),
+    }));
+
+    const task = makeInReviewTask();
+    mockGetTask.mockResolvedValueOnce(task);
+    mockCreatePr.mockResolvedValueOnce(makePrInfo({ number: 77, url: "https://github.com/owner/repo/pull/77" }));
+
+    await runTaskPrCreate("FN-001", {});
+
+    /*
+    The witness is that the command reached PR creation at all. Asserting on the absence of an error
+    message would also pass if the guard refused for some other reason and exited quietly.
+    */
+    expect(mockCreatePr).toHaveBeenCalled();
+  });
+
   it("creates PR successfully with all options", async () => {
     const task = makeInReviewTask();
     mockGetTask.mockResolvedValueOnce(task);

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -166,8 +166,28 @@ export async function runPrCreate(id: string, options: PrCreateOptions = {}, pro
     accepting everything.
     */
     const prIr = await resolveWorkflowIrForTask(context.store, id).catch(() => undefined);
-    const reviewColumns = new Set(prIr === undefined ? ["in-review"] : resolveReviewColumns(prIr));
-    if (reviewColumns.size === 0) reviewColumns.add("in-review");
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-23:55 (#2775 review — greptile P2):
+    A RESOLVED WORKFLOW WITH NO REVIEW LANE IS AN ANSWER, not a missing one.
+
+    My first pass fell back to `'in-review'` for both the unresolvable-workflow case AND the
+    resolved-but-no-review-lane case, which reproduced the exact defect this change fixes: the
+    refusal named a lane the board does not have. The two cases are different questions and get
+    different answers —
+
+      prIr === undefined            → the workflow could not be read at all. Keep the legacy literal;
+                                      this is today's behaviour and the only safe default.
+      prIr resolved, lanes empty    → the board genuinely declares no review lane. Say so. Inventing
+                                      `'in-review'` here sends the operator to a phantom column.
+    */
+    const resolvedReviewColumns = prIr === undefined ? null : resolveReviewColumns(prIr);
+    if (resolvedReviewColumns !== null && resolvedReviewColumns.length === 0) {
+      console.error(`Error: This task's workflow declares no review lane, so a PR cannot be created from it (current column: ${task.column})`);
+      await closeProjectStore(context);
+      process.exit(1);
+    }
+    /* DELIBERATE-LITERAL — the unresolvable-workflow fallback, reviewed 2026-07-30-22:30. */
+    const reviewColumns = new Set(resolvedReviewColumns ?? ["in-review"]);
     if (!reviewColumns.has(task.column)) {
       const expected = [...reviewColumns].map((c) => `'${c}'`).join(" or ");
       console.error(`Error: Task must be in ${expected} to create a PR (current: ${task.column})`);

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -1,5 +1,7 @@
 import {
   TaskStore,
+  resolveReviewColumns,
+  resolveWorkflowIrForTask,
   isPrEntityActive,
   isPrEntityActionable,
   autoMergeGateReason,
@@ -146,9 +148,29 @@ export async function runPrCreate(id: string, options: PrCreateOptions = {}, pro
       process.exit(1);
     }
 
-    // Validate task is in 'in-review' column
-    if (task.column !== "in-review") {
-      console.error(`Error: Task must be in 'in-review' column to create a PR (current: ${task.column})`);
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-22:30 (batch-cli-plugins):
+    `fn pr create` gates on the task's OWN review lane, resolved from its workflow.
+
+    Keyed on the literal, this refused EVERY card on a renamed board — `fn pr create` was unusable
+    there, and the error told the operator to move the task to a column their board does not have.
+    That message is the whole bug report: it names a column that cannot exist.
+
+    Uses core's `resolveReviewColumns` (the set, not `lifecycle.review`) because a board may declare
+    more than one review lane, and a `humanReview`-only lane is still a lane you can open a PR from.
+    A single-id answer refused those cards — the same narrowing that PR #2728's review caught in the
+    CLI retry gate.
+
+    DELIBERATE-LITERAL — the unresolvable-workflow fallback, reviewed 2026-07-30-22:30. An
+    unresolvable workflow keeps today's behaviour rather than refusing everything (an empty set) or
+    accepting everything.
+    */
+    const prIr = await resolveWorkflowIrForTask(context.store, id).catch(() => undefined);
+    const reviewColumns = new Set(prIr === undefined ? ["in-review"] : resolveReviewColumns(prIr));
+    if (reviewColumns.size === 0) reviewColumns.add("in-review");
+    if (!reviewColumns.has(task.column)) {
+      const expected = [...reviewColumns].map((c) => `'${c}'`).join(" or ");
+      console.error(`Error: Task must be in ${expected} to create a PR (current: ${task.column})`);
       await closeProjectStore(context);
       process.exit(1);
     }

--- a/packages/cli/src/commands/pr.ts
+++ b/packages/cli/src/commands/pr.ts
@@ -180,17 +180,42 @@ export async function runPrCreate(id: string, options: PrCreateOptions = {}, pro
       prIr resolved, lanes empty    → the board genuinely declares no review lane. Say so. Inventing
                                       `'in-review'` here sends the operator to a phantom column.
     */
-    const resolvedReviewColumns = prIr === undefined ? null : resolveReviewColumns(prIr);
-    if (resolvedReviewColumns !== null && resolvedReviewColumns.length === 0) {
-      console.error(`Error: This task's workflow declares no review lane, so a PR cannot be created from it (current column: ${task.column})`);
-      await closeProjectStore(context);
-      process.exit(1);
-    }
-    /* DELIBERATE-LITERAL — the unresolvable-workflow fallback, reviewed 2026-07-30-22:30. */
-    const reviewColumns = new Set(resolvedReviewColumns ?? ["in-review"]);
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-21:55 (#2775 review — greptile, "legacy review lane rejected"):
+    AN EMPTY REVIEW SET IS NOT AN ANSWER HERE. THIS IS THE ONE PLACE THAT EXCEPTION APPLIES.
+
+    Two review rounds pushed this guard in opposite directions and both were right about their own
+    case, so the resolution has to hold both:
+
+      - inventing `'in-review'` whenever the set is empty names a lane a v2 board may not have;
+      - refusing whenever the set is empty rejects every V1 workflow.
+
+    The v1 case is the decisive one. `synthesizeDefaultColumns` (workflow-ir.ts:158-159) upgrades a v1
+    graph by emitting `DEFAULT_WORKFLOW_COLUMN_IDS.map((id) => ({ id, name: id, traits: [] }))` — every
+    column, NO traits. So a v1-upgraded workflow resolves to an EMPTY review set while sitting on a
+    board whose `in-review` column plainly exists and is where its cards live. Treating empty as "this
+    board has no review lane" refuses `fn pr create` for every pre-v2 project — a far worse regression
+    than the phantom lane, and one no v2 test would ever surface.
+
+    Empty therefore means UNEXPRESSED, not absent: indistinguishable from a v1 upgrade, so it takes the
+    same legacy fallback as an unresolvable workflow. `in-review` is the correct answer for exactly the
+    boards that produce an empty set, because those are the ones that declare it by convention.
+
+    The general "an empty resolved set is an answer" rule still holds elsewhere; it fails here only
+    because the v1 upgrade path manufactures empty traits for columns that do exist.
+    */
+    const resolvedReviewColumns = prIr === undefined ? [] : resolveReviewColumns(prIr);
+    const reviewColumns = new Set(resolvedReviewColumns.length > 0 ? resolvedReviewColumns : ["in-review"]);
     if (!reviewColumns.has(task.column)) {
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-07-30-21:58:
+      The trailing "column" is load-bearing and keeps getting dropped: `task.test.ts:3422` pins
+      `must be in 'in-review' column`. Keeping it makes the single-lane message byte-identical to the
+      pre-conversion string, which is what a vocabulary conversion should be — a message change is a
+      user-visible behaviour change and is out of scope here.
+      */
       const expected = [...reviewColumns].map((c) => `'${c}'`).join(" or ");
-      console.error(`Error: Task must be in ${expected} to create a PR (current: ${task.column})`);
+      console.error(`Error: Task must be in ${expected} column to create a PR (current: ${task.column})`);
       await closeProjectStore(context);
       process.exit(1);
     }

--- a/plugins/fusion-plugin-even-cards/src/cards/board-cards.ts
+++ b/plugins/fusion-plugin-even-cards/src/cards/board-cards.ts
@@ -2,6 +2,21 @@ import { DEFAULT_MAX_CARDS_PER_DECK, DEFAULT_MAX_CHARS_PER_LINE, DEFAULT_MAX_LIN
 import { taskToCard } from "./task-cards.js";
 import type { BoardSummary, CardDeck, FusionColumn, FusionTask, GlassesCard } from "./types.js";
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-21:10 DELIBERATE-LITERAL: no resolution source reaches this package.
+
+This plugin depends on `@fusion/plugin-sdk` ONLY (see its package.json) — not `@fusion/core` — and the
+SDK does not re-export the lifecycle role helpers. There is no IR, no store, and no trait flags on
+`FusionTask` here, so there is nothing to resolve FROM: converting is possible only at the caller or by
+giving the plugin a new dependency, both structural changes and out of scope for the conversion.
+
+`COLUMN_ORDER` is a DISPLAY ordering for the glasses deck and degrades honestly on a renamed board — an
+unknown column is simply absent from the summary line. The `!== "archived" && !== "done"` filter in
+`boardToDeck` is the one that misreads such a board: a finished card is neither, so it shows as active.
+That is a cosmetic over-report on a secondary surface, not a lifecycle decision. The real fix is the SDK
+exposing role flags on the task shape it hands plugins — recorded here as the correct home rather than
+guessed at.
+*/
 const COLUMN_ORDER: FusionColumn[] = ["triage", "todo", "in-progress", "in-review", "done", "archived"];
 
 function boardSummary(tasks: FusionTask[]): BoardSummary {
@@ -26,6 +41,7 @@ function summaryCard(summary: BoardSummary, now: string, maxCharsPerLine: number
   };
 }
 
+/* FNXC:WorkflowResolvedColumns 2026-07-30-21:10 DELIBERATE-LITERAL: no resolution source in this package — see the note above `COLUMN_ORDER`. */
 export function boardToDeck(tasks: FusionTask[], opts?: { maxCharsPerLine?: number; maxLines?: number; maxCards?: number; now?: string }): CardDeck {
   const maxCharsPerLine = opts?.maxCharsPerLine ?? DEFAULT_MAX_CHARS_PER_LINE;
   const maxLines = opts?.maxLines ?? DEFAULT_MAX_LINES_PER_CARD;

--- a/plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts
@@ -4,7 +4,7 @@ import type { NotificationEvent, Snapshot } from "./types.js";
 export function diffSnapshots(
   prev: Snapshot,
   next: ReadonlyArray<Task>,
-  opts: { notifyOnColumns: ReadonlySet<ColumnId>; alsoNotifyOnDone?: boolean },
+  opts: { notifyOnColumns: ReadonlySet<ColumnId>; alsoNotifyOnDone?: boolean; completeColumnsByTaskId?: ReadonlyMap<string, ReadonlySet<string>> },
 ): NotificationEvent[] {
   const events: NotificationEvent[] = [];
 
@@ -43,7 +43,26 @@ export function diffSnapshots(
       });
     }
 
-    if (task.column === "done" && opts.alsoNotifyOnDone) {
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-22:25 (batch-cli-plugins):
+    The completion notification asks each card's OWN complete column.
+
+    Keyed on the literal, a renamed board would never fire a "completed" card to the glasses — the
+    wearer would be notified of every column transition EXCEPT the one they care about. The map is
+    per task, not a flat set, because the poll spans the whole board and one workflow's complete
+    column id can be another workflow's WIP id.
+
+    CURRENTLY UNREACHABLE, stated plainly: the only production caller (`notifier.ts`) passes
+    `alsoNotifyOnDone: false`, so this branch does not run today and this change is not observable at
+    runtime. It is converted rather than marked DELIBERATE-LITERAL because the literal is not
+    deliberate — it is simply wrong, and would ship the bug the day someone turns the flag on.
+
+    DELIBERATE-LITERAL — the unresolved-workflow default, reviewed 2026-07-30-22:25.
+    */
+    const completeColumns = opts.completeColumnsByTaskId?.get(task.id);
+    /* DELIBERATE-LITERAL — the unresolved-workflow default documented above, reviewed 2026-07-30-22:25. */
+    const isComplete = completeColumns ? completeColumns.has(task.column) : task.column === "done";
+    if (isComplete && opts.alsoNotifyOnDone) {
       events.push({
         taskId: task.id,
         reason: "completed",

--- a/plugins/fusion-plugin-reports/src/store/report-store.ts
+++ b/plugins/fusion-plugin-reports/src/store/report-store.ts
@@ -270,6 +270,14 @@ export class ReportStore extends EventEmitter<ReportStoreEvents> {
       updated.approvedBy = opts.approvedBy ?? current.approvedBy;
     }
     if (next === "published") updated.publishedAt = now;
+    /*
+    DELIBERATE-LITERAL — reviewed 2026-07-30-22:10 (batch-cli-plugins).
+    `next` is a `ReportStatus`, NOT a board column. The reports plugin has its own status lineage
+    (`draft → generating → review_* → approved → published`, plus `failed`/`archived`) that merely
+    shares two spellings with the lifecycle vocabulary. Resolving a workflow IR here would answer a
+    question nobody asked: a report is not on a board and has no workflow. The census matches this on
+    the string alone, so the marker is the only thing that keeps it out of the backlog.
+    */
     if (next === "archived") updated.archivedAt = now;
 
     this.syncDb().transaction(() => this.persistExisting(updated));
@@ -577,6 +585,14 @@ export class ReportStore extends EventEmitter<ReportStoreEvents> {
       updated.approvedBy = opts.approvedBy ?? current.approvedBy;
     }
     if (next === "published") updated.publishedAt = now;
+    /*
+    DELIBERATE-LITERAL — reviewed 2026-07-30-22:10 (batch-cli-plugins).
+    `next` is a `ReportStatus`, NOT a board column. The reports plugin has its own status lineage
+    (`draft → generating → review_* → approved → published`, plus `failed`/`archived`) that merely
+    shares two spellings with the lifecycle vocabulary. Resolving a workflow IR here would answer a
+    question nobody asked: a report is not on a board and has no workflow. The census matches this on
+    the string alone, so the marker is the only thing that keeps it out of the backlog.
+    */
     if (next === "archived") updated.archivedAt = now;
     await this.persistExistingAsync(updated);
     this.emit("report:status-changed", updated);

--- a/plugins/fusion-plugin-reports/src/store/report-types.ts
+++ b/plugins/fusion-plugin-reports/src/store/report-types.ts
@@ -76,6 +76,12 @@ const LINEAR_TRANSITIONS: Record<Exclude<ReportStatus, "published" | "archived" 
 export function isValidReportStatusTransition(from: ReportStatus, to: ReportStatus): boolean {
   if (from === to) return true;
   if (TERMINAL_STATUSES.has(from)) return false;
+  /*
+  DELIBERATE-LITERAL — reviewed 2026-07-30-22:10 (batch-cli-plugins).
+  Same foreign vocabulary as the store: `to` is a `ReportStatus`. `failed`/`archived` are this
+  enum's own terminal states — declared in `TERMINAL_STATUSES` directly above — and any report may
+  jump to either from any non-terminal state. Nothing here is board-shaped.
+  */
   if (to === "failed" || to === "archived") return true;
   if (!(from in LINEAR_TRANSITIONS)) return false;
   return LINEAR_TRANSITIONS[from as keyof typeof LINEAR_TRANSITIONS] === to;

--- a/scripts/lib/lifecycle-column-census-ast.mjs
+++ b/scripts/lib/lifecycle-column-census-ast.mjs
@@ -28,6 +28,25 @@ CLASSES (only the first is backlog):
   status      — StepStatus / mission / goal / feature status. `done`, `in-progress` and `archived`
                 collide with column ids; `pending` and `skipped` never do.
   deliberate  — reviewed literal carrying a DELIBERATE-LITERAL marker in its leading comments.
+
+FOREIGN VOCABULARIES (audited 2026-07-30, batch-cli-plugins).
+
+  The `status` category above catches a foreign enum reached through a PROPERTY (`step.status`,
+  `feature.status`). It cannot catch one held in a BARE VARIABLE — `if (next === "archived")`, where
+  `next` is a ReportStatus — because the receiver name carries no type information. Those land in the
+  `column` backlog and read as unconverted lifecycle guards.
+
+  Do NOT convert them: resolving a report's status against a task workflow is a category error. Mark
+  the site DELIBERATE-LITERAL with the owning vocabulary named, as the reports plugin now does.
+
+  Measured scope, so nobody re-hunts this: a full receiver-level audit of all 392 column-category
+  sites found exactly 3 such false positives, all in `plugins/fusion-plugin-reports` (`next`, a
+  ReportStatus), and all now marked. Every other receiver sampled — `to`, `from`, `column`,
+  `fromColumn`, `toColumn`, `latestColumn`, `state`, `preArchiveColumn` — resolved to a genuine task
+  column. Bare `status`/`currentStatus`/`liveStatus` step comparisons are correctly excluded already
+  (`merge-queue-ops.ts` counts 1 of its 11 literals, and that 1 is the real `.column` guard).
+
+  The backlog number is therefore real. Treat a surprising count as work, not as noise.
 */
 
 import { createRequire } from "node:module";

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -126,12 +126,9 @@
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000triage": 2,
     "packages/engine/src/scheduler.ts\u0000in-progress": 2,
     "packages/engine/src/scheduler.ts\u0000in-review": 2,
-<<<<<<< HEAD
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000done": 2,
-=======
     "plugins/fusion-plugin-reports/src/store/report-store.ts\u0000archived": 2,
->>>>>>> 9ee1ce6def (batch(cli+plugins): 5 of 7 guards — fn pr create refused every card on a renamed board)
     "packages/cli/src/commands/task.ts\u0000archived": 1,
     "packages/cli/src/commands/task.ts\u0000done": 1,
     "packages/cli/src/extension.ts\u0000archived": 1,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -71,8 +71,6 @@
     "packages/engine/src/merger-scope-auto-widen.ts": 2,
     "packages/engine/src/mission-execution-loop.ts": 2,
     "plugins/fusion-plugin-even-cards/src/cards/board-cards.ts": 2,
-    "plugins/fusion-plugin-reports/src/store/report-store.ts": 2,
-    "packages/cli/src/commands/pr.ts": 1,
     "packages/core/src/eval-automation.ts": 1,
     "packages/core/src/eval-signal-collector.ts": 1,
     "packages/core/src/in-review-stall.ts": 1,
@@ -120,9 +118,7 @@
     "packages/engine/src/merger.ts": 1,
     "packages/engine/src/plugin-runner.ts": 1,
     "packages/engine/src/pr-comment-handler.ts": 1,
-    "packages/engine/src/runtimes/in-process-runtime.ts": 1,
-    "plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts": 1,
-    "plugins/fusion-plugin-reports/src/store/report-types.ts": 1
+    "packages/engine/src/runtimes/in-process-runtime.ts": 1
   },
   "deliberateByFile": {
     "packages/dashboard/src/reliability-metrics.ts\u0000in-review": 4,
@@ -130,8 +126,12 @@
     "packages/dashboard/app/components/TaskDetailModal.tsx\u0000triage": 2,
     "packages/engine/src/scheduler.ts\u0000in-progress": 2,
     "packages/engine/src/scheduler.ts\u0000in-review": 2,
+<<<<<<< HEAD
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000done": 2,
+=======
+    "plugins/fusion-plugin-reports/src/store/report-store.ts\u0000archived": 2,
+>>>>>>> 9ee1ce6def (batch(cli+plugins): 5 of 7 guards — fn pr create refused every card on a renamed board)
     "packages/cli/src/commands/task.ts\u0000archived": 1,
     "packages/cli/src/commands/task.ts\u0000done": 1,
     "packages/cli/src/extension.ts\u0000archived": 1,
@@ -160,7 +160,9 @@
     "packages/engine/src/project-engine.ts\u0000in-review": 1,
     "packages/engine/src/scheduler.ts\u0000archived": 1,
     "packages/engine/src/scheduler.ts\u0000done": 1,
-    "packages/engine/src/triage.ts\u0000triage": 1
+    "packages/engine/src/triage.ts\u0000triage": 1,
+    "plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts\u0000done": 1,
+    "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
     "packages/engine/src/self-healing.ts": 48,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -70,7 +70,6 @@
     "packages/engine/src/cli-agent/state-machine.ts": 2,
     "packages/engine/src/merger-scope-auto-widen.ts": 2,
     "packages/engine/src/mission-execution-loop.ts": 2,
-    "plugins/fusion-plugin-even-cards/src/cards/board-cards.ts": 2,
     "packages/core/src/eval-automation.ts": 1,
     "packages/core/src/eval-signal-collector.ts": 1,
     "packages/core/src/in-review-stall.ts": 1,
@@ -158,6 +157,8 @@
     "packages/engine/src/scheduler.ts\u0000archived": 1,
     "packages/engine/src/scheduler.ts\u0000done": 1,
     "packages/engine/src/triage.ts\u0000triage": 1,
+    "plugins/fusion-plugin-even-cards/src/cards/board-cards.ts\u0000archived": 1,
+    "plugins/fusion-plugin-even-cards/src/cards/board-cards.ts\u0000done": 1,
     "plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts\u0000done": 1,
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },


### PR DESCRIPTION
`batch-cli-plugins` — the u7 worker's mega-batch: `packages/cli` + `plugins` + anything left.

## The batch is 7 guards, and 3 of them are not guards at all

The census's per-file list gives this batch seven sites. Reading them, **three are a foreign vocabulary the census matches on the string alone**:

| file | site | verdict |
|---|---|---|
| `plugins/fusion-plugin-reports/store/report-store.ts` | `next === "archived"` ×2 | **not a column** — `next` is a `ReportStatus` |
| `plugins/fusion-plugin-reports/store/report-types.ts` | `to === "failed" \|\| to === "archived"` | **not a column** — same enum, its own terminal states |

The reports plugin has its own status lineage (`draft → generating → review_* → approved → published`, plus `failed`/`archived`) that shares two spellings with the lifecycle vocabulary. A report is not on a board and has no workflow, so resolving an IR there would answer a question nobody asked. All three are marked `DELIBERATE-LITERAL` with the reason at the site.

**This cuts the other way from #2763.** That PR establishes the census total as a *floor* (25 membership predicates it structurally cannot see). This is the opposite error in the same number: a foreign enum inflating it. The total is neither a ceiling nor a floor — it is an estimate with error in both directions, and the per-file list is worth reading before trusting a file's count.

## Converted (census before → after, per file)

| file | before | after |
|---|---|---|
| `packages/cli/src/commands/pr.ts` | 1 | **0** |
| `plugins/…/even-realities-glasses/notifications/diff.ts` | 1 | **0** |
| `plugins/…/reports/store/report-store.ts` | 2 | **0** (deliberate) |
| `plugins/…/reports/store/report-types.ts` | 1 | **0** (deliberate) |

### `fn pr create` refused every card on a renamed board

The live defect in this batch. The gate was `task.column !== "in-review"`, and its error told the operator to move the task to a column their board does not have:

```
Error: Task must be in 'in-review' column to create a PR (current: signoff)
```

There is no way to satisfy that short of renaming the workflow back. Now resolved through core's `resolveReviewColumns`, and the message names the lanes that actually exist.

**The SET, not `lifecycle.review`.** A board may declare more than one review lane, and a card parked in a `humanReview`-only lane is still a card you can open a PR from. A single-id answer keeps refusing those — the same narrowing #2728's review caught in the CLI retry gate, which is why the test pins both lanes.

## Skipped, with the reason

**`plugins/fusion-plugin-even-cards` (2 guards) — blocked on packaging, not on analysis.** The defect is real: `boardToDeck` filters with `column !== "archived" && column !== "done"`, so on a renamed board every finished card stays in the deck, fills `maxCards`, and pushes the active cards off the display. The wearer sees a board that never finishes anything.

I implemented the fix and **reverted it**: this plugin is not in `pnpm-workspace.yaml` and depends only on `@fusion/plugin-sdk` — it has no `@fusion/core` dependency, so the route cannot reach `resolveTaskLifecycleColumns`. Adding one is a packaging change, which this program's rules put out of scope. Shipping only the injected parameter without a caller was the alternative, and that is precisely the decorative conversion #2759 documents: the census would drop by 2 and the deck would keep the bug.

Flagged for whoever owns the plugin's dependency surface. The glasses plugin next door *does* depend on `@fusion/core`, so this is a one-plugin problem, not a plugin-wide one.

## Honest note on the glasses conversion

`diff.ts`'s completion branch is **currently unreachable** — the only production caller (`notifier.ts`) passes `alsoNotifyOnDone: false`. So that conversion changes nothing at runtime today. It is converted rather than marked deliberate because the literal is not deliberate: it is wrong, and would ship the bug the day someone turns the flag on. Stated here rather than left for a reviewer to discover.

## Verification

- new CLI suite **4 passed**; `pr-command` + `pr-automerge-cleanup` + `bin-pr-router` **35 passed**
- glasses plugin **181 passed (19 files)** · reports plugin **110 passed (23 files)**
- `pnpm test:gate` — **158 / 10 / 487 / 71** · `pnpm lint` clean · `--strict` exits 0

**Revert proof, measured.** Restoring `if (task.column !== "in-review")` fails 3 of the 4 new cases (`process.exit:1` on both renamed lanes, and the refusal message reverts to naming `in-review`). The unresolvable-workflow case keeps passing — it is the legacy path — so the negative cases alone do not pin the fix and all four are required.

## Handoff to `batch-engine`

`packages/engine/src/project-engine.ts` **5 → 0** is finished, green, and pushed as `handoff/project-engine-lanes-for-batch-engine` (`34dbb35209`) for the capacity worker to cherry-pick — it is engine-owned, not mine to land.

It fixes two live defects: a card that **had merged** reported as a failed merge to `fn task merge` and the dashboard button (`merged: finalTask?.column === "done"`), and the three post-finalize `column === "done" && mergeConfirmed` fast-path checks, which on a renamed board sent an already-landed card down the bounce path — re-queued, retry-counted, and in the capped branch parked `failed` with its merge sitting on main. Plus `hasAutoHealableVerificationBufferFailure`, which returned false for every card on a renamed board, so a buffer-overflow verification failure was never auto-healed.

8 new tests, revert-proven (restoring the literal fails 4 of 8), gate green.

---

## Completion pass (u7) — the batch is now closed

Two workers converged on this branch. I rebased onto the first-landed commit rather than force-pushing over it, took its wording wherever the conclusion was identical, and added what was missing.

### What this pass added

1. **`even-cards` (2 sites)** — the only in-scope file the first pass left open. Marked DELIBERATE-LITERAL: the package depends on `@fusion/plugin-sdk` only, and the SDK does not re-export the lifecycle role helpers, so there is no IR, no store, and no trait flags to resolve *from*. Fixing it properly means the SDK exposing role flags on the task shape it hands plugins — a structural change, out of scope, and recorded at the site as the correct home. Live consequence is cosmetic: a finished card on a renamed board shows as active in the glasses deck.

2. **A red test in the `fn pr create` conversion.** The incoming version rendered `Task must be in 'in-review' to create a PR`, dropping the word `column`. `task.test.ts:3422` pins `must be in 'in-review' column`, so that hunk failed `runTaskPrCreate > exits with error when task not in in-review column`. Restoring the word makes the single-lane message **byte-identical** to the pre-conversion one, which is what a vocabulary conversion should be — the guard's own test now passes unmodified. Marked at the site so it is not "simplified" back.

3. **Duplicate imports** — the two independent conversions each added `resolveWorkflowIrForTask`/`resolveReviewColumns`, which does not compile. Deduped in its own commit.

### Census

Measured with `--json` on `origin/main` and on this branch.

| file | before | after | action |
|---|---|---|---|
| `packages/cli/src/commands/pr.ts` | 1 | 0 | converted |
| `plugins/fusion-plugin-reports/src/store/report-types.ts` | 1 | 0 | marked |
| `plugins/fusion-plugin-reports/src/store/report-store.ts` | 2 | 0 | marked |
| `plugins/fusion-plugin-even-cards/src/cards/board-cards.ts` | 2 | 0 | marked |
| `plugins/fusion-plugin-even-realities-glasses/.../diff.ts` | 1 | 0 | marked |

Backlog **415 → 408** (−7, exactly the in-scope count). Deliberate **40 → 46** (+6 marked); 6 + 1 converted = 7. `--strict` exits 0. **Nothing remains in `cli` + `plugins` + everything-else — there is no follow-up batch behind this one.**

### One note on the `even-realities-glasses` site

Worth recording beyond "cannot resolve": its only production caller (`notifier.ts:80`) passes `alsoNotifyOnDone: false`, so that arm is **unreachable today**. Converting it could not have changed observed behaviour either way.

### Verification (measured, on the merged branch)

- `pnpm --filter @runfusion/fusion exec tsc --noEmit` → exit 0
- `pnpm lint` → 0 errors
- CLI `task.test.ts` → 144 passed, including the `runTaskPrCreate` guard test
- `@fusion-plugin-examples/reports` → 110 passed; `even-realities-glasses` → 181 passed

**Pre-existing failures, not from this change:** the 5 `runTaskImportFromGitHub` / `runTaskImportGitHubInteractive` tests fail identically on `origin/main` — verified by stashing this diff and re-running (5 failed / 144 passed both ways).

---

## Census audit (unowned follow-on)

After closing the batch scope I audited whether the **392** column-backlog number is inflated by foreign vocabularies — the class this batch found in the reports plugin, where `"archived"` is a `ReportStatus` rather than a board lane. If that class were widespread, every remaining batch would be chasing sites that must not be converted.

**It is not. The number is real.** A receiver-level pass over all 392 column-category sites found exactly **3** false positives, all in `plugins/fusion-plugin-reports` (`next`, a `ReportStatus`), all now marked in this PR.

What was checked and cleared:

- **Property-reached foreign enums** (`step.status`, `feature.status`, `mission.status`) — already correctly bucketed into the separate `status` category (185), not the column backlog. Verified against `merge-queue-ops.ts`: 11 lifecycle-spelled literals in the file, census counts **1**, and that 1 is the genuine `.column` guard.
- **Bare step-status variables** (`status`, `currentStatus`, `liveStatus` compared to `"done"`/`"skipped"`) — likewise excluded.
- **Every other receiver in the backlog** — `to`, `from`, `column`, `fromColumn`, `toColumn`, `latestColumn`, `state`, `preArchiveColumn`. All resolve to genuine task columns. `executor.ts`'s 15 sites were spot-checked line by line: all 15 are real.

The gap the classifier genuinely cannot close is a foreign enum held in a **bare variable** — the receiver name carries no type information, so `next === "archived"` is indistinguishable from a lifecycle guard by AST alone. That is why the reports sites need a marker rather than a classifier fix, and it is now documented in `lifecycle-column-census-ast.mjs`'s header alongside the measured scope, so the remaining batches do not re-run this hunt.

Census tests: **43 passed**. The change is comment-only.