### PR TITLE
chore(census): commit the tightened lifecycle baseline — the tool asked for it

### DIFF
--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
One line. `lifecycle-column-census --strict` on `main` prints:

```
lifecycle-column-census --strict: baseline TIGHTENED — the tree has fewer guards than it allowed
The baseline file has been rewritten downward. COMMIT IT so the allowance cannot be regrown into;
```

…and rewrites the file. Nobody had committed the rewrite, so the allowance stayed one entry wider than the tree:

```
packages/engine/src/workflow-node-handlers.ts: 1 -> 0   (entry removed)
```

That guard was converted by **#2900** ("the review handoff killed the walk on a renamed review lane"). Confirmed the file has no legacy guard left — the census report no longer mentions it at all.

This is the residual the census names in its own source: *in CI the tightening write is discarded with the runner, so the committed baseline stays stale until someone commits a tightened one.* This is someone committing it. After the commit, a second `--strict` run is clean and exits 0.

## How I found it, which is the part worth recording

My routine "verify main's gates" check runs the census. The census rewrites this file every time it tightens. For several turns I saw `scripts/lib/lifecycle-column-census-baseline.json` show up as modified in my worktree, assumed it was leftover state from an earlier probe of mine, and quietly `git checkout --`-ed it away.

**It was the tool telling me main's baseline was stale — once per turn — and I kept discarding the message.** A dirty file in a worktree reads as noise; that one was a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)