### PR TITLE
fix(deps): every Build is red — AWS unpublished @aws-sdk/core@3.977.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/node': ^25.5.2
   protobufjs: ^7.5.8
+  '@aws-sdk/core': 3.977.3
   '@earendil-works/pi-agent-core': 0.82.1
   '@earendil-works/pi-ai': 0.82.1
   '@earendil-works/pi-coding-agent': 0.82.1
@@ -1431,8 +1432,8 @@ packages:
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.976.0':
-    resolution: {integrity: sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA==}
+  '@aws-sdk/core@3.977.3':
+    resolution: {integrity: sha512-6YZTpF5Zzl0KdSrztM0l6ErKdnXrnnodIDYfayHE9SFfZU8Ubxls7H2XnfWT121jgwiG+WP1z5kyfVDsH5V4qA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.60':
@@ -1503,8 +1504,8 @@ packages:
     resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/xml-builder@3.972.36':
-    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -3036,6 +3037,10 @@ packages:
     resolution: {integrity: sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.12':
     resolution: {integrity: sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q==}
     engines: {node: '>=18.0.0'}
@@ -3054,6 +3059,10 @@ packages:
 
   '@smithy/node-http-handler@4.9.9':
     resolution: {integrity: sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.8':
@@ -8217,7 +8226,7 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/credential-provider-node': 3.972.71
       '@aws-sdk/eventstream-handler-node': 3.972.29
       '@aws-sdk/middleware-eventstream': 3.972.24
@@ -8230,20 +8239,20 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.976.0':
+  '@aws-sdk/core@3.977.3':
     dependencies:
       '@aws-sdk/types': 3.974.2
-      '@aws-sdk/xml-builder': 3.972.36
+      '@aws-sdk/xml-builder': 3.972.37
       '@aws/lambda-invoke-store': 0.3.0
-      '@smithy/core': 3.29.7
-      '@smithy/signature-v4': 5.6.8
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
       '@smithy/types': 4.16.1
       bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.60':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/types': 4.16.1
@@ -8251,7 +8260,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.62':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/fetch-http-handler': 5.6.9
@@ -8261,7 +8270,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.973.5':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/credential-provider-env': 3.972.60
       '@aws-sdk/credential-provider-http': 3.972.62
       '@aws-sdk/credential-provider-login': 3.972.67
@@ -8277,7 +8286,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.67':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -8300,7 +8309,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.60':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/types': 4.16.1
@@ -8308,7 +8317,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-sso@3.973.4':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/token-providers': 3.1092.0
       '@aws-sdk/types': 3.974.2
@@ -8318,7 +8327,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.66':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -8341,7 +8350,7 @@ snapshots:
 
   '@aws-sdk/middleware-websocket@3.972.42':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
       '@smithy/fetch-http-handler': 5.6.9
@@ -8351,7 +8360,7 @@ snapshots:
 
   '@aws-sdk/nested-clients@3.997.34':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/signature-v4-multi-region': 3.996.41
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -8369,7 +8378,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -8378,7 +8387,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1092.0':
     dependencies:
-      '@aws-sdk/core': 3.976.0
+      '@aws-sdk/core': 3.977.3
       '@aws-sdk/nested-clients': 3.997.34
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.29.7
@@ -8394,7 +8403,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.36':
+  '@aws-sdk/xml-builder@3.972.37':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -10103,6 +10112,11 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.12':
     dependencies:
       '@smithy/core': 3.29.7
@@ -10128,6 +10142,12 @@ snapshots:
   '@smithy/node-http-handler@4.9.9':
     dependencies:
       '@smithy/core': 3.29.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,20 @@ overrides:
   # FNXC:DesktopPackaging 2026-07-26-22:55: Advance the matched closure 0.82.0 → 0.82.1 so
   # electron-builder's production-dependency walk accepts pi-agent-core's pi-ai@^0.82.1 requirement
   # (Desktop packaging PR-lane failure when deploy resolved a newer agent-core patch beside 0.82.0 ai).
+  # FNXC:UpstreamDependencyPin 2026-07-30-21:40:
+  # AWS UNPUBLISHED `@aws-sdk/core@3.977.4` after releasing it. The lockfile still carries a valid
+  # integrity hash for it, which is how it got in, but `npm view @aws-sdk/core@3.977.4` is now a 404
+  # and the latest release is 3.977.3. Every Build in the repo fails in the desktop `pnpm deploy`
+  # step with ERR_PNPM_NO_MATCHING_VERSION, reached transitively through
+  # pi-ai -> @aws-sdk/client-bedrock-runtime -> @aws-sdk/middleware-websocket.
+  #
+  # Pinned on CORE, not on the websocket package. Pinning middleware-websocket one patch back was the
+  # first attempt and it does NOT work: its range is `^3.977.3`, so pnpm still resolves UP to the
+  # unpublished 3.977.4. Only constraining core itself removes the unresolvable target.
+  #
+  # REMOVE THIS once AWS republishes 3.977.4 or ships a later patch; it is an upstream publishing
+  # accident, not a decision about our dependency surface.
+  '@aws-sdk/core': 3.977.3
   '@earendil-works/pi-agent-core': 0.82.1
   '@earendil-works/pi-ai': 0.82.1
   '@earendil-works/pi-coding-agent': 0.82.1


### PR DESCRIPTION
**Every `Build` check in the repo is failing**, including #2347 and #2953. It is not any of our changes.

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @aws-sdk/core@^3.977.4
  at @earendil-works/pi-ai@0.82.1
  at @aws-sdk/client-bedrock-runtime@3.1048.0
  at @aws-sdk/middleware-websocket@3.972.47
The latest release of @aws-sdk/core is "3.977.3".
```

**AWS unpublished the version after releasing it.** The lockfile still carries a valid integrity hash for `3.977.4` — which is how it got in — while `npm view @aws-sdk/core@3.977.4` now returns 404. So this is not a range that was always wrong; it broke underneath a tree that had resolved fine, which is why older PR builds (#2376, #2377) are green and every recent one is red.

## The obvious pin does not work

My first attempt pinned `@aws-sdk/middleware-websocket` one patch back to `3.972.46`, whose declared range is `^3.977.3` — satisfiable on paper, and the least invasive option.

It fails. pnpm still resolves **up** inside that caret to `3.977.4`, so the regenerated lockfile came back with the unpublished version and the identical error. I only caught it by grepping the lockfile rather than trusting that `pnpm install` exiting 0 meant the problem was gone — the local install succeeded against cached metadata while CI's fresh install would not have.

Only constraining `@aws-sdk/core` itself removes the unresolvable target. Verified: `grep -c 3.977.4 pnpm-lock.yaml` goes **3 → 0**.

## Scope

One override, on the package that lost a version — not on the consumers around it. Marked in-place for **removal** once AWS republishes or ships a later patch: this is an upstream publishing accident, not a decision about our dependency surface.

## Verification

- `pnpm install --frozen-lockfile` — succeeds
- `pnpm --filter @fusion/core build` — succeeds
- `pnpm lint` — clean
- FNXC-date gate — green
- no `3.977.4` anywhere in the lockfile

Checked first that nobody else had a PR touching `package.json` / `pnpm-lock` / `pnpm-workspace` — this is the third shared breakage today and I have duplicated another worker twice, so the check came before the fix this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)