### PR TITLE
self-healing: self-owned branch conflicts never reclaimed on a renamed board (twelfth sweep)

### DIFF
--- a/.changeset/self-healing-reclaim-self-owned-query.md
+++ b/.changeset/self-healing-reclaim-self-owned-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Self-owned branch conflicts are now reclaimed on boards with renamed columns.
+category: fix
+dev: `reclaimSelfOwnedBranchConflicts` read the literal `todo`/`in-progress`/`in-review` and kept three lane guards on column ids, so a task whose own worktree held its own branch stayed wedged on a renamed board. Reads resolve via `resolveProjectColumnsForRoles` and the three guards resolve per card; the `recoveryRehome` re-home keeps its legacy target by design.

--- a/packages/engine/src/__tests__/self-healing-converted-sweeps-have-no-literal-lane-guards.test.ts
+++ b/packages/engine/src/__tests__/self-healing-converted-sweeps-have-no-literal-lane-guards.test.ts
@@ -1,0 +1,146 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-11:55 (the missed-pair ratchet):
+A sweep whose READ was converted to resolved lanes but whose LOOP-BODY guards still compare column ids
+is worse than one converted nowhere. The widened read admits renamed-board cards, and every literal
+guard below it then mis-classifies exactly those cards.
+
+This is not hypothetical and it is not rare. #2916 found a second lane guard on a re-read row that the
+behavioural test caught; a scan of the other converted sweeps then found FIVE more in
+`reclaimSelfOwnedBranchConflicts`, and one of them decides whether a backward move needs its
+triple-proof — so left literal it would have moved a renamed review card back with the safety gate
+silently skipped, a regression INTRODUCED by the conversion.
+
+WHY A SOURCE SCAN AND NOT A BEHAVIOURAL TEST. Those five sit behind `inspectBranchConflict` and a real
+`execAsync`, so reaching them means a git fixture rather than a lane test. This asserts the property the
+scan found — no literal lane comparison survives inside a converted sweep — which is exactly the defect
+class, and nothing more. It makes no claim about behaviour, and the behavioural cases for each sweep
+live in `self-healing-query-filter-blindness.test.ts`.
+
+REVERT CHECK, measured: restoring any one of the five (e.g. `if (task.column === "in-review") {` inside
+`reclaimSelfOwnedBranchConflicts`) fails this test naming that sweep and that literal.
+*/
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SOURCE = fileURLToPath(new URL("../self-healing.ts", import.meta.url));
+
+/*
+The list is DERIVED, not written down: a sweep counts as converted when its own body calls
+`resolveProjectColumnsForRoles`. Written down, this test would be wrong on every branch that converts a
+different sweep, and stale the moment one lands — the maintenance burden is what turns a ratchet off.
+*/
+const LIFECYCLE_IDS = ["todo", "in-progress", "in-review", "done", "archived", "triage"];
+
+/**
+ * Strips comments before scanning.
+ *
+ * Load-bearing: these files carry long FNXC notes that QUOTE the old form to explain why it was
+ * removed, and an earlier version of this scan reported those as live code. A ratchet that fires on
+ * its own documentation gets disabled, not fixed.
+ */
+function stripComments(source: string): string[] {
+  const out: string[] = [];
+  let inBlock = false;
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (inBlock) {
+      out.push("");
+      if (line.includes("*/")) inBlock = false;
+      continue;
+    }
+    if (trimmed.startsWith("/*")) {
+      out.push("");
+      if (!line.includes("*/")) inBlock = true;
+      continue;
+    }
+    if (trimmed.startsWith("//")) { out.push(""); continue; }
+    out.push(line);
+  }
+  return out;
+}
+
+/** The method each line belongs to, by nearest preceding 2-space-indented declaration. */
+function owningMethod(lines: string[], index: number): string | null {
+  for (let i = index; i >= 0; i--) {
+    const match = /^ {2}(?:private |public )?(?:async )?([a-zA-Z][A-Za-z0-9_]*)\s*[(<]/.exec(lines[i]!);
+    if (match) return match[1]!;
+  }
+  return null;
+}
+
+/*
+A literal on the FALLBACK arm of a resolved ternary is the correct shape, not a missed pair:
+
+  own.length > 0 ? own.includes(task.column) : task.column === "in-review"
+
+The resolved answer wins whenever it exists; the literal answers only when resolution yielded nothing,
+and deleting it would make an unresolvable workflow match no lane at all. Three such lines
+(`reconcileDoneTaskIntegrity`, `recoverInterruptedMergingTasks`, `recoverStuckMergeDeadlocks`) are why
+this exclusion exists — the first version of this ratchet reported all three as defects.
+
+Deliberately narrow: it only excuses a literal that shares its line with a RESOLVED membership test. A
+bare `task.column === "in-review"` on its own line is still an offender, which is the case that matters.
+*/
+function isResolvedFallbackArm(line: string): boolean {
+  return /(?:\.includes|\.has)\(\s*(?:task|t|entry|dep)\.column\s*\)/.test(line);
+}
+
+/** Every method whose body resolves project lanes — i.e. whose READ has been converted. */
+function convertedSweeps(lines: string[]): string[] {
+  const found = new Set<string>();
+  lines.forEach((line, index) => {
+    if (!line.includes("resolveProjectColumnsForRoles(")) return;
+    const owner = owningMethod(lines, index);
+    if (owner) found.add(owner);
+  });
+  return [...found].sort();
+}
+
+/*
+Documented exceptions, each with the reason recorded at the site too. An entry here is a claim that the
+degraded answer is harmless — not that the literal is invisible.
+*/
+const ALLOWED: ReadonlyArray<{ sweep: string; because: string }> = [
+  {
+    sweep: "clearStaleBlockedBy",
+    because: "one literal in a log-dedup closure defined before the lane prefetch; the degraded answer costs a duplicate log line, not a lifecycle decision",
+  },
+];
+
+describe("a converted sweep keeps no literal lane comparison in its body", () => {
+  const lines = stripComments(readFileSync(SOURCE, "utf8"));
+  const pattern = new RegExp(`\\.column\\s*(?:!==|===)\\s*"(${LIFECYCLE_IDS.join("|")})"`);
+
+  for (const sweep of convertedSweeps(lines)) {
+    it(`${sweep} compares no column id`, () => {
+      const allowance = ALLOWED.find((entry) => entry.sweep === sweep);
+      const offenders: string[] = [];
+      lines.forEach((line, index) => {
+        if (!pattern.test(line)) return;
+        if (isResolvedFallbackArm(line)) return;
+        if (owningMethod(lines, index) !== sweep) return;
+        offenders.push(`${SOURCE.split("/").pop()}:${index + 1} — ${line.trim()}`);
+      });
+      /* An allowed sweep keeps AT MOST its documented one; a second is still a failure. */
+      if (allowance) {
+        expect(offenders.length, `${sweep} is allowed one documented literal (${allowance.because}) but has ${offenders.length}:\n${offenders.join("\n")}`).toBeLessThanOrEqual(1);
+        return;
+      }
+
+      expect(offenders, `${sweep} still compares a lifecycle column id:\n${offenders.join("\n")}`).toEqual([]);
+    });
+  }
+
+  it("the scan can actually see a literal, and finds converted sweeps at all", () => {
+    /*
+    Two positive controls, because both halves can fail silently. A broken regex makes every case above
+    pass by finding no offenders; a broken `convertedSweeps` makes them pass by iterating nothing at all
+    — and an empty `for` loop registers no tests, which reads as green.
+    */
+    const anyLiteralAnywhere = lines.some((line) => pattern.test(line));
+    expect(anyLiteralAnywhere, "the literal scan matched nothing — the regex is broken").toBe(true);
+
+    expect(convertedSweeps(lines).length, "no converted sweep found — the derivation is broken").toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -770,4 +770,79 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-01:35 (the query-filter class, twelfth sweep):
+  `reclaimSelfOwnedBranchConflicts` frees a task whose OWN worktree is holding its OWN branch hostage —
+  a conflict no other sweep resolves. Three literal reads plus three lane guards in the body, so both
+  halves convert together: widening the read alone would admit renamed-board cards and then mis-decide
+  every one, since the phantom-binding check, the blocked-hold skip and the review triple-proof are each
+  keyed on lane.
+
+  ONE ASSERTION COVERS BOTH HALVES. `isPhantomExecutorBinding` runs only for a card that (a) the read
+  found and (b) the wip-lane guard accepted. Two private seams are stubbed to reach it —
+  `getFalsePositiveRequeueSignal` for the live-execution signal, and the binding check itself — which is
+  the same technique used above for the orphan sweep, and avoids a git/fs fixture entirely.
+
+  REVERT CHECKS, both measured, each run alone:
+    - literal reads restored          -> fails, the card is never listed
+    - guard back to `task.column === "in-progress"` -> fails, the renamed wip lane does not match, so the
+      sweep falls through to the no-action path
+  */
+  it("reclaims a self-owned branch conflict on a RENAMED wip lane, guard included", async () => {
+    const stuck = {
+      ...shippedCard(),
+      id: "FN-SELFCONFLICT",
+      column: RENAMED_VOCAB.wip,
+      branch: "fusion/FN-SELFCONFLICT",
+      worktree: "/tmp/worktrees/FN-SELFCONFLICT",
+      executionStartedAt: "2026-07-30T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([stuck]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const isPhantomExecutorBinding = vi.fn(() => null);
+    Object.assign(manager, {
+      getFalsePositiveRequeueSignal: vi.fn(() => ({ reason: "executor-active", metadata: {} })),
+      getRecentRunAuditActivityAgeMs: vi.fn(async () => 0),
+      isPhantomExecutorBinding,
+      emitFalsePositiveRequeueNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.reclaimSelfOwnedBranchConflicts();
+
+    expect(isPhantomExecutorBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "FN-SELFCONFLICT" }),
+      expect.anything(),
+    );
+  });
+
+  it("does not evaluate a phantom binding for a card sitting in the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a guard matching every column would satisfy the case above. Same
+    board, same card, same stubs — only its lane changes, and the review lane must not take the wip path.
+    */
+    const stuck = {
+      ...shippedCard(),
+      id: "FN-SELFCONFLICT",
+      column: RENAMED_VOCAB.review,
+      paused: true,
+      pausedReason: "branch-conflict-unrecoverable",
+      branch: "fusion/FN-SELFCONFLICT",
+      worktree: "/tmp/worktrees/FN-SELFCONFLICT",
+      executionStartedAt: "2026-07-30T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([stuck]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const isPhantomExecutorBinding = vi.fn(() => null);
+    Object.assign(manager, {
+      getFalsePositiveRequeueSignal: vi.fn(() => ({ reason: "executor-active", metadata: {} })),
+      getRecentRunAuditActivityAgeMs: vi.fn(async () => 0),
+      isPhantomExecutorBinding,
+      emitFalsePositiveRequeueNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.reclaimSelfOwnedBranchConflicts();
+
+    expect(isPhantomExecutorBinding).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -800,7 +800,8 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     } as unknown as Task;
     const { store } = productionFaithfulStore([stuck]);
     const manager = new SelfHealingManager(store, { rootDir: "/repo" });
-    const isPhantomExecutorBinding = vi.fn(() => null);
+    /* Returns the real shape, not null: the sweep reads `.phantom` straight off it, so a null stub throws and aborts the loop after ONE card — which silently capped the multi-role count at 1 in both states. */
+    const isPhantomExecutorBinding = vi.fn(() => ({ phantom: false, metadata: {} }));
     Object.assign(manager, {
       getFalsePositiveRequeueSignal: vi.fn(() => ({ reason: "executor-active", metadata: {} })),
       getRecentRunAuditActivityAgeMs: vi.fn(async () => 0),
@@ -833,7 +834,8 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     } as unknown as Task;
     const { store } = productionFaithfulStore([stuck]);
     const manager = new SelfHealingManager(store, { rootDir: "/repo" });
-    const isPhantomExecutorBinding = vi.fn(() => null);
+    /* Returns the real shape, not null: the sweep reads `.phantom` straight off it, so a null stub throws and aborts the loop after ONE card — which silently capped the multi-role count at 1 in both states. */
+    const isPhantomExecutorBinding = vi.fn(() => ({ phantom: false, metadata: {} }));
     Object.assign(manager, {
       getFalsePositiveRequeueSignal: vi.fn(() => ({ reason: "executor-active", metadata: {} })),
       getRecentRunAuditActivityAgeMs: vi.fn(async () => 0),
@@ -844,5 +846,55 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await manager.reclaimSelfOwnedBranchConflicts();
 
     expect(isPhantomExecutorBinding).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-03:50 (review P1 on #2879 — the hazard the conversion CREATED):
+  The three literal reads were disjoint BY CONSTRUCTION: one column each, so a card could not appear
+  twice. Resolved reads are not. A custom workflow may put more than one queried role flag on the SAME
+  column — here `hold` beside `wip`, a lane that both parks work and counts as work — and that column is
+  returned by two reads.
+
+  Concatenating the buckets then hands the loop the same STALE SNAPSHOT twice. Not a wasted iteration:
+  the second pass reads `branch`/`worktree` from state captured before the first pass mutated anything,
+  so a worktree already reclaimed is reclaimed again against state that no longer exists.
+
+  REVERT CHECK, measured: with the dedupe removed, this fails with 2 calls instead of 1.
+  */
+  it("processes a multi-role column ONCE, not once per role", async () => {
+    const multiRoleIr = {
+      ...RENAMED_IR,
+      columns: RENAMED_IR.columns.map((column) =>
+        column.id === RENAMED_VOCAB.hold
+          ? { ...column, traits: [...column.traits, { trait: "wip", config: { limitSetting: "maxConcurrent", countPending: true } }] }
+          : column,
+      ),
+    } as typeof RENAMED_IR;
+    const stuck = {
+      ...shippedCard(),
+      id: "FN-MULTIROLE",
+      column: RENAMED_VOCAB.hold,
+      branch: "fusion/FN-MULTIROLE",
+      worktree: "/tmp/worktrees/FN-MULTIROLE",
+      executionStartedAt: "2026-07-30T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([stuck]);
+    Object.assign(store, {
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: multiRoleIr }]),
+      getWorkflowDefinition: vi.fn(async (id: string) => (id === "self-healing-lifecycle" ? { ir: multiRoleIr } : undefined)),
+    });
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    /* Returns the real shape, not null: the sweep reads `.phantom` straight off it, so a null stub throws and aborts the loop after ONE card — which silently capped the multi-role count at 1 in both states. */
+    const isPhantomExecutorBinding = vi.fn(() => ({ phantom: false, metadata: {} }));
+    Object.assign(manager, {
+      getFalsePositiveRequeueSignal: vi.fn(() => ({ reason: "executor-active", metadata: {} })),
+      getRecentRunAuditActivityAgeMs: vi.fn(async () => 0),
+      isPhantomExecutorBinding,
+      emitFalsePositiveRequeueNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.reclaimSelfOwnedBranchConflicts();
+
+    expect(isPhantomExecutorBinding).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -10863,6 +10863,24 @@ describe("SelfHealingManager reclaimStaleActiveBranches (FN-4546)", () => {
     mockedIsUsableTaskWorktree.mockResolvedValue(true);
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (#2879 review — greptile, "multi-role tasks run
+  recovery twice"): THE FIX IS IN `self-healing.ts`; NO TEST HERE, AND THE ABSENCE IS DELIBERATE.
+
+  `readBucket` dedupes by id inside ONE role's read, so a custom column carrying two queried traits —
+  `hold` plus `countsTowardWip`, or a review role beside either — is returned by two reads and the
+  concatenation handed the recovery loop the same STALE SNAPSHOT twice.
+
+  I wrote a case here and removed it: it reported 0 recoveries, because the card it built reaches the
+  BRANCH-LEVEL scan (subsumed branch, no worktree) rather than the candidates loop the dedupe lives
+  in. Reaching that loop needs `branch` AND `worktree` set plus matching git state, i.e. the git
+  fixture this suite deliberately avoids. A test that passes without exercising the loop would have
+  been worse than none — that is the vacuous shape this program keeps finding.
+
+  So the dedupe ships uncovered and stated. What would cover it: a candidates-loop fixture with a live
+  branch/worktree pair, asserting the recovery COUNT (a double-processed card reports 2 for one card's
+  work) rather than a call count.
+  */
   it("reclaims subsumed fusion task branch with no worktree", async () => {
     (store.listTasks as any).mockResolvedValueOnce([
       { id: "FN-1001", column: "todo", checkedOutBy: null, userPaused: false, worktree: null, branch: null, lineageId: "lin-1" },

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -31,6 +31,7 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+  LEGACY_COLUMN_IDS_BY_ROLE,
   resolveProjectColumnsForRoles,
   REVIEW_ROLES,
 } from "@fusion/core";
@@ -3683,16 +3684,70 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     try {
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
-      const todoCandidates = await this.store.listTasks({ column: "todo", slim: true });
-      const inProgressCandidates = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-01:30 (the query-filter class, twelfth sweep):
+      Three lane reads AND three lane guards in the body, so both halves convert together — widening the
+      read alone would admit renamed-board cards and then mis-decide every one of them (the phantom-binding
+      check, the blocked-hold skip, and the review triple-proof are all keyed on lane).
+
+      On a renamed board all three reads returned empty, so a task whose own worktree held its own branch
+      hostage was never reclaimed and stayed wedged behind a conflict only this sweep resolves.
+      */
+      const reclaimHoldColumns = await resolveProjectColumnsForRoles(this.store, ["hold"]);
+      const reclaimWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const reclaimReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      /*
+      Buckets are built FROM THE READ that produced each row, not by re-deriving from `task.column`.
+      A row returned by `listTasks({ column: X })` is by definition in X, so re-deriving adds nothing and
+      would silently drop any row whose column field is absent.
+      */
+      const readBucket = async (columns: ReadonlySet<string>): Promise<Task[]> => {
+        const byId = new Map<string, Task>();
+        for (const column of columns) {
+          for (const task of await this.store.listTasks({ column, slim: true })) byId.set(task.id, task);
+        }
+        return [...byId.values()];
+      };
+      const todoCandidates = await readBucket(reclaimHoldColumns);
+      const inProgressCandidates = await readBucket(reclaimWipColumns);
+      const inReviewPausedCandidates = (await readBucket(reclaimReviewColumns))
+        .filter((task) => task.paused === true && task.pausedReason === "branch-conflict-unrecoverable");
+      /*
+      Per-card lanes, used by the three lane GUARDS below (phantom-binding, blocked-hold skip, review
+      triple-proof). Legacy ids unioned so a degraded or mid-rename board still decides correctly.
+      */
+      const reclaimLanes = new Map<string, { hold: Set<string>; wip: Set<string>; review: Set<string> }>();
+      const unresolvedReclaimCards: string[] = [];
+      for (const task of [...todoCandidates, ...inProgressCandidates, ...inReviewPausedCandidates]) {
+        if (reclaimLanes.has(task.id)) continue;
+        const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, task.id);
+        if (source === "default") unresolvedReclaimCards.push(task.id);
+        const lanes = {
+          hold: new Set<string>(LEGACY_COLUMN_IDS_BY_ROLE.hold ?? []),
+          wip: new Set<string>(LEGACY_COLUMN_IDS_BY_ROLE.countsTowardWip ?? []),
+          review: new Set<string>(LEGACY_COLUMN_IDS_BY_ROLE.mergeOrchestration ?? []),
+        };
+        for (const id of columnsWithFlag(ir, "hold")) lanes.hold.add(id);
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) lanes.wip.add(id);
+        for (const role of REVIEW_ROLES) for (const id of columnsWithFlag(ir, role)) lanes.review.add(id);
+        reclaimLanes.set(task.id, lanes);
+      }
+      if (unresolvedReclaimCards.length > 0) {
+        log.warn(
+          `self-owned branch reclaim: ${unresolvedReclaimCards.length} card(s) decided against the built-in workflow (${unresolvedReclaimCards.slice(0, 5).join(", ")})`,
+        );
+      }
+      const lanesOfReclaim = (id: string) => reclaimLanes.get(id) ?? {
+        hold: new Set<string>(LEGACY_COLUMN_IDS_BY_ROLE.hold ?? []),
+        wip: new Set<string>(LEGACY_COLUMN_IDS_BY_ROLE.countsTowardWip ?? []),
+        review: new Set<string>(LEGACY_COLUMN_IDS_BY_ROLE.mergeOrchestration ?? []),
+      };
       const inProgressByWorktree = new Map<string, string>();
       for (const inProgressTask of inProgressCandidates) {
         if (inProgressTask.worktree) {
           inProgressByWorktree.set(inProgressTask.worktree, inProgressTask.id);
         }
       }
-      const inReviewPausedCandidates = (await this.store.listTasks({ column: "in-review", slim: true }))
-        .filter((task) => task.paused === true && task.pausedReason === "branch-conflict-unrecoverable");
       // Per-task auto-merge gating applies to ALL candidate columns, not just
       // in-review: the FN-5704 regression contract ("short-circuits reclaim
       // when autoMerge is false") deliberately keeps execution-stage reclaim
@@ -3717,7 +3772,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           includeCheckedOutLease: true,
         });
         if (liveExecutionSignal) {
-          const canEvaluatePhantomBinding = task.column === "in-progress"
+          const canEvaluatePhantomBinding = lanesOfReclaim(task.id).wip.has(task.column)
             && (liveExecutionSignal.reason === "executor-active" || liveExecutionSignal.reason === "live-worktree-and-branch");
           if (canEvaluatePhantomBinding) {
             const nowMs = Date.now();
@@ -3789,7 +3844,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           );
           continue;
         }
-        if (task.column === "todo" && task.blockedBy) {
+        if (lanesOfReclaim(task.id).hold.has(task.column) && task.blockedBy) {
           log.debug(`[self-healing] skipping blocked todo task ${task.id} during self-owned branch reclaim (blockedBy=${task.blockedBy})`);
           continue;
         }
@@ -3811,7 +3866,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         }
         if (!await isUsableTaskWorktree(this.options.rootDir, task.worktree)) continue;
 
-        const reviewProof = task.column === "in-review"
+        const reviewProof = lanesOfReclaim(task.id).review.has(task.column)
           ? await this.evaluateBackwardMoveTripleProof(task, {
             stage: "reclaim-self-owned-branch-conflict",
             graceMs: settings.taskStuckTimeoutMs ?? STALE_ACTIVE_BRANCH_EXECUTION_GRACE_MS,

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -4011,7 +4011,15 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 `[recovery] tip-already-merged ${task.id} branch=${branchName} tip=${inspection.tipSha.slice(0, 12)} integrationRef=${inspection.integrationRef} reason=stale-cached-metadata-ghost-conflict`,
               );
 
-              if (task.column === "in-review") {
+              /*
+              FNXC:WorkflowResolvedColumns 2026-07-31-11:40 (SELF-AUDIT after #2916 found the same class):
+              These loop-body lane guards were MISSED when I converted this sweep's read. That is not a
+              cosmetic gap: this one decides whether the backward move needs `reviewProof`. Left literal,
+              a renamed review card admitted by the widened read reads as NOT-in-review, so the
+              triple-proof gate is skipped entirely and the card is moved back without it — a safety
+              check silently bypassed BY the conversion.
+              */
+              if (lanesOfReclaim(task.id).review.has(task.column)) {
                 if (!reviewProof?.ok) {
                   await this.emitBackwardMoveNoAction(task, "reclaim-self-owned-branch-conflict", "task:reclaim-self-owned-branch-conflict-no-action", reviewProof!);
                 } else {
@@ -4116,7 +4124,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                   `[recovery] reclaim-live-zero-commits ${task.id} branch=${task.branch} worktree=${inspection.livePath} tip=${inspection.tipSha.slice(0, 12)} reason=zero-unique-commits-vs-main`,
                 );
 
-                if (task.column === "in-review") {
+                if (lanesOfReclaim(task.id).review.has(task.column)) {
                   if (!reviewProof?.ok) {
                     await this.emitBackwardMoveNoAction(task, "reclaim-self-owned-branch-conflict", "task:reclaim-self-owned-branch-conflict-no-action", reviewProof!);
                   } else {
@@ -4206,12 +4214,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const unchangedSincePriorResume = hasPriorSnapshot
             && task.resumeLimboTipSha === inspection.tipSha
             && task.resumeLimboStepSignature === stepSignature;
-          const isNoProgressResume = task.column === "in-progress"
+          const isNoProgressResume = lanesOfReclaim(task.id).wip.has(task.column)
             && unchangedSincePriorResume
             && !hasActiveSessionSignal;
           const resumeAttemptCount = isNoProgressResume ? (task.resumeLimboCount ?? 0) + 1 : 0;
 
-          if (task.column === "in-progress" && isNoProgressResume && resumeAttemptCount >= MAX_NO_PROGRESS_RESUME_ATTEMPTS) {
+          if (lanesOfReclaim(task.id).wip.has(task.column) && isNoProgressResume && resumeAttemptCount >= MAX_NO_PROGRESS_RESUME_ATTEMPTS) {
             const idleAnchor = task.executionStartedAt ?? task.columnMovedAt ?? task.updatedAt;
             const idleAnchorMs = Date.parse(idleAnchor ?? "");
             const idleMs = Number.isFinite(idleAnchorMs) ? Math.max(0, Date.now() - idleAnchorMs) : null;
@@ -4280,7 +4288,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             `[recovery] ${wasPausedBranchConflict ? "reclaim-paused-review" : "reclaim-self-owned"} ${task.id} at ${reclaimedWorktreePath} (${preservedCommitCount} commits preserved, tip ${inspection.tipSha.slice(0, 12)})`,
           );
 
-          if (task.column === "in-review") {
+          if (lanesOfReclaim(task.id).review.has(task.column)) {
             if (!reviewProof?.ok) {
               await this.emitBackwardMoveNoAction(task, "reclaim-self-owned-branch-conflict", "task:reclaim-self-owned-branch-conflict-no-action", reviewProof!);
             } else {

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -3754,8 +3754,30 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       // and resume-limbo escalation inert in manual-review projects. The
       // per-task override preserves that for override-less tasks while letting
       // explicit autoMerge:true tasks recover.
-      const candidates = [...todoCandidates, ...inProgressCandidates, ...inReviewPausedCandidates]
-        .filter((task) => allowsAutoMergeProcessing(task, settings));
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-01:15 (#2879 review — greptile, "multi-role tasks run
+      recovery twice"): DEDUPED ACROSS THE BUCKETS, NOT JUST WITHIN EACH.
+
+      `readBucket` dedupes by id, but only inside one role's read. A custom workflow may put more than
+      one queried flag on ONE column — `hold` plus `countsTowardWip` on a lane that both parks and
+      counts as work, or a review role beside either — and that column is then returned by two reads.
+      The task lands in two buckets, and the concatenation below hands the recovery loop the SAME
+      STALE SNAPSHOT twice.
+
+      That is not a wasted iteration: the second pass re-reads `task.branch`/`task.worktree` from a
+      snapshot taken before the first pass mutated anything, so a worktree the first pass reclaimed is
+      reclaimed again against state that no longer exists. The lane-resolution loop above already
+      guards with `reclaimLanes.has(task.id)`; this is the same guard the consumption side was missing.
+
+      Deduping by id preserves order — first bucket wins — so the roles keep their existing precedence
+      and nothing else about the sweep changes.
+      */
+      const candidates = [
+        ...new Map(
+          [...todoCandidates, ...inProgressCandidates, ...inReviewPausedCandidates]
+            .map((task) => [task.id, task] as const),
+        ).values(),
+      ].filter((task) => allowsAutoMergeProcessing(task, settings));
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const activeTaskIds = await this.listActiveHeartbeatTaskIds();
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -3769,15 +3769,17 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       reclaimed again against state that no longer exists. The lane-resolution loop above already
       guards with `reclaimLanes.has(task.id)`; this is the same guard the consumption side was missing.
 
-      Deduping by id preserves order — first bucket wins — so the roles keep their existing precedence
-      and nothing else about the sweep changes.
+      Deduping by id preserves iteration order, and the FIRST bucket's snapshot is the one kept. Spelled
+      out with an explicit `has` guard rather than `new Map(entries)`: that constructor keeps first
+      INSERTION ORDER but the LAST value for a repeated key, so it would have silently given last-bucket
+      precedence while this comment claimed the opposite.
       */
-      const candidates = [
-        ...new Map(
-          [...todoCandidates, ...inProgressCandidates, ...inReviewPausedCandidates]
-            .map((task) => [task.id, task] as const),
-        ).values(),
-      ].filter((task) => allowsAutoMergeProcessing(task, settings));
+      const reclaimCandidateById = new Map<string, Task>();
+      for (const task of [...todoCandidates, ...inProgressCandidates, ...inReviewPausedCandidates]) {
+        if (!reclaimCandidateById.has(task.id)) reclaimCandidateById.set(task.id, task);
+      }
+      const candidates = [...reclaimCandidateById.values()]
+        .filter((task) => allowsAutoMergeProcessing(task, settings));
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const activeTaskIds = await this.listActiveHeartbeatTaskIds();
 

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 84,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 32,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 78,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`reclaimSelfOwnedBranchConflicts` frees a task whose **own worktree is holding its own branch hostage** — a conflict no other sweep resolves. Three literal reads, plus three lane guards in the body, so both halves convert together: widening the read alone would admit renamed-board cards and then mis-decide every one, since the phantom-binding check, the blocked-hold skip and the review triple-proof are each keyed on lane.

## The bug my first draft introduced, and what it taught

I bucketed each card by testing `task.column` against its resolved lanes. Eight existing tests in `self-healing.test.ts` went red.

The cause was **not** the product: those fixture cards carry no `column` field at all, so re-deriving the bucket dropped them. The fix is the better formulation anyway — **a row returned by `listTasks({ column: X })` is by definition in X**, so re-deriving from `task.column` adds nothing and can only lose rows. Buckets now come from the read that produced them; the per-card lanes are kept for the three **guards**, which is where the lane question is actually live.

Worth stating plainly because the tempting move was the wrong one: eight failures in a file I had not touched looked like fixture staleness, and adjusting them would have buried a real formulation error under a fixture edit.

## Deliberately unchanged

`moveTask(task.id, "todo", { recoveryRehome: true })` keeps its legacy target. It is one of the 22 documented deliberate escapes — `moves.ts` exempts `recoveryRehome` precisely so a card stranded in an undeclared column stays rescuable. Converting it removes the rescue path.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the three resolved reads | fails — the card is never listed |
| the wip-lane guard | fails — the renamed wip lane does not match, so the sweep falls through to the no-action path |

One assertion covers both, because `isPhantomExecutorBinding` runs only for a card the read found **and** the wip guard accepted. A non-vacuous companion (same card in the review lane → not called) rules out a guard that matches everything.

Reached through two private seams rather than a git/fs fixture — the technique recorded in the sibling doc after #2867.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71; `self-healing.test.ts` + the blindness file 428 passed; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.