### PR TITLE
test(core): fix two identity assertions that main's copy-branding invalidated

### DIFF
--- a/packages/core/src/__tests__/workflow-ir-resolver.test.ts
+++ b/packages/core/src/__tests__/workflow-ir-resolver.test.ts
@@ -73,7 +73,23 @@ describe("resolveWorkflowIrForTask", () => {
       defs: { "wf-gone": undefined },
     });
     const ir = await resolveWorkflowIrForTask(store, "t1");
-    expect(ir).toBe(BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR);
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-08-01-18:40 (identity -> equality on the FALLBACK paths only):
+    A FALLBACK CARRIES ITS OWN OBJECT. `markFellBack` used to brand the returned IR in place, and
+    `resolveDefaultWorkflowIr()` hands back a SHARED module constant — so one fallback anywhere marked
+    the singleton for the rest of the process, and every later resolution of the real `builtin:coding`
+    was reported as `source: "default"`, including tasks that genuinely selected it. It brands a
+    shallow COPY now.
+
+    So `toBe` cannot hold on this path, and re-asserting it would force the singleton-poisoning back.
+    The copy is deep-equal to the canonical IR — the brand is non-enumerable — so `toEqual` states what
+    the contract actually guarantees: the caller gets the canonical default's CONTENT. Identity was
+    never part of that guarantee; it was an artefact of handing back the shared object.
+
+    NOTE the five OTHER `toBe` assertions in this file are untouched and still pass: they cover paths
+    that return the shared IR legitimately, and weakening them would hide a future regression.
+    */
+    expect(ir).toEqual(BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR);
   });
 
   it("falls back to the default when there is no selection", async () => {
@@ -130,7 +146,9 @@ describe("resolveWorkflowIrById", () => {
   it("falls back to the canonical IR for an unknown built-in id", async () => {
     const store = makeStore({});
     const ir = await resolveWorkflowIrById(store, "builtin:missing");
-    expect(ir).toBe(BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR);
+    /* Same as the case above: an unregistered builtin id is a fallback, so it carries a branded copy
+       rather than the shared canonical object. Equality is the guarantee here, not identity. */
+    expect(ir).toEqual(BUILTIN_STEPWISE_FINAL_REVIEW_CODING_WORKFLOW_IR);
     expect(store.getWorkflowDefinition).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Main is red; this fixes it

`packages/core/src/__tests__/workflow-ir-resolver.test.ts` — 2 failures on `main`, and they are fallout from my #2815.

```
× resolveWorkflowIrForTask > falls back to the built-in default when the definition is missing
× resolveWorkflowIrById   > falls back to the canonical IR for an unknown built-in id
   → expected { version: 'v2', …(6), …(1) } to be { version: 'v2', …(6) }
```

`markFellBack` now brands a **shallow copy** of the default IR instead of the object itself — a change made during #2815's review, and a necessary one: `resolveDefaultWorkflowIr()` returns a **shared module constant**, so branding it in place marked the singleton for the rest of the process. After one fallback anywhere, every later resolution of the real `builtin:coding` came back branded and was reported as `source: "default"` — including tasks that genuinely selected it. That is the lying signal #2815 exists to remove, pointing the other way.

Both failing assertions use `toBe`, so a copy fails them by construction.

## Why `toEqual` is the right fix, not appeasement

**Identity was never the contract.** It was an artefact of handing back the shared object, and re-asserting it would force the singleton-poisoning back — the tests would be pinning the bug. The branded copy is **deep-equal** to the canonical IR (the brand is non-enumerable), so `toEqual` states exactly what callers are still guaranteed: the canonical default's *content*.

**The other five `toBe` assertions in this file are untouched and still pass.** They cover paths that return the shared IR legitimately; weakening them would hide a future regression. Only the two fallback paths — the ones that now carry their own object by design — are changed, and each carries a comment explaining why.

## How it was found

By running the **full core suite** rather than my usual pg-surface + `test:gate`. The curated gate does not include this file, and my live-PG E2E covers the *behaviour* (`source: "default"` for an unregistered builtin — still green) but not the *identity* of the returned object. A behavioural suite cannot see an identity assertion; that gap is exactly what the broader run caught.

Bisected to confirm ownership rather than assumed: `bcc8bf17c1~1` → **14/14**, `bcc8bf17c1` (my branding) → **12/14**.

## Verification

- `workflow-ir-resolver.test.ts` — **14/14**
- full `@fusion/core` suite — **442 files, 4792 passed, 1 skipped, 0 failed**
- `workflow-ir-provenance-live-e2e.pg.test.ts` (#2815's own E2E) — **5/5**, including the unregistered-builtin case
- `pnpm lint` — clean

Test-only change; no production file is touched, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)