### PR TITLE
chore(gate): re-record the SQL column-literal baseline after team-analytics.ts converted

### DIFF
--- a/scripts/lib/sql-column-literals-baseline.json
+++ b/scripts/lib/sql-column-literals-baseline.json
@@ -11,6 +11,6 @@
   "packages/core/src/task-store/reads.ts": 1,
   "packages/core/src/task-store/task-artifacts-ops.ts": 1,
   "packages/core/src/task-store/workflow-definitions.ts": 2,
-  "packages/core/src/team-analytics.ts": 6,
+  "packages/core/src/team-analytics.ts": 3,
   "packages/core/src/workflow-analytics.ts": 6
 }


### PR DESCRIPTION
## The merge gate is red on main; this fixes it

`pnpm test:gate` exits 1 — and this is the **blocking** lane, so it is currently stopping every PR in the program, not just a non-blocking suite.

```
[check-sql-column-literals] SQL column-literal population changed:

  packages/core/src/team-analytics.ts: 3 site(s) now, baseline still allows 6 — re-record it (--update-baseline)
```

A conversion took `team-analytics.ts` from 6 SQL column-literal sites to 3 without re-recording the ratchet's baseline.

## The whole diff

```diff
-  "packages/core/src/team-analytics.ts": 6,
+  "packages/core/src/team-analytics.ts": 3,
```

One line. Nothing else moved — 28 sites across 14 files, otherwise unchanged.

## Why committing it is the prescribed workflow

The check says so in its own failure output:

> If a count went DOWN, re-record the baseline in the same commit.

Leaving the stale `6` keeps an allowance open for three SQL column-literals to regrow into, which is exactly what the ratchet exists to prevent.

**It cannot hide a regression.** The check fails on a *rise*; only a drop is re-recordable, and the new number is lower.

## This is the second instance of a recurring pattern

#2844 was the same failure on the lifecycle-column census: a conversion landed, the count dropped, the baseline was not re-recorded, and `main` went red for whoever ran next. That one was a non-blocking lane. **This one is the merge gate**, so the cost is higher — every worker's PR is blocked until it lands.

Both ratchets prescribe re-recording in the converting commit. Worth flagging to whoever owns conversion review that this is now a repeat, not a one-off: the two ratchets fail in different lanes and neither failure names the PR that caused it.

## Verification

- `pnpm test:gate` — **exit 0** (was exit 1)
- live-PG E2E surface — **171/171**
- census (`check:lifecycle-columns`) — exit 0

No changeset: baseline state for internal tooling, not published behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)