### PR TITLE
self-healing: the "unfixable" query, and an arity bug beside it (twenty-seventh sweep)

### DIFF
--- a/.changeset/self-healing-missing-worktree-review-query.md
+++ b/.changeset/self-healing-missing-worktree-review-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Review failures from a missing worktree recover on renamed boards, and on boards with two review columns.
+category: fix
+dev: `recoverMissingWorktreeReviewFailures` had per-candidate lane wiring but still read the literal `in-review`, so only boards whose review lane kept that name benefited. The read now resolves via `resolveProjectColumnsForRoles`. Its per-candidate set also came from `resolveTaskLifecycleColumns().review` (first column per role) while the classifiers take a membership set; it now unions `columnsWithFlag` across the three review roles.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -770,4 +770,80 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:55 (the query-filter class, twenty-seventh sweep):
+  `recoverMissingWorktreeReviewFailures` requeues a review card failed because its worktree was gone when
+  the session tried to start. Its per-candidate lane wiring was already in place — and a note at the site
+  called the literal QUERY above it "unfixable without a project-level lane resolution before the read".
+  `resolveProjectColumnsForRoles` is that resolution; it did not exist when the note was written. So the
+  wiring only ever helped boards whose review lane still happened to be named `in-review`.
+
+  The error string uses a REAL prefix from MISSING_WORKTREE_SESSION_PREFIXES; invented prose is rejected
+  by `isMissingWorktreeSessionStartFailure` and the case would pass with the fix reverted.
+
+  REVERT CHECK, measured: with the literal read restored, this fails — the card is never listed.
+  */
+  it("requeues a missing-worktree review failure on a RENAMED review lane", async () => {
+    const card = {
+      ...shippedCard(),
+      id: "FN-NOWT",
+      column: RENAMED_VOCAB.review,
+      status: "failed",
+      error: "Refusing to start coding agent in missing worktree: /tmp/gone",
+      steps: [{ id: "s1", status: "pending" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const proof = vi.fn(async () => ({ ok: false, reason: "test" }));
+    Object.assign(manager, {
+      evaluateBackwardMoveTripleProof: proof,
+      emitBackwardMoveNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.recoverMissingWorktreeReviewFailures();
+
+    expect(proof).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-NOWT" }), expect.anything());
+  });
+
+  it("resolves the review lanes as a MEMBERSHIP set, not just the first one", async () => {
+    /*
+    The arity half. The per-candidate set was built from `resolveTaskLifecycleColumns().review`, which is
+    the FIRST column per role — so on a board declaring a separate merge lane beside its human-review
+    lane, a card in the second one read as not-in-review and was skipped. This drives exactly that board.
+
+    REVERT CHECK, measured: with the set back to `new Set([lifecycle?.review ?? "in-review", "in-review"])`
+    this fails — the card in the second review column is never classified as recoverable.
+    */
+    const splitReviewIr = {
+      ...RENAMED_IR,
+      columns: [
+        ...RENAMED_IR.columns,
+        { id: "merging", name: "Merging", traits: [{ trait: "merge" }] },
+      ],
+    } as typeof RENAMED_IR;
+    const card = {
+      ...shippedCard(),
+      id: "FN-NOWT2",
+      column: "merging",
+      status: "failed",
+      error: "Refusing to start coding agent in missing worktree: /tmp/gone",
+      steps: [{ id: "s1", status: "pending" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    Object.assign(store, {
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: splitReviewIr }]),
+      getWorkflowDefinition: vi.fn(async (id: string) => (id === "self-healing-lifecycle" ? { ir: splitReviewIr } : undefined)),
+    });
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const proof = vi.fn(async () => ({ ok: false, reason: "test" }));
+    Object.assign(manager, {
+      evaluateBackwardMoveTripleProof: proof,
+      emitBackwardMoveNoAction: vi.fn(async () => undefined),
+    });
+
+    await manager.recoverMissingWorktreeReviewFailures();
+
+    expect(proof).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-NOWT2" }), expect.anything());
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -30,7 +30,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
   resolveProjectColumnsForRoles,
   REVIEW_ROLES,
 } from "@fusion/core";
@@ -12649,7 +12649,20 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     try {
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-14:45 (the query-filter class, twenty-seventh sweep):
+      THE NOTE BELOW SAID THIS WAS UNFIXABLE. It called the literal query "unfixable without a
+      project-level lane resolution before the read" — which is precisely what
+      `resolveProjectColumnsForRoles` provides; it did not exist when that note was written. The wiring
+      below was therefore doing real work only for boards whose review lane still happens to be called
+      `in-review`. Fully renamed boards never reached it.
+      */
+      const missingWtColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const missingWtById = new Map<string, Task>();
+      for (const column of missingWtColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) missingWtById.set(entry.id, entry);
+      }
+      const tasks = [...missingWtById.values()];
       /*
       FNXC:WorkflowLifecycleColumns 2026-08-02-20:20 (PR #2745 review — greptile P1: "recovery lanes are not
       wired", and it is right):
@@ -12664,9 +12677,22 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       workflow (the common partial-rename case) and for the merge-active variant.
       */
       const recoveryIrCache = new Map<string, WorkflowIr>();
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-14:50 (the ARITY trap, same seam):
+      These classifiers take a MEMBERSHIP set, and `resolveTaskLifecycleColumns().review` is the FIRST
+      column per role — so a board declaring more than one review column contributed only one of them and
+      a card sitting in the others read as not-in-review. `columnsWithFlag` over the three review roles is
+      the membership answer; the legacy id stays unioned for a board mid-rename.
+      */
       const reviewColumnsFor = async (taskId: string): Promise<ReadonlySet<string>> => {
-        const lifecycle = await resolveTaskLifecycleColumns(this.store, taskId, recoveryIrCache);
-        return new Set([lifecycle?.review ?? "in-review", "in-review"]);
+        const columns = new Set<string>(["in-review"]);
+        try {
+          const ir = await resolveWorkflowIrForTask(this.store, taskId, recoveryIrCache);
+          if (ir) {
+            for (const role of REVIEW_ROLES) for (const id of columnsWithFlag(ir, role)) columns.add(id);
+          }
+        } catch { /* degraded: the legacy id above still answers */ }
+        return columns;
       };
       const candidateChecks = await Promise.all(tasks.map(async (task) => {
         const reviewColumns = await reviewColumnsFor(task.id);

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 86,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`recoverMissingWorktreeReviewFailures` requeues a review card failed because its worktree was gone when the session tried to start. Two independent defects here.

## 1. The note at the site said the query was unfixable

It called the literal read *"unfixable without a project-level lane resolution before the read"*. `resolveProjectColumnsForRoles` **is** that resolution — it did not exist when the note was written.

So the careful per-candidate lane wiring below it only ever helped boards whose review lane still happened to be named `in-review` (the partial-rename case the note itself calls out). Fully renamed boards never reached it. A note recording a real constraint outlived the constraint, and read as a closed question.

## 2. An arity bug in the same seam

The per-candidate set came from `resolveTaskLifecycleColumns().review` — the **first** column per role — while all three classifiers take a **membership** set:

```ts
return (reviewColumns ? reviewColumns.has(task.column) : task.column === "in-review")
```

On a board declaring a separate merge lane beside its human-review lane, a card in the second one read as not-in-review and was skipped. Now unions `columnsWithFlag` across the three review roles. This is the arity trap this program keeps hitting — first-per-role answering a membership question.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | **both** cases fail — the cards are never listed |
| the membership set | **only** the two-review-column case fails |

That asymmetry is the point: it shows the two fixes are independent, not one fix asserted twice.

## Fixture note

The error string uses a **real** prefix from `MISSING_WORKTREE_SESSION_PREFIXES`. Invented prose is rejected by `isMissingWorktreeSessionStartFailure`, and the case would then pass with the fix reverted.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` + the blindness file 430 and `restart-recovery-coordinator.test.ts`; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.
