### PR TITLE
self-healing: workspace tasks stranded mid-land on a renamed board (sweeps 33 and 34)

### DIFF
--- a/.changeset/self-healing-workspace-lane-queries.md
+++ b/.changeset/self-healing-workspace-lane-queries.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Workspace tasks finish their partial lands and release their worktrees on renamed boards.
+category: fix
+dev: `reconcileWorkspacePartialLands` and `reconcileOrphanedWorkspaceWorktrees` read the literal `in-review`/`done`, so on a renamed board a workspace task stranded mid-land was never re-enqueued and a finished one never released its per-repo worktrees. Reads resolve via `resolveProjectColumnsForRoles` (review roles, and `complete` only for the cleanup); the partial-land per-card check resolves per card.

--- a/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
+++ b/packages/engine/src/__tests__/self-healing-query-filter-blindness.test.ts
@@ -899,4 +899,71 @@ describe("self-healing sweeps are bounded by a hardcoded column QUERY, not by th
 
     expect(classifyForeignOnlyContamination).not.toHaveBeenCalled();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-18:15 (the query-filter class, sweeps thirty-three and -four):
+  The two WORKSPACE sweeps. A workspace task lands PER-REPO, so its failure modes are its own: a
+  partial land leaves some repos merged and some not, and a finished one leaves per-repo worktrees on
+  disk. Both were bounded by literal reads, so on a renamed board neither ran — the partial land never
+  finished, and the disk was never reclaimed.
+
+  `isWorkspaceTaskLive` is what the partial-land sweep calls once per surviving candidate, before any
+  git or disk work — the private-seam technique, so no workspace fixture is needed.
+
+  REVERT CHECKS, both measured, each alone:
+    - partial-land literal read + verdict restored -> that case fails, the card is never listed
+    - orphaned-worktree literal read restored -> that case fails, the done card is never listed
+  */
+  function workspaceCard(id: string, column: string): Task {
+    return {
+      ...shippedCard(),
+      id,
+      column,
+      workspaceRepos: [{ path: "repo-a" }],
+      workspaceWorktrees: { "repo-a": { worktreePath: "/tmp/ws/repo-a" } },
+      mergeDetails: {},
+    } as unknown as Task;
+  }
+
+  it("re-enqueues a partially-landed workspace task on a RENAMED review lane", async () => {
+    const { store } = productionFaithfulStore([workspaceCard("FN-WSPARTIAL", RENAMED_VOCAB.review)]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const isWorkspaceTaskLive = vi.fn(() => ({ live: true, livePaths: ["/tmp/ws/repo-a"] }));
+    Object.assign(manager, { isWorkspaceTaskLive, emitWorkspacePartialLandNoAction: vi.fn(async () => undefined) });
+
+    await manager.reconcileWorkspacePartialLands();
+
+    expect(isWorkspaceTaskLive).toHaveBeenCalledWith(expect.objectContaining({ id: "FN-WSPARTIAL" }));
+  });
+
+  it("does not re-enqueue a workspace task still in the RENAMED wip lane", async () => {
+    /*
+    Non-vacuous companion: a workspace task in wip has not started landing, so there is no partial land
+    to finish — the comment at the site says execution-stage reconcilers own that lane.
+    */
+    const { store } = productionFaithfulStore([workspaceCard("FN-WSPARTIAL", RENAMED_VOCAB.wip)]);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo" });
+    const isWorkspaceTaskLive = vi.fn(() => ({ live: true, livePaths: ["/tmp/ws/repo-a"] }));
+    Object.assign(manager, { isWorkspaceTaskLive, emitWorkspacePartialLandNoAction: vi.fn(async () => undefined) });
+
+    await manager.reconcileWorkspacePartialLands();
+
+    expect(isWorkspaceTaskLive).not.toHaveBeenCalled();
+  });
+
+  it("cleans orphaned workspace worktrees for a card on a RENAMED complete lane", async () => {
+    const { store } = productionFaithfulStore([workspaceCard("FN-WSDONE", RENAMED_VOCAB.complete)]);
+    const listTasksSpy = (store as unknown as { listTasks: ReturnType<typeof vi.fn> }).listTasks;
+    listTasksSpy.mockClear();
+
+    await new SelfHealingManager(store, { rootDir: "/repo" }).reconcileOrphanedWorkspaceWorktrees();
+
+    /*
+    The sweep's disk work is guarded by `isPathActive` and real fs checks, so the honest observable is
+    that it ASKED for the board's own complete lane at all — nothing downstream vetoes on lane here
+    (the only filter is `isWorkspaceTask`), which is what makes a query assertion sound rather than lazy.
+    */
+    const queried = listTasksSpy.mock.calls.map(([options]) => (options as { column?: string })?.column);
+    expect(queried).toContain(RENAMED_VOCAB.complete);
+  });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -8879,9 +8879,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const activeMergeTaskId = this.options.getActiveMergeTaskId?.() ?? null;
       // Workspace tasks live in in-review (post-capture/review, pre/partial land). A task already
       // done is finished; todo/in-progress are owned by execution-stage reconcilers.
-      const tasks = await this.store.listTasks({ column: "in-review", slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-18:05 (the query-filter class, thirty-third sweep):
+      A WORKSPACE task lands per-repo, and this re-enqueues one whose lands are partial or zero. The
+      literal read meant that on a renamed board a workspace task stranded mid-land was never
+      re-enqueued — some repos landed, some not, and nothing to finish the job.
+
+      The comment above records WHY the review lane is the right one; it stays true, only the way the
+      lane is named changes.
+      */
+      const wsPartialColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const wsPartialById = new Map<string, Task>();
+      for (const column of wsPartialColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) wsPartialById.set(entry.id, entry);
+      }
+      const tasks = [...wsPartialById.values()];
+      /* NARROW WHEN THE CARD CAN ANSWER, BROAD WHEN IT CANNOT (#2891). */
+      const wsPartialLanes = new Map<string, Set<string>>();
+      for (const entry of tasks) {
+        try {
+          const { ir, source } = await resolveWorkflowIrForTaskWithProvenance(this.store, entry.id);
+          wsPartialLanes.set(
+            entry.id,
+            source === "default"
+              ? new Set(wsPartialColumns)
+              : new Set(REVIEW_ROLES.flatMap((role) => [...columnsWithFlag(ir, role)])),
+          );
+        } catch {
+          wsPartialLanes.set(entry.id, new Set(wsPartialColumns));
+        }
+      }
       const candidates = tasks.filter((task) =>
-        task.column === "in-review" &&
+        (wsPartialLanes.get(task.id) ?? wsPartialColumns).has(task.column) &&
         isWorkspaceTask(task) &&
         task.mergeDetails?.mergeConfirmed !== true &&
         // Active transient merge statuses are owned by the live merger; recover-interrupted /
@@ -9286,8 +9315,21 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return 0;
 
       // Done workspace tasks are the canonical "safe to clean" set (their lands are finalized).
-      const doneTasks = await this.store.listTasks({ column: "done", slim: true });
-      const candidates = doneTasks.filter((task) => isWorkspaceTask(task));
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-18:10 (the query-filter class, thirty-fourth sweep):
+      Removes the per-repo worktrees a finished workspace task left behind. The literal read meant that
+      on a renamed board they were never removed — disk held by tasks that finished, growing quietly.
+
+      `complete` only, NOT the terminal union: the comment above calls DONE tasks "the canonical safe to
+      clean set" precisely because their lands are finalized, and an archived row is a different claim.
+      No per-card verdict: the filter is `isWorkspaceTask`, not a lane test.
+      */
+      const wsDoneColumns = await resolveProjectColumnsForRoles(this.store, ["complete"]);
+      const wsDoneById = new Map<string, Task>();
+      for (const column of wsDoneColumns) {
+        for (const entry of await this.store.listTasks({ column, slim: true })) wsDoneById.set(entry.id, entry);
+      }
+      const candidates = [...wsDoneById.values()].filter((task) => isWorkspaceTask(task));
       if (candidates.length === 0) return 0;
 
       let cleaned = 0;

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 84,
+    "packages/engine/src/self-healing.ts": 83,
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 8,
     "packages/core/src/task-store/async-comments-attachments.ts": 6,
@@ -128,7 +128,7 @@
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 32,
+    "packages/engine/src/self-healing.ts": 30,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/async-mission-store.ts": 1,


### PR DESCRIPTION
The two **workspace** sweeps, converted together because they are one domain and one file region.

## `reconcileWorkspacePartialLands`

A workspace task lands **per-repo**. This re-enqueues one whose lands are partial or zero. The literal read meant that on a renamed board it never ran — so a task sat with *some repos merged and some not*, with nothing to finish the job.

That is the worst resting state anywhere in this series: not a stalled task but an **inconsistent** one.

## `reconcileOrphanedWorkspaceWorktrees`

Removes the per-repo worktrees a finished workspace task left behind. The literal read meant disk held by tasks that finished, growing quietly with no signal at all.

It resolves **`complete` only**, not the terminal union — its own comment calls done tasks *"the canonical safe to clean set"* because their lands are finalized, and an archived row is a different claim. Same call as #2934, opposite of #2899; each time the existing code already said which it meant.

## Revert results

Each applied alone and the file re-run:

| conversion | reverted → |
| --- | --- |
| partial-land read + verdict | that case fails — the card is never listed |
| orphaned-worktree read | that case fails — the done card is never listed |

The partial-land observable is `isWorkspaceTaskLive`, private and called once per surviving candidate before any git or disk work. The cleanup sweep's disk work is guarded by `isPathActive` and real fs checks, so its assertion is on the **query** — sound here specifically because nothing downstream vetoes on lane (the only filter is `isWorkspaceTask`), which is the condition the sibling doc sets for when a query assertion is honest rather than lazy.

## Verification

`pnpm test:gate` 161 + 487 + 13 + 71, plus `self-healing.test.ts` and `workspace-self-healing.test.ts`; `tsc` engine clean; `pnpm lint`, `check:changesets`, census `--strict` and `check-sql-column-literals` clean, each run explicitly.
