### PR TITLE
self-healing: partially-completed work was never retried on a renamed board (thirtieth sweep)

### DIFF
--- a/.changeset/self-healing-done-merge-metadata-query.md
+++ b/.changeset/self-healing-done-merge-metadata-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Completed tasks get their merge metadata repaired again on renamed boards.
+category: fix
+dev: `recoverDoneTaskMergeMetadata` read the literal `done`, so on a renamed board a completed card's merge metadata was never repaired and could keep pointing at a commit that is not the one that landed. Read resolves via `resolveProjectColumnsForRoles(["complete"])` — deliberately not the terminal union — and the per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,53 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-17:10 (the query-filter class, thirty-first sweep):
+  `recoverDoneTaskMergeMetadata` repairs the merge metadata of a card that already reached the COMPLETE
+  lane — the commit sha an operator sees, and that later reconcilers trust. The literal read meant that
+  on a renamed board a done card's metadata was never repaired, so a completed task could keep pointing
+  at a commit that is not the one that landed.
+
+  Scoped to `complete`, NOT the terminal union: an archived card is out of scope, and widening to
+  TERMINAL_ROLES would start repairing rows nobody reads — a behaviour change wearing a conversion's
+  clothes. The companion case pins that.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column !== "done"` -> fails, the renamed complete lane is filtered out
+  */
+  function doneMetaFixture(column: string) {
+    const card = {
+      ...shippedCard(),
+      id: "FN-DONEMETA",
+      column,
+      mergeDetails: { mergeConfirmed: true, commitSha: "abcdef1234567890" },
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const findLandedTaskCommit = vi.fn(async () => null);
+    Object.assign(manager, { findLandedTaskCommit });
+    return { manager, findLandedTaskCommit };
+  }
+
+  it("repairs merge metadata on a RENAMED complete lane", async () => {
+    const { manager, findLandedTaskCommit } = doneMetaFixture(RENAMED_VOCAB.complete);
+
+    await manager.recoverDoneTaskMergeMetadata();
+
+    expect(findLandedTaskCommit).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-DONEMETA" }));
+  });
+
+  it("does not touch a card in the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. A card
+    still in review has not landed, so "repairing" its merge metadata would invent an answer.
+    */
+    const { manager, findLandedTaskCommit } = doneMetaFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverDoneTaskMergeMetadata();
+
+    expect(findLandedTaskCommit).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -9363,9 +9363,35 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
   async recoverDoneTaskMergeMetadata(): Promise<number> {
     try {
-      const tasks = await this.store.listTasks({ column: "done", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:05 (the query-filter class, thirty-first sweep):
+      Repairs the merge metadata of a card that already reached the COMPLETE lane — the commit sha an
+      operator sees, and that later reconcilers trust. The literal read meant that on a renamed board a
+      done card's metadata was never repaired, so a completed task could keep pointing at a commit that
+      is not the one that landed.
+
+      `complete` only, NOT the terminal union: an ARCHIVED card is out of scope here, and widening to
+      TERMINAL_ROLES would start repairing metadata on rows nobody is reading — a behaviour change
+      wearing a conversion's clothes.
+      */
+      const doneMetaColumns = await resolveProjectColumnsForRoles(this.store, ["complete"]);
+      const doneMetaById = new Map<string, Task>();
+      for (const column of doneMetaColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) doneMetaById.set(entry.id, entry);
+      }
+      const tasks = [...doneMetaById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const doneMetaLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          doneMetaLanes.set(entry.id, source === "default" ? new Set(doneMetaColumns) : new Set(columnsWithFlag(ir, "complete")));
+        } catch {
+          doneMetaLanes.set(entry.id, new Set(doneMetaColumns));
+        }
+      }
       const candidates = tasks.filter((task) => {
-        if (task.column !== "done" || task.paused) return false;
+        if (!(doneMetaLanes.get(task.id) ?? doneMetaColumns).has(task.column) || task.paused) return false;
         if (task.mergeDetails?.commitSha) return true;
         return Boolean(task.baseCommitSha);
       });

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverPartialProgressNoTaskDoneFailures` retries a review card failed for *"no fn_task_done"* that **did** make step progress — real work exists, so the sweep spends a retry rather than discarding it.

The literal read meant that on a renamed board the retry never fired: the work was parked failed with its **retry budget untouched**. That budget exists precisely to avoid losing partial work, so the safeguard and the work were lost together.

## No second pair

Verified with the derived ratchet added in #2879.

## Fixture note

One step `done` and another `pending`. All-done trips `isTaskWorkComplete` and none-done trips `hasStepProgress` — either would filter the card out for a reason unrelated to lanes, and the case would then pass with the fix reverted.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed review lane is filtered out |

Observable is `evaluateBackwardMoveTripleProof`, private and called once per candidate. A non-vacuous companion (same failure while the card is still in wip → no retry) rules out a read that returns everything: a card still in wip has not finished its attempt, so spending a retry there burns the budget on work that is still running.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.
