### PR TITLE
batch-portal-test-fixes: both portal query-root failures in one PR (supersedes #2911, #2913)

### DIFF
--- a/packages/dashboard/app/components/__tests__/AgentListModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/AgentListModal.test.tsx
@@ -272,7 +272,15 @@ describe("AgentListModal", () => {
         expect(screen.getAllByText((_, el) => el?.textContent === "FN-PROGRESS · In Progress").length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText((_, el) => el?.textContent === "FN-BARE · Unresolved task").length).toBeGreaterThanOrEqual(1);
       });
-      expect(container.querySelectorAll(".agent-task").length).toBe(3);
+  /*
+      FNXC:PortalQueryRoot 2026-07-31-20:10:
+      document, not container — this modal renders through a PORTAL.
+
+      `container` from `render()` is empty for a portalled subtree, so this lookup could only ever
+      return nothing. Same defect as #2885 / #2890 / #2893 / #2895 / #2907; probed here before
+      converting (`PROBE container=0 document=3`).
+      */
+      expect(document.querySelectorAll(".agent-task").length).toBe(3);
     });
 
     it("shows empty state when no agents exist", async () => {

--- a/packages/dashboard/app/components/__tests__/MailboxModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/MailboxModal.test.tsx
@@ -245,7 +245,7 @@ describe("MailboxModal", () => {
     const { container } = render(<MailboxModal {...defaultProps} />);
 
     await waitFor(() => {
-      const times = Array.from(container.querySelectorAll(".mailbox-item-time")).map((node) => node.textContent);
+      const times = Array.from(document.querySelectorAll(".mailbox-item-time")).map((node) => node.textContent);
       expect(times).toEqual(expect.arrayContaining([
         "Just now",
         "5m ago",
@@ -1376,9 +1376,9 @@ describe("MailboxModal", () => {
       fireEvent.click(screen.getByTestId("mailbox-item-msg-001"));
 
       await waitFor(() => {
-        expect(container.querySelector(".mailbox-message-detail-header")).toBeTruthy();
-        expect(container.querySelector(".mailbox-message-detail-actions")).toBeTruthy();
-        expect(container.querySelector(".mailbox-message-participants")).toBeTruthy();
+        expect(document.querySelector(".mailbox-message-detail-header")).toBeTruthy();
+        expect(document.querySelector(".mailbox-message-detail-actions")).toBeTruthy();
+        expect(document.querySelector(".mailbox-message-participants")).toBeTruthy();
       });
     });
   });

--- a/packages/dashboard/app/components/__tests__/SubtaskBreakdownModal.test.tsx
+++ b/packages/dashboard/app/components/__tests__/SubtaskBreakdownModal.test.tsx
@@ -131,7 +131,16 @@ describe("SubtaskBreakdownModal", () => {
 
     const { container } = renderModal();
     await waitFor(() => expect(mockStartSubtaskBreakdown).toHaveBeenCalled());
-    const modal = container.querySelector(".planning-modal");
+    /*
+    FNXC:PortalQueryRoot 2026-07-31-20:10:
+    document, not container — the planning modal renders through a PORTAL.
+
+    `container.querySelector(".planning-modal")` returned null, and the `?.` below turned that into
+    `undefined`, so the failure surfaced as "the given combination of arguments (undefined and
+    string) is invalid for this assertion" rather than as a missing element. Optional chaining is
+    what disguised a query-root bug as an assertion-type error.
+    */
+    const modal = document.querySelector(".planning-modal");
 
     expect(mockUseMobileKeyboard).toHaveBeenCalledWith({ enabled: true });
     expect(modal?.getAttribute("style")).toContain("--keyboard-overlap: 250px");


### PR DESCRIPTION
Family fold: #2911 + #2913, cherry-picked clean. One root cause (portalled modals queried the render container instead of document.body). Scoped verification: 167/167. NOTE: the portal family is 2, not ~8 — the real jam is ~24 self-healing 'renamed board' PRs plus an unlisted census/sentinel family of ~9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated modal test coverage to correctly validate content rendered through portals.
  * Improved assertions for task counts, timestamps, mobile detail views, and keyboard-related behavior.
  * Added test comments clarifying portal-based rendering and assertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->