### PR TITLE
self-healing: the zero-commit audit went half-blind on a renamed board (twenty-eighth sweep)

### DIFF
--- a/.changeset/self-healing-no-commits-audit-query.md
+++ b/.changeset/self-healing-no-commits-audit-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: The zero-commit audit sees quietly-parked review cards again on renamed boards.
+category: fix
+dev: `auditNoCommitsExpectedCandidates` read the literal `in-review`, so on a renamed board only the `no_commits` error path fed the audit and a card sitting in a renamed review lane with zero commits and no error was never flagged. Read resolves via `resolveProjectColumnsForRoles`, the lane verdict resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -37,6 +37,17 @@ import { EventEmitter } from "node:events";
 import type { Settings, Task, TaskStore } from "@fusion/core";
 import { resolveLifecycleColumns } from "@fusion/core";
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-15:35:
+`isBranchAheadOfBase` is a static named import that shells out to git, so it is mocked rather than
+spied — the ESM binding is already resolved by the time a spy could replace it.
+*/
+const isBranchAheadOfBase = vi.fn(async () => ({ aheadCount: 0 }));
+vi.mock("../self-healing-branch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../self-healing-branch.js")>();
+  return { ...actual, isBranchAheadOfBase: (...args: unknown[]) => isBranchAheadOfBase(...args as []) };
+});
+
 vi.mock("../run-audit.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../run-audit.js")>();
   return {
@@ -769,5 +780,58 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
     await new SelfHealingManager(store, { rootDir: "/repo" }).recoverStaleMergingStatus();
 
     expect(updateTask).not.toHaveBeenCalled();
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:40 (the query-filter class, twenty-eighth sweep):
+  `auditNoCommitsExpectedCandidates` flags a card that finished every step and pushed NO commits — either
+  a legitimately commit-free task nobody declared as such, or work that silently produced nothing.
+
+  The literal read meant that on a renamed board only the `no_commits` ERROR path fed the audit, so a card
+  sitting quietly in a renamed review lane with zero commits and no error was never flagged. The sweep
+  did not go dead — it went half-blind, which is harder to notice.
+
+  REVERT CHECK, measured: with the literal read and verdict restored, this fails — the card contributes
+  nothing, because it has no `no_commits` error to be caught by the other arm.
+  */
+  it("flags a zero-commit card on a RENAMED review lane with no error text", async () => {
+    const card = {
+      ...shippedCard(),
+      id: "FN-NOCOMMITS",
+      column: RENAMED_VOCAB.review,
+      status: null,
+      error: null,
+      steps: [{ id: "s1", status: "done" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    isBranchAheadOfBase.mockClear();
+
+    const flagged = await new SelfHealingManager(store, { rootDir: "/repo" }).auditNoCommitsExpectedCandidates();
+
+    expect(isBranchAheadOfBase).toHaveBeenCalled();
+    expect(flagged).toBe(1);
+  });
+
+  it("does not flag a zero-commit card that already declared noCommitsExpected", async () => {
+    /*
+    Non-vacuous companion: without it, a sweep flagging every zero-commit card it found would satisfy the
+    case above. Same board, same lane — only the declaration differs, which is the whole point of the flag.
+    */
+    const card = {
+      ...shippedCard(),
+      id: "FN-NOCOMMITS",
+      column: RENAMED_VOCAB.review,
+      status: null,
+      error: null,
+      noCommitsExpected: true,
+      steps: [{ id: "s1", status: "done" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    isBranchAheadOfBase.mockClear();
+
+    const flagged = await new SelfHealingManager(store, { rootDir: "/repo" }).auditNoCommitsExpectedCandidates();
+
+    expect(isBranchAheadOfBase).not.toHaveBeenCalled();
+    expect(flagged).toBe(0);
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -11353,18 +11353,48 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
   async auditNoCommitsExpectedCandidates(): Promise<number> {
     try {
-      const inReviewTasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-15:30 (the query-filter class, twenty-eighth sweep):
+      Audits cards that finished every step but pushed NO commits — either a legitimately commit-free task
+      that never declared itself so, or work that silently produced nothing. The literal read meant that on
+      a renamed board only the `no_commits` ERROR path fed the audit, so a card sitting quietly in a
+      renamed review lane with zero commits and no error was never flagged.
+
+      The lane verdict below converts with it; the failed-task read beside it is already lane-independent.
+      */
+      const noCommitsColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const noCommitsById = new Map<string, Task>();
+      for (const column of noCommitsColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) noCommitsById.set(entry.id, entry);
+      }
+      const inReviewTasks = [...noCommitsById.values()];
       const allTasks = await this.store.listTasks({ slim: true });
       const failedTasks = allTasks.filter((task) => task.status === "failed");
       const candidateMap = new Map<string, Task>();
       for (const task of [...inReviewTasks, ...failedTasks]) {
         candidateMap.set(task.id, task);
       }
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). Covers the failed-task rows too,
+         which arrive from the lane-independent read above. */
+      const noCommitsLanes = new Map<string, Set<string>>();
+      for (const entry of candidateMap.values()) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          noCommitsLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(noCommitsColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          noCommitsLanes.set(entry.id, new Set(noCommitsColumns));
+        }
+      }
       const candidates = [...candidateMap.values()].filter((task) => {
         if (task.noCommitsExpected === true) return false;
         if (task.steps.length === 0 || !task.steps.every((step) => step.status === "done" || step.status === "skipped")) return false;
         const noCommitsError = typeof task.error === "string" && /no_commits/i.test(task.error);
-        return task.column === "in-review" || noCommitsError;
+        return (noCommitsLanes.get(task.id) ?? noCommitsColumns).has(task.column) || noCommitsError;
       });
 
       if (candidates.length === 0) return 0;

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 85,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`auditNoCommitsExpectedCandidates` flags a card that finished every step and pushed **no commits** — either a legitimately commit-free task nobody declared as such, or work that silently produced nothing.

## Half-blind, not dead — which is harder to notice

This sweep has two arms. It also reads all *failed* tasks, and that read is lane-independent, so on a renamed board the `no_commits` **error** arm kept working while the **lane** arm went silent. A card sitting quietly in a renamed review lane with zero commits and no error was never flagged.

Every other sweep in this series went fully dead on a renamed board, which at least produces a conspicuous absence. This one kept reporting, just less — the failure mode that survives longest.

## Revert result

| conversion | reverted → |
| --- | --- |
| the resolved read + lane verdict | fails — the card contributes nothing, having no `no_commits` error for the other arm to catch |

A non-vacuous companion (same card, `noCommitsExpected: true`) rules out a sweep that flags every zero-commit card it finds — the declaration is the entire point of the flag.

`isBranchAheadOfBase` is mocked rather than spied: it is a static named import that shells out to git, so the ESM binding is already resolved before a spy could replace it.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed zero-commit audit detection for projects using renamed review lanes.
  - Correctly evaluates each completed card’s lane verdict, including cards with zero commits.
  - Preserves support for cards explicitly marked as not requiring commits.

- **Tests**
  - Added coverage for renamed review lanes and zero-commit audit scenarios.

- **Chores**
  - Updated release metadata and lifecycle tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->