### PR TITLE
fix(guard): my own PR put two FALSE entries in the unwired-lane guard — name the type

### DIFF
--- a/packages/core/src/task-store/workflow-definitions.ts
+++ b/packages/core/src/task-store/workflow-definitions.ts
@@ -44,6 +44,7 @@ import { resolveSwitchReconciliation } from "../workflow-reconciliation.js";
 import { WORKFLOW_COMPILED_STEP_TEMPLATE_PREFIX } from "../store.js";
 import { resolveWorkflowIrForTask } from "../workflow-ir-resolver.js";
 import { resolveProjectColumnsForRoles, REVIEW_ROLES } from "../project-lane-vocabulary.js";
+import type { InReviewDurationLanes } from "./async-audit.js";
 
 export async function getAgentLogsByTimeRangeImpl(store: TaskStore,
     taskId: string,
@@ -1008,7 +1009,22 @@ failed resolve leaves the query on its documented legacy lanes rather than faili
 */
 export async function getInReviewDurationEventsImpl(store: TaskStore, options: { since: string; until: string }): Promise<ActivityLogEntry[]> {
         const layer = store.asyncLayer!;
-    let lanes: { reviewColumns?: string[]; completeColumns?: string[] } | undefined;
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-31-06:20:
+    Named type, not an inferred literal, and the reason is a tool contract rather than style.
+
+    `scripts/lib/unwired-lane-parameter.mjs` decides a lane parameter is WIRED when some other file
+    mentions both the parameter name and its declaring symbol. For an interface passed as an inferred
+    object literal there is no mention of the type anywhere, so this call site — which does supply
+    both lanes — was reported as unwired, and #2875 landed two false entries into a guard written to
+    catch the opposite mistake.
+
+    Annotating the local is the smallest honest fix. I tried three variations of the heuristic first;
+    each traded the false positive for false NEGATIVES (the widest hid twelve genuine entries), which
+    is the usual sign that a co-occurrence check has reached its limit. Naming the type costs one
+    word, makes the wiring visible to both the reader and the tool, and leaves the guard's rule alone.
+    */
+    let lanes: InReviewDurationLanes | undefined;
     try {
       const [review, complete] = await Promise.all([
         resolveProjectColumnsForRoles(store, REVIEW_ROLES),


### PR DESCRIPTION
`unwired-lane-parameter-guard.test.ts` has been **failing on main** since #2875 merged, and the two entries it reports are wrong.

```
+ "packages/core/src/task-store/async-audit.ts completeColumns",
+ "packages/core/src/task-store/async-audit.ts reviewColumns",
```

Both **are** wired — `getInReviewDurationEventsImpl` resolves the lane sets and passes them. So a guard I wrote, to catch parameters nobody supplies, was reporting the opposite of the truth about my own change.

## Cause: owner-scoping cannot apply to a type the caller never writes

The rule I added earlier requires a mention to come from a file that also names the **declaring symbol**. Correct for a function — a caller has to name it to call it. Structurally impossible for an interface passed as an inferred object literal:

```ts
lanes = { reviewColumns: [...], completeColumns: [...] };   // wires it
getInReviewDurationEventsAsync(db, projectId, options, lanes);
```

Nothing there writes `InReviewDurationLanes`, and nothing ever will — the type comes from the parameter.

## Fixed at the caller, after trying the tool three ways

| attempt | result |
|---|---|
| relax type-owned properties to the original loose rule | hid **12** genuine entries |
| resolve owner to the functions consuming the type | hid **6** |
| annotate the local with the named type | **correct, one word, no rule change** |

Each heuristic refinement traded the false positive for false **negatives**. That is the usual sign a co-occurrence check has reached its limit — and an under-reporting guard is worse than an occasionally over-reporting one, because nobody notices the silence.

The other option was recording two *wired* parameters in `KNOWN_UNWIRED`. That would put non-debt in the debt list, which is how a ratchet starts lying — the same failure this PR is fixing, one layer up.

Naming the type is also just better code: the wiring is now visible to a reader, not only inferred.

## Verification

- `unwired-lane-parameter-guard.test.ts` — **9/9**, baseline unchanged at 17
- `pnpm test:gate` — 161 / 487 / 13 / 71 passed
- `pnpm lint` — clean
- `tsc --noEmit` (`@fusion/core`) — clean
- `activity-log-parity.pg.test.ts` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety for in-review duration event processing without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->