### PR TITLE
self-healing: completed tasks kept wrong merge metadata on a renamed board (thirty-first sweep)

### DIFF
--- a/.changeset/self-healing-done-merge-metadata-query.md
+++ b/.changeset/self-healing-done-merge-metadata-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Completed tasks get their merge metadata repaired again on renamed boards.
+category: fix
+dev: `recoverDoneTaskMergeMetadata` read the literal `done`, so on a renamed board a completed card's merge metadata was never repaired and could keep pointing at a commit that is not the one that landed. Read resolves via `resolveProjectColumnsForRoles(["complete"])` — deliberately not the terminal union — and the per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,53 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-17:10 (the query-filter class, thirty-first sweep):
+  `recoverDoneTaskMergeMetadata` repairs the merge metadata of a card that already reached the COMPLETE
+  lane — the commit sha an operator sees, and that later reconcilers trust. The literal read meant that
+  on a renamed board a done card's metadata was never repaired, so a completed task could keep pointing
+  at a commit that is not the one that landed.
+
+  Scoped to `complete`, NOT the terminal union: an archived card is out of scope, and widening to
+  TERMINAL_ROLES would start repairing rows nobody reads — a behaviour change wearing a conversion's
+  clothes. The companion case pins that.
+
+  REVERT CHECKS, both measured, each alone:
+    - literal read restored -> fails, the card is never listed
+    - verdict back to `task.column !== "done"` -> fails, the renamed complete lane is filtered out
+  */
+  function doneMetaFixture(column: string) {
+    const card = {
+      ...shippedCard(),
+      id: "FN-DONEMETA",
+      column,
+      mergeDetails: { mergeConfirmed: true, commitSha: "abcdef1234567890" },
+    } as unknown as Task;
+    const { store } = productionFaithfulStore([card]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const findLandedTaskCommit = vi.fn(async () => null);
+    Object.assign(manager, { findLandedTaskCommit });
+    return { manager, findLandedTaskCommit };
+  }
+
+  it("repairs merge metadata on a RENAMED complete lane", async () => {
+    const { manager, findLandedTaskCommit } = doneMetaFixture(RENAMED_VOCAB.complete);
+
+    await manager.recoverDoneTaskMergeMetadata();
+
+    expect(findLandedTaskCommit).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-DONEMETA" }));
+  });
+
+  it("does not touch a card in the RENAMED review lane", async () => {
+    /*
+    Non-vacuous companion: without it, a read returning every column would satisfy the case above. A card
+    still in review has not landed, so "repairing" its merge metadata would invent an answer.
+    */
+    const { manager, findLandedTaskCommit } = doneMetaFixture(RENAMED_VOCAB.review);
+
+    await manager.recoverDoneTaskMergeMetadata();
+
+    expect(findLandedTaskCommit).not.toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -9363,9 +9363,35 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
   async recoverDoneTaskMergeMetadata(): Promise<number> {
     try {
-      const tasks = await this.store.listTasks({ column: "done", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:05 (the query-filter class, thirty-first sweep):
+      Repairs the merge metadata of a card that already reached the COMPLETE lane — the commit sha an
+      operator sees, and that later reconcilers trust. The literal read meant that on a renamed board a
+      done card's metadata was never repaired, so a completed task could keep pointing at a commit that
+      is not the one that landed.
+
+      `complete` only, NOT the terminal union: an ARCHIVED card is out of scope here, and widening to
+      TERMINAL_ROLES would start repairing metadata on rows nobody is reading — a behaviour change
+      wearing a conversion's clothes.
+      */
+      const doneMetaColumns = await resolveProjectColumnsForRoles(this.store, ["complete"]);
+      const doneMetaById = new Map<string, Task>();
+      for (const column of doneMetaColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) doneMetaById.set(entry.id, entry);
+      }
+      const tasks = [...doneMetaById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const doneMetaLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          doneMetaLanes.set(entry.id, source === "default" ? new Set(doneMetaColumns) : new Set(columnsWithFlag(ir, "complete")));
+        } catch {
+          doneMetaLanes.set(entry.id, new Set(doneMetaColumns));
+        }
+      }
       const candidates = tasks.filter((task) => {
-        if (task.column !== "done" || task.paused) return false;
+        if (!(doneMetaLanes.get(task.id) ?? doneMetaColumns).has(task.column) || task.paused) return false;
         if (task.mergeDetails?.commitSha) return true;
         return Boolean(task.baseCommitSha);
       });

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`recoverDoneTaskMergeMetadata` repairs the merge metadata of a card that already reached the **complete** lane — the commit sha an operator sees, and that later reconcilers trust. The literal read meant that on a renamed board it was never repaired, so a completed task could keep pointing at a commit that is not the one that landed.

## Scoped to `complete`, deliberately not the terminal union

An **archived** card is out of scope here. Widening to `TERMINAL_ROLES` would start repairing metadata on rows nobody reads — a behaviour change wearing a conversion's clothes.

Contrast #2899 (`reconcileStaleMergerStatus`), which *does* use the terminal union: its filter genuinely does not distinguish complete from archived, so splitting them there would have invented a distinction. Here the sweep does distinguish, so the union would erase one. Same series, opposite call, and the difference is in what the code already says rather than in what is convenient.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| the resolved read | fails — the card is never listed |
| the per-card verdict | fails — the renamed complete lane is filtered out |

Observable is `findLandedTaskCommit`, private and called once per candidate. A non-vacuous companion (same card in the review lane → untouched) rules out a read that returns everything: a card still in review has not landed, so "repairing" its merge metadata would invent an answer rather than correct one.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` 412; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.
