### PR TITLE
fix(tests): summary-tab queries container; the modal is portalled (2 → 0)

### DIFF
--- a/packages/dashboard/app/components/__tests__/TaskDetailModal.summary-tab.test.tsx
+++ b/packages/dashboard/app/components/__tests__/TaskDetailModal.summary-tab.test.tsx
@@ -89,7 +89,7 @@ describe("TaskDetailModal Summary tab", () => {
       />,
     );
 
-    expect(container.querySelector(".detail-tabs")?.firstElementChild?.textContent).toBe("Activity");
+    expect(document.querySelector(".detail-tabs")?.firstElementChild?.textContent).toBe("Activity");
     const summaryButton = screen.getByRole("button", { name: "Summary" });
     expectButtonActive(summaryButton);
     /*
@@ -110,7 +110,7 @@ describe("TaskDetailModal Summary tab", () => {
     fireEvent.click(activityButton);
     expectButtonActive(activityButton);
     expect(screen.queryByText("Completion summary")).toBeNull();
-    expect(container.querySelector(".detail-section--chat [data-testid='task-chat-tab']")).toBeTruthy();
+    expect(document.querySelector(".detail-section--chat [data-testid='task-chat-tab']")).toBeTruthy();
   });
 
   it("honors explicit initialTab=\"chat\" for done tasks", () => {
@@ -513,7 +513,7 @@ describe("TaskDetailModal Summary tab", () => {
   it("keeps relocated Merge Details inside the existing mobile pr-card containment", () => {
     const { container } = render(<TaskSummaryTab task={doneTask({ mergeDetails: { commitSha: "abcdef1234567890", prNumber: 42 } })} />);
     const summary = screen.getByTestId("task-summary-tab");
-    const mergeCard = container.querySelector(".task-summary-tab .merge-details-card.pr-card");
+    const mergeCard = document.querySelector(".task-summary-tab .merge-details-card.pr-card");
 
     expect(mergeCard).toBeTruthy();
     expect(summary.contains(mergeCard)).toBe(true);
@@ -561,7 +561,7 @@ describe("TaskDetailModal Summary tab", () => {
       />,
     );
 
-    const tabs = container.querySelector(".detail-tabs");
+    const tabs = document.querySelector(".detail-tabs");
     const summaryButton = screen.getByRole("button", { name: "Summary" });
     expect(tabs?.contains(summaryButton)).toBe(true);
     expect(summaryButton.classList.contains("detail-tab")).toBe(true);
@@ -581,7 +581,7 @@ describe("TaskDetailModal Summary tab", () => {
     );
 
     expectButtonActive(screen.getByRole("button", { name: "Summary" }));
-    expect(container.querySelector(".detail-tabs")?.firstElementChild?.textContent).toBe("Activity");
+    expect(document.querySelector(".detail-tabs")?.firstElementChild?.textContent).toBe("Activity");
     expect(screen.getByText("Completion summary")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Fifth file, same defect

`TaskDetailModal.summary-tab.test.tsx` — the last `TaskDetailModal` spec still failing on the portal/query-root defect (#2885, #2890, #2893, #2895).

**Probed before converting**, as with each of the others:

```
PROBE container=false document=true
```

`TaskDetailModal` mounts through `createPortal`, so `container` is empty and its 5 lookups returned nothing. Both failures carried the signature that shape produces on a text read:

```
expected undefined to be 'Activity'      ← container.querySelector(x)?.textContent
```

## Evidence

| | result |
|---|---|
| the file | **17/17** (was 2 failed) |
| mutation: rename `.detail-tabs` in `TaskDetailModal` | **3 failed** |

`pnpm lint` clean. Test-only; `TaskDetailModal.tsx` restored clean.

## Deliberately not bundled: the other three in this shard

Each is a **different** cause, and lumping them in would hide that:

- **`AgentDetailView.mobile-scroll`** — `expected '0' to be 'var(--space-md)'`. That is the **jsdom-29 `var()` computed-style** case, the same one fixed for TaskCard in #2782: jsdom does not substitute custom properties, and what it does *instead* changed at the 27→29 bump. Not a query root.
- **`AgentListModal`** — `expected +0 to be 3`.
- **`SubtaskBreakdownModal`** — an undefined-vs-string assertion mismatch.

Three separate small fixes, not one sweep. Keeping them apart also keeps each mutation-check honest about what it proves.

## Portal defect, running total

| PR | file | cleared |
|---|---|---|
| #2885 | `models-progress-workflow` | 30 |
| #2890 | `settings-mobile` | 17 |
| #2893 | `definition-actions` | 12 |
| #2895 | `rendering` | 24 |
| this | `summary-tab` | 2 |

**85** backfill failures from one defect: tests querying `container` for components that render through a portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for task detail modal behavior, including tab ordering, chat content, merge-card containment, and summary rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->