### PR TITLE
fix(a11y): 13 dialogs announced their role twice ("Settings dialog, dialog")

### DIFF
--- a/packages/dashboard/app/components/ActivityLogModal.tsx
+++ b/packages/dashboard/app/components/ActivityLogModal.tsx
@@ -486,7 +486,7 @@ export function ActivityLogModal({
     <FloatingWindow
       windowKey="activity-log"
       title={t("activityLog.title", "Activity Log")}
-      ariaLabel={`${t("activityLog.title", "Activity Log")} dialog`}
+      ariaLabel={t("activityLog.title", "Activity Log")}
       onClose={onClose}
       hideHeader
       dragHandleSelector=".activity-log-header"

--- a/packages/dashboard/app/components/AddNodeModal.tsx
+++ b/packages/dashboard/app/components/AddNodeModal.tsx
@@ -257,7 +257,7 @@ export function AddNodeModal({ isOpen, onClose, onSubmit, onDiscoverRemoteProjec
 
   return (
     /* FNXC:ModalTouchGeometry 2026-07-26-13:15: Shared FloatingWindow owns this modal's touch drag, resize, clamping, and persistence while phone and short viewports retain their sheet behavior. */
-    <FloatingWindow windowKey="add-node" title={t("nodes.addNode", "Add Node")} ariaLabel={`${t("nodes.addNode", "Add Node")} dialog`} onClose={closeModal} hideHeader dragHandleSelector=".modal-header" className="floating-window--add-node" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:add-node" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
+    <FloatingWindow windowKey="add-node" title={t("nodes.addNode", "Add Node")} ariaLabel={t("nodes.addNode", "Add Node")} onClose={closeModal} hideHeader dragHandleSelector=".modal-header" className="floating-window--add-node" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:add-node" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
       <div className="modal modal-md add-node-modal" aria-label={t("nodes.addNode", "Add Node")}>
         <div className="modal-header">
           <h3>{t("nodes.addNode", "Add Node")}</h3>

--- a/packages/dashboard/app/components/ChangesDiffModal.tsx
+++ b/packages/dashboard/app/components/ChangesDiffModal.tsx
@@ -128,7 +128,7 @@ export function ChangesDiffModal({ columnFlags,
     <FloatingWindow
       windowKey="changes-diff"
       title={t("changes.title", "Changes")}
-      ariaLabel={`${t("changes.title", "Changes")} dialog`}
+      ariaLabel={t("changes.title", "Changes")}
       onClose={onClose}
       hideHeader
       dragHandleSelector=".changes-diff-modal-header"

--- a/packages/dashboard/app/components/ConnectNodeModal.tsx
+++ b/packages/dashboard/app/components/ConnectNodeModal.tsx
@@ -168,7 +168,7 @@ export function ConnectNodeModal({ open, onClose, onConnected, addToast, onSubmi
 
   return (
     /* FNXC:ModalTouchGeometry 2026-07-26-13:15: Shared FloatingWindow owns this modal's touch drag, resize, clamping, and persistence while phone and short viewports retain their sheet behavior. */
-    <FloatingWindow windowKey="connect-node" title={t("nodes.modal.title", "Connect to Node")} ariaLabel={`${t("nodes.modal.title", "Connect to Node")} dialog`} onClose={onClose} hideHeader dragHandleSelector=".modal-header" className="floating-window--connect-node" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:connect-node" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
+    <FloatingWindow windowKey="connect-node" title={t("nodes.modal.title", "Connect to Node")} ariaLabel={t("nodes.modal.title", "Connect to Node")} onClose={onClose} hideHeader dragHandleSelector=".modal-header" className="floating-window--connect-node" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:connect-node" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
       <div
         className="modal modal-md connect-node-modal"
         aria-label={t("nodes.modal.title", "Connect to Node")}

--- a/packages/dashboard/app/components/GitManagerModal.tsx
+++ b/packages/dashboard/app/components/GitManagerModal.tsx
@@ -1385,7 +1385,7 @@ export function GitManagerModal({ isOpen, onClose, tasks: _tasks, addToast, proj
     <FloatingWindow
       windowKey="git-manager"
       title={t("git.modalTitle", "Git Manager")}
-      ariaLabel={`${t("git.modalTitle", "Git Manager")} dialog`}
+      ariaLabel={t("git.modalTitle", "Git Manager")}
       onClose={handleClose}
       hideHeader
       dragHandleSelector=".modal-header"

--- a/packages/dashboard/app/components/GroupTaskModal.tsx
+++ b/packages/dashboard/app/components/GroupTaskModal.tsx
@@ -104,7 +104,7 @@ export function GroupTaskModal({ isOpen, onClose, groupId, projectId, onOpenMemb
 
   return (
     /* FNXC:ModalTouchGeometry 2026-07-26-13:15: Shared FloatingWindow owns this modal's touch drag, resize, clamping, and persistence while phone and short viewports retain their sheet behavior. */
-    <FloatingWindow windowKey="group-task" title={t("groupTask.title", "Branch Group")} ariaLabel={`${t("groupTask.ariaLabel", "Branch group details")} dialog`} onClose={onClose} hideHeader dragHandleSelector=".modal-header" className="floating-window--group-task" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:group-task" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
+    <FloatingWindow windowKey="group-task" title={t("groupTask.title", "Branch Group")} ariaLabel={t("groupTask.ariaLabel", "Branch group details")} onClose={onClose} hideHeader dragHandleSelector=".modal-header" className="floating-window--group-task" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:group-task" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
       <div className="modal modal-lg group-task-modal" aria-label={t("groupTask.ariaLabel", "Branch group details")}>
         <div className="modal-header">
           <h2>{t("groupTask.title", "Branch Group {{id}}", { id: groupId })}</h2>

--- a/packages/dashboard/app/components/ModelOnboardingModal.tsx
+++ b/packages/dashboard/app/components/ModelOnboardingModal.tsx
@@ -2455,7 +2455,7 @@ export function ModelOnboardingModal({
       persistGeometryKey="floating-window:model-onboarding"
       suspendGeometryPersistenceOnMobile
       suspendGeometryPersistenceOnShortViewport
-      ariaLabel={`${t("setup.titleAiSetup", "Set Up AI")} dialog`}
+      ariaLabel={t("setup.titleAiSetup", "Set Up AI")}
       ariaLabelledBy="onboarding-title"
     >
       <div className="modal model-onboarding-modal">

--- a/packages/dashboard/app/components/NodeDetailModal.tsx
+++ b/packages/dashboard/app/components/NodeDetailModal.tsx
@@ -439,7 +439,7 @@ export function NodeDetailModal({
 
   return (
     /* FNXC:ModalTouchGeometry 2026-07-26-13:15: Shared FloatingWindow owns this modal's touch drag, resize, clamping, and persistence while phone and short viewports retain their sheet behavior. */
-    <FloatingWindow windowKey="node-detail" title={t("nodes.modalTitle", "Node Details")} ariaLabel={`${t("nodes.modalAriaLabel", "Node details for {{name}}", { name: node.name })} dialog`} onClose={onClose} hideHeader dragHandleSelector=".modal-header" className="floating-window--node-detail" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:node-detail" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
+    <FloatingWindow windowKey="node-detail" title={t("nodes.modalTitle", "Node Details")} ariaLabel={t("nodes.modalAriaLabel", "Node details for {{name}}", { name: node.name })} onClose={onClose} hideHeader dragHandleSelector=".modal-header" className="floating-window--node-detail" defaultSize={{ width: 720, height: 560 }} minSize={{ width: 360, height: 280 }} persistGeometryKey="floating-window:node-detail" suspendGeometryPersistenceOnMobile suspendGeometryPersistenceOnShortViewport closeOnOutsidePointerDown>
       <div
         className="modal modal-lg node-detail-modal"
         aria-label={t("nodes.modalAriaLabel", "Node details for {{name}}", { name: node.name })}

--- a/packages/dashboard/app/components/PlanningModeModal.tsx
+++ b/packages/dashboard/app/components/PlanningModeModal.tsx
@@ -3555,7 +3555,7 @@ export function PlanningModeModal({ isOpen, onClose, onTaskCreated, onTasksCreat
     <FloatingWindow
       windowKey="planning-mode"
       title={t("planning.title", "Planning Mode")}
-      ariaLabel={`${t("planning.title", "Planning Mode")} dialog`}
+      ariaLabel={t("planning.title", "Planning Mode")}
       onClose={handleClose}
       hideHeader
       dragHandleSelector=".planning-modal > .modal-header"

--- a/packages/dashboard/app/components/ScheduledTasksModal.tsx
+++ b/packages/dashboard/app/components/ScheduledTasksModal.tsx
@@ -560,7 +560,7 @@ export function ScheduledTasksModal({ onClose, addToast, projectId, presentation
     <FloatingWindow
       windowKey="automation"
       title={t("schedule.title", "Automations")}
-      ariaLabel={`${t("schedule.title", "Automations")} dialog`}
+      ariaLabel={t("schedule.title", "Automations")}
       onClose={onClose}
       hideHeader
       dragHandleSelector=".automation-modal__drag-handle"

--- a/packages/dashboard/app/components/ScriptsModal.tsx
+++ b/packages/dashboard/app/components/ScriptsModal.tsx
@@ -181,7 +181,7 @@ export function ScriptsModal({ isOpen, onClose, addToast, projectId, onRunScript
     <FloatingWindow
       windowKey="scripts"
       title={t("scripts.title", "Scripts")}
-      ariaLabel={`${t("scripts.title", "Scripts")} dialog`}
+      ariaLabel={t("scripts.title", "Scripts")}
       onClose={onClose}
       hideHeader
       dragHandleSelector=".modal-header"

--- a/packages/dashboard/app/components/SettingsModal.tsx
+++ b/packages/dashboard/app/components/SettingsModal.tsx
@@ -4405,7 +4405,7 @@ export function SettingsModal({
     <FloatingWindow
       windowKey="settings"
       title={t("settings.title", "Settings")}
-      ariaLabel={`${t("settings.title", "Settings")} dialog`}
+      ariaLabel={t("settings.title", "Settings")}
       onClose={() => void requestClose()}
       hideHeader
       dragHandleSelector=".settings-modal > .modal-header"

--- a/packages/dashboard/app/components/WorkflowAddStepModal.tsx
+++ b/packages/dashboard/app/components/WorkflowAddStepModal.tsx
@@ -144,7 +144,7 @@ export function WorkflowAddStepModal({
     <FloatingWindow
       windowKey="workflow-add-step"
       title={t("workflowNodes.addStepTitle", "Add a step")}
-      ariaLabel={`${t("workflowNodes.addStepTitle", "Add a step")} dialog`}
+      ariaLabel={t("workflowNodes.addStepTitle", "Add a step")}
       onClose={onClose}
       hideHeader
       dragHandleSelector=".wf-add-step-header"

--- a/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
+++ b/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
@@ -52,6 +52,25 @@ describe("a FloatingWindow's accessible name never restates its role", () => {
     expect(sources.filter((s) => s.text.includes("ariaLabel=")).length).toBeGreaterThan(5);
   });
 
+  /*
+  THE MATCHER ITSELF IS COVERED, because the scan above is only as good as this regex: loosening it
+  (or breaking it during an unrelated edit) would leave a guard that scans everything and finds
+  nothing, reporting success while covering zero. The negative cases matter more than the positive
+  ones — each is a real string in this codebase that must NOT be flagged.
+  */
+  it.each([
+    ["ariaLabel={`Settings dialog`}", true, "trailing role word in a template literal"],
+    ['ariaLabel="Git Manager dialog"', true, "trailing role word in a plain string"],
+    ["ariaLabel={`Node details modal`}", true, "'modal' is equally redundant"],
+    ['ariaLabel={t("settings.title", "Settings")}', false, "a clean t() call"],
+    ['ariaLabel="Settings"', false, "a clean literal"],
+    ['aria-label="Close confirmation dialog"', false, "a BUTTON's aria-label — not a dialog, name is correct"],
+    ['ariaLabel="Dialog settings"', false, "role word present but not the trailing noun"],
+    ['ariaLabel="Windows update"', false, "'Windows' merely contains a role word"],
+  ])("matcher: %s -> %s (%s)", (source, shouldFlag) => {
+    expect(new RegExp(REDUNDANT_ROLE_SUFFIX.source, "i").test(source)).toBe(shouldFlag);
+  });
+
   it("no ariaLabel ends in a word the dialog role already announces", () => {
     const offenders: string[] = [];
     for (const { file, text } of componentSources()) {

--- a/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
+++ b/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
@@ -32,7 +32,45 @@ import { describe, expect, it } from "vitest";
 const COMPONENTS_DIR = resolve(fileURLToPath(import.meta.url), "../..");
 
 /** Role words that a `role="dialog"` host already announces on its own. */
-const REDUNDANT_ROLE_SUFFIX = /ariaLabel=\{?[`"'][^`"']*?[^A-Za-z](dialog|modal|window)[`"']\}?/gi;
+const ROLE_WORD_AT_END = /[^A-Za-z](dialog|modal|window)\s*[`"']\s*\}?\s*$/i;
+
+/*
+FNXC:Accessibility 2026-07-30-17:05:
+The value is extracted by BRACE MATCHING rather than by one regex over the raw source.
+
+The first version of this guard used a single pattern with `[^`"']*?` for the label body. Every real
+call site interpolates a translator call — ``ariaLabel={`${t("scripts.title", "Scripts")} dialog`}``
+— and those inner DOUBLE QUOTES terminate that character class, so the pattern matched none of the
+thirteen offenders. It passed against hand-written samples like ``{`Settings dialog`}`` that happen
+to contain no quotes, which is how it looked correct while covering nothing.
+
+Caught by mutation: re-adding the suffix to ScriptsModal in its original template-literal form left
+the suite green. A guard that cannot fail on the exact defect it was written for is worse than none,
+so the extraction is now structural and the case table below carries the real, quote-bearing shapes.
+*/
+function extractAriaLabelValues(text: string): string[] {
+  const values: string[] = [];
+  const PROP = /ariaLabel=/g;
+  for (let m = PROP.exec(text); m; m = PROP.exec(text)) {
+    let i = m.index + m[0].length;
+    if (text[i] === "{") {
+      let depth = 0;
+      const start = i;
+      for (; i < text.length; i += 1) {
+        if (text[i] === "{") depth += 1;
+        else if (text[i] === "}") {
+          depth -= 1;
+          if (depth === 0) { values.push(text.slice(start, i + 1)); break; }
+        }
+      }
+    } else if (text[i] === '"' || text[i] === "'") {
+      const quote = text[i];
+      const end = text.indexOf(quote, i + 1);
+      if (end > i) values.push(text.slice(i, end + 1));
+    }
+  }
+  return values;
+}
 
 function componentSources(): { file: string; text: string }[] {
   return readdirSync(COMPONENTS_DIR)
@@ -59,23 +97,29 @@ describe("a FloatingWindow's accessible name never restates its role", () => {
   ones — each is a real string in this codebase that must NOT be flagged.
   */
   it.each<[source: string, shouldFlag: boolean, why: string]>([
-    ["ariaLabel={`Settings dialog`}", true, "trailing role word in a template literal"],
-    ['ariaLabel="Git Manager dialog"', true, "trailing role word in a plain string"],
+    /* THE REAL SHAPES FIRST — every one of the thirteen offenders looked like this, with quotes
+       inside the interpolation. The original regex missed all of them. */
+    ['ariaLabel={`${t("scripts.title", "Scripts")} dialog`}', true, "interpolated t() + suffix — the actual defect"],
+    ['ariaLabel={`${t("nodes.modalAriaLabel", "Node details for {{name}}", { name: node.name })} dialog`}', true, "nested braces AND quotes"],
+    ['ariaLabel={t("scripts.title", "Scripts") + " dialog"}', true, "concatenation, not interpolation"],
+    ["ariaLabel={`Settings dialog`}", true, "quote-free template literal"],
+    ['ariaLabel="Git Manager dialog"', true, "plain string"],
     ["ariaLabel={`Node details modal`}", true, "'modal' is equally redundant"],
-    ['ariaLabel={t("settings.title", "Settings")}', false, "a clean t() call"],
+    ['ariaLabel={t("settings.title", "Settings")}', false, "the fixed form — a bare t() call"],
+    ['ariaLabel={`${t("nodes.addNode", "Add Node")}`}', false, "interpolation with no suffix"],
     ['ariaLabel="Settings"', false, "a clean literal"],
-    ['aria-label="Close confirmation dialog"', false, "a BUTTON's aria-label — not a dialog, name is correct"],
-    ['ariaLabel="Dialog settings"', false, "role word present but not the trailing noun"],
+    ['ariaLabel="Dialog settings"', false, "role word present but not trailing"],
     ['ariaLabel="Windows update"', false, "'Windows' merely contains a role word"],
   ])("matcher: %s -> %s (%s)", (source, shouldFlag) => {
-    expect(new RegExp(REDUNDANT_ROLE_SUFFIX.source, "i").test(source)).toBe(shouldFlag);
+    const flagged = extractAriaLabelValues(source).some((v) => ROLE_WORD_AT_END.test(v));
+    expect(flagged).toBe(shouldFlag);
   });
 
   it("no ariaLabel ends in a word the dialog role already announces", () => {
     const offenders: string[] = [];
     for (const { file, text } of componentSources()) {
-      for (const match of text.matchAll(REDUNDANT_ROLE_SUFFIX)) {
-        offenders.push(`${file}: ${match[0].slice(0, 90)}`);
+      for (const value of extractAriaLabelValues(text)) {
+        if (ROLE_WORD_AT_END.test(value)) offenders.push(`${file}: ${value.slice(0, 100)}`);
       }
     }
     expect(

--- a/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
+++ b/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
@@ -58,7 +58,7 @@ describe("a FloatingWindow's accessible name never restates its role", () => {
   nothing, reporting success while covering zero. The negative cases matter more than the positive
   ones — each is a real string in this codebase that must NOT be flagged.
   */
-  it.each([
+  it.each<[source: string, shouldFlag: boolean, why: string]>([
     ["ariaLabel={`Settings dialog`}", true, "trailing role word in a template literal"],
     ['ariaLabel="Git Manager dialog"', true, "trailing role word in a plain string"],
     ["ariaLabel={`Node details modal`}", true, "'modal' is equally redundant"],

--- a/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
+++ b/packages/dashboard/app/components/__tests__/floating-window-aria-label-role-redundancy.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+/*
+FNXC:Accessibility 2026-07-30-16:30:
+A DIALOG'S ACCESSIBLE NAME MUST NOT RESTATE ITS ROLE.
+
+`FloatingWindow` renders `role="dialog"` and `aria-label={ariaLabel}` on the SAME element
+(FloatingWindow.tsx:628 and :631). A screen reader announces the role itself, so an accessible name
+ending in "dialog" is read back as "Settings dialog, dialog". Thirteen callers had grown that suffix
+by copy-paste.
+
+WHY THIS IS A SOURCE SCAN RATHER THAN A RENDER TEST. The defect is a property VALUE at the call
+site, and there is no single render that reaches all thirteen modals — each needs its own store,
+route and fixture set, and several are lazy-loaded. A per-modal render test would pin the three or
+four someone bothered to write and let the next copy-paste through, which is the failure mode
+AGENTS.md's "fix the invariant, not the repro" rule exists to stop. Scanning every caller is the
+only assertion that covers the whole surface.
+
+The scan is deliberately narrow: it looks only for the role name at the END of the label, where it
+is redundant. A label that legitimately contains the word mid-string ("Close confirmation dialog"
+on a BUTTON, which is not a dialog) is untouched, and button labels are out of scope entirely
+because this only inspects `ariaLabel` props passed to FloatingWindow-family components.
+*/
+
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/* `import.meta.url`, matching the sibling source-scanning test (terminal-scrollback-floor) —
+   these run as ESM, where `__dirname` is not defined. */
+const COMPONENTS_DIR = resolve(fileURLToPath(import.meta.url), "../..");
+
+/** Role words that a `role="dialog"` host already announces on its own. */
+const REDUNDANT_ROLE_SUFFIX = /ariaLabel=\{?[`"'][^`"']*?[^A-Za-z](dialog|modal|window)[`"']\}?/gi;
+
+function componentSources(): { file: string; text: string }[] {
+  return readdirSync(COMPONENTS_DIR)
+    .filter((name) => name.endsWith(".tsx"))
+    .map((name) => ({ file: name, text: readFileSync(resolve(COMPONENTS_DIR, name), "utf8") }));
+}
+
+describe("a FloatingWindow's accessible name never restates its role", () => {
+  /*
+  ANTI-VACUITY. A scan that silently matched zero files would pass forever — including after a
+  refactor renamed the prop or moved these components. Assert the corpus is real and that it still
+  contains the prop this test is about, so the guard fails loudly instead of going quiet.
+  */
+  it("scans a real corpus that still uses ariaLabel (anti-vacuity)", () => {
+    const sources = componentSources();
+    expect(sources.length).toBeGreaterThan(20);
+    expect(sources.filter((s) => s.text.includes("ariaLabel=")).length).toBeGreaterThan(5);
+  });
+
+  it("no ariaLabel ends in a word the dialog role already announces", () => {
+    const offenders: string[] = [];
+    for (const { file, text } of componentSources()) {
+      for (const match of text.matchAll(REDUNDANT_ROLE_SUFFIX)) {
+        offenders.push(`${file}: ${match[0].slice(0, 90)}`);
+      }
+    }
+    expect(
+      offenders,
+      `An aria-label ending in its own role is announced twice ("Settings dialog, dialog").\n`
+      + `Drop the trailing role word — role="dialog" already conveys it:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Thirteen modals set an `aria-label` that restates the role they already carry. `FloatingWindow` renders `role="dialog"` and `aria-label={ariaLabel}` on the **same element** (`FloatingWindow.tsx:628` and `:631`), so `"Settings dialog"` is announced as **"Settings dialog, dialog."**

Fixed at all 13 call sites, plus a guard so the next copy-paste fails instead of shipping.

### Two independent lines of evidence

I found this by inspection. Then, chasing unexplained dashboard failures, I hit `NodesView.test.tsx`:

```
Unable to find an accessible element with the role "dialog" and name "Add Node"
  ...
  Name "Add Node dialog":
```

Two tests were already asserting the **correct** name and failing because the product had drifted to add the suffix. So this is not a style preference — it is a defect with pre-existing tests that were red. **Those 2 failures go green here**, and they were among the ones I had not yet accounted for.

### The guard was vacuous, and mutation is the only reason I know

My first version used one regex with `[^`"']*?` for the label body. It passed. It was worthless.

Every real call site interpolates a translator call:

```jsx
ariaLabel={`${t("scripts.title", "Scripts")} dialog`}
```

Those inner **double quotes terminate the character class**, so the pattern matched **none of the thirteen offenders**. It only matched hand-written samples like ``{`Settings dialog`}`` that happen to contain no quotes — which is exactly what I had put in the case table. Re-adding the suffix to `ScriptsModal` in its original form left the suite **green**.

Extraction is now structural (brace matching), and the case table carries the real quote-bearing shapes, including the nested-brace `NodeDetailModal` form and the `+ " dialog"` concatenation variant.

**Mutation now behaves:**

| state | result |
|---|---|
| clean tree | 13/13 pass |
| suffix re-added to `ScriptsModal` (faithful form) | **fails**, naming the file and the offending value |

I would have shipped a guard that could not fail on the defect it was written for. It is the same error the guard exists to prevent — a cheap proxy standing in for the real measurement — so the reasoning is recorded in the file rather than quietly fixed.

### Verified

- `NodesView` + `FloatingWindow` + the new guard: **110/110**, then **13/13** for the guard after the rewrite
- `tsc -p tsconfig.app.json`: **0 errors** · lint clean · FNXC gate exit 0
- **No i18n key or default string changed** — all 15 `t()` keys byte-identical across the diff; only the literal outside the call was dropped, and the now-pointless `` {`${…}`} `` wrappers were unwrapped

### Not fixed here

`agent-modals-mobile` (2) and `core-modals-mobile` (1) still fail on this branch — they fail identically on `main`, are CSS-structure assertions unrelated to aria naming, and belong to the #2915 dead-`.agent-detail-overlay` family. Left alone deliberately rather than bundled in.

No changeset: user-visible a11y correction with no API or setting change, and the release-notes audience is operators. Say the word if you want one.
