### PR TITLE
chore(census): the async archived check compares a sentinel, not a lane

### DIFF
--- a/packages/core/src/task-store/task-id-integrity.ts
+++ b/packages/core/src/task-store/task-id-integrity.ts
@@ -436,7 +436,23 @@ export async function isTaskArchivedAsyncImpl(store: TaskStore, id: string): Pro
     
     const layer = store.asyncLayer!;
     const live = await getLiveTaskColumn(layer.db, id, layer.projectId);
-    // getLiveTaskColumn returns "archived" for archived OR soft-deleted rows.
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-31-00:20 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+    `getLiveTaskColumn` NORMALIZES — it returns the string "archived" for an archived row AND for a
+    soft-deleted one, which is why the line below it distinguishes `null` separately. So this compares
+    against that function's RETURN VOCABULARY, not against a column id, and converting it to an
+    archived-role read would keep passing on the built-in board and start FAILING on a renamed one: a
+    soft-deleted task would report as not-archived.
+
+    Same class as the migration marker in `plugin-store.ts` and the document guards in
+    `comments-ops.ts` — a legacy id that is a protocol value rather than a lane. Marked so the backlog
+    stops claiming a conversion is owed here; see
+    docs/solutions/architecture-patterns/the-archived-literal-is-usually-a-sentinel-not-a-column.md.
+
+    The sibling `isTaskArchivedImpl` above reads `cached?.column`, which IS a board lane and remains
+    counted — it is real debt, blocked on resolving lanes from a sync path with no store.
+    */
     if (live === "archived") return true;
     if (live !== null) return false;
     return isTaskIdPresentInArchivedTasksTableAsyncImpl(store, id);

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -15,7 +15,6 @@
     "packages/core/src/task-store/moves.ts": 2,
     "packages/core/src/task-store/project-store-ops.ts": 2,
     "packages/core/src/task-store/reads.ts": 2,
-    "packages/core/src/task-store/task-id-integrity.ts": 2,
     "packages/dashboard/app/utils/taskRevert.ts": 2,
     "packages/dashboard/src/github-tracking-state.ts": 2,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 2,
@@ -30,6 +29,7 @@
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
     "packages/core/src/task-store/merge-queue-ops.ts": 1,
+    "packages/core/src/task-store/task-id-integrity.ts": 1,
     "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1,
     "packages/dashboard/app/components/TaskCard.tsx": 1,
     "packages/engine/src/backlog-pressure-reporter.ts": 1,
@@ -76,6 +76,7 @@
     "packages/core/src/task-move-disposer.ts\u0000todo": 1,
     "packages/core/src/task-store/archive-lifecycle-2.ts\u0000archived": 1,
     "packages/core/src/task-store/branch-and-pr-entities.ts\u0000archived": 1,
+    "packages/core/src/task-store/task-id-integrity.ts\u0000archived": 1,
     "packages/core/src/task-store/task-store-helpers.ts\u0000in-progress": 1,
     "packages/core/src/task-store/task-store-helpers.ts\u0000todo": 1,
     "packages/core/src/task-store/task-update.ts\u0000in-progress": 1,
@@ -137,7 +138,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`isTaskArchivedAsyncImpl` tests `getLiveTaskColumn(...) === "archived"`. That helper **normalizes**: it returns the string `"archived"` for an archived row *and* for a soft-deleted one — which is why the very next line handles `null` separately, and which the existing inline comment already states. The comparison is against the function's **return vocabulary**, not a column id.

Converting it would keep passing on the built-in board and start **failing** on a renamed one: a soft-deleted task would report as not-archived. Same class as the `plugin-store.ts` migration marker (#2921) and the `comments-ops.ts` document guards — a legacy id that is a *protocol value* rather than a lane.

## The sibling is real debt and stays counted

`isTaskArchivedImpl`, a few lines above, reads `cached?.column` — that **is** a board lane. It remains in the backlog, blocked on resolving lanes from a sync path that has no store, which is the same blocker recorded for `getLiveTaskColumn` itself (#2820).

Marking the sentinel while leaving the lane is the distinction this file needed. Before, its count of 2 implied two conversions were owed; now it points at the one line that actually is. **That is the value here — not the number moving, but the number meaning something.**

## Reporting

169 → 169. The census classifies this as a **reclassification, not a conversion**, and required the baseline re-recorded in the same change — the same guard that caught #2921. Nothing was fixed; one site was identified as never having been broken.

The doc cross-reference was **verified to resolve** before committing, having been burned by a dangling one on #2873.

Core `tsc` clean, `pnpm lint` clean, census `--strict` exits 0, gate green (161/487/13/71).