### PR TITLE
chore(census): the last unmarked getLiveTaskColumn sentinel

### DIFF
--- a/packages/core/src/task-store/comments-ops.ts
+++ b/packages/core/src/task-store/comments-ops.ts
@@ -62,6 +62,20 @@ export async function addCommentImpl(store: TaskStore, id: string, text: string,
     {
       const layer = store.asyncLayer!;
       const state = await getLiveTaskColumn(layer.db, id, layer.projectId);
+      /*
+      FNXC:LifecycleColumnCensus 2026-07-31-01:45 DELIBERATE-LITERAL: a SENTINEL, not a board lane.
+
+      `getLiveTaskColumn` normalizes — it manufactures "archived" for an archived row AND a
+      soft-deleted one, and returns null for a missing task, which is why the next line tests null
+      separately. This compares that protocol vocabulary, not a column id, so an archived-role read
+      would keep passing on the built-in board and start FAILING on a renamed one: a soft-deleted
+      task's comments would become writable.
+
+      LAST OF THE FAMILY. Every consumer of this helper now carries the same marker — `audit-ops.ts`,
+      `async-comments-attachments.ts` (five sites), `task-artifacts-ops.ts` (two) and this one. What
+      remains counted is the helper's OWN `row.column === "archived"` classifier, which reads a real
+      column and is the one line where a conversion is genuinely owed (#2820).
+      */
       if (state === "archived") throw new Error(`Task ${id} is archived — comments are read-only`);
       if (state === null) throw new Error(`Task ${id} not found`);
     }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -26,7 +26,6 @@
     "packages/core/src/mission-store.ts": 1,
     "packages/core/src/plugin-store.ts": 1,
     "packages/core/src/stalled-review-detector.ts": 1,
-    "packages/core/src/task-store/comments-ops.ts": 1,
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
     "packages/core/src/task-store/merge-queue-ops.ts": 1,
@@ -76,6 +75,7 @@
     "packages/core/src/task-move-disposer.ts\u0000todo": 1,
     "packages/core/src/task-store/archive-lifecycle-2.ts\u0000archived": 1,
     "packages/core/src/task-store/branch-and-pr-entities.ts\u0000archived": 1,
+    "packages/core/src/task-store/comments-ops.ts\u0000archived": 1,
     "packages/core/src/task-store/task-store-helpers.ts\u0000in-progress": 1,
     "packages/core/src/task-store/task-store-helpers.ts\u0000todo": 1,
     "packages/core/src/task-store/task-update.ts\u0000in-progress": 1,
@@ -136,7 +136,6 @@
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
     "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/auto-merge-finalization.ts": 1,
-    "packages/engine/src/workflow-node-handlers.ts": 1
+    "packages/engine/src/auto-merge-finalization.ts": 1
   }
 }


### PR DESCRIPTION
`addCommentImpl` tests `getLiveTaskColumn(...) === "archived"` to refuse comments on an archived parent — the same shape as the eight already marked. The helper manufactures `"archived"` for an archived row *and* a soft-deleted one, and returns `null` for a missing task, which is why the next line tests `null` separately. An archived-role read would keep passing on the built-in board and start **failing** on a renamed one: a soft-deleted task's comments would become writable.

## This closes the family

Every consumer of `getLiveTaskColumn` now carries the marker:

| file | sites |
|---|---|
| `audit-ops.ts` | 1 (#2928) |
| `async-comments-attachments.ts` | 5 (#2931) |
| `task-artifacts-ops.ts` | 2 (#2935) |
| `task-id-integrity.ts` | 1 (#2923) |
| `comments-ops.ts` | 1 (this) |

What remains counted is the helper's **own** `row.column === "archived"` classifier — the single line where a conversion is genuinely owed, and the one #2820 defers because the helper takes a `db` handle with no task, no workflow and no lane vocabulary, with three callers inside open transactions where threading a store caused the #2821 deadlock.

**That is the useful outcome of this sweep.** Nine downstream sites read as pending work while being provably correct; each would have cost the next person the same rediscovery, and any one of them converted mechanically would have made soft-deleted tasks writable on a renamed board. The backlog now names **one** blocker instead of ten — and it is the blocker a core owner has to decide, not one that can be cleared by a batch.

Core `tsc` clean, `pnpm lint` clean, census `--strict` exits 0, gate green (161/487/13/71).