### PR TITLE
fix(tests): two more portal query-root failures (AgentListModal, SubtaskBreakdownModal)

### DIFF
--- a/packages/dashboard/app/components/__tests__/AgentListModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/AgentListModal.test.tsx
@@ -272,7 +272,15 @@ describe("AgentListModal", () => {
         expect(screen.getAllByText((_, el) => el?.textContent === "FN-PROGRESS · In Progress").length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText((_, el) => el?.textContent === "FN-BARE · Unresolved task").length).toBeGreaterThanOrEqual(1);
       });
-      expect(container.querySelectorAll(".agent-task").length).toBe(3);
+  /*
+      FNXC:PortalQueryRoot 2026-07-31-20:10:
+      document, not container — this modal renders through a PORTAL.
+
+      `container` from `render()` is empty for a portalled subtree, so this lookup could only ever
+      return nothing. Same defect as #2885 / #2890 / #2893 / #2895 / #2907; probed here before
+      converting (`PROBE container=0 document=3`).
+      */
+      expect(document.querySelectorAll(".agent-task").length).toBe(3);
     });
 
     it("shows empty state when no agents exist", async () => {

--- a/packages/dashboard/app/components/__tests__/SubtaskBreakdownModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/SubtaskBreakdownModal.test.tsx
@@ -131,7 +131,16 @@ describe("SubtaskBreakdownModal", () => {
 
     const { container } = renderModal();
     await waitFor(() => expect(mockStartSubtaskBreakdown).toHaveBeenCalled());
-    const modal = container.querySelector(".planning-modal");
+    /*
+    FNXC:PortalQueryRoot 2026-07-31-20:10:
+    document, not container — the planning modal renders through a PORTAL.
+
+    `container.querySelector(".planning-modal")` returned null, and the `?.` below turned that into
+    `undefined`, so the failure surfaced as "the given combination of arguments (undefined and
+    string) is invalid for this assertion" rather than as a missing element. Optional chaining is
+    what disguised a query-root bug as an assertion-type error.
+    */
+    const modal = document.querySelector(".planning-modal");
 
     expect(mockUseMobileKeyboard).toHaveBeenCalledWith({ enabled: true });
     expect(modal?.getAttribute("style")).toContain("--keyboard-overlap: 250px");


### PR DESCRIPTION
## The last two in `app:backfill 1/4`

Both are the portal defect (#2885, #2890, #2893, #2895, #2907): `container` from `render()` is empty for a portalled subtree, so the lookups could only ever return nothing.

**Bundled because they are one defect and one line each.** The other three singles in this shard were deliberately kept separate (#2907, #2910) because they had three *different* causes — bundling those would have made each mutation-check prove less.

Probed before converting, as with every file in this series:

```
AgentListModal   PROBE container=0 document=3
```

## What made the second one hard to read

`SubtaskBreakdownModal` failed with:

```
the given combination of arguments (undefined and string) is invalid for this assertion
```

That sounds like a bad matcher, not a missing element. The cause:

```ts
const modal = container.querySelector(".planning-modal");   // → null
expect(modal?.getAttribute("style")).toContain("--keyboard-overlap: 250px");
```

`container.querySelector` returns null, and the `?.` turns that into `undefined` before `toContain` ever sees a string. **Optional chaining disguised a query-root bug as an assertion-type error** — worth recording, because that message gives no hint where to look, and this pattern (`x?.getAttribute(...)`) is common across these specs.

## Evidence

| | result |
|---|---|
| both files | **99/99** (was 2 failed) |
| mutation: rename `.agent-task` in `AgentListModal` | **1 failed** |
| mutation: rename `--keyboard-overlap` in `SubtaskBreakdownModal` | **1 failed** |

`pnpm lint` clean. Test-only; both components restored clean.

## Portal defect, running total

| PR | file(s) | cleared |
|---|---|---|
| #2885 | `models-progress-workflow` | 30 |
| #2890 | `settings-mobile` | 17 |
| #2893 | `definition-actions` | 12 |
| #2895 | `rendering` | 24 |
| #2907 | `summary-tab` | 2 |
| this | `AgentListModal` + `SubtaskBreakdownModal` | 2 |

**87 backfill failures from one defect.** With #2910 (jsdom shorthand, 1), `app:backfill 1/4` reaches **zero**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)