### PR TITLE
docs(workflow-learnings): date my measured claims, and correct one that was wrong

### DIFF
--- a/docs/solutions/workflow-learnings/lifecycle-conversions-that-score-as-wins.md
+++ b/docs/solutions/workflow-learnings/lifecycle-conversions-that-score-as-wins.md
@@ -152,7 +152,8 @@ hands in.** If your fixture passes the lane name, you have tested the consumer. 
 computes that argument in production, and whether they compute it or spell it.
 
 MEASURED, so nobody builds the wrong instrument: an AST probe for a call argument
-`{ column: "<legacy id>" }` finds **79 sites** across `packages/`. It flags the two real `moves.ts`
+`{ column: "<legacy id>" }` found **79 sites** across `packages/` when measured on 2026-07-30 (42 as
+of 2026-07-31, after the analytics conversions landed — the ratio is the point, not the total). It flags the two real `moves.ts`
 offenders, but most of the rest are legitimate — `set({ column: "archived" })` writing the archive
 state, `listTasks({ column: "todo" })` filtering a query. A blocking gate on this shape needs a
 curated list of consumers that interpret the column as a ROLE (as opposed to storing or filtering
@@ -167,7 +168,8 @@ a plausible "the census cannot see this" theory; each was measured.
 **Membership tests with inline literals** — `["done","archived"].includes(task.column)`. The census
 counts binary comparisons only, so this shape would be invisible. **Zero sites.** Nobody writes it.
 
-**Named legacy-id collections** — `const X = ["done","archived"]` then `X.has(col)`. **48 declarations**,
+**Named legacy-id collections** — `const X = ["done","archived"]` then `X.has(col)`. **48 declarations**
+measured 2026-07-30, 49 on 2026-07-31;
 and the raw count is misleading: on inspection they are all either
 
 - the intentional fallback vocabulary the role helpers degrade to (`LEGACY_TERMINAL_COLUMNS`,
@@ -182,9 +184,16 @@ would have been the same mistake as gating on `{ column: "<literal>" }` call arg
 mostly legitimate): a number that looks like a work list and is not.
 
 **The rule:** measure a candidate surface, then inspect a sample, before reporting it OR instrumenting
-it. A raw count is a hypothesis. The SQL surface survived this test — 14 sites, all genuinely
-vocabulary-bound — and got a ratchet. These two did not, and got nothing, which is the correct
-outcome and cost an hour to establish rather than a wrong gate to maintain.
+it. A raw count is a hypothesis. The SQL surface survived this test and got a ratchet; these two did
+not, and got nothing, which is the correct outcome and cost an hour to establish rather than a wrong
+gate to maintain.
+
+CORRECTION, 2026-07-31. This paragraph used to read "the SQL surface survived this test — 14 sites,
+all genuinely vocabulary-bound". Both halves were wrong within a day. The population was 31 once the
+scanner stopped missing Drizzle-templated queries, and hand-reading split it into roughly fourteen
+lane-bound sites, eleven `archived` comparisons (three of them CORRECT as literals — they read a
+state, not a lane), and one in dead code. Writing "all genuinely vocabulary-bound" was the same
+mistake this section warns about, committed in the sentence that warns about it.
 
 ## Guards start catching other people's work, not just yours
 

--- a/scripts/check-sql-column-literals.mjs
+++ b/scripts/check-sql-column-literals.mjs
@@ -23,8 +23,10 @@ baseline records per-file counts, a new file or a higher count fails, and a LOWE
 the baseline is ratcheted down as sites are migrated rather than silently drifting.
 
 COMMENTS ARE NOT MATCHED, and that is the whole reason this is AST-based. A line-oriented grep for
-the same pattern reports 37 hits, 25 of which are prose quoting `column === "done"` in an explanatory
-note. A guard with a 68% false-positive rate teaches its readers to skip it, and this repo already
+the same pattern reported 37 hits when this was written (2026-07-30), 25 of them prose quoting
+`column === "done"` in an explanatory note. Re-measured 2026-07-31: 38 grep hits against 20 real ones.
+The totals drift as conversions land and comments do not — the RATIO is the argument, and it has held
+at roughly half. A guard with a 68% false-positive rate teaches its readers to skip it, and this repo already
 learned that lesson the expensive way. Comments are not AST nodes, so walking string and template
 literals cannot match them at all.
 */


### PR DESCRIPTION
Following the rule #2904 just applied to the operator's own numbers. Three measured claims of mine in this file needed it, and one was not merely stale — it was wrong.

## Stale, now dated

| claim | when written | today |
|---|---|---|
| `{ column: "<legacy id>" }` probe finds **79 sites** | 2026-07-30 | **42** |
| **48** named legacy-id collections | 2026-07-30 | **49** |

Dated rather than rewritten, because for both of these the *ratio* to legitimate uses is the argument, not the total — and a bare updated number would lose the reason they were measured at all.

## Wrong, now corrected in place

> the SQL surface survived this test — **14 sites, all genuinely vocabulary-bound** — and got a ratchet

Both halves were wrong within a day of my writing them:

- the population was **31**, once the scanner stopped missing Drizzle-templated queries (#2841 review);
- hand-reading split it into roughly **14 lane-bound**, **11 `archived`** comparisons — three of which are *correct as literals*, reading a state rather than a lane — and **one in dead code**.

## Why this one is worth calling out

That sentence sits in the section headed *"measure a candidate surface, then inspect a sample, before reporting it OR instrumenting it."*

**I asserted an uninspected total in the paragraph telling people not to.** The correction is kept visible in the doc rather than silently overwritten, because the failure is more instructive than the corrected number — it is the third time in this program a claim of mine felt verified and was not.

Docs only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)