### PR TITLE
self-healing: no-progress failures kept their work slot on a renamed board (twenty-ninth sweep)

### DIFF
--- a/.changeset/self-healing-no-progress-notaskdone-query.md
+++ b/.changeset/self-healing-no-progress-notaskdone-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Failed tasks that produced nothing release their work slot again on renamed boards.
+category: fix
+dev: `recoverNoProgressNoTaskDoneFailures` read the literal `in-progress`, so a wip card failed for "no fn_task_done" with no step progress and no git work was never requeued on a renamed board and kept holding its slot. Read resolves via `resolveProjectColumnsForRoles`, per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -770,4 +770,54 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(updateTask).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-16:10 (the query-filter class, twenty-ninth sweep):
+  `recoverNoProgressNoTaskDoneFailures` requeues a wip card the executor failed for "no fn_task_done"
+  that made NO step progress and left no git work — nothing to salvage, so requeueing is safe. The
+  literal read meant that on a renamed board it was never requeued: a card that produced nothing sat
+  failed while still holding its wip slot.
+
+  Observable is `hasRecoverableGitWork`, private and called once per candidate before any requeue, so no
+  git fixture is needed. The error string carries the REAL phrase `isNoTaskDoneFailure` matches.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column === "in-progress"` -> fails, the renamed wip lane is filtered out
+  */
+  function noProgressFixture(column: string) {
+    const card = {
+      ...shippedCard(),
+      id: "FN-NOPROGRESS",
+      column,
+      status: "failed",
+      error: "Agent finished without calling fn_task_done",
+      steps: [{ id: "s1", status: "pending" }],
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const hasRecoverableGitWork = vi.fn(async () => true); // true -> sweep leaves it alone, so nothing else needs stubbing
+    Object.assign(manager, { hasRecoverableGitWork });
+    return { manager, hasRecoverableGitWork };
+  }
+
+  it("considers a no-progress failure on a RENAMED wip lane", async () => {
+    const { manager, hasRecoverableGitWork } = noProgressFixture(RENAMED_VOCAB.wip);
+
+    await manager.recoverNoProgressNoTaskDoneFailures();
+
+    expect(hasRecoverableGitWork).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-NOPROGRESS" }));
+  });
+
+  it("does not consider the same failure once the card reached the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: a card in review has handed off; requeueing it from here would undo a
+    completed hand-off rather than rescue a stalled one.
+    */
+    const { manager, hasRecoverableGitWork } = noProgressFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverNoProgressNoTaskDoneFailures();
+
+    expect(hasRecoverableGitWork).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -12565,11 +12565,35 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    */
   async recoverNoProgressNoTaskDoneFailures(): Promise<number> {
     try {
-      const tasks = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (the query-filter class, twenty-ninth sweep):
+      A wip card the executor failed for "no fn_task_done" that made NO step progress and left no git
+      work — nothing to salvage, so it is safe to requeue. The literal read meant that on a renamed board
+      it was never requeued, so a card that produced nothing sat failed while still holding its wip slot.
+
+      The per-card verdict below converts with it. No second pair; verified with the derived ratchet
+      from #2879.
+      */
+      const noProgressColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const noProgressById = new Map<string, Task>();
+      for (const column of noProgressColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) noProgressById.set(entry.id, entry);
+      }
+      const tasks = [...noProgressById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const noProgressLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          noProgressLanes.set(entry.id, source === "default" ? new Set(noProgressColumns) : new Set(columnsWithFlag(ir, "countsTowardWip")));
+        } catch {
+          noProgressLanes.set(entry.id, new Set(noProgressColumns));
+        }
+      }
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
 
       const candidates = tasks.filter((task) =>
-        task.column === "in-progress" &&
+        (noProgressLanes.get(task.id) ?? noProgressColumns).has(task.column) &&
         task.status === "failed" &&
         isNoTaskDoneFailure(task) &&
         !task.paused &&

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 87,
+    "packages/engine/src/self-healing.ts": 85,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 35,
+    "packages/engine/src/self-healing.ts": 33,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`recoverNoProgressNoTaskDoneFailures` requeues a wip card the executor failed for *"no fn_task_done"* that made **no step progress and left no git work** — nothing to salvage, so requeueing is safe. The literal read meant that on a renamed board it was never requeued.

The cost is doubled: the card sat failed *and* kept holding its wip slot, so the capacity was lost along with the task.

## No second pair

Verified with the derived ratchet added in #2879.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed wip lane is filtered out |

Observable is `hasRecoverableGitWork`, private and called once per candidate before any requeue, so no git fixture is involved. A non-vacuous companion (same failure once the card reached review → not considered) rules out a read that returns everything: a card in review has handed off, and requeueing from there would undo a completed hand-off rather than rescue a stalled one.

The error string carries the **real** phrase `isNoTaskDoneFailure` matches; invented prose is filtered out and the case would pass reverted.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.
