### PR TITLE
self-healing: transient merge failures never recovered on a renamed board (twenty-third sweep)

### DIFF
--- a/.changeset/self-healing-transient-merge-query.md
+++ b/.changeset/self-healing-transient-merge-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Merges that failed on a transient fault recover again on boards with renamed columns.
+category: fix
+dev: `recoverTransientMergeFailures` read the literal `in-review` and kept two lane guards on column ids, so a card that burned its retry budget on a network blip or provider fault stayed failed permanently on a renamed board. Read resolves via `resolveProjectColumnsForRoles`; both the slim-snapshot filter and the full-row re-check resolve per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,56 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-11:00 (the query-filter class, twenty-third sweep):
+  `recoverTransientMergeFailures` refunds the retry budget for a merge that failed for a TRANSIENT reason
+  and burned all its retries. The literal read meant that on a renamed board the refund never happened,
+  so a card that failed on a network blip or a provider fault stayed failed permanently — visibly failed
+  to the operator, with no visible cause.
+
+  The error string is a REAL signature (`classifyTransientMergeError` matches "ACP turn failed"), not
+  invented prose. An unrecognised string is filtered out one line later and the case would pass with the
+  fix reverted — the same trap that produced the post-done wedge fixture's first failure.
+
+  Observable is the injected `requeueForAutoMerge`, called once per recovered card.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `t.column === "in-review"` -> fails, the renamed review lane is filtered out
+  */
+  function transientFixture(column: string) {
+    const failed = {
+      ...shippedCard(),
+      id: "FN-TRANSIENT",
+      column,
+      status: "failed",
+      mergeRetries: 99,
+      error: "ACP turn failed while merging",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([failed]);
+    const requeueForAutoMerge = vi.fn(async () => true);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo", requeueForAutoMerge });
+    return { manager, requeueForAutoMerge };
+  }
+
+  it("refunds a transient merge failure on a RENAMED review lane", async () => {
+    const { manager, requeueForAutoMerge } = transientFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverTransientMergeFailures();
+
+    expect(requeueForAutoMerge).toHaveBeenCalled();
+  });
+
+  it("does not refund a transient failure for a card outside the review lanes", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. A
+    failed card in the wip lane has not reached merge at all — there is no merge budget to refund.
+    */
+    const { manager, requeueForAutoMerge } = transientFixture(RENAMED_VOCAB.wip);
+
+    await manager.recoverTransientMergeFailures();
+
+    expect(requeueForAutoMerge).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -8517,9 +8517,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return 0;
       const maxAutoMergeRetries = resolveMaxAutoMergeRetries(settings);
 
-      const slim = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-10:55 (the query-filter class, twenty-third sweep):
+      A merge that failed for a TRANSIENT reason and burned its whole retry budget. The literal read
+      meant that on a renamed board the retry budget was never refunded, so a card that failed on a
+      network blip stayed failed permanently — an operator-visible failure with no operator-visible cause.
+
+      The `t.column === "in-review"` check was redundant while the query pinned the column; under a
+      resolved read it becomes the per-card verdict, so it converts rather than being deleted.
+      */
+      const transientReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const transientById = new Map<string, Task>();
+      for (const column of transientReviewColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) transientById.set(entry.id, entry);
+      }
+      const slim = [...transientById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const transientLanes = new Map<string, Set<string>>();
+      for (const entry of slim) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          transientLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(transientReviewColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          transientLanes.set(entry.id, new Set(transientReviewColumns));
+        }
+      }
       const candidates = slim.filter((t) =>
-        t.column === "in-review"
+        (transientLanes.get(t.id) ?? transientReviewColumns).has(t.column)
         && allowsAutoMergeProcessing(t, settings)
         && t.status === "failed"
         && (t.mergeRetries ?? 0) >= maxAutoMergeRetries
@@ -8537,10 +8566,15 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       for (const slimTask of candidates) {
         const task = await this.store.getTask(slimTask.id).catch(() => null);
         if (!task) continue;
-        // Re-check selector on the full row — the slim snapshot is best-effort
-        // and may be stale once we await.
+        /*
+        Re-check selector on the full row — the slim snapshot is best-effort and may be stale once we
+        await. FNXC:WorkflowResolvedColumns 2026-07-31-11:10: this SECOND lane guard converts with the
+        first. Converting only the read left it rejecting every renamed-board card the widened query
+        found, and the new test failed on exactly that — the "convert the pair or neither" rule, caught
+        by the test rather than by reading.
+        */
         if (
-          task.column !== "in-review"
+          !(transientLanes.get(task.id) ?? transientReviewColumns).has(task.column)
           || task.status !== "failed"
           || (task.mergeRetries ?? 0) < maxAutoMergeRetries
         ) {

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 82,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverTransientMergeFailures` refunds the retry budget for a merge that failed for a **transient** reason and burned all its retries. The literal read meant that on a renamed board the refund never happened, so a card that failed on a network blip or a provider fault stayed failed permanently — visibly failed to the operator, with no visible cause.

## Two lane guards, and the test caught the second

I converted the read and the slim-snapshot filter, and the new case **still failed**. There is a *second* guard: after the full row is re-read, `task.column !== "in-review"` re-checks the selector. Converting only the first left it rejecting every renamed-board card the widened query had just found.

That is the "convert the pair or neither" rule from the sibling doc, and it was caught by **running the test**, not by reading the function — which is the argument for the test existing at all. A conversion that stops at the first guard looks complete and delivers nothing.

## Fixture note

The error string is a **real** transient signature — `"ACP turn failed"`, which `classifyTransientMergeError` matches — not invented prose. An unrecognised string is filtered out one line later, so the case would pass with the fix reverted. Same trap as the post-done wedge fixture earlier in this series.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read + both guards | fails — the card is never listed |
| the **second** guard alone | fails — the re-read row is rejected |

The second row is the one worth having: it proves the half I nearly shipped unconverted.

A non-vacuous companion (transient failure on a wip card → no refund) rules out a read that returns everything; a card that never reached merge has no merge budget to refund.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.