### PR TITLE
test(dashboard): mark the real list body so a skeleton can't satisfy "the list rendered"

### DIFF
--- a/packages/dashboard/app/components/ListView.tsx
+++ b/packages/dashboard/app/components/ListView.tsx
@@ -2851,7 +2851,15 @@ export function ListView({
   }
 
   return (
-    <div className={`list-view${useSinglePaneList ? " list-view--single-pane" : ""}`}>
+    /*
+    FNXC:ListView 2026-07-30-07:00:
+    `list-view-body` marks the REAL list, distinct from the workflow skeleton above which carries the
+    same `list-view` class for styling. Tests waited on `.list-view` to mean "the list rendered"; the
+    skeleton satisfied that, so the wait passed and the assertion inside failed against a DOM that
+    looked healthy. That cost five days of App.test.tsx being red and two wrong root causes. Wait on
+    this marker instead — it exists only when the list actually has lanes to draw.
+    */
+    <div className={`list-view${useSinglePaneList ? " list-view--single-pane" : ""}`} data-testid="list-view-body">
       {contextMenuState && hasContextMenuActions && createPortal(
         <div
           ref={contextMenuRef}

--- a/packages/dashboard/app/components/__tests__/App.test.tsx
+++ b/packages/dashboard/app/components/__tests__/App.test.tsx
@@ -663,47 +663,8 @@ import { fetchAuthStatus, fetchSettings, fetchGlobalSettings, fetchTaskDetail, f
 import { __resetShellHostContextForTests } from "../../shell-host";
 import { __test_clearDashboardViewsCache } from "../../hooks/usePluginDashboardViews";
 import * as apiNodeModule from "../../hooks/useRemoteNodeData";
+import { DEFAULT_BOARD_WORKFLOWS } from "./boardWorkflows.test-helpers";
 
-/*
-FNXC:WorkflowResolvedColumns 2026-07-30-06:10 (why these tests went red):
-
-ListView early-returns a workflow SKELETON when the board has no workflows:
-
-    if (boardWorkflows === null || boardWorkflows.workflows.length === 0) {
-      return renderListWorkflowSkeleton(boardWorkflows !== null);
-    }
-
-That skeleton carries the SAME `list-view` class as the real body, so every test that waits on
-`.list-view` and then reaches for a control inside it passed its `waitFor` and failed on the control,
-with a DOM that looks like the list rendered fine. Probe on the failing case:
-
-    cluster: false | listview: true | buttons: []
-
-The mock returned `workflows: []` with `flagEnabled: false`, which used to be fine: the flag-off path
-rendered legacy columns and needed no workflow. U12 deleted that path, so an empty `workflows` array
-now means "this board has no lanes" and there is nothing to render. The fixture, not the product,
-is what went stale.
-
-Mirrors the builtin coding lanes with the trait flags the board actually reads.
-*/
-const DEFAULT_BOARD_WORKFLOWS = {
-  flagEnabled: true,
-  defaultWorkflowId: "builtin:coding",
-  workflows: [
-    {
-      id: "builtin:coding",
-      name: "Coding",
-      columns: [
-        { id: "todo", name: "Todo", flags: { hold: true, intake: true } },
-        { id: "in-progress", name: "In Progress", flags: { countsTowardWip: true } },
-        { id: "in-review", name: "In Review", flags: { countsTowardWip: true, mergeBlocker: true, mergeOrchestration: true, humanReview: true } },
-        { id: "done", name: "Done", flags: { complete: true } },
-        { id: "archived", name: "Archived", flags: { archived: true, hiddenFromBoard: true } },
-      ],
-    },
-  ],
-  taskWorkflowIds: {},
-};
 
 
 async function waitForAppShell(): Promise<void> {
@@ -2490,7 +2451,7 @@ describe("App view switching", () => {
 
     // List view should be rendered (it has a different structure)
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     // Cleanup
@@ -2511,7 +2472,7 @@ describe("App view switching", () => {
     // Switch to list view
     fireEvent.click(screen.getByTestId("sidebar-nav-list"));
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     // Switch back to board view
@@ -2537,7 +2498,7 @@ describe("App view switching", () => {
     fireEvent.click(screen.getByTestId("sidebar-nav-list"));
 
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     fireEvent.click(screen.getByText("+ New Task"));
@@ -2586,7 +2547,7 @@ describe("App view switching", () => {
 
     // Wait for the app to render
     await waitFor(() => {
-      expect(document.querySelector(".list-view")).toBeTruthy();
+      expect(screen.queryByTestId("list-view-body")).toBeTruthy();
     });
 
     // List view should be active
@@ -2788,7 +2749,7 @@ describe("App view switching", () => {
 
     // Should NOT show board or list view
     expect(document.querySelector(".board")).toBeNull();
-    expect(document.querySelector(".list-view")).toBeNull();
+    expect(screen.queryByTestId("list-view-body")).toBeNull();
   });
 
   it("persists agents view preference to localStorage", async () => {
@@ -2855,7 +2816,7 @@ describe("App view switching", () => {
 
     // Should NOT show board, list, or agents view
     expect(document.querySelector(".board")).toBeNull();
-    expect(document.querySelector(".list-view")).toBeNull();
+    expect(screen.queryByTestId("list-view-body")).toBeNull();
     expect(document.querySelector(".agents-view")).toBeNull();
   });
 
@@ -3583,7 +3544,9 @@ describe("App footer-safe project layout", () => {
     await waitFor(() => {
       const wrapper = document.querySelector(".project-content--with-footer");
       expect(wrapper).toBeTruthy();
-      expect(wrapper?.querySelector(".list-view")).toBeTruthy();
+      /* Containment is the point here, so this stays a scoped query — but on the body marker, not
+         the `.list-view` class the workflow skeleton also carries. */
+      expect(wrapper?.querySelector('[data-testid="list-view-body"]')).toBeTruthy();
     });
   });
 

--- a/packages/dashboard/app/components/__tests__/boardWorkflows.test-helpers.ts
+++ b/packages/dashboard/app/components/__tests__/boardWorkflows.test-helpers.ts
@@ -1,0 +1,44 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-07:20:
+THE DEFAULT BOARD-WORKFLOWS FIXTURE, shared so it cannot drift per file.
+
+`ListView` early-returns a workflow skeleton when the board has no workflows, and that skeleton
+carries the same `list-view` class as the real body. A fixture with `workflows: []` therefore renders
+something that satisfies "the list rendered" while containing none of the list's controls.
+
+`workflows: []` used to be correct — the `flagEnabled: false` path rendered legacy columns and needed
+no workflow at all. U12 deleted that path, so an empty array now means "this board has no lanes". Two
+separate test files kept their own empty copy and both went quietly wrong: App.test.tsx went red for
+five days, and two board-mobile-view-switch cases kept PASSING while asserting against a skeleton.
+
+Hence one shared fixture rather than another private copy. Mirrors the builtin coding lanes with the
+trait flags the board actually reads; tests that need a different board should spread and override.
+
+NOTE ON board-mobile-view-switch.test.tsx: it still has its own `workflows: []` copy, deliberately.
+Its two cases assert SYNCHRONOUSLY, before ListView's async workflow fetch resolves, so they match
+the skeleton by construction — adopting this fixture does not change that, and making them await the
+real body turned up a separate harness failure I could not resolve. They are weak, not broken;
+tracked on #2829 rather than churned here.
+*/
+export const DEFAULT_BOARD_WORKFLOWS = {
+  flagEnabled: true,
+  defaultWorkflowId: "builtin:coding",
+  workflows: [
+    {
+      id: "builtin:coding",
+      name: "Coding",
+      columns: [
+        { id: "todo", name: "Todo", flags: { hold: true, intake: true } },
+        { id: "in-progress", name: "In Progress", flags: { countsTowardWip: true } },
+        {
+          id: "in-review",
+          name: "In Review",
+          flags: { countsTowardWip: true, mergeBlocker: true, mergeOrchestration: true, humanReview: true },
+        },
+        { id: "done", name: "Done", flags: { complete: true } },
+        { id: "archived", name: "Archived", flags: { archived: true, hiddenFromBoard: true } },
+      ],
+    },
+  ],
+  taskWorkflowIds: {},
+};


### PR DESCRIPTION
Stacked on #2833 (merge that first). That PR fixed the stale fixture; this removes the trap that made the failure invisible for five days.

## The trap

`ListView`'s workflow skeleton carries the **same `list-view` class** as the real body. Seven tests waited on `.list-view` to mean "the list rendered", and the skeleton satisfied every one of them — so the wait passed, the assertion inside failed, and the DOM looked healthy. Fixing the fixture cured the symptom; the ambiguous selector would have re-armed it the next time a board legitimately had no lanes.

## Changes

- `ListView`'s real body root now carries `data-testid="list-view-body"`. It exists only when the list actually has lanes to draw, so a skeleton cannot satisfy it.
- App.test.tsx's seven `.list-view` waits use it — including the one scoped inside `.project-content--with-footer`, which keeps its containment intent as a scoped query.
- The board-workflows fixture moves to a shared `boardWorkflows.test-helpers.ts`, following the existing `*.test-helpers.ts` convention in that directory. Two files kept private empty copies and both went quietly wrong; adding a third was the wrong answer.

## A finding I did not fix, deliberately

The marker immediately exposed two more silently-passing tests: **`board-mobile-view-switch.test.tsx`** asserts **synchronously**, before `ListView`'s async workflow fetch resolves, so it matches the skeleton *by construction* and does not prove the list rendered.

I tried converting them to the marker with an `await`. That surfaced a separate harness failure (`switch-to-board` not found) I could not resolve in two attempts. **Turning two green tests red to chase an invariant is a bad trade**, so I reverted that file entirely and left it passing exactly as before. Tracked on #2829.

That is also why the shared fixture is imported by one file so far, with a note at the fixture explaining why the other keeps its own copy.

## A gotcha worth keeping

`vi.mock` is hoisted above imports, so a factory referencing a top-level import fails with `Cannot access '__vi_import__' before initialization`. The async-factory form (`vi.mock(..., async () => ({ x: (await import("./fixture")).X }))`) is the way in. I hit this moving the fixture.

## Verification

App.test.tsx unchanged at its 2 known failures / 139 passed · board-mobile-view-switch 3 passed · `tsc` 0 · lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)