### PR TITLE
fix(tests): MailboxModal queries container; the modal is portalled (2 → 0)

### DIFF
--- a/packages/dashboard/app/components/__tests__/MailboxModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/MailboxModal.test.tsx
@@ -245,7 +245,7 @@ describe("MailboxModal", () => {
     const { container } = render(<MailboxModal {...defaultProps} />);
 
     await waitFor(() => {
-      const times = Array.from(container.querySelectorAll(".mailbox-item-time")).map((node) => node.textContent);
+      const times = Array.from(document.querySelectorAll(".mailbox-item-time")).map((node) => node.textContent);
       expect(times).toEqual(expect.arrayContaining([
         "Just now",
         "5m ago",
@@ -1376,9 +1376,9 @@ describe("MailboxModal", () => {
       fireEvent.click(screen.getByTestId("mailbox-item-msg-001"));
 
       await waitFor(() => {
-        expect(container.querySelector(".mailbox-message-detail-header")).toBeTruthy();
-        expect(container.querySelector(".mailbox-message-detail-actions")).toBeTruthy();
-        expect(container.querySelector(".mailbox-message-participants")).toBeTruthy();
+        expect(document.querySelector(".mailbox-message-detail-header")).toBeTruthy();
+        expect(document.querySelector(".mailbox-message-detail-actions")).toBeTruthy();
+        expect(document.querySelector(".mailbox-message-participants")).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
## Seventh file, same defect

Probed before converting, as with each one in this series:

```
PROBE container=false document=true
```

`MailboxModal` renders through a portal, so `container` is empty and its 4 lookups returned nothing.

## Both failures, two disguises

```
expected null to be truthy                       ← querySelector
expected [] to deeply equal ArrayContaining{…}   ← querySelectorAll → []
```

The second is worth recording: an empty `NodeList` maps to an empty array, so the failure reads as a **content mismatch** rather than a missing root.

**This series has now produced four distinct symptoms from one cause** — `null`, `undefined`, `+0`, and `[]` — plus one where optional chaining turned it into *"the given combination of arguments (undefined and string) is invalid for this assertion"* (#2911). That variety is why it went unrecognised for so long: no two files' failures looked related.

## Evidence

| | result |
|---|---|
| the file | **68/68** (was 2 failed) |
| mutation: rename `.mailbox-message-detail-header` in `MailboxModal.tsx` | **1 failed** |

`pnpm lint` clean. Test-only; `MailboxModal.tsx` restored clean.

## Not bundled — different causes, checked

- **`NodesView` (2)** — `Unable to find an accessible element with the role "dialog" and name "Add Node"`. That file has **zero** `container.querySelector` calls, so it is a dialog/a11y question, not a query root.
- **`agent-modals-mobile` (2)** — also zero container queries, despite the identical `expected null to be truthy` message.

I checked the call counts rather than assuming from the symptom; two files with the same error text turned out not to share this cause.

## Portal defect, running total

| PR | file(s) | cleared |
|---|---|---|
| #2885 | `models-progress-workflow` | 30 |
| #2890 | `settings-mobile` | 17 |
| #2893 | `definition-actions` | 12 |
| #2895 | `rendering` | 24 |
| #2907 | `summary-tab` | 2 |
| #2911 | `AgentListModal` + `SubtaskBreakdownModal` | 2 |
| this | `MailboxModal` | 2 |

**89 backfill failures from one defect.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MailboxModal test queries to reliably locate timestamp and detail-view elements across the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->