### PR TITLE
docs(gate): record why the SQL-literal gate deliberately does not scan .sql

### DIFF
--- a/scripts/check-sql-column-literals.mjs
+++ b/scripts/check-sql-column-literals.mjs
@@ -109,6 +109,29 @@ function* walk(dir) {
     if (SKIP_DIRS.has(entry)) continue;
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) yield* walk(full);
+    /*
+    FNXC:LifecycleColumnCensus 2026-07-30-00:00: `.sql` IS DELIBERATELY NOT SCANNED, AND THE REASON
+    IS THE PARSER, NOT AN OVERSIGHT.
+
+    The sibling FNXC-date gate had the opposite defect — a plain-text scanner whose extension list
+    named the file types stamps were EXPECTED in rather than the ones they OCCUR in, so it was blind
+    to `.sql` and `.css` (#2954). That fix does not generalize here, and the two look alike enough
+    that it is worth saying so once.
+
+    This gate is AST-based: `ts.createSourceFile(..., ScriptKind.TSX)`, then a walk over string and
+    template nodes. A `.sql` file is not TypeScript, so adding the extension would not widen coverage
+    — it would feed DDL to the TS parser and traverse whatever lenient-mode nodes fell out, which is
+    worse than not looking, because the gate would then REPORT coverage it does not have.
+
+    Measured before deciding (2026-07-30): 38 tracked `.sql` files hold exactly one lifecycle-looking
+    literal, `CHECK (status IN ('open','converged','archived'))` in 0022_ideation.sql. That is the
+    ideation-session status enum — a different domain that happens to reuse the word, and not a
+    `tasks.column` comparison this gate would flag even if it could see it. Zero real offenders.
+
+    So the honest scope is: raw SQL is UNWATCHED, and the thing that would make it worth watching is a
+    data backfill (`UPDATE tasks SET column = ...`) landing in a migration. If one ever does, this
+    needs a separate raw-text matcher against `COMPARISON`, not an entry in the filter below.
+    */
     else if (/\.tsx?$/.test(full) && !/\.d\.ts$/.test(full)) yield full;
   }
 }


### PR DESCRIPTION
Comment-only. No behavior change.

## Why this is worth a commit

#2954 fixed the FNXC-date gate's walk: its extension filter listed the file types stamps were **expected** in rather than the ones they **occur** in, so it was blind to `.sql` and `.css`. That is a tempting pattern to generalize, and `check-sql-column-literals.mjs` is the obvious next candidate — a gate about *SQL* column literals that scans only `.tsx?`.

Applying the same fix here would be wrong, and quietly so.

## The two gates are not the same kind of tool

The FNXC gate is a plain-text regex scanner, so widening its extension list is trivially correct. This one is **AST-based**: `ts.createSourceFile(..., ScriptKind.TSX)` followed by a walk over string and template nodes.

A `.sql` file is not TypeScript. Adding the extension would not widen coverage — it would feed DDL to the TS parser and traverse whatever lenient-mode nodes fell out. The gate would then **report coverage it does not have**, which is strictly worse than not looking, because the silence would read as "SQL is clean."

## Measured before deciding

38 tracked `.sql` files contain exactly one lifecycle-looking literal:

```
0022_ideation.sql:19  CONSTRAINT ideation_sessions_status_check
                      CHECK (status IN ('open','converged','archived'))
```

That is the **ideation-session** status enum — a different domain that happens to reuse the word — not a `tasks.column` comparison, and not something this gate would flag even if it could parse the file. **Zero real offenders.**

So the honest scope is recorded as: raw SQL is **unwatched**, and the trigger that would make it worth watching is a data backfill (`UPDATE tasks SET column = ...`) landing in a migration. If that ever happens it needs a separate raw-text matcher against the exported `COMPARISON`, not an entry in the extension filter.

## Verification

- `check-sql-column-literals` → exit 0
- `check-fnxc-future-dates` → exit 0, "478 known, none added" (the new stamp is dated today, local)
- `scripts/__tests__/check-sql-column-literals.test.mjs` → **26 pass, 0 fail**
- `scripts/__tests__/check-inert-flag-seams.test.mjs` → **12 pass, 0 fail**
- `eslint` clean

## Why a comment rather than a doc

Per AGENTS.md, decisions of this shape belong next to the code they constrain. The failure mode is specifically someone reading the walk, noticing `.sql` is missing, and "fixing" it — so the note has to be at the filter, where that person is looking, not in `docs/solutions/`.