### PR TITLE
docs(lanes): audit the three files the census points at with no reason attached

### DIFF
--- a/packages/core/src/async-mission-store-queries.ts
+++ b/packages/core/src/async-mission-store-queries.ts
@@ -2202,6 +2202,22 @@ export async function getTerminalTaskEvidence(handle: QueryHandle, taskId: strin
   const task = taskRows[0];
   const hasArchiveSnapshot = archiveRows.length > 0;
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-21:50 (audited — REAL, deferred with the cost stated):
+  On a renamed board a genuinely completed task is classified `nonterminal`.
+
+  `task.column === "done"` is the only test for the `done` verdict, so a card in a complete lane
+  called anything else falls through every branch to `{ kind: "nonterminal" }`. The caller is mission
+  TERMINAL EVIDENCE repair, so a finished feature reads as unfinished — a wrong verdict rather than an
+  error, which is the shape this program keeps finding. The `archived` test below is the same defect;
+  its `deletedAt` companion masks it for soft-deleted rows, which is why only the `done` half bites in
+  practice.
+
+  Not converted here because `getTerminalTaskEvidence` takes a bare `QueryHandle`: no store, no task
+  object, no workflow, nothing to resolve a lane vocabulary from. The fix is a resolved terminal-lane
+  set threaded in by the caller — the same shape `getLiveTaskColumn` needs, and it should land with
+  it so the two cannot disagree about what "finished" means.
+  */
   if (!task) return hasArchiveSnapshot ? { kind: "invalid-deleted", id: taskId } : { kind: "missing" };
   if (task.deletedAt === null && task.column === "done") return { kind: "done", id: task.id, column: "done" };
   if (task.deletedAt !== null && task.column === "archived" && hasArchiveSnapshot) {

--- a/packages/core/src/task-store/audit-ops.ts
+++ b/packages/core/src/task-store/audit-ops.ts
@@ -124,6 +124,20 @@ export async function logEntryImpl(store: TaskStore, id: string, action: string,
         {
           const layer = store.asyncLayer!;
           const state = await getLiveTaskColumn(layer.db, id, layer.projectId);
+          /*
+          FNXC:WorkflowLifecycleColumns 2026-07-30-21:20 (audited — SENTINEL, do NOT convert):
+          `getLiveTaskColumn` MANUFACTURES the string "archived" for an archived-or-soft-deleted
+          parent; it does not return the board's archived lane. So this compares against that
+          function's return vocabulary, not against a column id, and converting it to
+          `isArchivedColumnRole` would keep passing on the built-in board and start FAILING on a
+          renamed one — a soft-deleted task's log would become writable.
+
+          The convertible site is `getLiveTaskColumn`'s own `row.column === "archived"` test, and it
+          is deferred with its cost stated: that helper takes a `db` handle with no task, no workflow
+          and no lane vocabulary, so resolving there threads a lane set through a low-level query on a
+          hot path. See docs/solutions/architecture-patterns/
+          the-archived-literal-is-usually-a-sentinel-not-a-column.md.
+          */
           if (state === "archived") throw new Error(`Task ${id} is archived — logging is read-only`);
           if (state === null) throw new Error(`Task ${id} not found`);
         }
@@ -173,6 +187,18 @@ export async function logEntryImpl(store: TaskStore, id: string, action: string,
       if (!pgRow) {
         throw new Error(`Task ${id} not found`);
       }
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-07-30-21:20 (audited — REAL, deferred with the cost stated):
+      Unlike the sentinel above, this reads the task ROW, so `pgRow.column` is a real board lane and a
+      renamed archived column is not recognised — a card the board shows as archived keeps accepting
+      log writes. `deletedAt` covers the soft-delete half, which is why the gap is narrow rather than
+      absent, and why it has stayed invisible: the common path is soft-delete.
+
+      Not converted here because the fix is the same one `getLiveTaskColumn` needs — a resolved
+      archived-lane set threaded into a low-level, project-scoped read — and doing it in one of the
+      two places would leave the pair disagreeing about what "archived" means. Recorded so the census
+      keeps pointing at it with the reason attached.
+      */
       if (pgRow.column === "archived" || pgRow.deletedAt != null) {
         throw new Error(`Task ${id} is archived — logging is read-only`);
       }

--- a/packages/core/src/task-store/audit-ops.ts
+++ b/packages/core/src/task-store/audit-ops.ts
@@ -135,8 +135,8 @@ export async function logEntryImpl(store: TaskStore, id: string, action: string,
           The convertible site is `getLiveTaskColumn`'s own `row.column === "archived"` test, and it
           is deferred with its cost stated: that helper takes a `db` handle with no task, no workflow
           and no lane vocabulary, so resolving there threads a lane set through a low-level query on a
-          hot path. See docs/solutions/architecture-patterns/
-          the-archived-literal-is-usually-a-sentinel-not-a-column.md.
+          hot path. The same distinction governs the eight downstream comparisons in
+          `async-comments-attachments.ts`, which are sentinels for the same reason.
           */
           if (state === "archived") throw new Error(`Task ${id} is archived — logging is read-only`);
           if (state === null) throw new Error(`Task ${id} not found`);

--- a/packages/engine/src/planner-overseer.ts
+++ b/packages/engine/src/planner-overseer.ts
@@ -110,6 +110,31 @@ export function resolveWatchedStage(task: Partial<OverseerTaskRef> | null | unde
       }
     }
 
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-30-21:35 (audited — REAL and HIGH IMPACT, deferred):
+    On a renamed board this returns `null` for every card, so the planner overseer watches NOTHING.
+
+    Worth stating at full weight because the blast radius is larger than the three literals suggest:
+    `observeTask` returns early on a null stage, so no observation is recorded, no
+    `overseer:intervention` entry is emitted, and `PlannerRecoveryController` — which consumes those
+    observations — has nothing to steer, retry or targeted-fix. The entire oversight loop is inert and
+    silent about it, exactly like the self-healing sweeps whose queries returned empty arrays.
+
+    NOT MECHANICAL, which is why it is flagged rather than converted. `resolveWatchedStage` is a pure
+    sync function over a `Partial<OverseerTaskRef>` with no store and no task id it can resolve from,
+    so the lane answer has to arrive as a parameter. Its only production caller, `observeTask`, IS
+    async and the monitor does hold a store — but `observeTask` is called once per task per poll from
+    `project-engine.ts`, so resolving inside it buys a workflow read per card per poll on a timer.
+
+    The shape that works is the one the board-load enrichment ended up with (#2845): resolve at the
+    POLL, once, with an IR cache keyed by workflow, and pass the flags down. That is a change to
+    `project-engine.ts`'s poll as much as to this file, and it is a cost judgement about a periodic
+    engine loop rather than a rename — the same call `notification-service.ts` documents for its own
+    two sites.
+
+    Left counted with no exemption marker so the census keeps pointing here. `columnFlags` is in the
+    unwired-lane-parameter vocabulary, so whoever adds the parameter cannot leave it unwired.
+    */
     const column = task.column;
     if (column !== "in-progress" && column !== "in-review") {
       return null;


### PR DESCRIPTION
**No source change.** Every literal stays counted and none gets an exemption marker. What changes is that the census now points at these three with the analysis attached, instead of making each worker who reaches them re-derive it.

Peers have already done this well for `notification-service.ts` — converted it, *measured* a real delivery regression, reverted, and left it counted with the reason. These three had nothing at all, and one of them is the highest-impact unowned site I found.

## `planner-overseer.ts` (3 guards) — REAL, and larger than three literals suggest

On a renamed board `resolveWatchedStage` returns `null` for every card. `observeTask` returns early on a null stage, so **no observation is recorded**, no `overseer:intervention` entry is emitted, and `PlannerRecoveryController` — which consumes those observations — has nothing to steer, retry, or targeted-fix. **The entire oversight loop is inert and silent about it**, exactly like the self-healing sweeps whose queries returned empty arrays.

Not mechanical, which is why it is flagged rather than converted. `resolveWatchedStage` is a pure sync function over a `Partial<OverseerTaskRef>` with no store and no task id, so the lane answer has to arrive as a parameter. Its only production caller, `observeTask`, *is* async and the monitor *does* hold a store — but it runs **once per task per poll**, so resolving inside it buys a workflow read per card on a timer.

The shape that works is the one the board-load enrichment landed on in #2845: resolve at the **poll**, once, with an IR cache keyed by workflow, and pass the flags down. That makes it a change to `project-engine.ts`'s poll as much as to this file — a cost judgement about a periodic engine loop, not a rename. `columnFlags` is in the unwired-lane-parameter vocabulary, so whoever adds the parameter cannot leave it unwired.

## `async-mission-store-queries.ts` (1 of 3) — REAL

`getTerminalTaskEvidence` tests only `column === "done"` for its `done` verdict, so a completed card on a renamed board falls through every branch to `{ kind: "nonterminal" }`. The caller is mission **terminal evidence repair**, so a finished feature reads as unfinished — a wrong *verdict*, not an error. The `archived` test beside it has the same defect, masked for soft-deleted rows by its `deletedAt` companion, which is why only the `done` half bites in practice.

Takes a bare `QueryHandle`: no store, no task object, no workflow. The fix is a resolved terminal-lane set threaded in by the caller — the same shape `getLiveTaskColumn` needs, and it should land *with* it so the two cannot disagree about what "finished" means.

## `audit-ops.ts` (2) — one sentinel, one real, and they look identical

```ts
if (state === "archived")           // ← getLiveTaskColumn's MANUFACTURED value: do NOT convert
if (pgRow.column === "archived")    // ← a real board lane: convertible
```

The first compares against a string `getLiveTaskColumn` *fabricates* for an archived-or-soft-deleted parent, so converting it to `isArchivedColumnRole` would keep passing on the built-in board and start **failing** on a renamed one — a soft-deleted task's log would become writable. The second reads the task row, so a renamed archived column keeps accepting log writes; its `deletedAt` companion masks that in practice.

Two lines that look the same and need opposite treatment is precisely the reason these notes are worth more than the count.

## Verification

- `pnpm test:gate` — 161 / 487 / 13 / 71 passed
- `pnpm lint` — clean
- `tsc --noEmit` (`@fusion/core`, `@fusion/engine`) — clean
- `planner-overseer.test.ts` — 50 passed
- census `--strict` — exit 0, **counts unchanged** (that is the point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)