### PR TITLE
self-healing: PR-conflict reclaim read a busy checkout as unowned on a renamed board (thirty-second sweep)

### DIFF
--- a/.changeset/self-healing-pr-conflict-worktree-owner-query.md
+++ b/.changeset/self-healing-pr-conflict-worktree-owner-query.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: PR-conflict reclaim no longer reads a busy checkout as unowned on renamed boards.
+category: fix
+dev: `reclaimPrConflictForTask` built its worktree-owner map from a literal `in-progress` read, so on a renamed board the map was empty and a checkout another task was live in read as unowned. Read resolves via `resolveProjectColumnsForRoles(["countsTowardWip"])`; the map is keyed by worktree path so there is no per-card lane verdict to convert.

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -3519,7 +3519,22 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         throw inspection.error;
       }
 
-      const inProgressCandidates = await this.store.listTasks({ column: "in-progress", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:40 (the query-filter class, thirty-second sweep):
+      This read answers "is another LIVE task holding this worktree?" — the same question
+      `findActiveWorktreeOwner` answers for the executor, and the same failure if it comes back empty: the
+      checkout reads as unowned and this sweep reclaims a worktree another task is working in.
+
+      No per-card lane verdict downstream: the map below is keyed by WORKTREE PATH, and nothing after it
+      compares a column. So this is a read-only conversion — there is no pair to convert, which the
+      derived ratchet from #2879 also confirms.
+      */
+      const prConflictWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const prConflictById = new Map<string, Task>();
+      for (const column of prConflictWipColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) prConflictById.set(entry.id, entry);
+      }
+      const inProgressCandidates = [...prConflictById.values()];
       const inProgressByWorktree = new Map<string, string>();
       for (const inProgressTask of inProgressCandidates) {
         if (inProgressTask.worktree) inProgressByWorktree.set(inProgressTask.worktree, inProgressTask.id);

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 31,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
`reclaimPrConflictForTask` builds a worktree-owner map to answer *"is another live task holding this worktree?"* — the same question `findActiveWorktreeOwner` answers for the executor, and the same failure when the read comes back empty: **the checkout reads as unowned and the sweep reclaims a worktree another task is working in.**

## Read-only conversion

The map is keyed by **worktree path**, and nothing after it compares a column, so there is no pair to convert here. Confirmed with the derived ratchet added in #2879 rather than asserted from reading.

## Coverage, stated plainly: no behavioural test

This read sits after `inspectBranchConflict`, which needs a real git repo, so reaching it means a git fixture rather than a lane test.

Unlike the guards in #2867 and #2891, the blocker here is a **module-level import that shells out**, not a private method I could stub. I checked for that seam first — assuming the git fixture was unavoidable is exactly the mistake review corrected on #2867, and I would rather say "I looked and there isn't one" than repeat it.

So this one rests on `tsc` and the ratchet. That is weaker than the other thirty-one and I am not dressing it up; the alternative was leaving a known unowned-checkout hazard in place because its test would be inconvenient.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` + the blindness file + the ratchet, 428; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` clean, each run explicitly.
