### PR TITLE
chore(core): delete the dead merge-blocker guard, and catch exemptions for deleted seams

### DIFF
--- a/packages/core/src/default-workflow-hooks.ts
+++ b/packages/core/src/default-workflow-hooks.ts
@@ -15,8 +15,13 @@
  * path only.
  *
  * Hook classes (KTD-2):
- *   - guard  (sync, in-lock): merge-blocker, human-review. Implemented as the
- *     `evaluateDefaultWorkflowGuards` reader; pure DB-free reads off the task.
+ *   - guard  (sync, in-lock): merge-blocker, human-review. NOT implemented here.
+ *     The header used to credit an `evaluateDefaultWorkflowGuards` reader in this
+ *     file; no such function has ever existed. The merge-blocker guard is enforced
+ *     inline in `task-store/moves.ts` (~645 and ~821) via `getTaskMergeBlocker`,
+ *     gated on the RESOLVED trait flags (`toFacts.flags.complete` +
+ *     `fromFacts.flags.mergeBlocker`) rather than on column ids — which is why no
+ *     `guard` trait hook is registered below and none is missing.
  *   - onEnter / onExit (mutating, applied in-lock to the in-memory task before
  *     the commit for field effects; queue effects run in-txn): timing,
  *     reset-on-entry, abort-on-exit, merge.
@@ -34,50 +39,10 @@
 import { getTraitRegistry } from "./trait-registry.js";
 import type { LifecycleColumns } from "./workflow-lifecycle-traits.js";
 import type { TraitAuditWarning } from "./trait-registry.js";
-import { getTaskMergeBlocker } from "./task-merge.js";
 import type { Settings, Task } from "./types.js";
 
 // ── Guard evaluation (sync, in-lock) ─────────────────────────────────────────
 
-/** A guard verdict: undefined = allow; a string reason = reject. */
-export type GuardVerdict = string | undefined;
-
-/**
- * Evaluate the default workflow's sync guards for a move. Reproduces the legacy
- * `getTaskMergeBlocker` gate on `in-review → done`. (The default workflow does
- * not carry the human-review trait — see the Trait Vocabulary note — so there
- * is no human-review guard on this workflow.)
- *
- * `bypassGuards` (engine-sourced moves, KTD-9) skips guards entirely — the
- * caller is responsible for honoring that; this function still computes the
- * verdict so callers can choose. The store only consults it when not bypassing.
- */
-export function evaluateMergeBlockerGuard(
-  task: Pick<Task, "column" | "paused" | "status" | "error" | "steps" | "workflowStepResults">,
-  fromColumn: string,
-  toColumn: string,
-  /*
-  FNXC:WorkflowResolvedColumns 2026-07-31-04:20 (fleet phase):
-  The moving task's resolved lifecycle columns, so the review -> complete crossing this guard fires on
-  is a ROLE crossing. OPTIONAL and last, matching `DefaultWorkflowMoveContext.lifecycleColumns`: absent,
-  the legacy ids answer, which is the same degraded contract `planningColumnsOf` and
-  `liveWorkColumnsOf` already use in this file.
-  */
-  lifecycleColumns?: LifecycleColumns | undefined,
-): GuardVerdict {
-  if (
-    fromColumn === (lifecycleColumns?.review ?? "in-review")
-    && toColumn === (lifecycleColumns?.complete ?? "done")
-  ) {
-    return getTaskMergeBlocker(task);
-  }
-  return undefined;
-}
-
-// ── Move-effect context ───────────────────────────────────────────────────────
-
-/** Side-effect callbacks the store provides so the hooks stay engine-free and
- *  DB-handle-free; the store wires these to its in-txn / post-commit machinery. */
 export interface DefaultWorkflowMoveContext {
   task: Task;
   fromColumn: string;

--- a/scripts/check-inert-flag-seams.mjs
+++ b/scripts/check-inert-flag-seams.mjs
@@ -57,14 +57,7 @@ const ALLOWED = new Map([
       + "self-healing.ts and both supplying `reviewColumns`. This is the convenience wrapper over them, "
       + "kept as a public predicate and exercised only by its own tests. Engine-owned; left alone.",
   ],
-  [
-    "evaluateMergeBlockerGuard",
-    "TEMPORARY: core-owned; reported on #2783. NOT 'test-only' — that was this entry's previous "
-      + "stated reason and it was false. Including __tests__ in the scan finds zero callers there too: "
-      + "the function has exactly one reference in the repo, its own declaration. It is never "
-      + "registered as a trait hook either, and the `evaluateDefaultWorkflowGuards` reader its file "
-      + "header credits does not exist. So its `lifecycleColumns` conversion was applied to dead code.",
-  ],
+
   ["isPlanningContinuationTaskDispatchable", "TEMPORARY: engine-owned; reported on #2785."],
   [
     "sortTasksForDisplayColumn",
@@ -351,8 +344,20 @@ if (declared.size === 0) {
   process.exit(1);
 }
 
+/*
+AN EXEMPTION FOR A FUNCTION THAT NO LONGER EXISTS ALSO ROTS.
+
+The staleness check above only fires for a seam the scan still FINDS — it asks "is this site supplied
+now?". Delete the declaration and the name is never iterated, so its entry sits in the list forever,
+silently exempting nothing and misleading the next reader about what is tolerated. Found by deleting
+`evaluateMergeBlockerGuard` and watching the gate stay quiet about its leftover entry.
+*/
+for (const fn of ALLOWED.keys()) {
+  if (!declared.has(fn)) stale.push(`  ${fn} — no such seam declared any more; remove its ALLOWED entry`);
+}
+
 if (stale.length > 0) {
-  console.error("\n[check-inert-flag-seams] STALE allow-list entries — the sites are supplied now:\n");
+  console.error("\n[check-inert-flag-seams] STALE allow-list entries — supplied now, or no longer declared:\n");
   for (const line of stale.sort()) console.error(line);
   console.error("\nRemove them, or the check silently stops guarding those functions.\n");
   process.exit(1);

--- a/scripts/check-inert-flag-seams.mjs
+++ b/scripts/check-inert-flag-seams.mjs
@@ -356,6 +356,26 @@ for (const fn of ALLOWED.keys()) {
   if (!declared.has(fn)) stale.push(`  ${fn} — no such seam declared any more; remove its ALLOWED entry`);
 }
 
+/*
+FNXC:InertFlagSeams 2026-07-31-03:45 (#2830 review — greptile):
+THE SAME ROT REACHES ALLOWED_OMISSIONS, and the pass above did not cover it.
+
+Both staleness rules for the per-site list live inside the per-declaration loop, so they only run for
+a function the scan still FINDS. Delete or rename the function and that loop never visits it: the
+`<file>::<fn>` entry survives, exempting nothing, while reading as a reviewed and tolerated omission.
+
+This is the identical defect the ALLOWED pass above was added to fix — written for one of the two
+lists and not the other, which is the half-conversion shape this repo keeps producing. Same check,
+same failure mode, so it belongs immediately beside it rather than folded into the loop that cannot
+see deletions.
+*/
+for (const key of ALLOWED_OMISSIONS.keys()) {
+  const [, siteFn] = key.split("::");
+  if (!declared.has(siteFn)) {
+    stale.push(`  ${key} — no such seam declared any more; remove its ALLOWED_OMISSIONS entry`);
+  }
+}
+
 if (stale.length > 0) {
   console.error("\n[check-inert-flag-seams] STALE allow-list entries — supplied now, or no longer declared:\n");
   for (const line of stale.sort()) console.error(line);


### PR DESCRIPTION
Closes the last of the five findings I reported to batch-core (#2783), which merged without them. This one I held back twice on purpose; the reason is now resolved.

## The dead code

`evaluateMergeBlockerGuard` had **exactly one reference in the repo: its own declaration.** Never called, never re-exported from `index.ts`/`index.gate.ts`, never registered as a trait hook. Its `lifecycleColumns` conversion was applied to dead code, and the census counted it as progress.

## Why I would not delete it earlier, and what changed

I twice declined this, because no production `"guard"` trait hook is registered anywhere in the codebase — the only `registerTraitHookImpl(..., "guard", ...)` is in a test. If a registration had been dropped, that would be a real product bug and this function would be its evidence, so deleting it would have destroyed the breadcrumb.

**It is not missing.** Merge blocking is enforced inline in `task-store/moves.ts` (~645 and ~821) via `getTaskMergeBlocker`, gated on the **resolved trait flags** (`toFacts.flags.complete` + `fromFacts.flags.mergeBlocker`) rather than on column ids — a better implementation than the one being deleted. The logic moved; this function, and a file-header line crediting a never-existent `evaluateDefaultWorkflowGuards` reader, were left behind.

The header now records where the guard actually lives, so the next person does not repeat the investigation I just did.

Also removed: `GuardVerdict` (its return type, used nowhere else) and the orphaned `getTaskMergeBlocker` import — the latter caught by lint, not by me.

## The gap this exposed

The allow-list staleness check only fired for a seam the scan still **finds** — it asks *"is this site supplied now?"*. Delete the declaration and the name is never iterated, so its entry sits in the list forever, exempting nothing and misreporting what is tolerated.

I found this by deleting the function and watching the gate stay **silent** about its leftover entry.

**Measured:** an `ALLOWED` entry naming a non-existent seam now fails with `no such seam declared any more; remove its ALLOWED entry`; removing the probe returns exit 0. The failure header is reworded, since "the sites are supplied now" no longer covers both reasons.

This is the fourth blind spot closed in this check, and like the others it was found by exercising the gate rather than reading it.

## Verification

`pnpm test:gate` green · `tsc -p packages/core` 0 · lint 0 · gate now reports **20** seams (was 21 — the drop is this deletion).

No changeset: deleting unreachable internal code with no exported surface is behaviour-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)