### PR TITLE
chore(census): the two artifact/comment read-only guards are sentinels (3 → 1 in this file)

### DIFF
--- a/packages/core/src/task-store/task-artifacts-ops.ts
+++ b/packages/core/src/task-store/task-artifacts-ops.ts
@@ -655,6 +655,19 @@ export async function updateTaskCommentImpl(store: TaskStore, id: string, commen
     {
       const layer = store.asyncLayer!;
       const state = await getLiveTaskColumn(layer.db, id, layer.projectId);
+      /*
+      FNXC:LifecycleColumnCensus 2026-07-31-01:20 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+      
+      `getLiveTaskColumn` normalizes — it manufactures "archived" for an archived row AND a soft-deleted
+      one, and returns null for a missing task, which is why the next line tests null separately. This
+      compares that protocol vocabulary, not a column id, so an archived-role read here would keep passing
+      on the built-in board and start FAILING on a renamed one: a soft-deleted task's comments would become
+      writable.
+      
+      Same class as the checks marked in `audit-ops.ts` and `async-comments-attachments.ts`. The convertible
+      site in this file is the `preArchiveColumn` comparison at ~435, which reads a real column and stays
+      counted.
+      */
       if (state === "archived") throw new Error(`Task ${id} is archived — comments are read-only`);
       if (state === null) throw new Error(`Task ${id} not found`);
     }
@@ -689,6 +702,19 @@ export async function deleteTaskCommentImpl(store: TaskStore, id: string, commen
     {
       const layer = store.asyncLayer!;
       const state = await getLiveTaskColumn(layer.db, id, layer.projectId);
+      /*
+      FNXC:LifecycleColumnCensus 2026-07-31-01:20 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+      
+      `getLiveTaskColumn` normalizes — it manufactures "archived" for an archived row AND a soft-deleted
+      one, and returns null for a missing task, which is why the next line tests null separately. This
+      compares that protocol vocabulary, not a column id, so an archived-role read here would keep passing
+      on the built-in board and start FAILING on a renamed one: a soft-deleted task's comments would become
+      writable.
+      
+      Same class as the checks marked in `audit-ops.ts` and `async-comments-attachments.ts`. The convertible
+      site in this file is the `preArchiveColumn` comparison at ~435, which reads a real column and stays
+      counted.
+      */
       if (state === "archived") throw new Error(`Task ${id} is archived — comments are read-only`);
       if (state === null) throw new Error(`Task ${id} not found`);
     }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -9,7 +9,6 @@
     "packages/engine/src/replan-target.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
     "packages/core/src/async-mission-store-queries.ts": 3,
-    "packages/core/src/task-store/task-artifacts-ops.ts": 3,
     "packages/core/src/agent-store.ts": 2,
     "packages/core/src/task-store/audit-ops.ts": 2,
     "packages/core/src/task-store/moves.ts": 2,
@@ -30,6 +29,7 @@
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
     "packages/core/src/task-store/merge-queue-ops.ts": 1,
+    "packages/core/src/task-store/task-artifacts-ops.ts": 1,
     "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1,
     "packages/dashboard/app/components/TaskCard.tsx": 1,
     "packages/engine/src/backlog-pressure-reporter.ts": 1,
@@ -46,6 +46,7 @@
     "packages/core/src/task-merge.ts\u0000archived": 2,
     "packages/core/src/task-merge.ts\u0000done": 2,
     "packages/core/src/task-merge.ts\u0000in-review": 2,
+    "packages/core/src/task-store/task-artifacts-ops.ts\u0000archived": 2,
     "packages/dashboard/app/components/TaskCard.tsx\u0000todo": 2,
     "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 2,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000archived": 2,
@@ -136,7 +137,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`task-artifacts-ops.ts` tests `getLiveTaskColumn(...) === "archived"` twice, to refuse comment writes on an archived parent. That helper **normalizes** — it manufactures `"archived"` for an archived row *and* a soft-deleted one, and returns `null` for a missing task, which is why the line immediately after each check tests `null` separately. Both compare that **protocol vocabulary**, not a column id.

An archived-role read here would keep passing on the built-in board and start **failing** on a renamed one: a soft-deleted task's comments would become writable.

Same class as the checks already marked in `audit-ops.ts` (#2928) and `async-comments-attachments.ts` (#2931). This is the fourth file in that family, and they all trace to the same helper.

## What stays counted

The `preArchiveColumn` comparison at ~435 reads a real column and remains in the backlog. **Mark the sentinel, leave the lane** — this file's count now points at the one line that is genuinely owed rather than at three where two were never work.

## Note on the running total

The headline number in these PRs drifts because other workers are landing conversions concurrently; the per-file movement is the stable claim. Here it is **3 → 1**. A **reclassification, not a conversion** — the census enforces the distinction and required the baseline re-recorded in the same change.

Core `tsc` clean, `pnpm lint` clean, census `--strict` exits 0, gate green (161/487/13/71).