### PR TITLE
self-healing: branch misbinding went undetected on a renamed board (twenty-sixth sweep)

### DIFF
--- a/.changeset/self-healing-branch-misbound-query.md
+++ b/.changeset/self-healing-branch-misbound-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Branch-misbinding is detected again on boards with renamed columns.
+category: fix
+dev: `recoverBranchMisboundInReviewTasks` read the literal `in-review`, so on a renamed board a review card whose branch tip belongs to another task was never detected. Read resolves via `resolveProjectColumnsForRoles`, per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,59 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:15 (the query-filter class, twenty-sixth sweep):
+  `recoverBranchMisboundInReviewTasks` detects a review card whose BRANCH TIP is bound to a different
+  task's work. The literal read meant that on a renamed board the misbinding was never detected, so the
+  card would merge — or refuse to — against a branch that is not its own.
+
+  Observable is `resolveSelfHealingMergeTarget`, private and called once per candidate, so the assertion
+  sits downstream of both halves without a git fixture.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column === "in-review"` -> fails, the renamed review lane is filtered out
+  */
+  function misboundFixture(column: string) {
+    const card = {
+      ...shippedCard(),
+      id: "FN-MISBOUND",
+      column,
+      branch: "fusion/FN-MISBOUND",
+      mergeDetails: {},
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const resolveTarget = vi.fn(async () => ({ branch: "main", source: "settings" }));
+    Object.assign(manager, {
+      resolveSelfHealingMergeTarget: resolveTarget,
+      isBranchTipMisboundToTask: vi.fn(async () => ({ rejection: null, branchTip: "abc1234" })),
+    });
+    return { manager, resolveTarget };
+  }
+
+  it("checks branch binding for a card on a RENAMED review lane", async () => {
+    const { manager, resolveTarget } = misboundFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverBranchMisboundInReviewTasks();
+
+    expect(resolveTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "FN-MISBOUND" }),
+      expect.anything(),
+      "recover-branch-misbound-in-review",
+    );
+  });
+
+  it("does not check branch binding for a card in the RENAMED wip lane", async () => {
+    /*
+    Non-vacuous companion: a card still in wip legitimately owns a moving branch tip — checking it here
+    would flag normal in-progress work as misbound.
+    */
+    const { manager, resolveTarget } = misboundFixture(RENAMED_VOCAB.wip);
+
+    await manager.recoverBranchMisboundInReviewTasks();
+
+    expect(resolveTarget).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -10894,9 +10894,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return 0;
 
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-14:10 (the query-filter class, twenty-sixth sweep):
+      A review card whose BRANCH TIP is bound to a different task's work. The literal read meant that on
+      a renamed board the misbinding was never detected, so the card would merge — or refuse to — against
+      a branch that is not its own.
+
+      The per-card verdict below converts with it. No second pair; verified with the derived ratchet from
+      #2879 rather than by eye.
+      */
+      const misboundColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const misboundById = new Map<string, Task>();
+      for (const column of misboundColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) misboundById.set(entry.id, entry);
+      }
+      const tasks = [...misboundById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const misboundLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          misboundLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(misboundColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          misboundLanes.set(entry.id, new Set(misboundColumns));
+        }
+      }
       const candidates = tasks.filter((task) =>
-        task.column === "in-review" &&
+        (misboundLanes.get(task.id) ?? misboundColumns).has(task.column) &&
         Boolean(task.branch) &&
         task.mergeDetails?.mergeConfirmed !== true &&
         !executingIds.has(task.id),

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverBranchMisboundInReviewTasks` detects a review card whose **branch tip is bound to a different task's work**. The literal read meant that on a renamed board the misbinding was never detected, so the card would merge — or refuse to — against a branch that is not its own.

## No second pair

Verified with the derived ratchet added in #2879, not by eye.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed review lane is filtered out |

Observable is `resolveSelfHealingMergeTarget`, private and called once per candidate, so the assertion sits downstream of both halves without a git fixture.

A non-vacuous companion (same card in the wip lane → not checked) rules out a read that returns everything, and the reason is substantive: a card still in wip legitimately owns a *moving* branch tip, so checking it here would flag normal in-progress work as misbound.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.
