### PR TITLE
self-healing: post-done wedge recovery never ran on a renamed board (tenth sweep — both halves proven)

### DIFF
--- a/.changeset/self-healing-post-done-wedge-query.md
+++ b/.changeset/self-healing-post-done-wedge-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Post-done wedge recovery now unsticks completed tasks on boards with renamed columns.
+category: fix
+dev: `recoverPostDoneNonContinuableWedge` queried the literal `in-review`, so a task that finished every step and was wedged `failed` by a post-done continuation error stayed failed on a renamed board. Read now resolves via `resolveProjectColumnsForRoles`, and its `getTaskHardMergeBlocker` judges each card against its own workflow.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -86,8 +86,10 @@ function productionFaithfulStore(tasks: Task[]) {
     being a ratchet silently.
     */
     listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
+    logEntry: vi.fn(async () => undefined),
+    getAgentLogs: vi.fn(async () => []),
   }) as unknown as TaskStore & EventEmitter;
-  return { store, listTasks };
+  return { store, listTasks, updateTask: store.updateTask as unknown as ReturnType<typeof vi.fn> };
 }
 
 function shippedCard(): Task {
@@ -719,5 +721,63 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await manager.recoverMergedReviewTasks();
 
     expect(resolveTarget).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-23:58 (the query-filter class, tenth sweep):
+  `recoverPostDoneNonContinuableWedge` clears a `failed` status on a task that finished every step and
+  was then wedged only because a post-done session continuation hit a non-continuable error. Its literal
+  read meant a renamed board's card stayed failed forever with all work done.
+
+  THE ONE SWEEP WHERE BOTH HALVES ARE PROVABLE. Its outcome — updateTask clearing `status`/`error` — is
+  downstream of the read AND of the getTaskHardMergeBlocker wired in the same change, and nothing on the
+  path needs git. Contrast the orphan-only sweep, where the blocker sits behind two git calls and only
+  candidacy could be asserted.
+
+  REVERT CHECKS, both measured, each run alone:
+    - literal read restored              -> fails, the card is never listed
+    - `{ reviewColumns: wedgeLanes }` dropped -> fails, the blocker judges the renamed lane as
+      not-a-review-lane and the sweep declines the card it just found
+  */
+  it("clears a post-done wedge on a RENAMED board, and the blocker judges the card's own lanes", async () => {
+    const wedged = {
+      ...shippedCard(),
+      id: "FN-WEDGE",
+      column: RENAMED_VOCAB.review,
+      status: "failed",
+      steps: [{ id: "s1", status: "done" }],
+      log: [
+        { action: "Task marked done by agent", outcome: "" },
+        { action: "", outcome: "cannot continue from message role: assistant" },
+      ],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([wedged]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverPostDoneNonContinuableWedge();
+
+    expect(updateTask).toHaveBeenCalledWith("FN-WEDGE", expect.objectContaining({ status: null, error: null }));
+  });
+
+  it("does not clear a wedge for a card sitting in a lane that is NOT a review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read that returned every column would satisfy the case above.
+    Same renamed board, same wedged card — only its lane changes.
+    */
+    const wedged = {
+      ...shippedCard(),
+      id: "FN-WEDGE-WIP",
+      column: RENAMED_VOCAB.wip,
+      status: "failed",
+      steps: [{ id: "s1", status: "done" }],
+      log: [
+        { action: "Task marked done by agent", outcome: "" },
+        { action: "", outcome: "cannot continue from message role: assistant" },
+      ],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([wedged]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverPostDoneNonContinuableWedge();
+
+    expect(updateTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -10449,11 +10449,37 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     try {
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
-      const tasks = await this.store.listTasks({ column: "in-review", slim: false });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-30-23:55 (the query-filter class, tenth sweep):
+      Read the review lanes this PROJECT declares rather than the literal `in-review`, then decide each
+      card against ITS OWN workflow below. A card wedged `failed` after a post-done continuation error on
+      a renamed board was never listed at all, so it stayed failed with every step done.
+      */
+      const wedgeReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const wedgeById = new Map<string, Task>();
+      for (const column of wedgeReviewColumns) {
+        for (const task of await this.store.listTasks({ column, slim: false })) wedgeById.set(task.id, task);
+      }
+      const tasks = [...wedgeById.values()];
+      /* Per-card review lanes; also fed to the hard-blocker below so it judges the card's own vocabulary. */
+      const wedgeLanesByTask = new Map<string, Set<string>>();
+      const unresolvedWedgeCards: string[] = [];
+      for (const task of tasks) {
+        const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, task.id);
+        if (source === "default") unresolvedWedgeCards.push(task.id);
+        const own = REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)]);
+        wedgeLanesByTask.set(task.id, own.length > 0 ? new Set(own) : new Set(["in-review"]));
+      }
+      if (unresolvedWedgeCards.length > 0) {
+        log.warn(
+          `post-done non-continuable wedge recovery: ${unresolvedWedgeCards.length} card(s) fell back to the built-in workflow (${unresolvedWedgeCards.slice(0, 5).join(", ")})`,
+        );
+      }
       let recovered = 0;
 
       for (const task of tasks) {
-        if (task.column !== "in-review" || task.deletedAt) continue;
+        const wedgeLanes = wedgeLanesByTask.get(task.id) ?? new Set(["in-review"]);
+        if (!wedgeLanes.has(task.column) || task.deletedAt) continue;
         if (!allowsAutoMergeProcessing(task, settings)) continue;
         if (task.paused || task.userPaused) continue;
         if (task.status !== "failed") continue;
@@ -10461,7 +10487,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (!(task.steps ?? []).every((step) => step.status === "done" || step.status === "skipped")) continue;
         const doneMarker = [...(task.log ?? [])].reverse().find((entry) => entry.action === "Task marked done by agent");
         if (!doneMarker) continue;
-        if (getTaskHardMergeBlocker({ ...task, status: undefined, error: undefined, steps: task.steps ?? [], workflowStepResults: task.workflowStepResults })) continue;
+        /* Wired in the SAME change as the read: widening the query without this makes the sweep find renamed-board cards and decline every one. */
+        if (getTaskHardMergeBlocker({ ...task, status: undefined, error: undefined, steps: task.steps ?? [], workflowStepResults: task.workflowStepResults }, { reviewColumns: wedgeLanes })) continue;
 
         const evidence = this.getPostDoneNonContinuableEvidence(task);
         if (!evidence) continue;

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -10455,6 +10455,25 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       card against ITS OWN workflow below. A card wedged `failed` after a post-done continuation error on
       a renamed board was never listed at all, so it stayed failed with every step done.
       */
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-00:45 (#2869 review — greptile, "traitless review lanes
+      remain invisible"): CONFIRMED, DEFERRED, SAME CLASS AS #2876.
+
+      A board that renames its review lane but declares NO lifecycle traits contributes nothing to this
+      union, so the card is not in `wedgeById` and the per-card fallback below — including its
+      `new Set(["in-review"])` degraded answer — never runs for it. The fallback cannot rescue a card
+      the query never returned.
+
+      The three-state rule at PROJECT scope. Not fixed here because the safe direction differs by
+      caller: over-inclusion is free for a sweep (the per-card check discards it) and inflates an
+      operator-facing number in the analytics aggregators, so it needs an opt-in
+      (`{ untraitedProject: "declared-columns" }`) on the shared helper rather than a change to what it
+      returns by default.
+
+      Fixture note: hand-authored V2 without traits, NOT a v1 upgrade — `synthesizeDefaultColumns`
+      emits the default ids, so a v1-shaped fixture cannot express a renamed lane and would pass
+      vacuously.
+      */
       const wedgeReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
       const wedgeById = new Map<string, Task>();
       for (const column of wedgeReviewColumns) {

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 86,
     "packages/engine/src/scheduler.ts": 12,
     "packages/core/src/task-store/async-comments-attachments.ts": 9,
     "packages/engine/src/executor.ts": 8,
@@ -129,7 +129,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 34,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverPostDoneNonContinuableWedge` clears a `failed` status on a task that finished **every step** and was wedged only because a post-done session continuation hit a non-continuable error (`cannot continue from message role: assistant`, or a Codex transcript desync). Its literal `in-review` read meant a renamed board's card stayed failed forever with all the work done.

This is the last sweep holding **both** a literal query and an unwired `getTaskHardMergeBlocker`. Activation-risk sweeps: **1 → 0**.

## First sweep where both halves are revert-proven

The nine before it could only prove the read: their outcomes sat behind git calls, so a lane test that reached the blocker would have become a git fixture. This one's outcome — `updateTask` clearing `status`/`error` — is downstream of the read *and* of the blocker, with no git anywhere on the path.

| conversion | reverted alone → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| `{ reviewColumns: wedgeLanes }` on the blocker | fails — the blocker judges the renamed lane as not-a-review-lane and declines the card the widened read just found |

Both measured by applying each revert on its own and running the file, not inferred.

A non-vacuous companion case is included: the same wedged card on the same renamed board, sitting in the **wip** lane, must not be recovered. Without it, a read that returned every column would satisfy the positive case.

## Fixture note worth keeping

The first version of this test failed for a reason that had nothing to do with lanes: my error string was invented prose, and `isNonContinuableSessionError` matches a specific signature. A fixture that misses a *later* filter fails loudly here — but the same mistake in a test asserting `not.toHaveBeenCalled()` would have passed for the wrong reason. That is the shape of four of the five vacuous assertions this branch has already produced.

## Measured

Literal column queries in `self-healing.ts` against main, comments stripped: **36 → 35**. #2867 also takes 36 → 35 from main; they touch different sweeps and stack to 34 once both land.

## Deliberately unchanged

The audit metadata `source: "self-healing-in-review-sweep"` still names the legacy id. It is a stable discriminator consumers may match on, so renaming it is a behavior change, not a conversion.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.