### PR TITLE
fix(tests): the last CLI reds — import assertions still required the column U11 removed

### DIFF
--- a/packages/cli/src/commands/__tests__/task.test.ts
+++ b/packages/cli/src/commands/__tests__/task.test.ts
@@ -1688,7 +1688,16 @@ describe("runTaskImportGitHubInteractive", () => {
     expect(mockCreateTask).toHaveBeenCalledWith({
       title: "First Issue",
       description: "Description 1\n\nSource: https://github.com/owner/repo/issues/1",
-      column: "triage",
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-07-31-02:10:
+      NO `column` HERE — the import deliberately stopped choosing one. #2603 (U11) removed the
+      hardcoded `column: "triage"` from the GitHub/GitLab import writes so `createTaskImpl`
+      resolves the WORKFLOW'S intake column instead; passing `column` would override that
+      resolution and, post-U11, name a lane the default workflow no longer declares. This
+      assertion still required the removed literal, so a correct product change read as five CLI
+      failures. The mock RETURN values elsewhere in this file keep their column: what a created
+      task comes back as is a different question from what the import asks for.
+      */
       dependencies: [],
       sourceIssue: {
         provider: "github",
@@ -1702,7 +1711,6 @@ describe("runTaskImportGitHubInteractive", () => {
     expect(mockCreateTask).toHaveBeenCalledWith({
       title: "Third Issue",
       description: "Description 3\n\nSource: https://github.com/owner/repo/issues/3",
-      column: "triage",
       dependencies: [],
       sourceIssue: {
         provider: "github",
@@ -1821,7 +1829,6 @@ describe("runTaskImportGitHubInteractive", () => {
     expect(mockCreateTask).toHaveBeenCalledWith({
       title: "Second Issue",
       description: "Description 2\n\nSource: https://github.com/owner/repo/issues/2",
-      column: "triage",
       dependencies: [],
       sourceIssue: {
         provider: "github",
@@ -2077,7 +2084,6 @@ describe("runTaskImportFromGitHub", () => {
     expect(mockCreateTask).toHaveBeenCalledWith({
       title: "First Issue",
       description: "Description 1\n\nSource: https://github.com/owner/repo/issues/1",
-      column: "triage",
       dependencies: [],
       sourceIssue: {
         provider: "github",
@@ -2199,7 +2205,6 @@ describe("runTaskImportFromGitHub", () => {
     expect(mockCreateTask).toHaveBeenCalledWith({
       title: "No Body Issue",
       description: "(no description)\n\nSource: https://github.com/owner/repo/issues/1",
-      column: "triage",
       dependencies: [],
       sourceIssue: {
         provider: "github",
@@ -2221,7 +2226,6 @@ describe("runTaskImportFromGitHub", () => {
     expect(mockCreateTask).toHaveBeenCalledWith({
       title: "A".repeat(200),
       description: expect.stringContaining("Body"),
-      column: "triage",
       dependencies: [],
       sourceIssue: {
         provider: "github",


### PR DESCRIPTION
## What was red

All 5 failures in a full `@runfusion/fusion` run on `origin/main` (`5 failed / 1673 passed`), in `src/commands/__tests__/task.test.ts`:

```
- "column": "triage",
```

## The product change is intentional and documented

**#2603 (U11)** removed the hardcoded `column: "triage"` from the GitHub/GitLab import writes so `createTaskImpl` resolves the **workflow's** intake column instead. Passing `column` would override that resolution and, post-U11, name a lane the default workflow no longer declares.

`task.ts` still carries the note at three sites:

> `createTaskImpl` resolves the WORKFLOW'S intake column, and `input.column` would override it. Hard-coding `"triage"` created the card in a column the default [workflow does not declare].

Six `toHaveBeenCalledWith` assertions still required the removed literal, so a correct product change surfaced as five CLI failures.

## Scoped deliberately

Only the **six assertion-side** occurrences are removed. The other **16** `column: "triage"` literals in this file are mock *return* values and `makeTask` fixtures, and they stay — what a created task comes *back* as is a different question from what the import *asks for*, and blanking them would weaken unrelated cases.

## Evidence

- Full CLI package: **1678 passed / 106 skipped, 125 files green** (was 5 failed).
- **Mutation:** reintroduce `column: "triage"` into the import write → **2 failed**. The assertions still pin the invariant rather than having been loosened into always-true — the thing worth checking when a fix is "delete an expectation".
- Gate **732 green** · `pnpm lint` clean. Test-only (mutation reverted; `git diff` clean).

## Ownership

`packages/cli` belongs to the **batch-cli-plugins** owner (u7) under the mega-batch split. This is fix-forward on a red rather than a conversion, confined to one test file, and touches no production code.

With #2779 and #2786 this leaves engine, core and CLI at **0 failures** on main. The remaining known reds are the 123 dashboard failures documented in #2784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)