### PR TITLE
fix(tests): update the archived-gate inventory after #2780's conversions

### DIFF
--- a/packages/core/src/__tests__/archived-column-gate-parity.test.ts
+++ b/packages/core/src/__tests__/archived-column-gate-parity.test.ts
@@ -56,15 +56,12 @@ import { describe, expect, it } from "vitest";
  */
 const AUDITED_TS_SITES: Readonly<Record<string, number>> = {
   "packages/core/src/agent-store.ts": 1,
-  "packages/core/src/assigned-task-ranking.ts": 1,
   "packages/core/src/async-mission-store-queries.ts": 2,
   "packages/core/src/async-mission-store.ts": 2,
-  "packages/core/src/duplicate-intake.ts": 1,
   "packages/core/src/eval-signal-collector.ts": 1,
   "packages/core/src/live-agent-count.ts": 1,
   "packages/core/src/mission-store.ts": 1,
-  "packages/core/src/near-duplicate-canonical.ts": 1,
-  "packages/core/src/store.ts": 2,
+  "packages/core/src/store.ts": 1,
   "packages/core/src/task-merge.ts": 2,
   "packages/core/src/task-store/archive-lifecycle-2.ts": 2,
   "packages/core/src/task-store/async-comments-attachments.ts": 8,


### PR DESCRIPTION
## New red on main

`archived-column-gate-parity.test.ts` fails with **"TypeScript encoding changed"** after batch-core (#2780). It is the only failure in a full `@fusion/core` run (`1 failed / 4748 passed`).

## The conversions are right — this is their missing half

#2780 moved four files off raw `column === "archived"` comparisons onto `isTerminalColumnRole`, exactly the intended role-based pattern:

| file | before → after |
|---|---|
| `assigned-task-ranking.ts` | 1 → 0 |
| `duplicate-intake.ts` | 1 → 0 |
| `near-duplicate-canonical.ts` | 1 → 0 |
| `store.ts` | 2 → 1 |

(The literal still in `duplicate-intake.ts` is a `moveTask` **destination**, not a gate comparison — a different question, like the planner-lane move targets.)

The guard's own failure text asks for the inventory to be updated **in the same commit** as a conversion. That did not happen, so the ratchet went red on main. This PR is only that bookkeeping.

## Verified NOT a split-brain

That is the thing this file exists to catch — TypeScript moving to the resolved role while the SQL sides keep comparing the raw string, so on a renamed board one says a task is archived and the others return it as live.

The Drizzle and raw-sql inventories are **unchanged and both pass**. Worth stating explicitly because those two assertions run *after* the TypeScript one: a plain red tells you nothing about them, they had to be re-run green to know.

## The guard still bites

Appending a real `task.column === "archived"` to an audited file fails it immediately.

**Recorded because it nearly fooled me:** my first two mutation attempts *passed*, which looked like a guard blind to new comparisons — a much worse finding than a stale inventory. Both had been inserted at line 2 of a file whose line 1 opens a JSDoc block, so my "code" was comment text and was never compiled. **A mutation that does not compile is not evidence of anything.** Appended at end of file instead, the guard fails on the first run.

Gate **732 green** · lint clean. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)