### PR TITLE
fix(merger-ai): gate the no-commits dep-sync skip on the branch diff — the P1 #2501 shipped without

### DIFF
--- a/packages/engine/src/__tests__/merge-dependency-sync-lockfile-heal.test.ts
+++ b/packages/engine/src/__tests__/merge-dependency-sync-lockfile-heal.test.ts
@@ -64,6 +64,18 @@ function readLog(path: string): string[][] {
   return readFileSync(path, "utf-8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
 }
 
+/*
+FNXC:TestInfrastructure 2026-07-30-20:10 (PR #2501 review — coderabbit):
+DELETE AN ABSENT VAR, DO NOT ASSIGN `undefined`. `process.env.X = undefined` stores the STRING
+"undefined", so a var that was absent before the test is left set to a truthy string afterwards and
+leaks into every later test in the process — the shape that makes an unrelated suite fail with an
+env-dependent path.
+*/
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
 describe("buildNonFrozenRetryCommand", () => {
   it("negates pnpm frozen flag explicitly (overrides CI default)", () => {
     expect(buildNonFrozenRetryCommand("pnpm install --frozen-lockfile")).toBe("pnpm install --no-frozen-lockfile");
@@ -194,9 +206,9 @@ fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(env));
       expect(captured.npm_config_registry).toBe("https://fake.registry/");
     } finally {
       process.env.PATH = previousPath;
-      process.env.COREPACK_HOME = origCorepackHome;
-      process.env.PNPM_HOME = origPnpmHome;
-      process.env.npm_config_registry = origNpmRegistry;
+      restoreEnv("COREPACK_HOME", origCorepackHome);
+      restoreEnv("PNPM_HOME", origPnpmHome);
+      restoreEnv("npm_config_registry", origNpmRegistry);
     }
   });
 
@@ -253,9 +265,9 @@ fs.writeFileSync(${JSON.stringify(logPath)}, JSON.stringify(env));
       expect(captured.PATH).toBeDefined();
     } finally {
       process.env.PATH = previousPath;
-      process.env.COREPACK_HOME = origCorepackHome;
-      process.env.PNPM_HOME = origPnpmHome;
-      process.env.npm_config_registry = origNpmRegistry;
+      restoreEnv("COREPACK_HOME", origCorepackHome);
+      restoreEnv("PNPM_HOME", origPnpmHome);
+      restoreEnv("npm_config_registry", origNpmRegistry);
     }
   });
 });

--- a/packages/engine/src/__tests__/merger-ai-no-commits-deps-skip.test.ts
+++ b/packages/engine/src/__tests__/merger-ai-no-commits-deps-skip.test.ts
@@ -258,4 +258,56 @@ describeIfGit("landOneRepo no-commits dep-sync skip", () => {
     expect(result.outcome).toBe("landed");
     expect(vi.mocked(installWorktreeDependencies)).not.toHaveBeenCalled();
   });
+
+  it("STILL syncs when a no-commits task's branch changes a lockfile or manifest", async () => {
+    /*
+    FNXC:MergeNoCommits 2026-07-30-19:40 (PR #2501 review — greptile P1):
+    THE FLAG ALONE IS NOT SAFE TO SKIP ON. Control only reaches the dep-sync step when the branch is
+    AHEAD (the `rev-list --count` short-circuit returns `outcome: "empty"` at zero), and the two
+    empty-lane guards downstream both carve out `noCommitsExpected` tasks — so nothing revalidates
+    the expectation against what actually landed.
+
+    A task marked no-commits whose executor did commit a lockfile change would therefore have its
+    install AND its frozen-lockfile validation skipped, landing the change unvalidated. The skip is
+    now gated on the branch diff: the flag says look, the diff decides.
+
+    The case above stays as-is and still passes — `feature.txt` is not a dependency file, so an
+    ordinary source change on a no-commits task is still skipped. This case differs only in WHICH
+    file the branch touches, which is the whole point.
+    */
+    fx = createRepoFixture(false);
+    /* `createRepoFixture` leaves the working tree on main, so the lockfile commit has to be made on
+       the task branch explicitly — committing it here without switching puts it on MAIN, where the
+       `main...branch` diff cannot see it and the case passes for the wrong reason. */
+    execSync(`git checkout ${BRANCH}`, { cwd: fx.rootDir, stdio: "pipe" });
+    writeFileSync(path.join(fx.rootDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf-8");
+    execSync("git add pnpm-lock.yaml && git commit -m 'chore: bump lockfile'", { cwd: fx.rootDir, stdio: "pipe" });
+    execSync("git checkout main", { cwd: fx.rootDir, stdio: "pipe" });
+    store = createStore();
+    audit = createRunAuditor(store, {
+      runId: generateSyntheticRunId("ai-merge", TASK_ID),
+      agentId: "merger",
+      taskId: TASK_ID,
+      phase: "merge",
+    });
+
+    const result = await landOneRepo(fx.rootDir, BRANCH, "main", {
+      taskId: TASK_ID,
+      settings: { autoMerge: false } as never,
+      audit,
+      log: async () => undefined,
+      setStatus: async () => undefined,
+      maxPasses: 1,
+      mergeAgent: squashMergeAgent,
+      reviewAgent: approveReviewAgent,
+      stashResolveAgent: async () => undefined,
+      includeTaskId: true,
+      trailers: [],
+      store,
+      noCommitsExpected: true,
+    });
+
+    expect(result.outcome).toBe("landed");
+    expect(vi.mocked(installWorktreeDependencies)).toHaveBeenCalled();
+  });
 });

--- a/packages/engine/src/merge-dependency-sync.ts
+++ b/packages/engine/src/merge-dependency-sync.ts
@@ -8,7 +8,10 @@ import type { Settings } from "@fusion/core";
 const execAsync = promisify(exec);
 
 export const INSTALL_MARKER_RELPATH = join("node_modules", ".fusion-install-marker");
-const LOCKFILE_CANDIDATES = ["pnpm-lock.yaml", "package-lock.json", "yarn.lock", "bun.lockb", "bun.lock"];
+/* FNXC:MergeNoCommits 2026-07-30-19:25: exported so merger-ai's no-commits dep-sync skip tests the
+   SAME lockfile names this module installs against. A second copy of the list is how the skip and the
+   installer drift into disagreeing about what counts as a dependency change. */
+export const LOCKFILE_CANDIDATES = ["pnpm-lock.yaml", "package-lock.json", "yarn.lock", "bun.lockb", "bun.lock"];
 const INSTALL_TIMEOUT_MS = 300_000;
 
 export interface WorktreeDependencySyncLogger {

--- a/packages/engine/src/merger-ai.ts
+++ b/packages/engine/src/merger-ai.ts
@@ -88,7 +88,7 @@ import {
 } from "./merger.js";
 import { resolveBranchGroupMergeRouting, type BranchGroupMergeRouting, type SyncGroupPrFn } from "./group-merge-coordinator.js";
 import { DEFAULT_COMMIT_AUTHOR_EMAIL, DEFAULT_COMMIT_AUTHOR_NAME } from "./worktree-hooks.js";
-import { installWorktreeDependencies } from "./merge-dependency-sync.js";
+import { installWorktreeDependencies, LOCKFILE_CANDIDATES } from "./merge-dependency-sync.js";
 import { activeSessionRegistry } from "./active-session-registry.js";
 import { resolveMcpServersForStore } from "./mcp-resolution.js";
 /*
@@ -899,7 +899,55 @@ export async function landOneRepo(
       agents still run (they may verify documentation or produce merge metadata); only the
       dependency install is skipped.
       */
-      if (ctx.noCommitsExpected === true) {
+      /*
+      FNXC:MergeNoCommits 2026-07-30-19:20 (PR #2501 review — greptile P1, and the flag alone is not
+      safe to trust here):
+      THE BRANCH IS KNOWN TO HAVE COMMITS AT THIS POINT. The `rev-list --count` short-circuit above
+      returns `outcome: "empty"` when the branch is zero commits ahead, so control only reaches this
+      line when it is AHEAD. `noCommitsExpected` is a task-level EXPECTATION set before execution,
+      and nothing revalidates it against what actually landed on the branch — the two empty-lane
+      guards below (#2259 already-landed proof, FN-8141 executor veto) both explicitly carve out
+      `noCommitsExpected` tasks, so they cannot catch the inverse case either.
+
+      So skipping on the flag alone means: a task marked no-commits whose executor did commit a
+      manifest or lockfile change gets its dependency install AND its frozen-lockfile validation
+      skipped, and the change lands unvalidated. That is the review finding, and it is reachable
+      rather than hypothetical.
+
+      Gate on the DIFF instead. The flag still expresses intent — it is what makes us look — but the
+      skip now requires that the branch genuinely touches no dependency-relevant file. A branch that
+      does touch one falls through to the normal sync, which is the behaviour that existed before
+      this option and the one the lockfile guard depends on.
+
+      Fail-safe on an unreadable diff: `git` errors yield "", which contains no manifest path, so we
+      would skip. Treat a FAILED diff as "cannot prove it is safe" and sync, matching the hard-fail
+      contract documented directly above.
+      */
+      let noCommitsDepsSkipAllowed = ctx.noCommitsExpected === true;
+      if (noCommitsDepsSkipAllowed) {
+        const changedRaw = await git(["diff", "--name-only", `${integrationBranch}...${branch}`], repoRootDir)
+          .catch(() => null);
+        if (changedRaw === null) {
+          noCommitsDepsSkipAllowed = false;
+          await log(`AI merge: no-commits task, but the branch diff could not be read — running dependency sync rather than assuming it is safe to skip`);
+        } else {
+          const changedFiles = changedRaw.split("\n").map((line) => line.trim()).filter(Boolean);
+          const dependencyFiles = changedFiles.filter((file) => {
+            const name = file.split("/").pop() ?? file;
+            return name === "package.json" || LOCKFILE_CANDIDATES.includes(name);
+          });
+          if (dependencyFiles.length > 0) {
+            noCommitsDepsSkipAllowed = false;
+            await log(`AI merge: task is marked no-commits but its branch changes ${dependencyFiles.length} dependency file(s) (${dependencyFiles.slice(0, 3).join(", ")}) — running dependency sync so the lockfile is still validated`);
+            await audit.git({
+              type: "merge:ai-deps-sync",
+              target: integrationBranch,
+              metadata: { taskId, tipSha, mergeRoot: canonicalMergeRoot, noCommitsExpected: true, dependencyFileCount: dependencyFiles.length, skipOverridden: true },
+            });
+          }
+        }
+      }
+      if (noCommitsDepsSkipAllowed) {
         await log(`AI merge: skipping dependency sync — no-commits task (no code changes expected)`);
       } else {
       const depsSyncStartedAt = Date.now();


### PR DESCRIPTION
## #2501 merged without its P1 fix; this is that fix, alone

#2501 has landed. Its review threads were resolved — I judged and fixed them — but its head was a fork branch I could not push to, so **the fixes were never in it**. Confirmed on `main` at `c1c1b964af`:

```
merger-ai.ts:902:      if (ctx.noCommitsExpected === true) {      ← bare flag, no diff gate
merge-dependency-sync.ts: export const LOCKFILE_CANDIDATES → 0 matches
```

Rebasing dropped this PR's five duplicated base commits, so it is now **one commit**: the review fix and its regression.

## The defect on main

The dep-sync skip trusts `ctx.noCommitsExpected` alone, and **only ever runs on a branch that has commits** — the `rev-list --count` short-circuit ~50 lines above returns `outcome: "empty"` at zero ahead, so control reaches it only when the branch is AHEAD.

Nothing revalidates the flag. Both downstream empty-lane guards carve no-commits tasks out explicitly — `merger-ai.ts:1372` (#2259 already-landed proof) and `:1994` (FN-8141 executor veto) — and both guard the *opposite* direction: commit-expected task, empty branch. The inverse has no check.

So a task marked no-commits whose executor committed a manifest or lockfile change gets its dependency install **and** its frozen-lockfile validation skipped, and the change lands unvalidated.

## The fix

The flag says *look*; the branch diff decides. A `main...branch` diff touching `package.json` or any `LOCKFILE_CANDIDATES` entry falls through to the normal sync and emits an audit row with `skipOverridden: true`. An unreadable diff **also** syncs — matching the hard-fail contract documented directly above that block, rather than treating absence of evidence as evidence of safety.

`LOCKFILE_CANDIDATES` is exported instead of duplicated, so the skip and the installer cannot drift on what counts as a dependency change.

**Mutation-verified:** reverting to trust-the-flag fails exactly the new case and nothing else. The existing *"lands successfully with noCommitsExpected: true and actual changes"* case is untouched and still passes — `feature.txt` is not a dependency file, so an ordinary source change on a no-commits task still skips. The new case differs only in *which* file the branch touches.

## Also carried over from the #2501 review

**coderabbit's env nit** — `process.env.X = undefined` stores the string `"undefined"`, leaving a previously-absent var truthy and leaking into later tests. `restoreEnv` applied at both sites.

**Both entry paths** — deferred with reasons: `runAiMerge`/`landWorkspaceTask` sit behind real worktrees, sessions and a merge agent, and the cheap version is a mirrored-implementation test that cannot fail on a revert (this repo has deleted two of those). The fix above also means propagation is no longer the only thing between a stale flag and an unvalidated lockfile.

## A correction to my own work

My first version of the regression committed the lockfile while the fixture had left the tree on `main`, so the `main...branch` diff could not see it and the case **passed for the wrong reason**. Corrected, with the reason recorded in the test.

## Verification

- `merger-ai-no-commits-deps-skip` — **5/5**, mutation-verified
- `merge-dependency-sync-lockfile-heal` — **10/10**
- engine typecheck — clean
- `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)