### PR TITLE
chore: tighten the FNXC future-date baseline as the clock advances

### DIFF
--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -69,7 +69,6 @@
   "packages/core/src/task-store/merge-queue-ops-2.ts": 4,
   "packages/core/src/task-store/moves.ts": 2,
   "packages/core/src/task-store/project-store-ops.ts": 1,
-  "packages/core/src/task-store/reads.ts": 2,
   "packages/core/src/task-store/task-artifacts-ops.ts": 6,
   "packages/core/src/task-store/task-creation.ts": 2,
   "packages/core/src/task-store/task-id-integrity.ts": 1,


### PR DESCRIPTION
Retires `packages/core/src/task-store/reads.ts`'s allowance of 2. Its FNXC stamps are no longer in the future, so the headroom they held is removed rather than left sitting where a genuine regression could hide inside it.

## This is the drop path working, not a fix

The gate watches a **clock-dependent population**: stamps age out of "future" on their own, with no code change. That is why the drop path auto-lowers the baseline and exits 0 instead of failing.

The alternative — failing on drops, the way a code-measured ratchet should — would have turned this repo red on a day nobody touched it, and the noise would have trained everyone to re-baseline without looking. **A ratchet may only fail on drops when its measurement depends solely on code.** This one does not, so it tightens silently and a commit like this one records the new floor.

## What I verified

- Second consecutive run exits 0 with no further diff — the tightening is idempotent, not an oscillation between two states.
- Diff is a single removed line; the entry is deleted rather than set to `0`, so the file re-enters as a genuine addition if a future-dated stamp lands there again.
- `467` known future-dated stamps remain across 237 files, unchanged.

## What this does not do

It does not reduce the future-dated stamp count — those 467 are still there and still wrong. They came from agents (me included) stamping FNXC comments a day or two ahead. This only reclaims the allowance for one file that has aged out. **The count will keep falling on its own without anyone fixing anything**, so it should not be read as cleanup progress; the gate's value is blocking *new* future stamps, which it still does.