### PR TITLE
test(dashboard): restore 8 of 10 red App tests — the fixture went stale at the U12 flag cutover

### DIFF
--- a/packages/dashboard/app/components/ListView.tsx
+++ b/packages/dashboard/app/components/ListView.tsx
@@ -2851,7 +2851,15 @@ export function ListView({
   }
 
   return (
-    <div className={`list-view${useSinglePaneList ? " list-view--single-pane" : ""}`}>
+    /*
+    FNXC:ListView 2026-07-30-07:00:
+    `list-view-body` marks the REAL list, distinct from the workflow skeleton above which carries the
+    same `list-view` class for styling. Tests waited on `.list-view` to mean "the list rendered"; the
+    skeleton satisfied that, so the wait passed and the assertion inside failed against a DOM that
+    looked healthy. That cost five days of App.test.tsx being red and two wrong root causes. Wait on
+    this marker instead — it exists only when the list actually has lanes to draw.
+    */
+    <div className={`list-view${useSinglePaneList ? " list-view--single-pane" : ""}`} data-testid="list-view-body">
       {contextMenuState && hasContextMenuActions && createPortal(
         <div
           ref={contextMenuRef}

--- a/packages/dashboard/app/components/__tests__/App.test.tsx
+++ b/packages/dashboard/app/components/__tests__/App.test.tsx
@@ -663,47 +663,8 @@ import { fetchAuthStatus, fetchSettings, fetchGlobalSettings, fetchTaskDetail, f
 import { __resetShellHostContextForTests } from "../../shell-host";
 import { __test_clearDashboardViewsCache } from "../../hooks/usePluginDashboardViews";
 import * as apiNodeModule from "../../hooks/useRemoteNodeData";
+import { DEFAULT_BOARD_WORKFLOWS } from "./boardWorkflows.test-helpers";
 
-/*
-FNXC:WorkflowResolvedColumns 2026-07-30-06:10 (why these tests went red):
-
-ListView early-returns a workflow SKELETON when the board has no workflows:
-
-    if (boardWorkflows === null || boardWorkflows.workflows.length === 0) {
-      return renderListWorkflowSkeleton(boardWorkflows !== null);
-    }
-
-That skeleton carries the SAME `list-view` class as the real body, so every test that waits on
-`.list-view` and then reaches for a control inside it passed its `waitFor` and failed on the control,
-with a DOM that looks like the list rendered fine. Probe on the failing case:
-
-    cluster: false | listview: true | buttons: []
-
-The mock returned `workflows: []` with `flagEnabled: false`, which used to be fine: the flag-off path
-rendered legacy columns and needed no workflow. U12 deleted that path, so an empty `workflows` array
-now means "this board has no lanes" and there is nothing to render. The fixture, not the product,
-is what went stale.
-
-Mirrors the builtin coding lanes with the trait flags the board actually reads.
-*/
-const DEFAULT_BOARD_WORKFLOWS = {
-  flagEnabled: true,
-  defaultWorkflowId: "builtin:coding",
-  workflows: [
-    {
-      id: "builtin:coding",
-      name: "Coding",
-      columns: [
-        { id: "todo", name: "Todo", flags: { hold: true, intake: true } },
-        { id: "in-progress", name: "In Progress", flags: { countsTowardWip: true } },
-        { id: "in-review", name: "In Review", flags: { countsTowardWip: true, mergeBlocker: true, mergeOrchestration: true, humanReview: true } },
-        { id: "done", name: "Done", flags: { complete: true } },
-        { id: "archived", name: "Archived", flags: { archived: true, hiddenFromBoard: true } },
-      ],
-    },
-  ],
-  taskWorkflowIds: {},
-};
 
 
 async function waitForAppShell(): Promise<void> {
@@ -2490,7 +2451,7 @@ describe("App view switching", () => {
 
     // List view should be rendered (it has a different structure)
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     // Cleanup
@@ -2511,7 +2472,7 @@ describe("App view switching", () => {
     // Switch to list view
     fireEvent.click(screen.getByTestId("sidebar-nav-list"));
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     // Switch back to board view
@@ -2537,7 +2498,7 @@ describe("App view switching", () => {
     fireEvent.click(screen.getByTestId("sidebar-nav-list"));
 
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     fireEvent.click(screen.getByText("+ New Task"));
@@ -2586,7 +2547,7 @@ describe("App view switching", () => {
 
     // Wait for the app to render
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     // List view should be active
@@ -2788,7 +2749,7 @@ describe("App view switching", () => {
 
     // Should NOT show board or list view
     expect(document.querySelector(".board")).toBeNull();
-    expect(document.querySelector(".list-view")).toBeNull();
+    expect(screen.queryByTestId("list-view-body")).toBeNull();
   });
 
   it("persists agents view preference to localStorage", async () => {
@@ -2855,7 +2816,7 @@ describe("App view switching", () => {
 
     // Should NOT show board, list, or agents view
     expect(document.querySelector(".board")).toBeNull();
-    expect(document.querySelector(".list-view")).toBeNull();
+    expect(screen.queryByTestId("list-view-body")).toBeNull();
     expect(document.querySelector(".agents-view")).toBeNull();
   });
 
@@ -3583,7 +3544,9 @@ describe("App footer-safe project layout", () => {
     await waitFor(() => {
       const wrapper = document.querySelector(".project-content--with-footer");
       expect(wrapper).toBeTruthy();
-      expect(wrapper?.querySelector(".list-view")).toBeTruthy();
+      /* Containment is the point here, so this stays a scoped query — but on the body marker, not
+         the `.list-view` class the workflow skeleton also carries. */
+      expect(wrapper?.querySelector('[data-testid="list-view-body"]')).toBeTruthy();
     });
   });
 

--- a/packages/dashboard/app/components/__tests__/App.test.tsx
+++ b/packages/dashboard/app/components/__tests__/App.test.tsx
@@ -88,12 +88,7 @@ vi.mock("../../api", async (importOriginal) => {
       taskIdIntegrity: { status: "ok", checkedAt: "2026-05-12T00:00:00.000Z", anomalies: [], recommendedAction: null },
     })),
     fetchPluginDashboardViews: vi.fn(() => Promise.resolve([])),
-    fetchBoardWorkflows: vi.fn(() => Promise.resolve({
-      flagEnabled: false,
-      defaultWorkflowId: "builtin:coding",
-      workflows: [],
-      taskWorkflowIds: {},
-    })),
+    fetchBoardWorkflows: vi.fn(() => Promise.resolve(DEFAULT_BOARD_WORKFLOWS)),
     fetchExecutorStats: vi.fn(() => Promise.resolve({
       globalPause: false,
       enginePaused: false,
@@ -669,6 +664,48 @@ import { __resetShellHostContextForTests } from "../../shell-host";
 import { __test_clearDashboardViewsCache } from "../../hooks/usePluginDashboardViews";
 import * as apiNodeModule from "../../hooks/useRemoteNodeData";
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-06:10 (why these tests went red):
+
+ListView early-returns a workflow SKELETON when the board has no workflows:
+
+    if (boardWorkflows === null || boardWorkflows.workflows.length === 0) {
+      return renderListWorkflowSkeleton(boardWorkflows !== null);
+    }
+
+That skeleton carries the SAME `list-view` class as the real body, so every test that waits on
+`.list-view` and then reaches for a control inside it passed its `waitFor` and failed on the control,
+with a DOM that looks like the list rendered fine. Probe on the failing case:
+
+    cluster: false | listview: true | buttons: []
+
+The mock returned `workflows: []` with `flagEnabled: false`, which used to be fine: the flag-off path
+rendered legacy columns and needed no workflow. U12 deleted that path, so an empty `workflows` array
+now means "this board has no lanes" and there is nothing to render. The fixture, not the product,
+is what went stale.
+
+Mirrors the builtin coding lanes with the trait flags the board actually reads.
+*/
+const DEFAULT_BOARD_WORKFLOWS = {
+  flagEnabled: true,
+  defaultWorkflowId: "builtin:coding",
+  workflows: [
+    {
+      id: "builtin:coding",
+      name: "Coding",
+      columns: [
+        { id: "todo", name: "Todo", flags: { hold: true, intake: true } },
+        { id: "in-progress", name: "In Progress", flags: { countsTowardWip: true } },
+        { id: "in-review", name: "In Review", flags: { countsTowardWip: true, mergeBlocker: true, mergeOrchestration: true, humanReview: true } },
+        { id: "done", name: "Done", flags: { complete: true } },
+        { id: "archived", name: "Archived", flags: { archived: true, hiddenFromBoard: true } },
+      ],
+    },
+  ],
+  taskWorkflowIds: {},
+};
+
+
 async function waitForAppShell(): Promise<void> {
   await waitFor(() => {
     expect(fetchSettings).toHaveBeenCalled();
@@ -700,12 +737,7 @@ beforeEach(() => {
     },
     taskIdIntegrity: { status: "ok", checkedAt: "2026-05-12T00:00:00.000Z", anomalies: [], recommendedAction: null },
   });
-  vi.mocked(fetchBoardWorkflows).mockResolvedValue({
-    flagEnabled: false,
-    defaultWorkflowId: "builtin:coding",
-    workflows: [],
-    taskWorkflowIds: {},
-  });
+  vi.mocked(fetchBoardWorkflows).mockResolvedValue(DEFAULT_BOARD_WORKFLOWS);
   vi.mocked(apiNodeModule.useRemoteNodeData).mockReset();
   vi.mocked(apiNodeModule.useRemoteNodeData).mockReturnValue({
     projects: [],

--- a/packages/dashboard/app/components/__tests__/boardWorkflows.test-helpers.ts
+++ b/packages/dashboard/app/components/__tests__/boardWorkflows.test-helpers.ts
@@ -1,0 +1,44 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-07:20:
+THE DEFAULT BOARD-WORKFLOWS FIXTURE, shared so it cannot drift per file.
+
+`ListView` early-returns a workflow skeleton when the board has no workflows, and that skeleton
+carries the same `list-view` class as the real body. A fixture with `workflows: []` therefore renders
+something that satisfies "the list rendered" while containing none of the list's controls.
+
+`workflows: []` used to be correct — the `flagEnabled: false` path rendered legacy columns and needed
+no workflow at all. U12 deleted that path, so an empty array now means "this board has no lanes". Two
+separate test files kept their own empty copy and both went quietly wrong: App.test.tsx went red for
+five days, and two board-mobile-view-switch cases kept PASSING while asserting against a skeleton.
+
+Hence one shared fixture rather than another private copy. Mirrors the builtin coding lanes with the
+trait flags the board actually reads; tests that need a different board should spread and override.
+
+NOTE ON board-mobile-view-switch.test.tsx: it still has its own `workflows: []` copy, deliberately.
+Its two cases assert SYNCHRONOUSLY, before ListView's async workflow fetch resolves, so they match
+the skeleton by construction — adopting this fixture does not change that, and making them await the
+real body turned up a separate harness failure I could not resolve. They are weak, not broken;
+tracked on #2829 rather than churned here.
+*/
+export const DEFAULT_BOARD_WORKFLOWS = {
+  flagEnabled: true,
+  defaultWorkflowId: "builtin:coding",
+  workflows: [
+    {
+      id: "builtin:coding",
+      name: "Coding",
+      columns: [
+        { id: "todo", name: "Todo", flags: { hold: true, intake: true } },
+        { id: "in-progress", name: "In Progress", flags: { countsTowardWip: true } },
+        {
+          id: "in-review",
+          name: "In Review",
+          flags: { countsTowardWip: true, mergeBlocker: true, mergeOrchestration: true, humanReview: true },
+        },
+        { id: "done", name: "Done", flags: { complete: true } },
+        { id: "archived", name: "Archived", flags: { archived: true, hiddenFromBoard: true } },
+      ],
+    },
+  ],
+  taskWorkflowIds: {},
+};


### PR DESCRIPTION
Fixes most of #2829. `App.test.tsx` has been red on `main` since 2026-07-25 — deterministically, on every commit since, identically with and without any batch branch applied.

## Root cause

`ListView` early-returns a workflow skeleton when the board has no workflows:

```ts
if (boardWorkflows === null || boardWorkflows.workflows.length === 0) {
  return renderListWorkflowSkeleton(boardWorkflows !== null);
}
```

That skeleton carries the **same `list-view` class** as the real body. So every test that waits on `.list-view` and then reaches for a control inside it passed its `waitFor` and failed on the control — presenting a DOM that looks like a perfectly healthy list. That is why this read as "the board renders nothing" and then as an i18n problem; both were wrong.

The probe that settled it:

```
cluster: false | listview: true | buttons: []
```

The fixture returned `workflows: []` with `flagEnabled: false`. That **used to be correct** — the flag-off path rendered legacy columns and needed no workflow. **U12 deleted that path**, so an empty `workflows` array now means "this board has no lanes". The fixture went stale, not the product.

The mock now mirrors the builtin coding lanes with the trait flags the board actually reads.

## Measured

| | before | after |
|---|---|---|
| App.test.tsx | 10 failed / 131 passed | **2 failed / 139 passed** (141) |

`tsc` 0 · lint 0 · rest of the `dashboard-app-quality-app` project unaffected.

## Two remain — different root cause, deliberately not chased here

- **`opens the NewTaskModal from the list view new-task button`** now gets *past* the button (that was the skeleton bug) and fails on `role="heading"` name `"New Task"`. The heading exists as `<h3>{t("newTaskModal.title", "New Task")}</h3>`, so the modal is not rendering at all — plausibly FN-8620's FloatingWindow rework, **unverified**.
- **`keeps the 'subtask' background-session route unchanged`** — uncharacterised.

Two of my earlier root-cause guesses on this file were wrong, so I am not offering a third. #2829 stays open for these two with the evidence attached.

## Not quarantined

`test-quarantine.json` is for flakes. This failed deterministically, and quarantining would have started a 14-day deletion clock on 141 tests covering deep-link handling, view switching, board branch filters, and the FN-5817 mobile auto-merge shell — while hiding a fixture that had silently stopped exercising the list view at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)