### PR TITLE
self-healing: stale blockedBy never cleared on a renamed board (eleventh sweep)

### DIFF
--- a/.changeset/self-healing-stale-blockedby-query.md
+++ b/.changeset/self-healing-stale-blockedby-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Stale dependency blocks now clear on boards with renamed columns.
+category: fix
+dev: `clearStaleBlockedBy` read the literal `todo`/`in-progress`/`in-review`, so its already-lane-resolved body never ran on a renamed board and cards stayed blocked behind finished blockers. The three reads now resolve via `resolveProjectColumnsForRoles` and each card is bucketed against its own workflow.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -86,8 +86,10 @@ function productionFaithfulStore(tasks: Task[]) {
     being a ratchet silently.
     */
     listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
+    logEntry: vi.fn(async () => undefined),
+    parseFileScopeFromPrompt: vi.fn(async () => []),
   }) as unknown as TaskStore & EventEmitter;
-  return { store, listTasks };
+  return { store, listTasks, updateTask: store.updateTask as unknown as ReturnType<typeof vi.fn> };
 }
 
 function shippedCard(): Task {
@@ -719,5 +721,56 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await manager.recoverMergedReviewTasks();
 
     expect(resolveTarget).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-00:50 (the query-filter class, eleventh sweep):
+  `clearStaleBlockedBy` is the sweep that unsticks a card still pointing at a blocker that has since
+  finished. Its BODY was already lane-resolved — per-referenced-task lanes, a shared IR cache, legacy ids
+  unioned, all of it — and none of that ran, because the three reads above it asked for the literal
+  `todo`/`in-progress`/`in-review`. A textbook case of the class this file exists for: the expensive half
+  was converted and delivered nothing while the cheap half above it stayed literal.
+
+  Three reads, not one union: the buckets are treated DIFFERENTLY downstream (hold cards seed the
+  queued-dependency pass; review cards are exempted when paused), so each card is classified against its
+  own workflow after the union read.
+
+  REVERT CHECK, measured: with the three literal reads restored, this fails — the blocked card is never
+  listed, so its stale `blockedBy` is never cleared.
+  */
+  it("clears a stale blockedBy on a RENAMED board once the blocker has landed", async () => {
+    const blocker = { ...shippedCard(), id: "FN-BLOCKER", column: RENAMED_VOCAB.complete } as Task;
+    const blocked = {
+      ...shippedCard(),
+      id: "FN-STUCK",
+      column: RENAMED_VOCAB.wip,
+      blockedBy: "FN-BLOCKER",
+      dependencies: [],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([blocker, blocked]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).clearStaleBlockedBy();
+
+    expect(updateTask).toHaveBeenCalledWith("FN-STUCK", expect.objectContaining({ blockedBy: null }));
+  });
+
+  it("leaves blockedBy alone while the blocker is still in flight on a RENAMED board", async () => {
+    /*
+    Non-vacuous companion: without it, a sweep that cleared every blockedBy it found would satisfy the
+    case above. Same board, same pair — only the blocker's lane changes.
+    */
+    const blocker = { ...shippedCard(), id: "FN-BLOCKER", column: RENAMED_VOCAB.wip } as Task;
+    const blocked = {
+      ...shippedCard(),
+      id: "FN-STUCK",
+      column: RENAMED_VOCAB.wip,
+      blockedBy: "FN-BLOCKER",
+      dependencies: [],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([blocker, blocked]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).clearStaleBlockedBy();
+
+    expect(updateTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -5444,6 +5444,30 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       workflow. On a renamed board all three reads returned empty, so no stale `blockedBy` was ever cleared
       and the cards stayed blocked behind dependencies that had long since finished.
       */
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-00:30 (#2876 review — greptile, "traitless workflow
+      columns stay invisible"): CONFIRMED, DEFERRED, AND THE REASON IS THAT IT IS NOT LOCAL.
+
+      `resolveProjectColumnsForRoles` returns its legacy floor plus what workflows DECLARE for the
+      role. A board that renames its lanes but declares no lifecycle traits contributes nothing, so
+      the card never enters `blockedCandidates` and the per-card classification below — which is
+      correct — never runs for it. Invisible before the guard is reached.
+
+      This is the three-state rule at PROJECT scope: unreadable and untraited take the legacy answer,
+      and only a board that EXPRESSES traits and still lacks the role is answering. The merge queue
+      got the per-task version of this in #2819.
+
+      NOT FIXED HERE BECAUSE A BLANKET FIX WOULD BE WRONG. The safe direction differs by caller: for
+      a sweep, over-inclusion costs extra `listTasks` calls the per-card check discards; for the
+      analytics aggregators (#2864, #2866) the same widening inflates a number an operator reads. It
+      needs an opt-in — `resolveProjectColumnsForRoles(store, roles, { untraitedProject:
+      "declared-columns" })` defaulting to today's behaviour — which is a shared-helper contract
+      change touching every sweep, both aggregators and the glasses notifier.
+
+      Premise correction for whoever writes the fixture: this is a hand-authored V2 board, not a v1
+      upgrade. `synthesizeDefaultColumns` emits the DEFAULT ids with `traits: []`, so a v1-upgraded
+      board cannot have a renamed lane — a v1-shaped fixture would pass vacuously.
+      */
       /* `hold` only, NOT `intake`: the original read asked for `todo`. Adding intake would newly scan `triage` cards — a behavior change riding along in a conversion. */
       const blockedHoldColumns = await resolveProjectColumnsForRoles(this.store, ["hold"]);
       const blockedWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -31,6 +31,7 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+  LEGACY_COLUMN_IDS_BY_ROLE,
   resolveProjectColumnsForRoles,
   REVIEW_ROLES,
 } from "@fusion/core";
@@ -5435,9 +5436,51 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const executingTaskIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const now = Date.now();
 
-      const todoTasks = await this.store.listTasks({ column: "todo" });
-      const inProgressTasks = await this.store.listTasks({ column: "in-progress" });
-      const inReviewTasks = await this.store.listTasks({ column: "in-review" });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-00:45 (the query-filter class, eleventh sweep):
+      THREE lane reads whose downstream treatment DIFFERS — hold cards seed the queued-dependency pass,
+      review cards are exempted when paused — so this cannot collapse into one union. Read the project's
+      columns for all three role groups, dedupe into one map, then classify each card against ITS OWN
+      workflow. On a renamed board all three reads returned empty, so no stale `blockedBy` was ever cleared
+      and the cards stayed blocked behind dependencies that had long since finished.
+      */
+      /* `hold` only, NOT `intake`: the original read asked for `todo`. Adding intake would newly scan `triage` cards — a behavior change riding along in a conversion. */
+      const blockedHoldColumns = await resolveProjectColumnsForRoles(this.store, ["hold"]);
+      const blockedWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const blockedReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const blockedCandidates = new Map<string, Task>();
+      for (const column of new Set([...blockedHoldColumns, ...blockedWipColumns, ...blockedReviewColumns])) {
+        for (const task of await this.store.listTasks({ column })) blockedCandidates.set(task.id, task);
+      }
+      /* Per-card classification: a card the union pulled in must land in the bucket ITS workflow says. */
+      const todoTasks: Task[] = [];
+      const inProgressTasks: Task[] = [];
+      const inReviewTasks: Task[] = [];
+      const unresolvedBlockedCards: string[] = [];
+      for (const task of blockedCandidates.values()) {
+        const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, task.id);
+        if (source === "default") unresolvedBlockedCards.push(task.id);
+        /*
+        Legacy ids UNIONED into each bucket rather than compared separately: `resolveWorkflowIrForTask`
+        returns the BUILT-IN IR for a missing or corrupt workflow, and a board mid-rename still has rows
+        under the old id. This mirrors `lanesOf` below, which unions the same way for referenced tasks.
+        */
+        const bucket = (roles: readonly string[], legacy: readonly string[]): boolean => {
+          const lanes = new Set<string>(legacy);
+          for (const role of roles) {
+            for (const id of columnsWithFlag(ir, role as Parameters<typeof columnsWithFlag>[1])) lanes.add(id);
+          }
+          return lanes.has(task.column);
+        };
+        if (bucket(["hold"], LEGACY_COLUMN_IDS_BY_ROLE.hold ?? [])) todoTasks.push(task);
+        if (bucket(["countsTowardWip"], LEGACY_COLUMN_IDS_BY_ROLE.countsTowardWip ?? [])) inProgressTasks.push(task);
+        if (bucket(REVIEW_ROLES, LEGACY_COLUMN_IDS_BY_ROLE.mergeOrchestration ?? [])) inReviewTasks.push(task);
+      }
+      if (unresolvedBlockedCards.length > 0) {
+        log.warn(
+          `stale blockedBy cleanup: ${unresolvedBlockedCards.length} card(s) classified against the built-in workflow (${unresolvedBlockedCards.slice(0, 5).join(", ")})`,
+        );
+      }
       const blockedTasks = [
         ...todoTasks,
         ...inProgressTasks,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -129,7 +129,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 32,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`clearStaleBlockedBy` unsticks a card still pointing at a blocker that has since finished. Its **body was already fully lane-resolved** — per-referenced-task lanes, a shared IR cache, legacy ids unioned, the lot — and none of it ran, because the three reads above it asked for the literal `todo`/`in-progress`/`in-review`.

This is the clearest instance yet of what the query-filter class costs: the expensive half was converted, the census count went down, and an operator saw no change, because the cheap half above it stayed literal. The card sat blocked behind a dependency that finished days earlier.

## Three reads, not one union

The buckets are treated **differently** downstream — hold cards seed the queued-dependency pass, review cards are exempted when paused — so this cannot collapse into a single union read. The union read is followed by a per-card classification against each card's own workflow.

## Scope held deliberately

The hold read resolves role **`hold` only, not `intake`**. The original asked for `todo`; adding `intake` would newly scan `triage` cards, which is a behavior change riding along inside a conversion.

## The census caught my first draft

I wrote the legacy fallbacks as `|| task.column === "todo"` and the census scored **three new column guards** for it (89 → 92). It was right to: those are exactly the comparisons this program exists to remove. Rewritten to union the legacy ids into each bucket, mirroring the `lanesOf` helper twenty lines below that already did it that way.

**Measured:** `self-healing.ts` census allowance **37 → 34**; baseline rewritten downward and committed.

## Revert result

| conversion | reverted → |
| --- | --- |
| the three resolved reads | fails — the blocked card is never listed, so its stale `blockedBy` is never cleared |

A non-vacuous companion is included: same board, same pair, blocker still in the wip lane → nothing is cleared. Without it, a sweep that cleared every `blockedBy` it found would satisfy the positive case.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.