### PR TITLE
self-healing: step-incomplete review cards never requeued on a renamed board (twenty-fourth sweep)

### DIFF
--- a/.changeset/self-healing-stale-incomplete-review-query.md
+++ b/.changeset/self-healing-stale-incomplete-review-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Review cards with unfinished steps are requeued again on boards with renamed columns.
+category: fix
+dev: `recoverStaleIncompleteReviewTasks` read the literal `in-review`, so a card that reached review on a graph failure with steps still unfinished was never requeued on a renamed board. Read resolves via `resolveProjectColumnsForRoles`, per-card check resolves per card; the requeue keeps its literal target because it passes `recoveryRehome: true`.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,61 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-12:45 (the query-filter class, twenty-fourth sweep):
+  `recoverStaleIncompleteReviewTasks` requeues a review card whose STEPS are not finished — it reached
+  review on a graph failure, not on completed work. The literal read meant that on a renamed board it was
+  never requeued: the card sat in review claiming to be done while its own steps said otherwise.
+
+  Observable is `evaluateBackwardMoveTripleProof`, private and called once per candidate BEFORE the move,
+  so no git fixture is needed. `taskStuckTimeoutMs` is set and a step left non-terminal, or the card is
+  filtered out for reasons unrelated to lanes.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column === "in-review"` -> fails, the renamed review lane is filtered out
+  */
+  function staleIncompleteFixture(column: string) {
+    const card = {
+      ...shippedCard(),
+      id: "FN-INCOMPLETE",
+      column,
+      status: "failed",
+      steps: [{ id: "s1", status: "in-progress" }],
+      columnMovedAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: "2020-01-01T00:00:00.000Z",
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    Object.assign(store, {
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false, taskStuckTimeoutMs: 60_000 })),
+    });
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const proof = vi.fn(async () => ({ ok: false, reason: "test" }));
+    Object.assign(manager, {
+      evaluateBackwardMoveTripleProof: proof,
+      emitBackwardMoveNoAction: vi.fn(async () => undefined),
+    });
+    return { manager, proof };
+  }
+
+  it("requeues a step-incomplete card on a RENAMED review lane", async () => {
+    const { manager, proof } = staleIncompleteFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverStaleIncompleteReviewTasks();
+
+    expect(proof).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-INCOMPLETE" }), expect.anything());
+  });
+
+  it("leaves a step-incomplete card in the RENAMED wip lane alone", async () => {
+    /*
+    Non-vacuous companion: a card with unfinished steps in the WIP lane is not stale — it is simply being
+    worked on. A read returning every column would requeue live work.
+    */
+    const { manager, proof } = staleIncompleteFixture(RENAMED_VOCAB.wip);
+
+    await manager.recoverStaleIncompleteReviewTasks();
+
+    expect(proof).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -8005,7 +8005,37 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (!timeoutMs || timeoutMs <= 0) return 0;
 
       const now = Date.now();
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-12:40 (the query-filter class, twenty-fourth sweep):
+      A review card whose STEPS are not finished — it reached review on a graph failure, not on completed
+      work. The literal read meant that on a renamed board it was never requeued, so the card sat in
+      review claiming to be done while its own steps said otherwise.
+
+      The per-card verdict below converts with it. The triple-proof is NOT lane-gated in this sweep, so
+      there is no second pair to convert — checked deliberately, because that is the defect #2916 found
+      one sweep over and the self-audit found five of in another.
+      */
+      const staleIncompleteColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const staleIncompleteById = new Map<string, Task>();
+      for (const column of staleIncompleteColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) staleIncompleteById.set(entry.id, entry);
+      }
+      const tasks = [...staleIncompleteById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const staleIncompleteLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          staleIncompleteLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(staleIncompleteColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          staleIncompleteLanes.set(entry.id, new Set(staleIncompleteColumns));
+        }
+      }
       /*
        * FNXC:WorkflowLifecycle 2026-06-29-11:27:
        * Restart recovery must not leave errored review-column cards with unfinished
@@ -8014,7 +8044,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
        * progress preserved instead of waiting for the stale timeout.
        */
       const staleIncomplete = tasks.filter((task) =>
-        task.column === "in-review" &&
+        (staleIncompleteLanes.get(task.id) ?? staleIncompleteColumns).has(task.column) &&
         allowsAutoMergeProcessing(task, settings) &&
         !task.paused &&
         (!task.status || task.status === "failed") &&

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverStaleIncompleteReviewTasks` requeues a review card whose **steps are not finished** — it reached review on a graph failure, not on completed work. The literal read meant that on a renamed board it was never requeued: the card sat in review claiming to be done while its own steps said otherwise.

## Checked for a second pair, deliberately

The triple-proof in this sweep is **not** lane-gated, so unlike #2916 (a second guard on a re-read row) and #2879 (five more in the loop body), there is nothing else here to convert. Verified with the derived ratchet added in #2879 rather than by eye.

The requeue keeps its literal `todo`: `recoveryRehome: true`, one of the 22 documented escapes `moves.ts` exempts so a card stranded in an undeclared column stays rescuable.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed review lane is filtered out |

Observable is `evaluateBackwardMoveTripleProof`, private and called once per candidate before any move, so no git fixture is involved. A non-vacuous companion (same unfinished card in the wip lane → untouched) rules out a read that returns everything: unfinished steps in the wip lane mean the card is simply *being worked on*, and requeueing it would interrupt live work.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.
