### PR TITLE
self-healing: dead cards held a work slot forever on a renamed board (eighteenth sweep)

### DIFF
--- a/.changeset/self-healing-inprogress-limbo-query.md
+++ b/.changeset/self-healing-inprogress-limbo-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Dead cards no longer hold a work slot forever on boards with renamed columns.
+category: fix
+dev: `recoverInProgressLimbo` read the literal `in-progress`, so a card holding a wip slot with no worktree, no branch and no started step was never reclaimed on a renamed board. The read resolves via `resolveProjectColumnsForRoles` and the per-card column check resolves per card, falling back to the project set when a card's own workflow is unreadable.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -770,4 +770,68 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-07:45 (the query-filter class, eighteenth sweep):
+  `recoverInProgressLimbo` frees a card holding a wip slot with NO worktree, NO branch and no step
+  started — nothing is running and nothing will. The literal read meant that on a renamed board it was
+  never found, so the card kept its slot forever and denied that capacity to work that could run.
+
+  Observable is `getFalsePositiveRequeueSignal`, a private method called once per stranded candidate. It
+  runs BEFORE any lease or git work, so the assertion needs no fixture beyond the card itself.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column !== "in-progress"` -> fails, the renamed wip lane is filtered out
+  */
+  it("frees a slot-holding limbo card on a RENAMED wip lane", async () => {
+    const limbo = {
+      ...shippedCard(),
+      id: "FN-LIMBO",
+      column: RENAMED_VOCAB.wip,
+      worktree: null,
+      branch: null,
+      steps: [{ id: "s1", status: "pending" }],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([limbo]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const signal = vi.fn(() => ({ reason: "executor-active", metadata: {} }));
+    Object.assign(manager, {
+      getFalsePositiveRequeueSignal: signal,
+      emitFalsePositiveRequeueNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.recoverInProgressLimbo();
+
+    expect(signal).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-LIMBO" }), expect.anything());
+  });
+
+  it("ignores a limbo-shaped card sitting in the RENAMED hold lane", async () => {
+    /*
+    Non-vacuous companion: a card with no worktree and no branch is the NORMAL shape in a hold lane —
+    that is what a queued card looks like. Without this, a read returning every column would make the
+    sweep reclaim cards that were never holding a slot at all.
+    */
+    const queued = {
+      ...shippedCard(),
+      id: "FN-LIMBO",
+      column: RENAMED_VOCAB.hold,
+      worktree: null,
+      branch: null,
+      steps: [{ id: "s1", status: "pending" }],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([queued]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const signal = vi.fn(() => ({ reason: "executor-active", metadata: {} }));
+    Object.assign(manager, {
+      getFalsePositiveRequeueSignal: signal,
+      emitFalsePositiveRequeueNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.recoverInProgressLimbo();
+
+    expect(signal).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -11493,13 +11493,41 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     }
 
     try {
-      const tasks = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-07:40 (the query-filter class, eighteenth sweep):
+      A card holding a wip slot with NO worktree, NO branch and no step started — nothing is running and
+      nothing will. The literal read meant that on a renamed board it was never found, so the card kept
+      its slot indefinitely and the capacity it holds is denied to work that could actually run.
+
+      The `task.column !== "in-progress"` check was redundant while the query pinned the column; under a
+      resolved read it becomes the per-card verdict, so it converts rather than being deleted.
+      */
+      const limboWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const limboById = new Map<string, Task>();
+      for (const column of limboWipColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) limboById.set(entry.id, entry);
+      }
+      const tasks = [...limboById.values()];
+      /*
+      NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891): `resolveWorkflowIrForTask`
+      SUBSTITUTES the built-in IR rather than failing, so an unreadable selection would otherwise reject
+      the very card the project-scoped query just admitted from a renamed lane.
+      */
+      const limboLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          limboLanes.set(entry.id, source === "default" ? new Set(limboWipColumns) : new Set(columnsWithFlag(ir, "countsTowardWip")));
+        } catch {
+          limboLanes.set(entry.id, new Set(limboWipColumns));
+        }
+      }
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const activeHeartbeatTaskIds = await this.listActiveHeartbeatTaskIds();
       const now = Date.now();
 
       const stranded = tasks.filter((task) => {
-        if (task.column !== "in-progress" || task.paused) {
+        if (!(limboLanes.get(task.id) ?? limboWipColumns).has(task.column) || task.paused) {
           return false;
         }
         const hasMissingWorktreePath = typeof task.worktree === "string" && task.worktree.length > 0 && !existsSync(task.worktree);

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 85,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`recoverInProgressLimbo` frees a card holding a wip slot with **no worktree, no branch and no started step** — nothing is running and nothing will. The literal read meant that on a renamed board it was never found, so the card kept its slot indefinitely and that capacity was denied to work which could actually run.

## The redundant guard converts

`task.column !== "in-progress"` was redundant while the query pinned the column; under a resolved read it becomes the per-card verdict. Carries the #2891 shape — **narrow when the card can answer, broad when it cannot** — so an unreadable workflow selection does not reject the card the project-scoped query just admitted.

## The companion case is the interesting one here

A card with no worktree and no branch is the **normal** shape in a hold lane — that is exactly what a queued card looks like. So the non-vacuous companion is not a formality: without it, a read returning every column would make this sweep reclaim cards that were never holding a slot at all. That is a worse outcome than the bug being fixed.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed wip lane is filtered out |

Observable is `getFalsePositiveRequeueSignal`, called once per stranded candidate before any lease or git work, so the assertion needs no fixture beyond the card.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.