### PR TITLE
self-healing: step-complete tasks stayed stranded on a renamed board (seventeenth sweep)

### DIFF
--- a/.changeset/self-healing-stuck-completed-query.md
+++ b/.changeset/self-healing-stuck-completed-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Step-complete tasks stranded by a dead session now reach review on boards with renamed columns.
+category: fix
+dev: `recoverCompletedTasks` read the literal `in-progress`, so a task whose steps were all done but whose session died before the hand-off to review was never found on a renamed board. The read resolves via `resolveProjectColumnsForRoles` and the per-card column check resolves per card, falling back to the project set when a card's own workflow is unreadable.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -770,4 +770,51 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-07:15 (the query-filter class, seventeenth sweep):
+  `recoverCompletedTasks` rescues a task whose steps are ALL done but whose session died before the
+  executor could hand it to review. The literal read meant that on a renamed board it was never found:
+  finished implementation work sat in the wip lane with no session and nothing to move it on.
+
+  The observable is the injected `recoverCompletedTask` callback — called once per rescued card, with no
+  git anywhere on the path, so it sits downstream of both the read and the per-card verdict.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `t.column === "in-progress"` -> fails, the renamed wip lane does not match
+  */
+  it("rescues a step-complete card stranded on a RENAMED wip lane", async () => {
+    const stranded = {
+      ...shippedCard(),
+      id: "FN-STRANDED",
+      column: RENAMED_VOCAB.wip,
+      steps: [{ id: "s1", status: "done" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([stranded]);
+    const recoverCompletedTask = vi.fn(async () => true);
+
+    await new SelfHealingManager(store, { rootDir: "/repo", recoverCompletedTask }).recoverCompletedTasks();
+
+    expect(recoverCompletedTask).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-STRANDED" }));
+  });
+
+  it("does not rescue a step-complete card that already reached the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. Same
+    board, same finished card — only its lane changes, and a card already in review needs no rescue.
+    */
+    const alreadyMoved = {
+      ...shippedCard(),
+      id: "FN-STRANDED",
+      column: RENAMED_VOCAB.review,
+      steps: [{ id: "s1", status: "done" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([alreadyMoved]);
+    const recoverCompletedTask = vi.fn(async () => true);
+
+    await new SelfHealingManager(store, { rootDir: "/repo", recoverCompletedTask }).recoverCompletedTasks();
+
+    expect(recoverCompletedTask).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -2813,11 +2813,43 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     if (!recoverFn) return 0;
 
     try {
-      const tasks = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-07:10 (the query-filter class, seventeenth sweep):
+      A task whose steps are ALL done but whose session died before the executor could hand it to review.
+      The literal read meant that on a renamed board it was never found, so finished implementation work
+      sat in the wip lane with no session and nothing to move it on — the shape this sweep exists to
+      catch, made unreachable by the query above it.
+
+      The `t.column === "in-progress"` check was redundant while the query pinned the column; under a
+      resolved read it becomes the per-card verdict, so it converts rather than being deleted.
+      */
+      const stuckWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const stuckById = new Map<string, Task>();
+      for (const column of stuckWipColumns) {
+        for (const task of await this.store.listTasks({ column, slim: true })) stuckById.set(task.id, task);
+      }
+      const tasks = [...stuckById.values()];
+      /*
+      NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT — the shape #2891 settled on.
+      `resolveWorkflowIrForTask` SUBSTITUTES the built-in IR rather than failing, so a card with an
+      unreadable selection would otherwise be rejected by the verdict that the project-scoped query had
+      just admitted it under.
+      */
+      const stuckLanes = new Map<string, Set<string>>();
+      for (const task of tasks) {
+        let lanes: Set<string>;
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, task.id);
+          lanes = source === "default" ? new Set(stuckWipColumns) : new Set(columnsWithFlag(ir, "countsTowardWip"));
+        } catch {
+          lanes = new Set(stuckWipColumns);
+        }
+        stuckLanes.set(task.id, lanes);
+      }
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
 
       const stuckCompleted = tasks.filter((t) =>
-        t.column === "in-progress" &&
+        (stuckLanes.get(t.id) ?? stuckWipColumns).has(t.column) &&
         !t.paused &&
         !executingIds.has(t.id) &&
         t.steps.length > 0 &&

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 85,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`recoverCompletedTasks` rescues a task whose steps are **all done** but whose session died before the executor could hand it to review. The literal read meant that on a renamed board it was never found: finished implementation work sat in the wip lane with no session and nothing to move it on.

That is exactly the shape this sweep exists to catch, made unreachable by the query above it — the pattern this whole series is about.

## The redundant guard converts, it doesn't get deleted

`t.column === "in-progress"` was redundant while the query pinned the column. Under a resolved read it becomes the per-card verdict. Deleting it would silently widen the sweep.

Carries the #2891 shape: **narrow when the card can answer, broad when it cannot** — `resolveWorkflowIrForTask` *substitutes* the built-in IR rather than failing, so an unreadable selection would otherwise reject the very card the project-scoped query had just admitted from a renamed lane.

No dedupe needed here: a single role read, so no card can arrive twice.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed wip lane does not match |

Observable is the injected `recoverCompletedTask` callback, called once per rescued card with no git on the path, so it sits downstream of both halves. A non-vacuous companion (same finished card already in the review lane → not rescued) rules out a read that returns everything.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.