### PR TITLE
chore(gate): the sortTasksForDisplayColumn exemption is permanent, not pending — with evidence

### DIFF
--- a/scripts/check-inert-flag-seams.mjs
+++ b/scripts/check-inert-flag-seams.mjs
@@ -68,11 +68,21 @@ const ALLOWED = new Map([
   ["isPlanningContinuationTaskDispatchable", "TEMPORARY: engine-owned; reported on #2785."],
   [
     "sortTasksForDisplayColumn",
-    "TEMPORARY: core-owned (task-priority.ts). Its `columnFlags` argument is supplied by its own "
-      + "tests and no production caller — the three dashboard call sites bind to a DIFFERENT function "
-      + "of the same name in app/components/taskSorting.ts. Surfaced only once this check resolved "
-      + "imported shadows; before that the dashboard calls raised the arg-count max and cleared it.",
+    "PERMANENT, with evidence. core/task-priority.ts's copy has ZERO callers anywhere: the three "
+      + "dashboard call sites bind to a DIFFERENT function of the same name in "
+      + "app/components/taskSorting.ts, and only its own tests pass the flags. It is not reachable "
+      + "externally either — @fusion/core is private, @runfusion/fusion declares no `exports` map and "
+      + "re-exports nothing from core wholesale, and it is absent from plugin-sdk. So there is no "
+      + "production behaviour to be wrong, and nothing to wire a supplier from.\n"
+      + "Deliberately NOT 'fixed'. Deleting the parameter (this check's usual remedy) would trade a "
+      + "dormant-but-correct implementation for a dormant legacy-only one, and deleting the function "
+      + "would discard a well-documented ordering it is plausible someone wires later. Both are churn "
+      + "with no product effect. The honest resolution is a duplicate-vs-core consolidation with the "
+      + "dashboard twin, which is a refactor and needs an owner — not a seam fix.\n"
+      + "Was TEMPORARY pending #2783; that PR merged without it, so the pending-owner framing was a "
+      + "fiction and is removed rather than left to rot.",
   ],
+
 ]);
 
 /*


### PR DESCRIPTION
The last of my five batch-core findings, resolved by **not** changing code. Recording why, because "leave it" is the kind of decision that rots into "nobody looked".

## What was wrong with the entry

It read `TEMPORARY: core-owned; reported on #2783`. That PR merged without picking it up, so the entry implied an owner who was going to act, and none exists. A stale exemption misreports what the project tolerates — exactly the rot the staleness checks exist to prevent, and one they cannot catch: the site is genuinely still unsupplied, so nothing fires.

## Evidence, gathered rather than assumed

- **Zero callers anywhere.** The three dashboard call sites (`Lane`, `Board`, `ListView`) bind to a **different function of the same name** in `app/components/taskSorting.ts`. Only its own tests pass the flags.
- **Not reachable externally.** `@fusion/core` is private; `@runfusion/fusion` declares no `exports` map and re-exports nothing from core wholesale; it is absent from `plugin-sdk`.

So there is no production behaviour to be wrong, and no supplier to wire it from.

## Why I did not "fix" it

This check's usual remedy is *wire a supplier, or delete the parameter and leave the literal counted*. Neither is right here:

- **Deleting the parameter** trades a dormant-but-correct implementation for a dormant legacy-only one. The parameter is optional and harmless; the only thing it costs is that the census once counted it as a conversion when it changed nothing — and that is now recorded rather than hidden.
- **Deleting the function** discards a well-documented ordering (the note enumerates three real renamed-board defects) that someone may plausibly wire later.

Both are churn with no product effect, in a package I do not own.

The actual resolution is **consolidating the duplicate with the dashboard twin** — that name collision has already cost real time twice in this lane, including one "fix" `tsc` rejected and one bad cross-batch report. But that is a refactor with a design question attached, and it needs an owner rather than a seam-gate cleanup smuggling it in.

## Verification

Gate exit 0 · lint 0. No code change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)