### PR TITLE
chore(census): five of six "archived" checks in this file are sentinels, not lanes (169 → 165)

### DIFF
--- a/packages/core/src/task-store/async-comments-attachments.ts
+++ b/packages/core/src/task-store/async-comments-attachments.ts
@@ -465,6 +465,21 @@ export async function listTaskDocuments(
   projectId?: string,
 ): Promise<TaskDocument[]> {
   const column = await getLiveTaskColumn(db, taskId, projectId);
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-00:55 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+This compares `getLiveTaskColumn`'s RETURN VALUE, which is normalized — the helper manufactures the
+string "archived" for an archived row AND for a soft-deleted one, and returns `null` for a missing
+task. So the comparison is against that function's protocol vocabulary, not a column id.
+
+Converting it to an archived-role read would keep passing on the built-in board and start FAILING on
+a renamed one: a soft-deleted task's documents would become writable, and the archived-document
+read paths would start returning rows they must not. `audit-ops.ts` records the same distinction for
+its own copy of this check.
+
+The convertible site in this file is the CLASSIFIER at ~line 142 (`row.column === "archived"`),
+which reads a real DB column. It stays counted; see #2820 for why it is deferred rather than done.
+*/
   if (column === null || column === "archived") return [];
 
   const rows = await db
@@ -525,6 +540,21 @@ export async function deleteTaskDocument(
 ): Promise<void> {
   return layer.transactionImmediate(async (tx) => {
     const state = await getLiveTaskColumn(tx, taskId, layer.projectId);
+  /*
+  FNXC:LifecycleColumnCensus 2026-07-31-00:55 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+  This compares `getLiveTaskColumn`'s RETURN VALUE, which is normalized — the helper manufactures the
+  string "archived" for an archived row AND for a soft-deleted one, and returns `null` for a missing
+  task. So the comparison is against that function's protocol vocabulary, not a column id.
+
+  Converting it to an archived-role read would keep passing on the built-in board and start FAILING on
+  a renamed one: a soft-deleted task's documents would become writable, and the archived-document
+  read paths would start returning rows they must not. `audit-ops.ts` records the same distinction for
+  its own copy of this check.
+
+  The convertible site in this file is the CLASSIFIER at ~line 142 (`row.column === "archived"`),
+  which reads a real DB column. It stays counted; see #2820 for why it is deferred rather than done.
+  */
     if (state === "archived") throw new Error(`Task ${taskId} is archived — documents are read-only`);
     if (state === null) throw new Error(`Task ${taskId} not found`);
     const existing = await tx
@@ -585,6 +615,21 @@ export async function insertArtifactRow(
     // Gate: if taskId is set, the parent must be live.
     if (input.taskId) {
       const column = await getLiveTaskColumn(tx, input.taskId, layer.projectId);
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-31-00:55 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+    This compares `getLiveTaskColumn`'s RETURN VALUE, which is normalized — the helper manufactures the
+    string "archived" for an archived row AND for a soft-deleted one, and returns `null` for a missing
+    task. So the comparison is against that function's protocol vocabulary, not a column id.
+
+    Converting it to an archived-role read would keep passing on the built-in board and start FAILING on
+    a renamed one: a soft-deleted task's documents would become writable, and the archived-document
+    read paths would start returning rows they must not. `audit-ops.ts` records the same distinction for
+    its own copy of this check.
+
+    The convertible site in this file is the CLASSIFIER at ~line 142 (`row.column === "archived"`),
+    which reads a real DB column. It stays counted; see #2820 for why it is deferred rather than done.
+    */
       if (column === "archived") {
         throw new Error(`Task ${input.taskId} is archived — artifacts are read-only`);
       }
@@ -642,6 +687,21 @@ export async function updateArtifactRow(
     }
     if (existing.taskId) {
       const column = await getLiveTaskColumn(tx, existing.taskId, layer.projectId);
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-31-00:55 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+    This compares `getLiveTaskColumn`'s RETURN VALUE, which is normalized — the helper manufactures the
+    string "archived" for an archived row AND for a soft-deleted one, and returns `null` for a missing
+    task. So the comparison is against that function's protocol vocabulary, not a column id.
+
+    Converting it to an archived-role read would keep passing on the built-in board and start FAILING on
+    a renamed one: a soft-deleted task's documents would become writable, and the archived-document
+    read paths would start returning rows they must not. `audit-ops.ts` records the same distinction for
+    its own copy of this check.
+
+    The convertible site in this file is the CLASSIFIER at ~line 142 (`row.column === "archived"`),
+    which reads a real DB column. It stays counted; see #2820 for why it is deferred rather than done.
+    */
       if (column === "archived") {
         throw new Error(`Task ${existing.taskId} is archived — artifacts are read-only`);
       }
@@ -700,6 +760,21 @@ export async function getArtifacts(
   projectId?: string,
 ): Promise<Artifact[]> {
   const column = await getLiveTaskColumn(db, taskId, projectId);
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-00:55 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+This compares `getLiveTaskColumn`'s RETURN VALUE, which is normalized — the helper manufactures the
+string "archived" for an archived row AND for a soft-deleted one, and returns `null` for a missing
+task. So the comparison is against that function's protocol vocabulary, not a column id.
+
+Converting it to an archived-role read would keep passing on the built-in board and start FAILING on
+a renamed one: a soft-deleted task's documents would become writable, and the archived-document
+read paths would start returning rows they must not. `audit-ops.ts` records the same distinction for
+its own copy of this check.
+
+The convertible site in this file is the CLASSIFIER at ~line 142 (`row.column === "archived"`),
+which reads a real DB column. It stays counted; see #2820 for why it is deferred rather than done.
+*/
   if (column === null || column === "archived") return [];
 
   const rows = await db

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -4,7 +4,6 @@
     "packages/engine/src/self-healing.ts": 87,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
-    "packages/core/src/task-store/async-comments-attachments.ts": 6,
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/replan-target.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
@@ -26,6 +25,7 @@
     "packages/core/src/mission-store.ts": 1,
     "packages/core/src/plugin-store.ts": 1,
     "packages/core/src/stalled-review-detector.ts": 1,
+    "packages/core/src/task-store/async-comments-attachments.ts": 1,
     "packages/core/src/task-store/comments-ops.ts": 1,
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
@@ -39,6 +39,7 @@
     "packages/engine/src/triage.ts": 1
   },
   "deliberateByFile": {
+    "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 5,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
     "packages/core/src/live-agent-count.ts\u0000in-progress": 2,
     "packages/core/src/live-agent-count.ts\u0000in-review": 2,
@@ -136,7 +137,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`async-comments-attachments.ts` was the largest remaining non-engine entry in the backlog at **6**. Five of those six compare `getLiveTaskColumn`'s **return value**, not a column.

That helper normalizes: it manufactures the string `"archived"` for an archived row *and* for a soft-deleted one, and returns `null` for a missing task. The `column === null || column === "archived"` shape at two of the sites is the tell — nothing that reads a board column would ever compare it to `null`.

**Converting any of them would keep passing on the built-in board and start failing on a renamed one:** a soft-deleted task's documents would become writable, and the archived-document read paths would start returning rows they must not.

## The audit already existed and had never been applied here

`audit-ops.ts` records this exact distinction for its own copy of the check, and its note explicitly names *"the eight downstream comparisons in `async-comments-attachments.ts`, which are sentinels for the same reason."* The reasoning was done; it just never reached this file — the same gap as #2928, where the reasoning was present but the marker was not.

## What stays counted, and why that is the point

The **classifier** at ~142 (`row.column === "archived"`) reads a real DB column and remains in the backlog. That is the site reported on #2820, deferred because the helper takes a `db` handle with no task, no workflow and no lane vocabulary — and three of its callers run inside open transactions, where threading a store is what caused the #2821 deadlock.

So this file's count goes **6 → 1**, and the 1 is the line that genuinely blocks. A count of 6 implied six conversions were owed here; five of them were never work at all.

| | before | after |
|---|---|---|
| this file | 6 | **1** |
| total backlog | 169 | **165** |

A **reclassification, not a conversion** — the census enforces the distinction and required the baseline re-recorded in the same change.

Core `tsc` clean, `pnpm lint` clean, census `--strict` exits 0, gate green (161/487/13/71).