### PR TITLE
fix(gate): a dropped SQL-literal count tightens the baseline instead of failing the gate

### DIFF
--- a/scripts/check-sql-column-literals.mjs
+++ b/scripts/check-sql-column-literals.mjs
@@ -287,15 +287,29 @@ if (process.argv.includes("--update-baseline")) {
     }
   }
   /*
-  A count that DROPPED is also a failure, deliberately. A migrated site that leaves its baseline entry
-  behind is a slot the surface can silently regrow into later — the same rot as an allow-list entry for
-  a deleted function, which this repo hit once already.
+  FNXC:SqlColumnLiteralRatchet 2026-08-02-06:40 (a DROP now tightens instead of failing the merge gate):
+  A stale allowance is still rot — a migrated site that leaves its entry behind is a slot the surface
+  can regrow into. But hard-failing on it put THIS CHECK, which runs inside `pnpm test:gate`, into a
+  state where one converting PR blocked every other worker's PR until someone re-recorded by hand.
+  Observed twice: `team-analytics.ts` 6 -> 3 took the gate down, and the lifecycle census hit the same
+  shape earlier from a merge wave that dropped eleven files at once.
+
+  The census already resolved this exact trade-off and its reasoning applies here with MORE force,
+  because that ratchet is not in the blocking lane and this one is (docs/testing.md):
+
+    "the drop is almost never the failing author's to fix ... A permanently-red gate is a bigger hole
+     than a stale allowance, because it gets ignored and then nothing is guarded at all."
+
+  So a drop now rewrites the baseline downward, says what it lowered, and exits 0. The RISE check —
+  the actual purpose, "no new SQL column literals" — is untouched and still fails hard.
+
+  The rewritten file must be COMMITTED; in CI the write is discarded with the runner, which is why the
+  gate goes green rather than silently passing a stale allowance.
   */
+  const tightened = [];
   for (const [file, allowed] of Object.entries(baseline)) {
     const count = found[file] ?? 0;
-    if (count < allowed) {
-      problems.push(`  ${file}: ${count} site(s) now, baseline still allows ${allowed} — re-record it (--update-baseline)`);
-    }
+    if (count < allowed) tightened.push({ file, allowed, count });
   }
 
   if (problems.length > 0) {
@@ -308,6 +322,19 @@ if (process.argv.includes("--update-baseline")) {
       + "If a count went DOWN, re-record the baseline in the same commit.\n",
     );
     process.exit(1);
+  }
+
+  if (tightened.length > 0) {
+    writeFileSync(BASELINE, `${JSON.stringify(found, null, 2)}\n`);
+    console.log("\n[check-sql-column-literals] baseline TIGHTENED — fewer literals than it allowed\n");
+    for (const { file, allowed, count } of tightened.sort((a, b) => a.file.localeCompare(b.file))) {
+      console.log(`  ${file}: allowed ${allowed}, now ${count}`);
+    }
+    console.log(
+      "\nThe baseline has been rewritten downward. COMMIT IT so the allowance cannot be regrown into;\n"
+      + "in CI this write is discarded with the runner, which is why the gate is green and not silent.\n",
+    );
+    process.exit(0);
   }
 
   const total = Object.values(found).reduce((a, b) => a + b, 0);


### PR DESCRIPTION
## Why

`check-sql-column-literals` runs inside `pnpm test:gate` — the **blocking** lane. It hard-fails when a count *drops*, so a single converting PR that doesn't re-record takes down the gate for **every worker in the program** until someone fixes the baseline by hand.

That is not hypothetical. It is happening on `main` right now (`team-analytics.ts` 6 → 3, fixed by #2880), and it is the **second** instance of the shape — the lifecycle census hit it from a merge wave that dropped eleven files at once.

## The census already resolved this exact trade-off

From `docs/testing.md`, on why the census stopped hard-failing on a drop:

> "the drop is almost never the failing author's to fix ... A permanently-red gate is a bigger hole than a stale allowance, because it gets ignored and then nothing is guarded at all."

That reasoning applies here **with more force**, because the census is *not* in the blocking lane and this check *is*. Same failure mode, higher cost, opposite policy — this aligns them.

## What changes

A drop now rewrites the baseline downward, reports what it lowered, and exits 0:

```
[check-sql-column-literals] baseline TIGHTENED — fewer literals than it allowed

  packages/core/src/team-analytics.ts: allowed 6, now 3

The baseline has been rewritten downward. COMMIT IT so the allowance cannot be regrown into;
in CI this write is discarded with the runner, which is why the gate is green and not silent.
```

**The rise check is untouched.** "No new SQL column literals" is the ratchet's actual purpose and still fails hard.

The stale-allowance concern the old comment raised is real and is preserved: the rewritten file must be committed, and in CI the write is discarded with the runner — so the gate goes green rather than silently passing a stale allowance, exactly as the census does.

## Verified in both directions

| scenario | result |
|---|---|
| drop (`team-analytics.ts` 6 → 3, the live case) | **tightens, exit 0** |
| rise (a literal added to a zero-allowance file) | **fails, exit 1** — `task-age-staleness.ts: 1 SQL column literal(s), baseline allows 0` |

The rise probe needed a zero-allowance file: adding one literal to `team-analytics.ts` keeps it at 4 against an allowance of 6, which is correctly *not* a rise. Worth noting because it is an easy way to conclude the guard is dead when it is working.

## Relationship to #2880

#2880 fixes the **instance** — it re-records the current drift so the gate goes green now. This fixes the **class**, so the next conversion doesn't take the gate down again. They are independent and either can land first; if #2880 lands first, this becomes a no-op on a matching baseline.

## Verification

- `pnpm test:gate` — exit 0 with this change applied
- `pnpm lint` — clean

No changeset: gate tooling, not published behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)