### PR TITLE
chore(census): a migration marker is not a lifecycle lane (170 → 169)

### DIFF
--- a/packages/core/src/plugin-store.ts
+++ b/packages/core/src/plugin-store.ts
@@ -332,6 +332,18 @@ export class PluginStore extends EventEmitter<PluginStoreEvents> {
     const marker = this.localDb
       .prepare("SELECT value FROM __meta WHERE key = 'pluginCentralMigrationV1'")
       .get() as { value: string } | undefined;
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-30-23:59 DELIBERATE-LITERAL: a MIGRATION MARKER, not a lane.
+
+    The lifecycle-column census counts `=== "done"` comparisons, and this one is a `__meta` key/value
+    row recording whether `pluginCentralMigrationV1` has run — the same vocabulary the two writes below
+    use. It has nothing to do with a board column, and converting it to a role read would compare a
+    migration flag against a workflow's complete lane, which is meaningless and would break the
+    migration on any board that renames `done`.
+
+    Marked rather than left counted because an entry in the backlog is a claim that a conversion is
+    OWED here, and the next person to work the list would spend the time discovering it is not.
+    */
     if (marker?.value === "done") return;
 
     const hasPluginsTable = this.localDb

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -24,7 +24,6 @@
     "packages/core/src/eval-signal-collector.ts": 1,
     "packages/core/src/in-review-stall.ts": 1,
     "packages/core/src/mission-store.ts": 1,
-    "packages/core/src/plugin-store.ts": 1,
     "packages/core/src/stalled-review-detector.ts": 1,
     "packages/core/src/task-store/comments-ops.ts": 1,
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
@@ -68,6 +67,7 @@
     "packages/cli/src/extension.ts\u0000done": 1,
     "packages/core/src/live-agent-count.ts\u0000archived": 1,
     "packages/core/src/live-agent-count.ts\u0000done": 1,
+    "packages/core/src/plugin-store.ts\u0000done": 1,
     "packages/core/src/store.ts\u0000archived": 1,
     "packages/core/src/store.ts\u0000done": 1,
     "packages/core/src/store.ts\u0000in-progress": 1,
@@ -137,7 +137,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`plugin-store.ts:335` compares a `__meta` value against `"done"` to record whether `pluginCentralMigrationV1` has already run — the same vocabulary the two writes a few lines below it use. The census counts `=== "done"` comparisons, so it entered the backlog as an owed conversion.

**It is not one, and converting it would be actively harmful.** The comparison would then test a *migration flag* against a *workflow's complete lane* — meaningless on its face, and on any board that renames `done` the check would stop matching its own marker and the migration would re-run on every open.

## Why mark it rather than leave it counted

A backlog entry is a claim that work is owed at that line. The next person down the list spends real time discovering it is not — and the risk isn't just wasted time: this is exactly the shape that gets converted mechanically by someone working a count down, because `=== "done"` looks like every other guard in the list.

## The census's own reporting is correct here, and worth noting

`--strict` refused the change until the baseline was re-recorded, with the right diagnosis:

> Unconverted debt did NOT increase — a marker moved these sites out of the guard count.

That is precisely what happened: **170 → 169 is a reclassification, not a conversion.** Nothing was fixed; one site was correctly identified as never having been broken. The distinction matters for reading the program's progress, and the guard makes it impossible to bank a marker as if it were a conversion.

Core `tsc` clean, `pnpm lint` clean, census `--strict` exits 0, gate green (161/487/13/71).