### PR TITLE
chore: retire the scheduler-test future-date allowance (3 → 0)

### DIFF
--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -180,7 +180,6 @@
   "packages/engine/src/__tests__/review-handoff-lane.test.ts": 1,
   "packages/engine/src/__tests__/scheduler-fanout-escalation-lanes.test.ts": 2,
   "packages/engine/src/__tests__/scheduler-load-lane-union.test.ts": 2,
-  "packages/engine/src/__tests__/scheduler-paused-dispatch-refusal.test.ts": 3,
   "packages/engine/src/__tests__/self-blocked-dependency-deadlock.pg.test.ts": 1,
   "packages/engine/src/__tests__/self-healing-db-corruption.test.ts": 1,
   "packages/engine/src/__tests__/stale-task-reporter.test.ts": 1,


### PR DESCRIPTION
One line out of the baseline. No behavior change.

#2960 rewrote `packages/engine/src/__tests__/scheduler-paused-dispatch-refusal.test.ts`, removing three `2026-07-31` FNXC stamps and adding one dated correctly:

```
-FNXC:TaskDispatch 2026-07-31-01:35 (PR #2779 review — greptile P2):
-  FNXC:TestHygiene 2026-07-31-02:30 (PR #2779 review — greptile):
-FNXC:TestHygiene 2026-07-31-02:30 (PR #2779 review — greptile):
+FNXC:TestHygiene 2026-07-30-14:45:
```

The file's allowance of 3 is now headroom nothing occupies, which is exactly where a future-dated stamp can land unseen. Retiring it restores the floor.

## Worth distinguishing from the last one

#2953 was the same drop path for a different reason: those stamps aged out on their own as the clock advanced, with nobody touching the code. **This one is a real code change** — the author fixed the dates.

The distinction matters for how the gate is read. A clock-driven drop means the count is falling without anyone doing anything, and should not be reported as cleanup. A code-driven drop like this one is genuine cleanup, and it is the behavior the gate exists to encourage. Both take the same path (lower the ceiling, name what was lowered, exit 0) because the gate cannot tell them apart at runtime — only the diff can.

## Verified

- baseline diff is exactly one deletion
- second consecutive run exits 0 with no further change — idempotent, not oscillating
- `check-fnxc-future-dates` exit 0, now `475 known future-dated stamp(s), none added` (was 478)