### PR TITLE
self-healing: falsely-failed tasks stayed failed on a renamed board (twenty-fifth sweep)

### DIFF
--- a/.changeset/self-healing-misclassified-failures-query.md
+++ b/.changeset/self-healing-misclassified-failures-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Falsely-failed tasks with all steps done are cleared again on boards with renamed columns.
+category: fix
+dev: `recoverMisclassifiedFailures` read the literal `in-review`, so a task parked failed for "without calling fn_task_done" whose steps were all actually done stayed visibly failed on a renamed board. Read resolves via `resolveProjectColumnsForRoles`, per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -798,6 +798,50 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     const { store, updateTask } = productionFaithfulStore([stuck]);
 
     await new SelfHealingManager(store, { rootDir: "/repo" }).recoverStaleMergingStatus();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:25 (the query-filter class, twenty-fifth sweep):
+  `recoverMisclassifiedFailures` clears a failure the executor parked for "without calling fn_task_done"
+  on a task whose steps are ALL actually done — the failure is a misclassification, not real work left
+  undone. The literal read meant that on a renamed board it was never cleared, so finished work stayed
+  visibly failed and never entered normal review.
+
+  The error string must contain the REAL phrase `isNoTaskDoneFailure` matches. Invented prose is filtered
+  out one line later and the case would pass with the fix reverted — the same trap as #2916's fixture.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `t.column === "in-review"` -> fails, the renamed review lane is filtered out
+  */
+  function misclassifiedFixture(column: string) {
+    const card = {
+      ...shippedCard(),
+      id: "FN-MISCLASS",
+      column,
+      status: "failed",
+      error: "Agent finished without calling fn_task_done",
+      steps: [{ id: "s1", status: "done" }],
+    } as unknown as Task;
+    return productionFaithfulStore([card]);
+  }
+
+  it("clears a misclassified failure on a RENAMED review lane", async () => {
+    const { store, updateTask } = misclassifiedFixture(RENAMED_VOCAB.review);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverMisclassifiedFailures();
+
+    expect(updateTask).toHaveBeenCalledWith("FN-MISCLASS", expect.objectContaining({ status: null, error: null }));
+  });
+
+  it("does not clear the same failure for a card in the RENAMED wip lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. A card
+    still in wip has not handed off, so clearing its failure would hide a live problem.
+    */
+    const { store, updateTask } = misclassifiedFixture(RENAMED_VOCAB.wip);
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).recoverMisclassifiedFailures();
 
     expect(updateTask).not.toHaveBeenCalled();
   });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -11239,10 +11239,39 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    */
   async recoverMisclassifiedFailures(): Promise<number> {
     try {
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-13:20 (the query-filter class, twenty-fifth sweep):
+      A task the executor parked `failed` for "no fn_task_done" whose steps are ALL actually done — the
+      failure is a misclassification, not real. The literal read meant that on a renamed board the error
+      was never cleared, so finished work stayed visibly failed and never entered normal review.
+
+      The per-card verdict below converts with it. No second pair: nothing else in this sweep is
+      lane-gated (verified with the derived ratchet from #2879, not by eye).
+      */
+      const misclassifiedColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const misclassifiedById = new Map<string, Task>();
+      for (const column of misclassifiedColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) misclassifiedById.set(entry.id, entry);
+      }
+      const tasks = [...misclassifiedById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const misclassifiedLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          misclassifiedLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(misclassifiedColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          misclassifiedLanes.set(entry.id, new Set(misclassifiedColumns));
+        }
+      }
 
       const misclassified = tasks.filter((t) =>
-        t.column === "in-review" &&
+        (misclassifiedLanes.get(t.id) ?? misclassifiedColumns).has(t.column) &&
         !t.paused &&
         t.status === "failed" &&
         isNoTaskDoneFailure(t) &&

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverMisclassifiedFailures` clears a failure the executor parked for *"without calling fn_task_done"* on a task whose steps are **all actually done** — the failure is a misclassification, not real work left undone. The literal read meant that on a renamed board it was never cleared, so finished work stayed visibly failed and never entered normal review.

## No second pair

Verified with the derived ratchet added in #2879 rather than by eye. That instrument exists because #2916 found a second lane guard on a re-read row, and the follow-up audit found five more in another sweep — checking is now cheap, so it is not skipped.

## Fixture note

The error string carries the **real** phrase `isNoTaskDoneFailure` matches (`"without calling fn_task_done"`). Invented prose is filtered out one line later, and the case would then pass with the fix reverted. Third time this exact trap has come up in this series, so it is now the first thing I check when writing one of these fixtures.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed review lane is filtered out |

A non-vacuous companion (same card in the wip lane → untouched) rules out a read that returns everything: a card still in wip has not handed off, so clearing its failure would hide a live problem rather than fix a stale one.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.
