### PR TITLE
self-healing: idle assigned agents were never reattached on a renamed board (twentieth sweep)

### DIFF
--- a/.changeset/self-healing-reattach-assigned-query.md
+++ b/.changeset/self-healing-reattach-assigned-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Idle assigned agents are reattached to their work on boards with renamed columns.
+category: fix
+dev: `reattachOrphanedAssignedExecutions` read the literal `in-progress`, so on a renamed board an agent that stopped executing a task it was still assigned to was never resumed, leaving the card assigned-but-idle. Read resolves via `resolveProjectColumnsForRoles`, per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -770,4 +770,61 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-08:45 (the query-filter class, twentieth sweep):
+  `reattachOrphanedAssignedExecutions` reattaches a DURABLE AGENT to a task it is still assigned to but
+  has stopped executing. The literal read meant that on a renamed board the reattach never fired, so the
+  card sat assigned-but-idle — visibly owned by an agent that had gone quiet, which is worse than
+  unassigned because the board says someone is on it.
+
+  Observable is the injected `resumeAssignedTaskForAgent`, called once per agent with orphaned work.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column !== "in-progress"` -> fails, the renamed wip lane is skipped
+  */
+  function reattachFixture(column: string) {
+    const assigned = {
+      ...shippedCard(),
+      id: "FN-REATTACH",
+      column,
+      assignedAgentId: "agent-1",
+      worktree: null,
+      steps: [{ id: "s1", status: "pending" }],
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([assigned]);
+    const resumeAssignedTaskForAgent = vi.fn(async () => undefined);
+    const agentStore = {
+      getAgent: vi.fn(async () => ({ id: "agent-1" })),
+      getActiveHeartbeatRun: vi.fn(async () => null),
+    };
+    const manager = new SelfHealingManager(store, {
+      rootDir: "/repo",
+      agentStore: agentStore as never,
+      resumeAssignedTaskForAgent,
+    });
+    return { manager, resumeAssignedTaskForAgent };
+  }
+
+  it("reattaches an idle assigned agent on a RENAMED wip lane", async () => {
+    const { manager, resumeAssignedTaskForAgent } = reattachFixture(RENAMED_VOCAB.wip);
+
+    await manager.reattachOrphanedAssignedExecutions();
+
+    expect(resumeAssignedTaskForAgent).toHaveBeenCalledWith("agent-1");
+  });
+
+  it("does not reattach an agent whose card already reached the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. An
+    assigned card in review has finished its execution — resuming it would restart completed work.
+    */
+    const { manager, resumeAssignedTaskForAgent } = reattachFixture(RENAMED_VOCAB.review);
+
+    await manager.reattachOrphanedAssignedExecutions();
+
+    expect(resumeAssignedTaskForAgent).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -11739,13 +11739,37 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         return 0;
       }
 
-      const tasks = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-08:40 (the query-filter class, twentieth sweep):
+      Reattaches a DURABLE AGENT to a task it is still assigned to but has stopped executing. The literal
+      read meant that on a renamed board the reattach never fired, so the agent's own assignment was
+      never resumed and the card sat assigned-but-idle — visibly owned by an agent that had gone quiet.
+
+      The `task.column !== "in-progress"` check was redundant while the query pinned the column; under a
+      resolved read it becomes the per-card verdict, so it converts rather than being deleted.
+      */
+      const reattachWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const reattachById = new Map<string, Task>();
+      for (const column of reattachWipColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) reattachById.set(entry.id, entry);
+      }
+      const tasks = [...reattachById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const reattachLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          reattachLanes.set(entry.id, source === "default" ? new Set(reattachWipColumns) : new Set(columnsWithFlag(ir, "countsTowardWip")));
+        } catch {
+          reattachLanes.set(entry.id, new Set(reattachWipColumns));
+        }
+      }
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const now = Date.now();
       const candidates: Task[] = [];
 
       for (const task of tasks) {
-        if (task.column !== "in-progress") continue;
+        if (!(reattachLanes.get(task.id) ?? reattachWipColumns).has(task.column)) continue;
         if (task.paused || task.deletedAt) continue;
         if (!task.assignedAgentId) continue;
         if (executingIds.has(task.id)) continue;

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 85,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`reattachOrphanedAssignedExecutions` reattaches a **durable agent** to a task it is still assigned to but has stopped executing. The literal read meant that on a renamed board the reattach never fired.

The resulting state is worse than an unowned stall: the card sits **assigned-but-idle**. The board says an agent is on it, and no other sweep will pick it up while it carries an owner.

## The redundant guard converts

`task.column !== "in-progress"` was redundant while the query pinned the column; under a resolved read it becomes the per-card verdict. Carries the #2891 shape — **narrow when the card can answer, broad when it cannot**.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed wip lane is skipped |

Observable is the injected `resumeAssignedTaskForAgent`, called once per agent with orphaned work. The non-vacuous companion matters here: an assigned card that already reached review has **finished** its execution, so resuming it would restart completed work — a read returning every column would do exactly that.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.