### PR TITLE
self-healing: completing a task released no dependents on a renamed board (thirteenth sweep)

### DIFF
--- a/.changeset/self-healing-reconcile-completed-query.md
+++ b/.changeset/self-healing-reconcile-completed-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Completing a task now releases its dependents on boards with renamed columns.
+category: fix
+dev: `reconcileCompletedTask` read the literal `todo`/`in-progress`/`in-review`, so on a renamed board it released nothing and every dependent stayed blocked on finished work. The three reads resolve via `resolveProjectColumnsForRoles`, and dependency satisfaction resolves per dependency (complete/review/archived roles, legacy ids unioned).

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -859,4 +859,58 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
       .filter(([id, patch]) => id === "FN-WAITING" && (patch as { blockedBy?: unknown }).blockedBy === null);
     expect(clearingWrites).toHaveLength(1);
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-05:05 (#2883 review — "overbroad dependency satisfaction"):
+  A dependency is satisfied when it reaches a TERMINAL lane or a REVIEW lane, and review here means
+  `mergeBlocker ∪ humanReview` — NOT merge orchestration. My first version unioned all three review
+  roles, which counts a merge-orchestration-only column as satisfied and clears `blockedBy` while the
+  dependency is still being merged.
+
+  The fix is to call `resolveDependencySatisfactionColumns`, the answer the scheduler already uses for
+  this exact question, rather than to re-derive it. This case pins the narrowed semantics so a future
+  "simplification" back to the three-role union fails here.
+
+  REVERT CHECK, measured: widening the satisfaction set to include `mergeOrchestration` fails this — the
+  dependent is released while its dependency is still mid-merge.
+  */
+  it("does NOT treat a merge-orchestration-only dependency as satisfied", async () => {
+    /* A board whose merge lane is SEPARATE from its human-review lane. */
+    const splitReviewIr = {
+      ...RENAMED_IR,
+      columns: [
+        ...RENAMED_IR.columns.map((column) =>
+          column.id === RENAMED_VOCAB.review
+            ? { ...column, traits: column.traits.filter((t: { trait: string }) => t.trait !== "merge") }
+            : column,
+        ),
+        { id: "merging", name: "Merging", traits: [{ trait: "merge" }] },
+      ],
+    } as typeof RENAMED_IR;
+    const finished = { ...shippedCard(), id: "FN-DONE", column: RENAMED_VOCAB.complete } as Task;
+    const midMerge = { ...shippedCard(), id: "FN-MIDMERGE", column: "merging" } as Task;
+    const waiting = {
+      ...shippedCard(),
+      id: "FN-WAITING",
+      /*
+      The HOLD lane is load-bearing. A card in the wip lane takes the sweep's `else` branch, which clears
+      `blockedBy` without consulting `unresolvedDeps` at all — so the first version of this test passed
+      with the satisfaction set widened. Eighth vacuous assertion here, eighth caught by the revert.
+      Only the hold branch re-points the card at its next unmet dependency.
+      */
+      column: RENAMED_VOCAB.hold,
+      blockedBy: "FN-DONE",
+      dependencies: ["FN-MIDMERGE"],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([finished, midMerge, waiting]);
+    Object.assign(store, {
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: splitReviewIr }]),
+      getWorkflowDefinition: vi.fn(async (id: string) => (id === "self-healing-lifecycle" ? { ir: splitReviewIr } : undefined)),
+    });
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileCompletedTask("FN-DONE");
+
+    // Its dependency is still merging, so the card is RE-POINTED at it rather than released.
+    expect(updateTask).toHaveBeenCalledWith("FN-WAITING", expect.objectContaining({ blockedBy: "FN-MIDMERGE" }));
+  });
 });

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -821,4 +821,42 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalledWith("FN-WAITING", expect.objectContaining({ blockedBy: null }));
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-04:10 (the P1 raised on #2879, same hazard in this sweep):
+  Resolved reads can return ONE column for TWO roles, so a dependent lands in two buckets and the release
+  below runs twice — `updateTask` and `logEntry` both fire twice for one card, and `blockedByCleared`
+  over-counts. The literal reads could not do this: one column each, disjoint by construction.
+
+  REVERT CHECK, measured: without the dedupe this fails with 2 clearing writes instead of 1.
+  */
+  it("releases a dependent ONCE when its column carries two queried roles", async () => {
+    const multiRoleIr = {
+      ...RENAMED_IR,
+      columns: RENAMED_IR.columns.map((column) =>
+        column.id === RENAMED_VOCAB.hold
+          ? { ...column, traits: [...column.traits, { trait: "wip", config: { limitSetting: "maxConcurrent", countPending: true } }] }
+          : column,
+      ),
+    } as typeof RENAMED_IR;
+    const finished = { ...shippedCard(), id: "FN-DONE", column: RENAMED_VOCAB.complete } as Task;
+    const waiting = {
+      ...shippedCard(),
+      id: "FN-WAITING",
+      column: RENAMED_VOCAB.hold,
+      blockedBy: "FN-DONE",
+      dependencies: [],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([finished, waiting]);
+    Object.assign(store, {
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: multiRoleIr }]),
+      getWorkflowDefinition: vi.fn(async (id: string) => (id === "self-healing-lifecycle" ? { ir: multiRoleIr } : undefined)),
+    });
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileCompletedTask("FN-DONE");
+
+    const clearingWrites = (updateTask as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      .filter(([id, patch]) => id === "FN-WAITING" && (patch as { blockedBy?: unknown }).blockedBy === null);
+    expect(clearingWrites).toHaveLength(1);
+  });
 });

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -87,6 +87,8 @@ function productionFaithfulStore(tasks: Task[]) {
     */
     listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
     logEntry: vi.fn(async () => undefined),
+    parseFileScopeFromPrompt: vi.fn(async () => []),
+    getCompletionHandoffAcceptedMarker: vi.fn(async () => null),
   }) as unknown as TaskStore & EventEmitter;
   return { store, listTasks, updateTask: store.updateTask as unknown as ReturnType<typeof vi.fn> };
 }
@@ -769,5 +771,54 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await new SelfHealingManager(store, { rootDir: "/repo" }).recoverStaleMergingStatus();
 
     expect(updateTask).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-03:10 (the query-filter class, thirteenth sweep):
+  `reconcileCompletedTask` releases everything blocked on a task that just completed. Three literal reads
+  meant that on a renamed board it released NOTHING — every dependent stayed blocked on work that had
+  already finished. This is the most visible form of the class: the board simply stops moving, with no
+  error and no log line saying why.
+
+  The dependency-satisfaction guard converts in the same change, resolved PER DEPENDENCY: a dependency
+  routinely belongs to a different workflow than the card waiting on it.
+
+  REVERT CHECK, measured: with the three literal reads restored, this fails — the dependent is never
+  listed, so its `blockedBy` is never cleared.
+  */
+  it("releases a dependent on a RENAMED board when its blocker completes", async () => {
+    const finished = { ...shippedCard(), id: "FN-DONE", column: RENAMED_VOCAB.complete } as Task;
+    const waiting = {
+      ...shippedCard(),
+      id: "FN-WAITING",
+      column: RENAMED_VOCAB.wip,
+      blockedBy: "FN-DONE",
+      dependencies: [],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([finished, waiting]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileCompletedTask("FN-DONE");
+
+    expect(updateTask).toHaveBeenCalledWith("FN-WAITING", expect.objectContaining({ blockedBy: null }));
+  });
+
+  it("does not release a dependent blocked on a DIFFERENT task", async () => {
+    /*
+    Non-vacuous companion: without it, a sweep that cleared every blockedBy it found would satisfy the
+    case above. Same board, same shape — only the blocker id differs.
+    */
+    const finished = { ...shippedCard(), id: "FN-DONE", column: RENAMED_VOCAB.complete } as Task;
+    const waiting = {
+      ...shippedCard(),
+      id: "FN-WAITING",
+      column: RENAMED_VOCAB.wip,
+      blockedBy: "FN-SOMEONE-ELSE",
+      dependencies: [],
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([finished, waiting]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileCompletedTask("FN-DONE");
+
+    expect(updateTask).not.toHaveBeenCalledWith("FN-WAITING", expect.objectContaining({ blockedBy: null }));
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -172,6 +172,23 @@ import {
 
 
 const log = createLogger("self-healing");
+
+/*
+DELIBERATE-LITERAL — the no-metadata fallback for dependency satisfaction, mirroring
+`isLegacyDependencySatisfied` in scheduler.ts (reviewed there 2026-07-30-20:40).
+
+Reached ONLY when `resolveDependencySatisfactionColumns` left a dependency unmapped, i.e. its workflow
+could not be read at all. DELETING these literals does not "finish the conversion" — it makes an
+unresolvable dependency read as never-satisfied, which blocks its dependent forever. That is strictly
+worse than the legacy behaviour it would replace.
+
+Hoisted to module scope so the marker sits in the node's LEADING comments, which is where the census
+looks; inline in the conditional it was attached to the wrong node and scored as three unconverted
+guards (86 -> 89 on #2883).
+*/
+function isDependencySatisfiedWithoutWorkflowMetadata(column: string): boolean {
+  return column === "done" || column === "archived" || column === "in-review";
+}
 const worktreeMetadataReconcileLog = createLogger("worktree-metadata-reconcile");
 /*
 FNXC:EngineDiagnostics 2026-07-26-10:25:
@@ -4678,8 +4695,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             const columns = depSatisfaction.get(depId);
             const satisfied = columns
               ? columns.terminal.has(dep.column) || columns.review.has(dep.column)
-              /* DELIBERATE-LITERAL — the no-metadata fallback, matching isLegacyDependencySatisfied. */
-              : dep.column === "done" || dep.column === "archived" || dep.column === "in-review";
+              : isDependencySatisfiedWithoutWorkflowMetadata(dep.column);
             if (!satisfied) unresolvedDeps.push(depId);
           }
           const overlapBlockedBy = dependent.overlapBlockedBy === taskId ? null : (dependent.overlapBlockedBy ?? null);

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -31,6 +31,7 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+  LEGACY_COLUMN_IDS_BY_ROLE,
   resolveProjectColumnsForRoles,
   REVIEW_ROLES,
 } from "@fusion/core";
@@ -4595,9 +4596,28 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (blockerScope.length === 0 || isCoordinationOnlyTask(blocker, blockerScope)) return false;
         return pathsOverlap(dependentScope, blockerScope);
       };
-      const todoTasks = await this.store.listTasks({ column: "todo", slim: true });
-      const inProgressTasks = await this.store.listTasks({ column: "in-progress", slim: true });
-      const inReviewTasks = (await this.store.listTasks({ column: "in-review", slim: true })).filter((t) => !t.paused);
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-03:05 (the query-filter class, thirteenth sweep):
+      When a task completes, this releases everything blocked on it. Three literal reads meant that on a
+      renamed board it released NOTHING — every dependent stayed blocked on a task that had already
+      finished, which is the most visible form of this class: the board simply stops moving.
+
+      Buckets come from the read that produced each row (a row returned by `listTasks({ column: X })` is
+      in X by definition); re-deriving from `task.column` would only be able to lose rows.
+      */
+      const completedHoldColumns = await resolveProjectColumnsForRoles(this.store, ["hold"]);
+      const completedWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const completedReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const readDependentBucket = async (columns: ReadonlySet<string>): Promise<Task[]> => {
+        const byId = new Map<string, Task>();
+        for (const column of columns) {
+          for (const entry of await this.store.listTasks({ column, slim: true })) byId.set(entry.id, entry);
+        }
+        return [...byId.values()];
+      };
+      const todoTasks = await readDependentBucket(completedHoldColumns);
+      const inProgressTasks = await readDependentBucket(completedWipColumns);
+      const inReviewTasks = (await readDependentBucket(completedReviewColumns)).filter((t) => !t.paused);
 
       const dependents = [...todoTasks, ...inProgressTasks, ...inReviewTasks].filter(
         (t) => t.blockedBy === taskId || t.overlapBlockedBy === taskId,
@@ -4605,10 +4625,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const todoTaskIds = new Set(todoTasks.map((t) => t.id));
       for (const dependent of dependents) {
         try {
-          const unresolvedDeps = dependent.dependencies.filter((depId) => {
+          /*
+          A dependency is SATISFIED once it reaches a complete, review or archived lane — resolved per
+          DEPENDENCY, since a dependency routinely belongs to a different workflow than the card waiting
+          on it (the answer main settled on in branch-group-ops, #2720). Legacy ids unioned, because
+          `resolveWorkflowIrForTask` returns the built-in IR for a missing workflow and without the union
+          a degraded board reads a finished dependency as unmet — the exact stall being cleared here.
+          */
+          const depLaneCache = new Map<string, Set<string>>();
+          const satisfiedLanesFor = async (depId: string): Promise<Set<string>> => {
+            const cached = depLaneCache.get(depId);
+            if (cached) return cached;
+            const lanes = new Set<string>([
+              ...(LEGACY_COLUMN_IDS_BY_ROLE.complete ?? []),
+              ...(LEGACY_COLUMN_IDS_BY_ROLE.mergeOrchestration ?? []),
+              ...(LEGACY_COLUMN_IDS_BY_ROLE.archived ?? []),
+            ]);
+            try {
+              const ir = await resolveWorkflowIrForTask(this.store, depId);
+              if (ir) {
+                for (const role of ["complete", "archived", ...REVIEW_ROLES] as const) {
+                  for (const id of columnsWithFlag(ir, role)) lanes.add(id);
+                }
+              }
+            } catch { /* degraded: legacy ids above still answer */ }
+            depLaneCache.set(depId, lanes);
+            return lanes;
+          };
+          const unresolvedDeps: string[] = [];
+          for (const depId of dependent.dependencies) {
             const dep = taskById.get(depId);
-            return dep && dep.column !== "done" && dep.column !== "in-review" && dep.column !== "archived";
-          });
+            if (dep && !(await satisfiedLanesFor(depId)).has(dep.column)) unresolvedDeps.push(depId);
+          }
           const overlapBlockedBy = dependent.overlapBlockedBy === taskId ? null : (dependent.overlapBlockedBy ?? null);
           const hasActiveOverlapBlocker = await hasActiveFileScopeOverlapBlocker(dependent, overlapBlockedBy);
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -4619,9 +4619,24 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const inProgressTasks = await readDependentBucket(completedWipColumns);
       const inReviewTasks = (await readDependentBucket(completedReviewColumns)).filter((t) => !t.paused);
 
-      const dependents = [...todoTasks, ...inProgressTasks, ...inReviewTasks].filter(
-        (t) => t.blockedBy === taskId || t.overlapBlockedBy === taskId,
-      );
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-02:40 (#2883 review — greptile P1, "duplicate dependent
+      reconciliation"; same class as #2879 one sweep over):
+      DEDUPED ACROSS THE BUCKETS, NOT JUST WITHIN EACH.
+
+      `readDependentBucket` dedupes by id inside ONE role's read. A custom workflow may put two queried
+      roles on ONE column, which two reads then return, so the dependent landed in two buckets and was
+      reconciled twice from the same stale snapshot — the second pass deciding against `blockedBy` state
+      the first pass had already cleared.
+
+      Order is preserved (first bucket wins), so `todoTaskIds` below still classifies the dependent by
+      the read that found it first and role precedence is unchanged.
+      */
+      const dependents = [
+        ...new Map(
+          [...todoTasks, ...inProgressTasks, ...inReviewTasks].map((t) => [t.id, t] as const),
+        ).values(),
+      ].filter((t) => t.blockedBy === taskId || t.overlapBlockedBy === taskId);
       const todoTaskIds = new Set(todoTasks.map((t) => t.id));
       for (const dependent of dependents) {
         try {
@@ -4644,6 +4659,24 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             try {
               const ir = await resolveWorkflowIrForTask(this.store, depId);
               if (ir) {
+                /*
+                FNXC:WorkflowResolvedColumns 2026-07-31-02:50 (#2883 review — greptile P1, "overbroad
+                dependency satisfaction"): THE BREADTH IS THE LEGACY CONTRACT, NOT AN ACCIDENT.
+
+                The concern is that a `mergeOrchestration`-only lane reads as satisfying a dependency
+                while the scheduler wants a terminal, merge-blocking state. Measured against what this
+                replaced: the legacy set was `done` / `in-review` / `archived`, and `in-review` carries
+                `mergeOrchestration` on every builtin — so a dependency parked in review has ALWAYS
+                released its dependents. Including the review roles reproduces that exactly.
+
+                Narrowing to terminal-only would be a BEHAVIOUR CHANGE in the deadlock direction: every
+                dependent currently released by a dependency sitting in review would stay blocked, on a
+                sweep whose entire purpose is unblocking them. That is a scheduler-contract decision
+                about when a dependency counts as done, not a vocabulary conversion, and it belongs in a
+                change that can argue it on its own terms.
+
+                Recorded rather than silently kept, so the breadth reads as a decision.
+                */
                 for (const role of ["complete", "archived", ...REVIEW_ROLES] as const) {
                   for (const id of columnsWithFlag(ir, role)) lanes.add(id);
                 }

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -4627,16 +4627,21 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       `readDependentBucket` dedupes by id inside ONE role's read. A custom workflow may put two queried
       roles on ONE column, which two reads then return, so the dependent landed in two buckets and was
       reconciled twice from the same stale snapshot — the second pass deciding against `blockedBy` state
-      the first pass had already cleared.
+      the first pass had already cleared, and `updateTask`/`logEntry` firing twice for one card.
 
-      Order is preserved (first bucket wins), so `todoTaskIds` below still classifies the dependent by
-      the read that found it first and role precedence is unchanged.
+      FNXC:WorkflowResolvedColumns 2026-07-31-04:05 (precedence correction):
+      Written first as `new Map(entries)` with a comment claiming first-bucket precedence. That
+      constructor keeps first insertion ORDER but the LAST value for a repeated key, so it did the
+      opposite of what it said. The explicit `has` guard below makes the code match the claim; order is
+      still preserved, so `todoTaskIds` classifies the dependent by the read that found it first.
       */
-      const dependents = [
-        ...new Map(
-          [...todoTasks, ...inProgressTasks, ...inReviewTasks].map((t) => [t.id, t] as const),
-        ).values(),
-      ].filter((t) => t.blockedBy === taskId || t.overlapBlockedBy === taskId);
+      const dependentById = new Map<string, Task>();
+      for (const entry of [...todoTasks, ...inProgressTasks, ...inReviewTasks]) {
+        if (!dependentById.has(entry.id)) dependentById.set(entry.id, entry);
+      }
+      const dependents = [...dependentById.values()].filter(
+        (t) => t.blockedBy === taskId || t.overlapBlockedBy === taskId,
+      );
       const todoTaskIds = new Set(todoTasks.map((t) => t.id));
       for (const dependent of dependents) {
         try {

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -31,7 +31,6 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
-  LEGACY_COLUMN_IDS_BY_ROLE,
   resolveProjectColumnsForRoles,
   REVIEW_ROLES,
 } from "@fusion/core";
@@ -99,7 +98,7 @@ import {
   type NtfyNotifier,
 } from "./notifier.js";
 import type { GhostBugDecision } from "./triage-preflight.js";
-import { filterPathsByIgnoreList, getUnmetSchedulingDependencies, isCoordinationOnlyTask, pathsOverlap, shouldHoldActiveFileScopeLease } from "./scheduler.js";
+import { filterPathsByIgnoreList, getUnmetSchedulingDependencies, isCoordinationOnlyTask, pathsOverlap, resolveDependencySatisfactionColumns, shouldHoldActiveFileScopeLease } from "./scheduler.js";
 import { runSurfacingSweep, hours, type SurfacingCycle } from "./surfacing-sweeps.js";
 /* U4 substrate PR1: the git-evidence readers and their helpers now live in
    self-healing-git-evidence.ts. Imported back here because call sites remain. */
@@ -4639,6 +4638,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       for (const entry of [...todoTasks, ...inProgressTasks, ...inReviewTasks]) {
         if (!dependentById.has(entry.id)) dependentById.set(entry.id, entry);
       }
+      /* One IR cache for the whole reconcile, so a board spanning three workflows reads three IRs, not one per dependency row. */
+      const depSatisfactionIrCache = new Map<string, WorkflowIr>();
       const dependents = [...dependentById.values()].filter(
         (t) => t.blockedBy === taskId || t.overlapBlockedBy === taskId,
       );
@@ -4652,48 +4653,34 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           `resolveWorkflowIrForTask` returns the built-in IR for a missing workflow and without the union
           a degraded board reads a finished dependency as unmet — the exact stall being cleared here.
           */
-          const depLaneCache = new Map<string, Set<string>>();
-          const satisfiedLanesFor = async (depId: string): Promise<Set<string>> => {
-            const cached = depLaneCache.get(depId);
-            if (cached) return cached;
-            const lanes = new Set<string>([
-              ...(LEGACY_COLUMN_IDS_BY_ROLE.complete ?? []),
-              ...(LEGACY_COLUMN_IDS_BY_ROLE.mergeOrchestration ?? []),
-              ...(LEGACY_COLUMN_IDS_BY_ROLE.archived ?? []),
-            ]);
-            try {
-              const ir = await resolveWorkflowIrForTask(this.store, depId);
-              if (ir) {
-                /*
-                FNXC:WorkflowResolvedColumns 2026-07-31-02:50 (#2883 review — greptile P1, "overbroad
-                dependency satisfaction"): THE BREADTH IS THE LEGACY CONTRACT, NOT AN ACCIDENT.
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-31-05:00 (#2883 review — greptile P1, "overbroad
+          dependency satisfaction"): REUSE THE SCHEDULER'S RESOLVER, DO NOT RE-DERIVE IT.
 
-                The concern is that a `mergeOrchestration`-only lane reads as satisfying a dependency
-                while the scheduler wants a terminal, merge-blocking state. Measured against what this
-                replaced: the legacy set was `done` / `in-review` / `archived`, and `in-review` carries
-                `mergeOrchestration` on every builtin — so a dependency parked in review has ALWAYS
-                released its dependents. Including the review roles reproduces that exactly.
+          The first version unioned all three review roles, which counts a `mergeOrchestration`-only
+          column as satisfied. `resolveDependencySatisfactionColumns` — the shared answer the scheduler
+          already uses for exactly this question — defines review as `mergeBlocker ∪ humanReview` and
+          deliberately excludes merge orchestration. Two readers of one fact disagreeing is how this
+          program has already gone wrong; the fix is to call the existing one, not to match it by hand.
 
-                Narrowing to terminal-only would be a BEHAVIOUR CHANGE in the deadlock direction: every
-                dependent currently released by a dependency sitting in review would stay blocked, on a
-                sweep whose entire purpose is unblocking them. That is a scheduler-contract decision
-                about when a dependency counts as done, not a vocabulary conversion, and it belongs in a
-                change that can argue it on its own terms.
-
-                Recorded rather than silently kept, so the breadth reads as a decision.
-                */
-                for (const role of ["complete", "archived", ...REVIEW_ROLES] as const) {
-                  for (const id of columnsWithFlag(ir, role)) lanes.add(id);
-                }
-              }
-            } catch { /* degraded: legacy ids above still answer */ }
-            depLaneCache.set(depId, lanes);
-            return lanes;
-          };
+          Its contract also covers the degraded case: an unresolvable dependency is left UNMAPPED, and
+          the literal fallback below then answers, so a dependency whose workflow cannot be read does not
+          silently read as never-satisfied and block its dependent forever.
+          */
+          const depRows = dependent.dependencies
+            .map((depId) => taskById.get(depId))
+            .filter((dep): dep is Task => Boolean(dep));
+          const depSatisfaction = await resolveDependencySatisfactionColumns(this.store, depRows, depSatisfactionIrCache);
           const unresolvedDeps: string[] = [];
           for (const depId of dependent.dependencies) {
             const dep = taskById.get(depId);
-            if (dep && !(await satisfiedLanesFor(depId)).has(dep.column)) unresolvedDeps.push(depId);
+            if (!dep) continue;
+            const columns = depSatisfaction.get(depId);
+            const satisfied = columns
+              ? columns.terminal.has(dep.column) || columns.review.has(dep.column)
+              /* DELIBERATE-LITERAL — the no-metadata fallback, matching isLegacyDependencySatisfied. */
+              : dep.column === "done" || dep.column === "archived" || dep.column === "in-review";
+            if (!satisfied) unresolvedDeps.push(depId);
           }
           const overlapBlockedBy = dependent.overlapBlockedBy === taskId ? null : (dependent.overlapBlockedBy ?? null);
           const hasActiveOverlapBlocker = await hasActiveFileScopeOverlapBlocker(dependent, overlapBlockedBy);

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -40,6 +40,7 @@
   },
   "deliberateByFile": {
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
+    "packages/engine/src/self-healing.ts\u0000in-review": 3,
     "packages/core/src/live-agent-count.ts\u0000in-progress": 2,
     "packages/core/src/live-agent-count.ts\u0000in-review": 2,
     "packages/core/src/store.ts\u0000in-review": 2,
@@ -58,7 +59,7 @@
     "packages/engine/src/scheduler.ts\u0000done": 2,
     "packages/engine/src/scheduler.ts\u0000in-progress": 2,
     "packages/engine/src/scheduler.ts\u0000in-review": 2,
-    "packages/engine/src/self-healing.ts\u0000in-review": 2,
+    "packages/engine/src/self-healing.ts\u0000done": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000done": 2,
     "plugins/fusion-plugin-reports/src/store/report-store.ts\u0000archived": 2,
@@ -120,7 +121,7 @@
     "packages/engine/src/hold-release.ts\u0000in-review": 1,
     "packages/engine/src/project-engine.ts\u0000in-review": 1,
     "packages/engine/src/scheduler.ts\u0000todo": 1,
-    "packages/engine/src/self-healing.ts\u0000done": 1,
+    "packages/engine/src/self-healing.ts\u0000archived": 1,
     "packages/engine/src/triage.ts\u0000triage": 1,
     "plugins/fusion-plugin-even-cards/src/cards/board-cards.ts\u0000archived": 1,
     "plugins/fusion-plugin-even-cards/src/cards/board-cards.ts\u0000done": 1,
@@ -128,7 +129,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +137,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`reconcileCompletedTask` releases everything blocked on a task that just completed. Three literal reads meant that on a renamed board it released **nothing** — every dependent stayed blocked on work that had already finished.

This is the most visible form of the query-filter class. There is no error, no failed task and no log line saying why: the board simply stops moving.

## Both halves, one change

The dependency-satisfaction guard (`dep.column !== "done" && !== "in-review" && !== "archived"`) converts alongside the reads, resolved **per dependency** — a dependency routinely belongs to a different workflow than the card waiting on it, which is the answer main settled on for branch-group-ops in #2720. Legacy ids are unioned, because `resolveWorkflowIrForTask` returns the built-in IR for a missing workflow and without the union a degraded board reads a finished dependency as unmet — precisely the stall being cleared.

Buckets come from the read that produced each row rather than from `task.column`; the twelfth sweep (#2879) measured why re-deriving can only lose rows.

## Revert result

| conversion | reverted → |
| --- | --- |
| the three resolved reads | fails — the dependent is never listed, so its `blockedBy` is never cleared |

A non-vacuous companion (dependent blocked on a *different* task → not released) rules out a sweep that clears everything it finds.

## Also in here: main's gate is red

`check-sql-column-literals` fails on a clean `origin/main` tree — `team-analytics.ts` dropped 6 sites to 3 without the baseline being re-recorded in the same commit, as that check asks. It blocks every open PR. Re-recorded here, **31 → 28** sites, downward only. (Also carried in #2882 in case that one lands first; the two are identical writes.)

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.