### PR TITLE
fix(tests): archived-gate inventory after #2886 — the count moved, the behaviour did not

### DIFF
--- a/packages/core/src/__tests__/archived-column-gate-parity.test.ts
+++ b/packages/core/src/__tests__/archived-column-gate-parity.test.ts
@@ -63,7 +63,30 @@ const AUDITED_TS_SITES: Readonly<Record<string, number>> = {
   "packages/core/src/store.ts": 1,
   "packages/core/src/task-merge.ts": 2,
   "packages/core/src/task-store/archive-lifecycle-2.ts": 1,
-  "packages/core/src/task-store/async-comments-attachments.ts": 8,
+  /*
+  FNXC:ArchivedGateParity 2026-07-31-22:10:
+  8 -> 5 after #2886, AND THE COUNT MOVED WITHOUT THE BEHAVIOUR MOVING. Read this before trusting it.
+
+  #2886 fixed a real bug (the archived-document guards failed in OPPOSITE directions on a renamed
+  lane) by replacing three `column === "archived"` comparisons with `isArchivedLane(column,
+  archivedColumns)`. The AST scan counts raw comparisons, so the tally dropped and this file went red
+  on main — the ratchet noticing the TypeScript half move, which is what it is for.
+
+  What it is NOT is three sites converted. `archivedColumns` is an OPTIONAL parameter defaulting to
+  `LEGACY_ARCHIVED_LANES = new Set(["archived"])`, and MEASURED: no caller anywhere in packages/core
+  or packages/engine passes it. Every call therefore resolves to the same literal it replaced, so the
+  behaviour is byte-identical and the resolved path is dead code today.
+
+  That matters for the header's split-brain argument above. The danger it describes — the TypeScript
+  half resolving the role while the SQL halves still compare the string — is NOT live here, precisely
+  because the resolved half is unwired. It becomes live the moment a caller threads real lanes in
+  without the SQL sides moving too. The Drizzle and raw-sql inventories are unchanged and still pass.
+
+  So this number now means "5 raw comparisons remain" and NOT "3 sites are done". Wiring
+  `archivedColumns` is the unfinished half, and doing it in isolation is the split brain this file
+  exists to catch. Flagged on #2886.
+  */
+  "packages/core/src/task-store/async-comments-attachments.ts": 5,
   "packages/core/src/task-store/audit-ops.ts": 1,
   "packages/core/src/task-store/branch-and-pr-entities.ts": 1,
   "packages/core/src/task-store/lifecycle-ops.ts": 1,


### PR DESCRIPTION
## Main is red on core

```
archived-column-gate-parity > all three encodings of the archived gate stay in lockstep
AssertionError: TypeScript encoding changed.
  async-comments-attachments.ts: 8 → 5
```

**#2886 fixed a real bug** — the archived-document guards failed in *opposite* directions on a renamed lane — by replacing three `column === "archived"` comparisons with `isArchivedLane(column, archivedColumns)`. The AST scan counts raw comparisons, so the tally dropped and the ratchet fired. That is the ratchet working; the file header records the same thing happening for #2746 and `update-task-deps.ts`.

## What I did *not* do is record it as three sites converted

Measured: **`archivedColumns` is an optional parameter defaulting to `LEGACY_ARCHIVED_LANES = new Set(["archived"])`, and no caller anywhere in `packages/core` or `packages/engine` passes it.**

```
grep -rn "archivedColumns:" packages/core/src packages/engine/src --include="*.ts" | grep -v __tests__
→ (no matches)
```

Every call resolves to the same literal it replaced. The behaviour is byte-identical and **the resolved path is dead code today**.

That distinction is load-bearing for this file's entire argument. Its header warns that converting the TypeScript half while the SQL halves still compare the string produces a split brain *"no test would catch, because every builtin workflow spells the column `archived` so the two halves agree by accident on every board we ship."*

**That danger is not live here — precisely because the resolved half is unwired.** It becomes live the moment someone threads real lanes into `archivedColumns` without moving the SQL sides too. So the number now means *"5 raw comparisons remain"*, not *"3 sites are done"*, and the inventory says so inline where the next reader will hit it.

This is the same shape as #2803's *"five unwired parameters, five defects in their callers"*: an optional resolved parameter that nothing passes is a conversion that has not happened yet, and a count that drops for it will read as progress.

## Verified not a split brain

The Drizzle and raw-sql inventories are **unchanged and both pass**. Worth stating explicitly: those assertions run *after* the TypeScript one, so a plain red says nothing about them — they had to be re-run green to know.

## Evidence

- Guard still bites: appending a real `task.column === "archived"` to an audited file → **fails**.
- Edit scoped to `AUDITED_TS_SITES` **by line range** — these paths appear in more than one inventory here, and an unscoped replace would quietly edit the raw-sql side too, making the parity guard agree with itself (the trap I hit in #2817).
- Core **4852 passed / 0 failed** · lint clean. Test-only.

Flagged on #2886 for its author: wiring `archivedColumns` is the unfinished half, and doing it in isolation is exactly what this guard exists to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)