### PR TITLE
self-healing: the orphaned-execution signal was never emitted on a renamed board (nineteenth sweep)

### DIFF
--- a/.changeset/self-healing-orphaned-executions-query.md
+++ b/.changeset/self-healing-orphaned-executions-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: The orphaned-execution signal is now emitted on boards with renamed columns.
+category: fix
+dev: `recoverOrphanedExecutions` read the literal `in-progress`, so on a renamed board it never emitted `task:orphan-detected-no-action` and an operator had no signal that a wip card had no live session. The sweep takes no lifecycle action; this restores visibility only. Read resolves via `resolveProjectColumnsForRoles`, per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -45,6 +45,7 @@ vi.mock("../run-audit.js", async (importOriginal) => {
   };
 });
 
+import { createRunAuditor } from "../run-audit.js";
 import { SelfHealingManager } from "../self-healing.js";
 import { executingTaskLock } from "../active-session-registry.js";
 import { RENAMED_VOCAB, lifecycleIr } from "./_workflow-vocabulary-fixture.js";
@@ -769,5 +770,62 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await new SelfHealingManager(store, { rootDir: "/repo" }).recoverStaleMergingStatus();
 
     expect(updateTask).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-08:15 (the query-filter class, nineteenth sweep):
+  `recoverOrphanedExecutions` takes NO lifecycle action — it emits `task:orphan-detected-no-action` so an
+  operator can see a wip card with no live session behind it. The literal read meant that on a renamed
+  board the event was never emitted, so the one signal pointing at an orphaned execution was silently
+  absent. What this restores is visibility, not a repair.
+
+  The observable is therefore the AUDITOR construction, which happens once per detected candidate.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `t.column !== "in-progress"` -> fails, the renamed wip lane is filtered out
+  */
+  it("emits the orphan-detected signal for a card on a RENAMED wip lane", async () => {
+    const orphan = {
+      ...shippedCard(),
+      id: "FN-ORPHANEXEC",
+      column: RENAMED_VOCAB.wip,
+      worktree: null,
+      steps: [{ id: "s1", status: "pending" }],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([orphan]);
+    (createRunAuditor as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverOrphanedExecutions();
+
+    expect(createRunAuditor).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ taskId: "FN-ORPHANEXEC", phase: "recover-orphaned-executions" }),
+    );
+  });
+
+  it("does not emit the orphan signal for a card already in the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. A card
+    in review is not an orphaned EXECUTION — it has no slot and no session to be missing.
+    */
+    const reviewing = {
+      ...shippedCard(),
+      id: "FN-ORPHANEXEC",
+      column: RENAMED_VOCAB.review,
+      worktree: null,
+      steps: [{ id: "s1", status: "pending" }],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([reviewing]);
+    (createRunAuditor as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverOrphanedExecutions();
+
+    expect(createRunAuditor).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ phase: "recover-orphaned-executions" }),
+    );
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -11659,12 +11659,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    */
   async recoverOrphanedExecutions(): Promise<number> {
     try {
-      const tasks = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-08:10 (the query-filter class, nineteenth sweep):
+      WHAT THIS SWEEP RESTORES IS VISIBILITY, NOT A REPAIR. It takes no lifecycle action — it only emits
+      `task:orphan-detected-no-action` so an operator can see a wip card with no live session behind it.
+      The literal read meant that on a renamed board the event was never emitted, so the one signal
+      pointing at an orphaned execution was silently absent. Worth stating because the rest of this series
+      fixes stalls; this one fixes a blind spot.
+
+      The `t.column !== "in-progress"` check was redundant while the query pinned the column; under a
+      resolved read it becomes the per-card verdict, so it converts rather than being deleted.
+      */
+      const orphanWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const orphanExecById = new Map<string, Task>();
+      for (const column of orphanWipColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) orphanExecById.set(entry.id, entry);
+      }
+      const tasks = [...orphanExecById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const orphanExecLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          orphanExecLanes.set(entry.id, source === "default" ? new Set(orphanWipColumns) : new Set(columnsWithFlag(ir, "countsTowardWip")));
+        } catch {
+          orphanExecLanes.set(entry.id, new Set(orphanWipColumns));
+        }
+      }
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const now = Date.now();
 
       const orphaned = tasks.filter((t) => {
-        if (t.column !== "in-progress" || t.paused || executingIds.has(t.id) || isTaskWorkComplete(t)) {
+        if (!(orphanExecLanes.get(t.id) ?? orphanWipColumns).has(t.column) || t.paused || executingIds.has(t.id) || isTaskWorkComplete(t)) {
           return false;
         }
         const staleness = now - new Date(t.updatedAt).getTime();

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 85,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
**What this restores is visibility, not a repair** — worth saying up front, because every other PR in this series fixes a stall.

`recoverOrphanedExecutions` takes no lifecycle action. It emits `task:orphan-detected-no-action` so an operator can see a wip card with no live session behind it — deliberately operator-decides. The literal read meant that on a renamed board the event was never emitted, so the one signal pointing at an orphaned execution was silently absent. The card was just as stuck; nothing said so.

## The redundant guard converts

`t.column !== "in-progress"` was redundant while the query pinned the column; under a resolved read it becomes the per-card verdict. Carries the #2891 shape — **narrow when the card can answer, broad when it cannot** — so an unreadable workflow selection does not reject the card the project-scoped query just admitted.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed wip lane is filtered out |

The observable is the auditor construction, which happens once per detected candidate. A non-vacuous companion (same card in the review lane → no signal) rules out a read that returns everything: a card in review is not an orphaned *execution* — it holds no slot and has no session to be missing.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.