### PR TITLE
fix(gate): main is red — re-record the SQL baseline #2864 tightened

### DIFF
--- a/scripts/lib/sql-column-literals-baseline.json
+++ b/scripts/lib/sql-column-literals-baseline.json
@@ -11,6 +11,6 @@
   "packages/core/src/task-store/reads.ts": 1,
   "packages/core/src/task-store/task-artifacts-ops.ts": 1,
   "packages/core/src/task-store/workflow-definitions.ts": 2,
-  "packages/core/src/team-analytics.ts": 6,
+  "packages/core/src/team-analytics.ts": 3,
   "packages/core/src/workflow-analytics.ts": 6
 }


### PR DESCRIPTION
**Main's merge gate is currently red, and every PR in the queue is blocked behind it.**

`check-sql-column-literals` entered the gate with #2841. #2864 then legitimately converted `team-analytics.ts` from 6 SQL column literals to 3 — a real improvement — without re-recording the baseline. The gate fails on a count going **down** as well as up, so:

```
[check-sql-column-literals] SQL column-literal population changed:
  packages/core/src/team-analytics.ts: 3 site(s) now, baseline still allows 6 — re-record it
```

Baseline 30 → 28. No source change. The tool's own message says *"If a count went DOWN, re-record the baseline in the same commit"* — this is that, one commit late.

Verified: `node scripts/check-sql-column-literals.mjs` exits 0, and the full `pnpm test:gate` passes 161 / 487 / 13 / 71.

## Deliberately not changing the tool

Failing on a downward move is correct — it is what makes the surface a **ratchet** rather than a high-water mark, and the miss here was procedural rather than a design flaw.

Worth flagging to whoever owns it, though, that the lifecycle census solves the same problem differently: it **rewrites the baseline downward itself** and prints *"COMMIT IT so the allowance cannot be regrown into"*, so a legitimate conversion cannot red main by forgetting a flag. With a fleet actively converting lane literals, this will recur — I hit it myself in the next PR up (#2875 removes a `done` literal from `async-audit.ts`). That is a behaviour change to a gate that landed hours ago, so it belongs to its author, not to a drive-by fix that is trying to unblock the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal analytics baseline to reflect the latest expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->