### PR TITLE
docs(core): mark the three archived STATE literals as deliberate

### DIFF
--- a/packages/core/src/task-store/async-maintenance.ts
+++ b/packages/core/src/task-store/async-maintenance.ts
@@ -37,6 +37,13 @@ export async function pruneAgentLogFilesAsync(
     severityAuditLog.warn("[fusion] PostgreSQL agent-log-file pruning is using the legacy unscoped project sentinel because asyncLayer.projectId is missing");
   }
   const projectId = boundProjectId || "__legacy_unscoped__";
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-22:12 DELIBERATE-LITERAL:
+  `'archived'` is the STATE marker here, not a lane. This sweep collects rows Fusion itself archived
+  or soft-deleted; a card merely sitting in a workflow's archived-TRAIT lane is live work and must not
+  be collected. Widening to the resolved archived set would pull real cards into a cleanup pass.
+  See #2839 for why the live-VIEW exclusions that share this literal are a different question.
+  */
   const rows = (await layer.db.execute(
     sql`SELECT id FROM project.tasks WHERE project_id = ${projectId} AND (deleted_at IS NOT NULL OR "column" = 'archived')`,
   )) as unknown as Array<{ id: string }>;

--- a/packages/core/src/task-store/workflow-definitions.ts
+++ b/packages/core/src/task-store/workflow-definitions.ts
@@ -115,6 +115,20 @@ export function migrateLegacyArchiveEntriesToArchiveDbImpl(store: TaskStore): vo
 }
 
 export async function migrateActiveArchivedTasksToArchiveDbImpl(store: TaskStore): Promise<void> {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-22:10 DELIBERATE-LITERAL:
+    `'archived'` here is the STATE marker, not a board lane, and must NOT be widened to the resolved
+    archived columns.
+
+    This finds live rows that Fusion's own archive path stamped (`archive-lifecycle-2.ts` and
+    `serialization.ts` both hardcode `column: "archived"`) so they can be migrated into the archive
+    DB. A workflow may also declare an archived-TRAIT lane under any id — `resolveLifecycleColumns`
+    resolves it, and a card can be moved there — but such a card was never archived by Fusion, has no
+    archive-store row, and migrating it would move live work out of the board.
+
+    So the resolved set is the wrong question at this site even though it is the right one for the
+    live-view exclusions that share this literal. See issue #2839 for the split.
+    */
     const rows = store.db.prepare(`SELECT * FROM tasks WHERE "column" = 'archived'`).all() as unknown as TaskRow[];
     if (rows.length === 0) {
       return;
@@ -904,6 +918,12 @@ export function pruneAgentLogFilesImpl(store: TaskStore, retentionDays: number):
     if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
       return { prunedFiles: 0, prunedEntries: 0, freedBytes: 0 };
     }
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-22:14 DELIBERATE-LITERAL:
+    STATE marker again, same reasoning as migrateActiveArchivedTasksToArchiveDbImpl above: this prunes
+    agent-log files for rows Fusion archived or soft-deleted. A card in a workflow's archived-TRAIT
+    lane is live work whose logs must survive, so the resolved set would delete data here.
+    */
     // Only prune JSONL files for tasks that are no longer active (soft-deleted or archived)
     const inactiveTaskIds = new Set(
       (


### PR DESCRIPTION
Comments only, no behaviour change. Records a conclusion I re-derived **three times across as many turns**, each pass starting from scratch — which is the actual cost this fixes.

## The three sites

| site | purpose |
|---|---|
| `workflow-definitions.ts` — `migrateActiveArchivedTasksToArchiveDbImpl` | migrates live archived rows into the archive DB |
| `workflow-definitions.ts` — agent-log pruning | deletes logs for inactive tasks |
| `async-maintenance.ts` — orphan sweep | collects deleted-or-archived rows |

All three search the **live** table for rows Fusion's own archive path stamped — `archive-lifecycle-2.ts` and `serialization.ts` both hardcode `column: "archived"`.

## Why the literal is correct here

A workflow may **also** declare an archived-trait lane under any id. Both halves of that are verified, not assumed: `resolveLifecycleColumns(ir).archived` resolves to the custom id, and `moveTask` into such a lane succeeds (probes on #2839).

But a card sitting there **was never archived by Fusion**. It has no archive-store row and it is live work. Resolving the set at these three sites would migrate it out of the board, sweep it as an orphan, or delete its agent logs — so the "conversion" would be data loss, not a fix.

## Why this kept looking unanswerable

The other eight `'archived'` literals are live-VIEW exclusions where the resolved set is probably right. Treated as one decision, every answer was wrong for half the sites. Split by intent, three are settled and eight have a clear, narrower question — see #2839.

I have deliberately not touched the eight: `reads.ts:522` sits behind an `includeArchived` flag and `liveParentFilter` gates lineage checks on destructive archive operations, so widening those changes what counts as live for deletion-adjacent logic. That failure mode is data loss rather than a wrong number, and it wants an owner's eye.

## Verification

`tsc -p packages/core` 0 · lint 0. (The SQL gate is red on `main` pending #2878, unrelated to this change and unaffected by it — comments are not AST nodes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)