### PR TITLE
self-healing: ghost review cards went undetected on a renamed board (twenty-second sweep)

### DIFF
--- a/.changeset/self-healing-ghost-review-query.md
+++ b/.changeset/self-healing-ghost-review-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Ghost review cards are detected again on boards with renamed columns.
+category: fix
+dev: `recoverGhostReviewTasks` read the literal `in-review`, so a card parked past the stuck timeout with no merge-lane owner was never found on a renamed board. Read resolves via `resolveProjectColumnsForRoles` and the per-card check resolves per card; the kick-back keeps its literal target because it passes `recoveryRehome: true`.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,61 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-10:25 (the query-filter class, twenty-second sweep):
+  A GHOST review card is one parked in review past the stuck timeout with nobody owning its merge lane.
+  The literal read meant that on a renamed board it was never found: no merger, no session, and no
+  timeout ever firing against it.
+
+  THE OBSERVABLE IS CHOSEN CAREFULLY. `isMergeLaneOwned` is called once per surviving candidate, AFTER
+  the read and the per-card verdict — earlier on this branch I positioned this same spy UPSTREAM of the
+  guard I was testing and it passed with the fix reverted. Here it sits downstream of both, which is the
+  whole difference.
+
+  `taskStuckTimeoutMs` must be set and `columnMovedAt` ancient, or the card is filtered out by the
+  timeout rather than by lane, and the case would pass reverted for the wrong reason.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column === "in-review"` -> fails, the renamed review lane is filtered out
+  */
+  function ghostFixture(column: string) {
+    const ghost = {
+      ...shippedCard(),
+      id: "FN-GHOST",
+      column,
+      columnMovedAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: "2020-01-01T00:00:00.000Z",
+      mergeDetails: {},
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([ghost]);
+    Object.assign(store, {
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false, taskStuckTimeoutMs: 60_000 })),
+    });
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const isMergeLaneOwned = vi.fn(async () => true); // owned -> no kick-back, so nothing else has to be stubbed
+    Object.assign(manager, { isMergeLaneOwned });
+    return { manager, isMergeLaneOwned };
+  }
+
+  it("evaluates a ghost review card on a RENAMED review lane", async () => {
+    const { manager, isMergeLaneOwned } = ghostFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverGhostReviewTasks();
+
+    expect(isMergeLaneOwned).toHaveBeenCalledWith("FN-GHOST");
+  });
+
+  it("does not treat a long-idle card outside the review lanes as a ghost", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. A card
+    idle in the HOLD lane is just queued — kicking it back would be the sweep inventing work.
+    */
+    const { manager, isMergeLaneOwned } = ghostFixture(RENAMED_VOCAB.hold);
+
+    await manager.recoverGhostReviewTasks();
+
+    expect(isMergeLaneOwned).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -8409,10 +8409,43 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
       const now = Date.now();
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-10:20 (the query-filter class, twenty-second sweep):
+      A GHOST review card — parked in review past the stuck timeout with nobody owning its merge lane.
+      The literal read meant that on a renamed board it was never found, so the card sat in review
+      indefinitely with no merger, no session and no timeout ever firing against it.
+
+      The `task.column === "in-review"` check was redundant while the query pinned the column; under a
+      resolved read it becomes the per-card verdict, so it converts rather than being deleted.
+
+      The kick-back below keeps its literal `todo` DELIBERATELY: it passes `recoveryRehome: true`, one of
+      the 22 documented escapes `moves.ts` exempts so a card stranded in an undeclared column stays
+      rescuable. Converting it removes the rescue path.
+      */
+      const ghostReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const ghostById = new Map<string, Task>();
+      for (const column of ghostReviewColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) ghostById.set(entry.id, entry);
+      }
+      const tasks = [...ghostById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const ghostLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          ghostLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(ghostReviewColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          ghostLanes.set(entry.id, new Set(ghostReviewColumns));
+        }
+      }
       // Pre-filter sync conditions, then resolve async merge-lane ownership.
       const candidates = tasks.filter((task) =>
-        task.column === "in-review" &&
+        (ghostLanes.get(task.id) ?? ghostReviewColumns).has(task.column) &&
         allowsAutoMergeProcessing(task, settings) &&
         !task.paused &&
         !executingIds.has(task.id) &&

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverGhostReviewTasks` finds a **ghost**: a card parked in review past the stuck timeout with nobody owning its merge lane. The literal read meant that on a renamed board it was never found — no merger, no session, and no timeout ever firing against it.

## The redundant guard converts; the kick-back does not

`task.column === "in-review"` was redundant while the query pinned the column; under a resolved read it becomes the per-card verdict.

The kick-back keeps its literal `todo` **deliberately**: it passes `recoveryRehome: true`, one of the 22 documented escapes `moves.ts` exempts so a card stranded in an undeclared column stays rescuable. Converting it removes the rescue path.

## The observable is chosen, not convenient

`isMergeLaneOwned` runs once per surviving candidate, **after** the read and the verdict.

Worth stating plainly: earlier on this branch I positioned this *same spy* **upstream** of the guard I was testing, and it passed with the fix reverted. That was one of the vacuous assertions. The spy is not the problem — its position relative to the change is.

Same reason `taskStuckTimeoutMs` is set and `columnMovedAt` is ancient in the fixture: otherwise the card is filtered out by the timeout rather than by lane, and the case would pass reverted for a reason that has nothing to do with columns.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed review lane is filtered out |

A non-vacuous companion (long-idle card in the hold lane → not a ghost) rules out a read that returns everything: a card idle in hold is just queued, and kicking it back would be the sweep inventing work.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.