### PR TITLE
self-healing: a finished task blocked the merger queue on a renamed board (sixteenth sweep)

### DIFF
--- a/.changeset/self-healing-stale-merger-status-query.md
+++ b/.changeset/self-healing-stale-merger-status-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: A finished task no longer blocks the merger queue on boards with renamed columns.
+category: fix
+dev: `reconcileStaleMergerStatus` read the literal `done`/`archived`, so a terminal card still carrying `merging`/`merging-pr` was never cleared on a renamed board and held the merger queue for every task behind it. One resolved union read over `TERMINAL_ROLES`, deduped.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -87,6 +87,7 @@ function productionFaithfulStore(tasks: Task[]) {
     */
     listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
     logEntry: vi.fn(async () => undefined),
+    recordRunAuditEvent: vi.fn(async () => undefined),
   }) as unknown as TaskStore & EventEmitter;
   return { store, listTasks, updateTask: store.updateTask as unknown as ReturnType<typeof vi.fn> };
 }
@@ -767,6 +768,41 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     const { store, updateTask } = productionFaithfulStore([stuck]);
 
     await new SelfHealingManager(store, { rootDir: "/repo" }).recoverStaleMergingStatus();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-06:45 (the query-filter class, sixteenth sweep):
+  A card that reached a terminal lane while still carrying `merging`/`merging-pr` holds the MERGER QUEUE.
+  Two literal reads meant that on a renamed board the stale status was never cleared, so one finished
+  card blocked every task queued behind it — the widest blast radius in this series, since the damage is
+  not confined to the stranded card.
+
+  REVERT CHECK, measured: with the literal reads restored, this fails — the card is never listed, so its
+  stale status is never cleared and the queue stays blocked.
+  */
+  it("clears a stale merging status on a RENAMED terminal lane", async () => {
+    const stale = {
+      ...shippedCard(),
+      id: "FN-STALEMERGE",
+      column: RENAMED_VOCAB.complete,
+      status: "merging",
+    } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([stale]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileStaleMergerStatus();
+
+    expect(updateTask).toHaveBeenCalledWith("FN-STALEMERGE", expect.objectContaining({ status: null }));
+  });
+
+  it("leaves a card with no stale merging status alone", async () => {
+    /*
+    Non-vacuous companion: without it, a sweep that cleared the status of everything it found would
+    satisfy the case above. Same board, same terminal lane — only the status differs.
+    */
+    const settled = { ...shippedCard(), id: "FN-SETTLED", column: RENAMED_VOCAB.complete, status: null } as unknown as Task;
+    const { store, updateTask } = productionFaithfulStore([settled]);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileStaleMergerStatus();
 
     expect(updateTask).not.toHaveBeenCalled();
   });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -31,6 +31,7 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+  TERMINAL_ROLES,
   resolveProjectColumnsForRoles,
   REVIEW_ROLES,
 } from "@fusion/core";
@@ -6408,9 +6409,22 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    */
   async reconcileStaleMergerStatus(): Promise<number> {
     try {
-      const done = await this.store.listTasks({ column: "done", slim: true });
-      const archived = await this.store.listTasks({ column: "archived", slim: true });
-      const candidates = [...done, ...archived].filter((task) => {
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-06:40 (the query-filter class, sixteenth sweep):
+      A card that reached a terminal lane while still carrying `merging`/`merging-pr` holds the merger
+      queue. Two literal reads meant that on a renamed board the stale status was never cleared, so one
+      finished card blocked the queue for every task behind it.
+
+      ONE union read, not two buckets: unlike the sweeps before it, nothing here treats complete and
+      archived differently — the only filter is on `status` — so splitting them would add a distinction
+      the code does not make. Deduped, because the two roles can share a column (the P1 on #2879).
+      */
+      const terminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
+      const terminalById = new Map<string, Task>();
+      for (const column of terminalColumns) {
+        for (const task of await this.store.listTasks({ column, slim: true })) terminalById.set(task.id, task);
+      }
+      const candidates = [...terminalById.values()].filter((task) => {
         const s = task.status;
         return s === "merging" || s === "merging-pr";
       });

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 86,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 32,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`reconcileStaleMergerStatus` clears a `merging`/`merging-pr` status left on a card that already reached a terminal lane. Two literal reads meant that on a renamed board it was never cleared.

**Unlike every other sweep in this series, the damage is not confined to the stranded card:** the stale status holds the **merger queue** for every task behind it. One finished card, and the board stops merging.

## One union read, not two buckets

The sweeps before this one split their reads per role because the buckets were treated differently downstream. Here nothing distinguishes complete from archived — the only filter is on `status` — so a single union over `TERMINAL_ROLES` is the honest shape. Splitting them would encode a distinction the code does not make.

Deduped, since the two roles can share a column (the P1 reviewed on #2879).

## No per-card verdict, deliberately

This sweep has **no column comparison to convert**. Adding one would be inventing a gate rather than resolving an existing one, which is out of scope for a conversion — the same reason the redundant guards in #2891 and #2897 were *converted* rather than deleted.

## Revert result

| conversion | reverted → |
| --- | --- |
| the resolved union read | fails — the card is never listed, so its stale status is never cleared |

A non-vacuous companion (same terminal lane, no stale status → untouched) rules out a sweep that clears whatever it finds.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.