### PR TITLE
fix(missions): shipped-delivery repair refused a completed card on a renamed board

### DIFF
--- a/.changeset/terminal-evidence-lanes.md
+++ b/.changeset/terminal-evidence-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Mission delivery repair now accepts a completed card on boards that rename the done lane.
+category: fix
+dev: `getTerminalTaskEvidence` tested only `column === "done"`, so a completed card on a renamed board classified as `nonterminal` and `reconcileFeatureDoneWithTerminalTask` threw `TASK_NOT_TERMINAL`. It now takes resolved complete/archived lane sets, supplied by `AsyncMissionStore` from its `taskStore`. The `TerminalTaskEvidence` type's `column` field was widened from the pinned literals to `string`.

--- a/packages/core/src/__tests__/postgres/mission-store.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/mission-store.pg.test.ts
@@ -397,6 +397,54 @@ pgTest("MissionStore (PostgreSQL backend mode)", () => {
   FNXC:MissionReconciliation 2026-07-20-08:34:
   Regression coverage exercises every terminal-evidence representation through the real PostgreSQL store. Reconciliation must never route through ordinary triage linking, mutate loop attempts or mission controls, or partially commit when the transaction fails.
   */
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-05:05:
+  THE INVARIANT: terminal evidence is the card's ROLE, not the id `done`.
+
+  `getTerminalTaskEvidence` tested only `column === "done"`, so a genuinely completed card on a
+  renamed board fell through every branch to `nonterminal` and this method threw
+  `TASK_NOT_TERMINAL: ... must be in done or supported archived state, not shipped`. Mission
+  shipped-delivery repair refused valid work — and the message named the real column while the check
+  could not see it, which is the tell that the classifier and the reporter disagreed.
+
+  I deferred this twice on the premise that `AsyncMissionStore` "holds a layer, not a store". It
+  holds an OPTIONAL `taskStore`, and the single production construction site supplies it. That is the
+  third deferral of mine this session to dissolve on inspection, which is the argument for checking a
+  premise before recording it as a blocker.
+
+  REVERT PROOF, measured: restore `column === "done"` and this fails with a
+  `TASK_NOT_TERMINAL` rejection naming `shipped`.
+  */
+  it("accepts a completed card whose board calls the lane something else", async () => {
+    const m = missions();
+    const store = h.store();
+    await store.createWorkflowDefinition({
+      name: "Renamed complete",
+      ir: {
+        version: "v2",
+        name: "Renamed complete",
+        columns: [
+          { id: "todo", name: "Todo", traits: [{ trait: "intake" }, { trait: "hold" }] },
+          { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+        ],
+        nodes: [
+          { id: "start", kind: "start", column: "todo" },
+          { id: "end", kind: "end", column: "shipped" },
+        ],
+        edges: [{ from: "start", to: "end", condition: "success" }],
+      } as never,
+    });
+    const mission = await m.createMission({ title: "Renamed-lane repair" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "Delivered" });
+    const task = await store.createTask({ description: "shipped elsewhere", column: "shipped" as never });
+
+    const reconciled = await m.reconcileFeatureDoneWithTerminalTask(feature.id, task.id);
+
+    expect(reconciled).toMatchObject({ taskId: task.id, status: "done" });
+  });
+
   it("atomically reconciles live done evidence and remains idempotent", async () => {
     const m = missions();
     const mission = await m.createMission({ title: "Parked repair" });

--- a/packages/core/src/async-mission-store-queries.ts
+++ b/packages/core/src/async-mission-store-queries.ts
@@ -2173,9 +2173,19 @@ export async function listLiveLinkedTaskIds(handle: QueryHandle, taskIds: string
   return new Set(rows.map((row) => row.id));
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-05:05:
+`column` is the lane the card ACTUALLY reached, not the built-in name for its role.
+
+These two arms pinned `"done"` and `"archived"` in the TYPE, which is the census-invisible shape that
+blocks a conversion from the other end: the resolver below could not report the real column without a
+compile error, so the type would have forced the literal back in even after the predicate was fixed.
+`kind` already carries the role — that is what a consumer switches on — so the column field is free to
+carry the truth.
+*/
 export type TerminalTaskEvidence =
-  | { kind: "done"; id: string; column: "done" }
-  | { kind: "archived"; id: string; column: "archived" }
+  | { kind: "done"; id: string; column: string }
+  | { kind: "archived"; id: string; column: string }
   | { kind: "nonterminal"; id: string; column: string }
   | { kind: "invalid-deleted"; id: string; column?: string }
   | { kind: "missing" };
@@ -2184,7 +2194,11 @@ export type TerminalTaskEvidence =
  * FNXC:MissionReconciliation 2026-07-20-08:34:
  * Terminal evidence repair must distinguish a supported archive (the retained archived task tombstone plus its project-scoped cold snapshot) from an arbitrary soft/hard deletion. Read both representations on the caller's transaction handle so validation and feature linkage share one snapshot.
  */
-export async function getTerminalTaskEvidence(handle: QueryHandle, taskId: string): Promise<TerminalTaskEvidence> {
+export async function getTerminalTaskEvidence(
+  handle: QueryHandle,
+  taskId: string,
+  terminalColumns?: { complete?: ReadonlySet<string>; archived?: ReadonlySet<string> },
+): Promise<TerminalTaskEvidence> {
   const taskRows = await handle
     .select({
       id: schema.project.tasks.id,
@@ -2218,12 +2232,27 @@ export async function getTerminalTaskEvidence(handle: QueryHandle, taskId: strin
   set threaded in by the caller — the same shape `getLiveTaskColumn` needs, and it should land with
   it so the two cannot disagree about what "finished" means.
   */
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-05:05:
+  The lane sets arrive from the caller; omitted, the legacy ids answer exactly as before.
+
+  I deferred this twice on the premise that `AsyncMissionStore` "holds a layer, not a store" and so
+  could not resolve anything. It holds an OPTIONAL `taskStore`, and the single production construction
+  site supplies it (`workflow-definitions.ts`: `new AsyncMissionStore(layer, store)`). That is the
+  third deferral of mine to dissolve on inspection, which is why the premise is now recorded next to
+  the fix rather than in a note claiming it cannot be done.
+  */
+  const isComplete = (column: string) =>
+    terminalColumns?.complete ? terminalColumns.complete.has(column) : column === "done";
+  const isArchived = (column: string) =>
+    terminalColumns?.archived ? terminalColumns.archived.has(column) : column === "archived";
+
   if (!task) return hasArchiveSnapshot ? { kind: "invalid-deleted", id: taskId } : { kind: "missing" };
-  if (task.deletedAt === null && task.column === "done") return { kind: "done", id: task.id, column: "done" };
-  if (task.deletedAt !== null && task.column === "archived" && hasArchiveSnapshot) {
-    return { kind: "archived", id: task.id, column: "archived" };
+  if (task.deletedAt === null && isComplete(task.column)) return { kind: "done", id: task.id, column: task.column };
+  if (task.deletedAt !== null && isArchived(task.column) && hasArchiveSnapshot) {
+    return { kind: "archived", id: task.id, column: task.column };
   }
-  if (task.deletedAt !== null || task.column === "archived") {
+  if (task.deletedAt !== null || isArchived(task.column)) {
     return { kind: "invalid-deleted", id: task.id, column: task.column };
   }
   return { kind: "nonterminal", id: task.id, column: task.column };

--- a/packages/core/src/async-mission-store.ts
+++ b/packages/core/src/async-mission-store.ts
@@ -52,6 +52,7 @@ import type { Goal } from "./goal-types.js";
 import {
   deriveMilestoneAcceptanceCriteriaFromFeatures,
 } from "./mission-store.js";
+import { resolveProjectColumnsForRoles } from "./project-lane-vocabulary.js";
 import type {
   MissionSummary,
   MissionAssertionBackfillReport,
@@ -1158,7 +1159,26 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
         );
       }
 
-      const evidence = await getTerminalTaskEvidence(tx, taskId);
+      /*
+      FNXC:WorkflowLifecycleColumns 2026-07-31-05:05:
+      Resolve the board's terminal lanes and hand them down; without this the predicate is inert.
+
+      Keyed on the literals, a genuinely completed card on a renamed board fell through every branch
+      to `nonterminal`, and this method then threw `TASK_NOT_TERMINAL: ... must be in done or
+      supported archived state, not shipped`. Mission shipped-delivery repair refused valid work, and
+      the message named the real column while the check could not see it.
+
+      `this.taskStore` is optional on the class but the single production construction site supplies
+      it (`workflow-definitions.ts`). Absent, the resolver is skipped and the legacy ids answer —
+      which is what every test that constructs the store without one already relies on.
+      */
+      const terminalColumns = this.taskStore
+        ? {
+            complete: await resolveProjectColumnsForRoles(this.taskStore, ["complete"]).catch(() => undefined),
+            archived: await resolveProjectColumnsForRoles(this.taskStore, ["archived"]).catch(() => undefined),
+          }
+        : undefined;
+      const evidence = await getTerminalTaskEvidence(tx, taskId, terminalColumns);
       if (evidence.kind === "missing") {
         throw new TerminalTaskReconciliationError("TASK_NOT_FOUND", `Delivery task ${taskId} not found`);
       }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -8,9 +8,9 @@
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/replan-target.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
-    "packages/core/src/async-mission-store-queries.ts": 3,
     "packages/core/src/task-store/task-artifacts-ops.ts": 3,
     "packages/core/src/agent-store.ts": 2,
+    "packages/core/src/async-mission-store-queries.ts": 2,
     "packages/core/src/task-store/audit-ops.ts": 2,
     "packages/core/src/task-store/moves.ts": 2,
     "packages/core/src/task-store/project-store-ops.ts": 2,
@@ -137,7 +137,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`getTerminalTaskEvidence` tested only `column === "done"`, so a genuinely completed card on a renamed board fell through every branch to `nonterminal`, and `reconcileFeatureDoneWithTerminalTask` threw:

```
TASK_NOT_TERMINAL: Delivery task KB-001 must be in done or supported archived state, not shipped
```

Valid operator work refused — and note the tell: **the message names the real column while the check cannot see it.** The classifier and the reporter disagreed, which is usually the cheapest signal that a lane literal is in the wrong place.

## I deferred this twice on a premise I never checked

Both of my earlier notes said `AsyncMissionStore` *"holds a layer, not a store"* and therefore could resolve nothing. It holds an **optional `taskStore`**, and the single production construction site supplies it:

```ts
store.missionStore = new AsyncMissionStore(layer, store);   // workflow-definitions.ts
```

That is the **third** deferral of mine this session to dissolve on inspection — after the planner overseer's cost argument (#2898, where the poll already awaited a per-task resolve) and the review-handoff seam's file conflict (#2900, where the blocking PR had merged). The pattern is consistent enough to state plainly: *my "blocked" notes have been wrong more often than right, and checking costs minutes.*

## The type had to move first

```ts
| { kind: "done"; id: string; column: "done" }        // ← pinned
| { kind: "archived"; id: string; column: "archived" }
```

The resolver could not report the real column without a compile error, so the **annotation would have forced the literal back in** after the predicate was fixed. This is the census-invisible type-annotation class blocking a conversion from the far end. `kind` already carries the role — that is what consumers switch on — so `column` is free to carry the truth.

## Compatibility

Absent a store the resolver is skipped and the legacy ids answer, which is exactly what every test constructing `AsyncMissionStore` without one already relies on — all 34 in `mission-store.pg.test.ts` stay green.

Deliberately calls `resolveProjectColumnsForRoles` directly rather than the `resolveArchivedLanes` helper, which lives on #2925 — keeping this PR independent of that one rather than stacking.

## Revert proof (measured, real PostgreSQL)

Restore `column === "done"`:

```
FAIL > accepts a completed card whose board calls the lane something else
TerminalTaskReconciliationError: Delivery task KB-001 must be in done or supported archived state, not shipped
```

## Verification

- `pnpm test:gate` — 161 / 487 / 13 / 71 passed
- `pnpm lint` — clean
- `tsc --noEmit` (`@fusion/core`) — clean
- `mission-store.pg.test.ts` — 34 passed against real PostgreSQL
- SQL-literal gate green; census baseline tightened and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)