### PR TITLE
chore(census): an audited sentinel had its reasoning but not its marker

### DIFF
--- a/packages/core/src/task-store/audit-ops.ts
+++ b/packages/core/src/task-store/audit-ops.ts
@@ -125,7 +125,12 @@ export async function logEntryImpl(store: TaskStore, id: string, action: string,
           const layer = store.asyncLayer!;
           const state = await getLiveTaskColumn(layer.db, id, layer.projectId);
           /*
-          FNXC:WorkflowLifecycleColumns 2026-07-30-21:20 (audited — SENTINEL, do NOT convert):
+          FNXC:WorkflowLifecycleColumns 2026-07-30-21:20 DELIBERATE-LITERAL (audited — SENTINEL, do NOT convert):
+
+          MARKED 2026-07-31: the reasoning below was written and the MARKER was not, so the census kept
+          counting this line as owed work. A comment that explains why a site is correct does not reach
+          the instrument — only the marker string does — so the audit was invisible to the one reader
+          that acts on it, and the next person down the backlog would have re-derived it.
           `getLiveTaskColumn` MANUFACTURES the string "archived" for an archived-or-soft-deleted
           parent; it does not return the board's archived lane. So this compares against that
           function's return vocabulary, not against a column id, and converting it to

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -11,7 +11,6 @@
     "packages/core/src/async-mission-store-queries.ts": 3,
     "packages/core/src/task-store/task-artifacts-ops.ts": 3,
     "packages/core/src/agent-store.ts": 2,
-    "packages/core/src/task-store/audit-ops.ts": 2,
     "packages/core/src/task-store/moves.ts": 2,
     "packages/core/src/task-store/project-store-ops.ts": 2,
     "packages/core/src/task-store/reads.ts": 2,
@@ -26,6 +25,7 @@
     "packages/core/src/mission-store.ts": 1,
     "packages/core/src/plugin-store.ts": 1,
     "packages/core/src/stalled-review-detector.ts": 1,
+    "packages/core/src/task-store/audit-ops.ts": 1,
     "packages/core/src/task-store/comments-ops.ts": 1,
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
@@ -75,6 +75,7 @@
     "packages/core/src/task-move-disposer.ts\u0000in-progress": 1,
     "packages/core/src/task-move-disposer.ts\u0000todo": 1,
     "packages/core/src/task-store/archive-lifecycle-2.ts\u0000archived": 1,
+    "packages/core/src/task-store/audit-ops.ts\u0000archived": 1,
     "packages/core/src/task-store/branch-and-pr-entities.ts\u0000archived": 1,
     "packages/core/src/task-store/task-store-helpers.ts\u0000in-progress": 1,
     "packages/core/src/task-store/task-store-helpers.ts\u0000todo": 1,
@@ -137,7 +138,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`audit-ops.ts` already carries a full FNXC note explaining that `state === "archived"` compares `getLiveTaskColumn`'s **normalized** return value — `"archived"` covers archived *and* soft-deleted — and that converting it would make a soft-deleted task's log **writable** on a renamed board. The audit was done, and it was right.

**It carried no `DELIBERATE-LITERAL` marker, so the census kept counting the line as owed work.**

That gap is the point of this change. A comment explaining why a site is correct does not reach the instrument — only the marker string does. So a careful audit was invisible to the one reader that acts on it, and the next person working the backlog would have re-derived the entire argument, or worse, converted it and shipped the defect the note warns about.

## What moved and what did not

| | before | after |
|---|---|---|
| `audit-ops.ts` counted | 2 | **1** |
| total backlog | 169 | 169 |

The remaining one is real: `pgRow.column === "archived"` at ~202 reads an actual DB column. Same shape as #2923 — **mark the sentinel, leave the lane**, so the count points at the line that is genuinely owed rather than at a pair where one is already settled.

The census classifies this as a **reclassification, not a conversion**, and required the baseline re-recorded in the same change. Nothing was fixed; a completed audit was made legible to the tool.

Core `tsc` clean, `pnpm lint` clean, census `--strict` exits 0, gate green (161/487/13/71).