### PR TITLE
feat(census): split the query class into read-shaped and write — most of the remainder must not be converted

### DIFF
--- a/packages/engine/src/__tests__/census-query-role-split.test.ts
+++ b/packages/engine/src/__tests__/census-query-role-split.test.ts
@@ -1,0 +1,67 @@
+/*
+FNXC:LifecycleColumnCensus 2026-08-01-04:00:
+
+THE INVARIANT: the query class is reported split into READ-shaped (convertible) and WRITE (must not
+be converted).
+
+WHY. `column:` sits in an options-shaped object for both a source query and a write, so the existing
+definition-vs-query rule cannot separate them and the single number reads as "dead reads to convert".
+Measured while converting this class: outside `self-healing.ts`, the read-shaped sites are the
+convertible ones and the rest are soft-delete TOMBSTONE writes plus synthetic in-memory literals.
+
+Converting a tombstone write is **harmful**, not merely pointless: `getLiveTaskColumn` returns
+"archived" as a SENTINEL for any soft-deleted row, so the write and the sentinel have to agree. That
+is the same shape as #2808's `recoveryRehome` moves — a class where some members must NOT be fixed,
+and a count alone cannot tell you which.
+
+REPORTED, NOT RATCHETED. The pinned `QUERY filters` total and `queryByFile` are untouched, so the
+baseline does not move. A number that misleads is worth splitting even when the pinned total must
+stay byte-identical — and changing what a ratchet ENFORCES is the owner's call, not a side effect of
+improving what it SAYS.
+*/
+import { describe, expect, it } from "vitest";
+
+import { findComparisons, summarize } from "../../../../scripts/lib/lifecycle-column-census-ast.mjs";
+
+const read = `export async function sweep(store) {
+  const tasks = await store.listTasks({ column: "in-review", slim: true });
+  return tasks;
+}`;
+
+const write = `export async function tombstone(tx, id, deletedAt) {
+  await tx.update(rows).set({ column: "archived", deletedAt });
+}`;
+
+const definition = `export const ir = { nodes: [{ id: "review", kind: "review", column: "in-review" }] };`;
+
+function roles(source: string) {
+  return summarize(findComparisons("packages/x/src/probe.ts", source)).queryRoles;
+}
+
+describe("the census splits query properties by role", () => {
+  it("counts a listTasks filter as READ-shaped", () => {
+    expect(roles(read)).toMatchObject({ read: 1, write: 0 });
+  });
+
+  it("counts a .set() tombstone as a WRITE", () => {
+    // The one that must never be converted — see the header.
+    expect(roles(write)).toMatchObject({ read: 0, write: 1 });
+  });
+
+  it("still excludes IR node definitions from the query class entirely", () => {
+    // A definition carries `id:`/`kind:`; converting one would be nonsense, and the pre-existing
+    // rule that separates them must keep working.
+    const summary = summarize(findComparisons("packages/x/src/probe.ts", definition));
+
+    expect(summary.properties.definition).toBe(1);
+    expect(summary.properties.query).toBe(0);
+  });
+
+  it("leaves the pinned query total unchanged by the split", () => {
+    // The ratchet pins `properties.query` and `queryByFile`; the split must be additive.
+    const summary = summarize(findComparisons("packages/x/src/probe.ts", `${read}\n${write}`));
+
+    expect(summary.properties.query).toBe(2);
+    expect(summary.queryRoles.read + summary.queryRoles.write + summary.queryRoles.other).toBe(2);
+  });
+});

--- a/scripts/lib/lifecycle-column-census-ast.mjs
+++ b/scripts/lib/lifecycle-column-census-ast.mjs
@@ -242,6 +242,43 @@ builtin IR files hold ~32 of these. Converting one would be nonsense. They are t
 structurally rather than by filename: a definition's object literal also carries `id:` or `kind:`,
 a query's does not.
 */
+/*
+FNXC:LifecycleColumnCensus 2026-08-01-04:00:
+A QUERY property is not always a READ, and the difference decides whether it is convertible.
+
+`column:` sits in an options-shaped object for both a source query and a write, so the existing
+definition-vs-query rule (below) cannot separate them — and the resulting single number reads as
+"dead reads to convert" when it is not. Measured while converting this class: of the sites outside
+`self-healing.ts`, the read-shaped ones are convertible and the rest are soft-delete TOMBSTONE writes
+(`.set({ column: "archived", deletedAt, … })`) and synthetic in-memory literals.
+
+Converting a tombstone write would be actively harmful: `getLiveTaskColumn` returns `"archived"` as a
+SENTINEL for any soft-deleted row, so the write and the sentinel must agree. This is the same shape
+as #2808's `recoveryRehome` moves — a class where some members must NOT be fixed, and the count alone
+cannot tell you which.
+
+REPORTED, NOT RATCHETED. `queryByFile` and the `QUERY filters` total stay byte-identical so the pinned
+baseline does not move; this adds a breakdown beside them. A number that misleads is worth splitting
+even when the pinned total must not change.
+*/
+function queryPropertyRole(node) {
+  for (let cursor = node.parent; cursor; cursor = cursor.parent) {
+    if (ts.isCallExpression(cursor)) {
+      const callee = cursor.expression;
+      const name = ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)
+        ? callee.name.text
+        : ts.isIdentifier(callee) ? callee.text : undefined;
+      if (name === undefined) return "other";
+      /* Drizzle's `.set(...)` and `.values(...)` are writes; `listTasks`/`searchTasks` are reads. */
+      if (name === "set" || name === "values" || name === "insert" || name === "update") return "write";
+      if (/^(list|search|find|get|count)/i.test(name)) return "read";
+      return "other";
+    }
+    if (ts.isVariableDeclaration(cursor) || ts.isReturnStatement(cursor)) return "other";
+  }
+  return "other";
+}
+
 function classifyColumnProperty(node) {
   const object = node.parent;
   if (!object || !ts.isObjectLiteralExpression(object)) return "query";
@@ -410,6 +447,7 @@ export function findComparisons(filePath, source) {
         columnId: columnProperty,
         receiver: "column",
         kind: hasDeliberateMarker(sourceFile, node) ? "deliberate" : classifyColumnProperty(node),
+        queryRole: queryPropertyRole(node),
       });
     }
     ts.forEachChild(node, visit);
@@ -452,6 +490,8 @@ export function summarize(findings) {
   const properties = { query: 0, definition: 0 };
   const queryByFile = new Map();
   const queryByColumnId = {};
+  /* Read / write / other split of the query class — reported, never ratcheted. */
+  const queryRoles = { read: 0, write: 0, other: 0 };
 
   for (const finding of findings) {
     if (finding.kind === "query" || finding.kind === "definition") {
@@ -459,6 +499,7 @@ export function summarize(findings) {
       if (finding.kind === "query") {
         queryByColumnId[finding.columnId] = (queryByColumnId[finding.columnId] ?? 0) + 1;
         queryByFile.set(finding.file, (queryByFile.get(finding.file) ?? 0) + 1);
+        queryRoles[finding.queryRole ?? "other"] = (queryRoles[finding.queryRole ?? "other"] ?? 0) + 1;
       }
       continue;
     }
@@ -494,6 +535,7 @@ export function summarize(findings) {
     properties,
     queryByColumnId,
     queryByFile: [...queryByFile].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+    queryRoles,
   };
 }
 

--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -118,6 +118,20 @@ if (json) {
   counted apart again: they are the lineage describing itself and are not convertible.
   */
   console.log(`  QUERY filters (column: "<legacy>"): ${summary.properties.query}`);
+  /*
+  FNXC:LifecycleColumnCensus 2026-08-01-04:00:
+  The split, because the single number reads as "dead reads to convert" and most of it is not.
+  Measured while converting this class: outside `self-healing.ts` the read-shaped sites are
+  convertible; the rest are soft-delete TOMBSTONE writes and synthetic in-memory literals, and
+  converting a tombstone write is HARMFUL — `getLiveTaskColumn` returns "archived" as a sentinel for
+  any soft-deleted row, so the write and the sentinel have to agree.
+
+  Reported only. The pinned total above and `queryByFile` are unchanged, so the ratchet does not move.
+  */
+  if (summary.queryRoles) {
+    const { read = 0, write = 0, other = 0 } = summary.queryRoles;
+    console.log(`    of those: ${read} read-shaped (convertible), ${write} writes (do NOT convert), ${other} other`);
+  }
   console.log(`  IR node definitions (not convertible): ${summary.properties.definition}\n`);
   console.log("  by column id:");
   for (const [id, count] of Object.entries(summary.byColumnId).sort((a, b) => b[1] - a[1])) {


### PR DESCRIPTION
Splits the census's query class into **read-shaped** (convertible) and **write** (must not be converted), reported beside the existing total.

On current `main`:

```
  QUERY filters (column: "<legacy>"): 63
    of those: 48 read-shaped (convertible), 5 writes (do NOT convert), 10 other
```

## Why the single number misleads

`column:` sits in an options-shaped object for both a source query and a write, so the existing definition-vs-query rule cannot separate them. The result reads as "dead reads to convert" — and after #2818 landed, **48 of the 63 are `self-healing.ts` and the rest are largely not convertible at all.**

Converting a write in this class is **harmful, not merely pointless**. `async-persistence.ts` soft-deletes with `.set({ column: "archived", deletedAt, … })`, and `getLiveTaskColumn` returns `"archived"` as a **sentinel** for any soft-deleted row — the write and the sentinel have to agree. A sweep that "finished the query class" by converting all 63 would break live-column resolution for every deleted task.

That is the same shape #2808 flagged for `recoveryRehome` moves. **Two of the census-invisible classes now have members that must not be fixed**, and in both cases the count alone cannot tell you which.

## Reported, not ratcheted

`properties.query` and `queryByFile` are byte-identical, so the pinned baseline does not move and no open PR's Lint changes. The split is one extra line of output.

**Changing what a ratchet enforces is the owner's call; improving what it says is not.** Same line I drew when making marker-only failures legible without loosening them.

## Honest limit

Read-shaped is a better filter than the raw count and **still not a verdict**. `auto-merge-finalization.ts:242` is classified read-shaped and must NOT be converted — its own comment records that it is `getTaskHardMergeBlocker`'s review-eligible sentinel, deliberately not re-keyed. Nothing mechanical would catch that; only the comment beside it does. The split narrows a haystack to a readable list; it does not decide the list.

## Verification

4 new cases — a `listTasks` filter counts read, a `.set()` tombstone counts write, IR node definitions stay excluded from the class entirely (the pre-existing rule must keep working), and the pinned total is unchanged by the split. Revert proof: dropping the write branch fails the tombstone case.

Census's own suites **87 passed**, gate **161 / 13 / 487 / 71**, lint clean, `--strict` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
