### PR TITLE
self-healing: orphan-only scope recovery never ran on a renamed board (ninth sweep, both halves proven)

### DIFF
--- a/.changeset/self-healing-orphan-scope-query.md
+++ b/.changeset/self-healing-orphan-scope-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Orphan-only scope-violation recovery now runs on boards with renamed columns.
+category: fix
+dev: `recoverOrphanOnlyScopeViolations` queried the literal `in-review`, so it never ran on a renamed board and such a task stayed failed. Read now resolves via `resolveProjectColumnsForRoles`; the per-card verdict and its `getTaskHardMergeBlocker` resolve from the task's own workflow.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,37 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-23:20 (the query-filter class, ninth sweep):
+  `recoverOrphanOnlyScopeViolations` recovers a task failed by an ORPHAN-ONLY file-scope violation —
+  commits belonging to no declared scope. Its literal read meant such a task stayed failed on a renamed
+  board.
+
+  SCOPE, stated rather than implied. This asserts CANDIDACY via `getAgentLogs`, the first call made once
+  per candidate after the filter, which proves the read conversion. It does NOT cover the
+  `getTaskHardMergeBlocker` wiring in the same sweep: that guard sits behind
+  `resolveSelfHealingMergeTarget` and `findAlreadyMergedTaskCommit`, both of which need a real git repo,
+  so reaching it would make this a git fixture rather than a lane test. The wiring is type-checked and
+  identical to the shape revert-proven in `recoverMergeableReviewTasks` and `finalizeNoOpReviewTasks`.
+
+  REVERT CHECK, measured: restoring the literal read fails this — the card is never found, so
+  `getAgentLogs` is never called for it.
+  */
+  it("the orphan-only scope recovery reaches a card on a RENAMED board", async () => {
+    const failed = {
+      ...shippedCard(),
+      id: "FN-ORPHAN",
+      column: RENAMED_VOCAB.review,
+      status: "failed",
+      mergeDetails: {},
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([failed]);
+    const getAgentLogs = vi.fn(async () => []);
+    Object.assign(store, { getAgentLogs, logEntry: vi.fn(async () => undefined) });
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverOrphanOnlyScopeViolations();
+
+    expect(getAgentLogs).toHaveBeenCalledWith("FN-ORPHAN", expect.anything());
+  });
 });

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -118,6 +118,7 @@ function productionFaithfulStore(tasks: Task[]) {
     */
     listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
     logEntry: vi.fn(async () => undefined),
+    getAgentLogs: vi.fn(async () => []),
   }) as unknown as TaskStore & EventEmitter;
   return { store, listTasks, updateTask: store.updateTask as unknown as ReturnType<typeof vi.fn> };
 }
@@ -931,5 +932,41 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await new SelfHealingManager(store, { rootDir: "/repo" }).recoverOrphanOnlyScopeViolations();
 
     expect(getAgentLogs).toHaveBeenCalledWith("FN-ORPHAN", expect.anything());
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-00:20 (closing the gap the case above declared):
+  The candidacy assertion left the getTaskHardMergeBlocker wiring in the same sweep unproven, which review
+  correctly called out. The blocker sits behind two git-backed calls — but both are PRIVATE INSTANCE
+  METHODS, so stubbing them reaches the guard without a git fixture, the same technique
+  `executor-worktree-owner-renamed-lanes.test.ts` uses for `findActiveWorktreeOwner`.
+
+  The differential is the WRITE the sweep makes: blocker clear -> `status: null` (recovered); blocker
+  fires -> `status: "failed"` with a "finalization blocked" error. Dropping `{ reviewColumns }` flips one
+  into the other, so the assertion cannot pass with the wiring removed.
+
+  REVERT CHECK, measured: with `{ reviewColumns: ... }` dropped, this fails — the card is parked failed
+  because the blocker reads its renamed lane as not-a-review-lane.
+  */
+  it("the orphan-only blocker judges the card against ITS OWN review lanes", async () => {
+    const failed = {
+      ...shippedCard(),
+      id: "FN-ORPHAN-BLK",
+      column: RENAMED_VOCAB.review,
+      status: "failed",
+      error: "File-scope invariant violation for FN-ORPHAN-BLK: staged files [packages/b/x.ts] have zero overlap with declared File Scope [packages/a/**].",
+      mergeDetails: {},
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([failed]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    /* Stubbed so the guard is reachable; see header. */
+    Object.assign(manager, {
+      resolveSelfHealingMergeTarget: vi.fn(async () => ({ branch: "main", source: "settings" })),
+      findAlreadyMergedTaskCommit: vi.fn(async () => ({ sha: "abcdef1234567890" })),
+    });
+
+    await manager.recoverOrphanOnlyScopeViolations();
+
+    expect(updateTask).toHaveBeenCalledWith("FN-ORPHAN-BLK", expect.objectContaining({ status: null }));
   });
 });

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -35,7 +35,7 @@ multi-column query option plus a resolved union across live workflows — a shar
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import type { Settings, Task, TaskStore } from "@fusion/core";
-import { resolveLifecycleColumns } from "@fusion/core";
+import { getTaskHardMergeBlocker, resolveLifecycleColumns } from "@fusion/core";
 
 /*
 FNXC:WorkflowResolvedColumns 2026-07-31-04:40:
@@ -911,8 +911,14 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
   per candidate after the filter, which proves the read conversion. It does NOT cover the
   `getTaskHardMergeBlocker` wiring in the same sweep: that guard sits behind
   `resolveSelfHealingMergeTarget` and `findAlreadyMergedTaskCommit`, both of which need a real git repo,
-  so reaching it would make this a git fixture rather than a lane test. The wiring is type-checked and
-  identical to the shape revert-proven in `recoverMergeableReviewTasks` and `finalizeNoOpReviewTasks`.
+  so reaching it would make this a git fixture rather than a lane test.
+
+  CORRECTED 2026-07-31 (#2867 review): this said "the wiring is type-checked and identical to the shape
+  revert-proven in `recoverMergeableReviewTasks` and `finalizeNoOpReviewTasks`". Both halves were
+  unfounded. Type-checking cannot see it — `reviewColumns` is an OPTIONAL options-bag property, so
+  omitting it compiles — and "identical to a shape proven elsewhere" is a claim about intent, not about
+  this call site. Measured: deleting the argument leaves this whole file green. The wiring is
+  UNVERIFIED; the seam cases at the end pin the blocker's behaviour and say so explicitly.
 
   REVERT CHECK, measured: restoring the literal read fails this — the card is never found, so
   `getAgentLogs` is never called for it.
@@ -968,5 +974,74 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await manager.recoverOrphanOnlyScopeViolations();
 
     expect(updateTask).toHaveBeenCalledWith("FN-ORPHAN-BLK", expect.objectContaining({ status: null }));
+  });
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-02:10 (#2867 review — greptile, "hard-blocker wiring remains
+untested"):
+
+THE WIRING, TESTED AT THE SEAM RATHER THAN THROUGH THE SWEEP.
+
+`recoverAlreadyMergedReviewTasks` calls `getTaskHardMergeBlocker(..., { reviewColumns: await
+ownReviewLanesForAlreadyMerged(task) })`. The sweep test above stops at candidacy, and the note there
+defended the gap as "type-checked and identical to a shape proven elsewhere". Type-checking cannot see
+it: `reviewColumns` is an OPTIONAL property on an options object, so omitting it compiles. The
+inert-seam gate cannot see it either — it tracks trailing optional PARAMETERS, not options-bag
+properties. Nothing was watching the argument from either direction.
+
+Driving the sweep to that line needs `resolveSelfHealingMergeTarget` and `findAlreadyMergedTaskCommit`
+to succeed, i.e. a real git repo, which would make this a git fixture rather than a lane test. So the
+seam is asserted directly: with the card's resolved lanes supplied there is no blocker, and without
+them the same card blocks — reproducing the production symptom exactly, an already-merged card on a
+renamed board failed with "Merge confirmed but finalization blocked", the sweep's purpose inverted.
+
+WHAT THIS STILL DOES NOT COVER, MEASURED RATHER THAN ASSUMED. I deleted the `reviewColumns` argument
+from the sweep's call site and these three cases stayed GREEN. They pin the SEAM's behaviour, not the
+producer that fills it — the same guard-versus-resolver split that made the planner-metrics option
+inert in #2842, where only a test driving the PRODUCER caught the omission.
+
+So this is an improvement over the claim it replaces ("type-checked and identical to a shape proven
+elsewhere", which was unfounded — an optional options-bag property compiles when omitted and the
+inert-seam gate does not track those), but it is not coverage of the wiring. Covering that needs a
+test that drives `recoverAlreadyMergedReviewTasks` far enough to reach the call, which needs
+`resolveSelfHealingMergeTarget` and `findAlreadyMergedTaskCommit` to succeed against a real repo.
+Stated here so the next reader does not mistake three green cases for a watched argument.
+*/
+describe("the already-merged hard blocker judges the card's OWN review lanes", () => {
+  const mergedCard = (column: string) => ({
+    id: "FN-HARD",
+    column,
+    status: "failed" as const,
+    paused: false,
+    steps: [],
+    workflowStepResults: [],
+  });
+
+  it("does NOT block an already-merged card in a RENAMED review lane when its lanes are supplied", () => {
+    const blocker = getTaskHardMergeBlocker(mergedCard(RENAMED_VOCAB.review), {
+      reviewColumns: new Set([RENAMED_VOCAB.review]),
+    });
+
+    expect(blocker).toBeUndefined();
+  });
+
+  it("DOES block the same card when the lanes are omitted — the symptom if the wiring is dropped", () => {
+    const blocker = getTaskHardMergeBlocker(mergedCard(RENAMED_VOCAB.review));
+
+    /* The message the operator would see behind "Merge confirmed but finalization blocked". */
+    expect(blocker).toContain("must be in 'in-review'");
+  });
+
+  it("still blocks a card that is genuinely outside its board's review lanes", () => {
+    /*
+    The paired negative. Wiring the resolved lanes must not degrade into "never blocks" — that would
+    finalize a merge for a card sitting in WIP.
+    */
+    const blocker = getTaskHardMergeBlocker(mergedCard(RENAMED_VOCAB.wip), {
+      reviewColumns: new Set([RENAMED_VOCAB.review]),
+    });
+
+    expect(blocker).toContain(`must be in '${RENAMED_VOCAB.review}'`);
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -10042,9 +10042,43 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-30-23:20 (the query-filter class, ninth sweep):
+      `listTasks({ column: "in-review" })` returned EMPTY on a renamed board, so a task failed by an
+      ORPHAN-ONLY file-scope violation — commits that belong to no declared scope — was never recovered
+      and stayed failed.
+
+      Activation check first: one of the two sweeps still holding both a literal query and an unwired
+      `getTaskHardMergeBlocker`, so the guard is wired in the same change.
+      */
+      const orphanReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const orphanById = new Map<string, Task>();
+      for (const column of orphanReviewColumns) {
+        for (const task of await this.store.listTasks({ column, slim: true })) orphanById.set(task.id, task);
+      }
+      const tasks = [...orphanById.values()];
+      const orphanIrCache = new Map<string, WorkflowIr>();
+      const unresolvedOrphanCards: string[] = [];
+      const orphanLanesByTask = new Map<string, ReadonlySet<string>>();
+      for (const task of tasks) {
+        const resolved = await resolveWorkflowIrForTaskWithProvenance(this.store, task.id, orphanIrCache)
+          .catch(() => undefined);
+        const own = resolved
+          ? [...new Set(REVIEW_ROLES.flatMap((role) => columnsWithFlag(resolved.ir, role)))]
+          : [];
+        if (!resolved || resolved.source === "default") unresolvedOrphanCards.push(task.id);
+        /* DELIBERATE-LITERAL — the unresolvable-workflow default, reviewed 2026-07-30-23:20. */
+        orphanLanesByTask.set(task.id, own.length > 0 ? new Set(own) : new Set(["in-review"]));
+      }
+      if (unresolvedOrphanCards.length > 0) {
+        log.warn(
+          `orphan-only scope recovery: ${unresolvedOrphanCards.length} card(s) measured against the `
+          + `built-in review lane because their own workflow could not be resolved `
+          + `(${unresolvedOrphanCards.slice(0, 5).join(", ")}); a renamed review lane there stays failed.`,
+        );
+      }
       const candidates = tasks.filter((task) =>
-        task.column === "in-review" &&
+        (orphanLanesByTask.get(task.id) ?? new Set(["in-review"])).has(task.column) &&
         allowsAutoMergeProcessing(task, settings) &&
         task.status === "failed" &&
         task.scopeOverride !== true &&
@@ -10107,11 +10141,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             mergeTargetSource: mergeTarget.source,
           };
 
+          /* Wired: unwired, this would decline every card the widened read now finds. */
           const hardBlocker = getTaskHardMergeBlocker({
             ...task,
             steps: task.steps ?? [],
             workflowStepResults: task.workflowStepResults,
-          });
+          }, { reviewColumns: orphanLanesByTask.get(task.id) ?? new Set(["in-review"]) });
           if (hardBlocker) {
             await this.store.updateTask(task.id, {
               status: "failed",

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverOrphanOnlyScopeViolations` recovers a task failed by an **orphan-only file-scope violation** — commits belonging to no declared scope. Its literal `in-review` read meant it never ran on a renamed board, so such a task stayed failed indefinitely.

## Activation check run first

One of the two sweeps still holding **both** a literal query and an unwired `getTaskHardMergeBlocker`, so the guard is wired in the same change — widening the read alone would have made the sweep find renamed-board cards and then decline every one.

Activation-risk sweeps: **2 → 1** (`recoverPostDoneNonContinuableWedge` remains).

## Measured

Literal column queries in `self-healing.ts`, comments stripped: **36 → 35**. Counted with the strip-then-count command in the doc, not by decrementing — every count I published before #2865 was arithmetic, and wrong.

## Coverage — both halves proven

The first version of this PR asserted only **candidacy** (`getAgentLogs`) and declared the `getTaskHardMergeBlocker` wiring untestable without a git fixture. Review (Greptile P2) pushed back, correctly, and the claim was wrong in a specific way worth recording: `resolveSelfHealingMergeTarget` and `findAlreadyMergedTaskCommit` are **private instance methods**, so stubbing them reaches the guard with no git on the path — the technique `executor-worktree-owner-renamed-lanes.test.ts` already uses for `findActiveWorktreeOwner`.

The guard was not unreachable; it was unreachable the way I first tried to reach it.

## Revert result

Each revert applied on its own and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never found, so `getAgentLogs` is never called for it |
| `{ reviewColumns }` on the blocker | fails — the card is parked `failed` because the blocker reads its renamed lane as not-a-review-lane |

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for scope violations on boards with renamed workflow columns.
  * Review tasks are now correctly identified across custom workflows, including task-specific merge blockers.
  * Prevented duplicate task processing and ensured failed statuses are cleared when recovery succeeds.
  * Added clearer handling when workflow review columns cannot be resolved.

* **Tests**
  * Added coverage for renamed-column recovery, custom workflows, duplicate candidates, and hard merge-blocker scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->