### PR TITLE
fix(gate): re-record the SQL column-literal baseline — main's MERGE GATE is red

### DIFF
--- a/scripts/lib/sql-column-literals-baseline.json
+++ b/scripts/lib/sql-column-literals-baseline.json
@@ -11,6 +11,6 @@
   "packages/core/src/task-store/reads.ts": 1,
   "packages/core/src/task-store/task-artifacts-ops.ts": 1,
   "packages/core/src/task-store/workflow-definitions.ts": 2,
-  "packages/core/src/team-analytics.ts": 6,
+  "packages/core/src/team-analytics.ts": 3,
   "packages/core/src/workflow-analytics.ts": 6
 }


### PR DESCRIPTION
## Main's merge gate is red

```
[check-sql-column-literals] SQL column-literal population changed:
  packages/core/src/team-analytics.ts: 3 site(s) now, baseline still allows 6 — re-record it (--update-baseline)
```

The count went **down**: three raw column literals inside query strings were resolved away, which is exactly the direction this gate exists to encourage. The baseline was not re-recorded in the same commit, which the check's own message asks for.

**This one is in the merge gate.** Unlike the census ratchet — which auto-tightens and exits 0 — `check-sql-column-literals` exits **1** on a drop (measured), so it blocks every PR in the queue rather than reddening a non-blocking suite.

## The fix

`--update-baseline`: 28 sites in 14 files, one entry changed.

```diff
-  "packages/core/src/team-analytics.ts": 6,
+  "packages/core/src/team-analytics.ts": 3,
```

Verified: the check exits **0** afterwards, and `pnpm test:gate` is **732 green**.

## Follow-up worth considering — deliberately not done here

This is the **fourth time today** a derived baseline going *down* has reddened something:

| baseline | effect of a drop |
|---|---|
| lifecycle census | reddened a non-blocking guard test — fixed in **#2856** |
| SQL column literals | **blocks the merge gate** — this PR, one instance |

#2856 fixed the shape for the census: a tightening now reports healthy instead of failing, so "somebody improved the tree and hasn't re-recorded yet" stops being an emergency. This gate has the same shape with **higher stakes** — a conversion PR that improves the tree stops the whole queue until a human notices and re-records.

The census CLI already models the better behaviour: auto-tighten, exit 0, print *"COMMIT IT"*. Porting that here is a small change, but it alters **merge-gate semantics**, so it deserves its own review rather than riding along in a red-clearing commit. Flagging rather than doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)