### PR TITLE
fix(glasses): the summary card reported five hardcoded lanes, so a renamed board read as empty

### DIFF
--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/cards.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/cards.test.ts
@@ -26,6 +26,44 @@ describe("cards", () => {
     expect(card.lines).toContain("todo: 2");
   });
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-22:20:
+  THE INVARIANT: the summary card reports the lanes the board HAS, whatever they are called.
+
+  Untested before this — the only summary coverage above exercises `boardSummaryCard`, an export no
+  production file calls, while the card the deck actually ships (`boardSummaryCardFromCounts`, via
+  `boardToDeck`) had none. That gap is why five hardcoded lane ids survived here.
+
+  Reverted, the first case reports `Triage 0 Todo 0 Doing 0 Review 0 Done 0` for a board holding four
+  live cards and fails on every assertion below; the second still carries the dead `Triage 0`.
+  */
+  it("summarises a renamed board by its real lanes, not the legacy five", () => {
+    const renamed = ["backlog", "backlog", "building", "shipped"].map((column, i) => ({
+      ...task,
+      id: `FN-${i + 10}`,
+      column,
+    }));
+
+    const text = boardToDeck(renamed, { terminalColumns: new Set(["shipped"]) }).cards[0]!.lines.join(" ");
+
+    expect(text).toContain("backlog 2");
+    expect(text).toContain("building 1");
+    expect(text).toContain("shipped 1");
+    expect(text).not.toContain("Todo 0");
+    expect(text).not.toMatch(/Triage/);
+  });
+
+  it("drops the triage lane U11 deleted instead of spending display width on it", () => {
+    const text = boardToDeck([{ ...task, column: "todo" }], {}).cards[0]!.lines.join(" ");
+
+    expect(text).toContain("Todo 1");
+    expect(text).not.toMatch(/Triage/);
+  });
+
+  it("says so plainly when no lane holds work, rather than rendering an empty line", () => {
+    expect(boardToDeck([], {}).cards[0]!.lines.join(" ")).toBe("No active work");
+  });
+
   it("creates notification cards", () => {
     const card = notificationCard(task, "entered-column");
     expect(card.id).toBe("notif:FN-1:entered-column");

--- a/plugins/fusion-plugin-even-realities-glasses/src/cards.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/cards.ts
@@ -105,8 +105,52 @@ function boardSummary(tasks: Task[]): BoardSummary {
   return { counts, updatedAt };
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-22:20:
+The summary card names the lanes the BOARD actually has, not five hardcoded ids.
+
+This line read `Triage ${counts.triage} Todo ${counts.todo} Doing ${counts["in-progress"]} Review
+${counts["in-review"]} Done ${counts.done}`. `boardSummary` seeds those five keys to 0 and then
+counts by real `task.column`, so on a board whose lanes are named anything else EVERY interpolated
+value is the seeded 0: the summary card — the FIRST card in every deck, and the whole payload of
+`GET /board/summary` — reads "Triage 0 Todo 0 Doing 0 Review 0 Done 0" while the real work sits in
+lanes it never mentions. The wearer is told the board is empty.
+
+It is also wrong on the DEFAULT board today: U11 (#2515) deleted the `triage` lane, so `Triage 0` is
+always dead text — 9 of the 24 characters this display gets per line, spent on a lane no board has.
+
+Derived from `counts` rather than taken as a resolved-lanes parameter. That is deliberate: this
+program's recurring defect is the "optional lane answer + documented literal fallback" shape shipped
+without wiring the caller (see `unwired-lane-parameter-guard.test.ts` — five were live on `main` at
+once), and `counts` is already keyed by real `task.column` values, so the lane vocabulary is in hand
+with no resolution, no new plumbing, and nothing that can be left unwired.
+
+Zero-count lanes are dropped so the scarce line budget goes to lanes with work; legacy ids keep their
+familiar order and labels, unknown ids sort after them alphabetically so output stays deterministic.
+`counts` itself is unchanged — the route returns it as the API body and consumers still see every key.
+*/
+const LANE_LABELS: Record<string, string> = {
+  triage: "Triage",
+  todo: "Todo",
+  "in-progress": "Doing",
+  "in-review": "Review",
+  done: "Done",
+  archived: "Archived",
+};
+
+function orderedLanes(counts: Record<string, number>): string[] {
+  const rank = (id: string) => {
+    const index = COLUMN_ORDER.indexOf(id as Task["column"]);
+    return index === -1 ? COLUMN_ORDER.length : index;
+  };
+  return Object.keys(counts).sort((a, b) => (rank(a) === rank(b) ? a.localeCompare(b) : rank(a) - rank(b)));
+}
+
 function boardSummaryCardFromCounts(summary: BoardSummary, now: string, maxCharsPerLine: number, maxLines: number): GlassesCard {
-  const summaryText = `Triage ${summary.counts.triage} Todo ${summary.counts.todo} Doing ${summary.counts["in-progress"]} Review ${summary.counts["in-review"]} Done ${summary.counts.done}`;
+  const occupied = orderedLanes(summary.counts).filter((id) => (summary.counts[id] ?? 0) > 0);
+  const summaryText = occupied.length
+    ? occupied.map((id) => `${LANE_LABELS[id] ?? id} ${summary.counts[id]}`).join(" ")
+    : "No active work";
   return {
     id: "summary",
     kind: "summary",


### PR DESCRIPTION
## The defect

`boardSummaryCardFromCounts` built its text from five hardcoded lane ids:

```ts
`Triage ${counts.triage} Todo ${counts.todo} Doing ${counts["in-progress"]} Review ${counts["in-review"]} Done ${counts.done}`
```

`boardSummary` seeds exactly those five keys to `0`, then counts by real `task.column`. On a board whose lanes are named anything else, **every interpolated value is the seeded zero** — so the summary card, which is the first card in every deck and the entire body of `GET /board/summary`, reads:

```
Triage 0 Todo 0 Doing 0 Review 0 Done 0
```

…while the real work sits in lanes it never mentions. The wearer is told the board is empty.

It is also wrong on the **default** board today: U11 (#2515) deleted the `triage` lane, so `Triage 0` is permanently dead text — 9 of the 24 characters this display gets per line.

## Why there was no test

The only summary coverage in `cards.test.ts` exercised `boardSummaryCard`, an **export no production file calls** (its sole caller is that test). The function the deck actually ships had none. That gap is why five hardcoded ids survived here.

## The fix, and one deliberate choice

The lanes are derived from `counts` instead of taken as an optional resolved-lanes parameter.

That is on purpose. This program's recurring defect is precisely the "optional lane answer + documented literal fallback" shape shipped without wiring the caller — `unwired-lane-parameter-guard.test.ts` documents **five live on `main` at once**, and in four of five the parameter was unreachable because the caller held a larger defect. `counts` is already keyed by real `task.column` values, so the vocabulary is in hand with **no resolution, no new plumbing, and nothing that can be left unwired**.

Zero-count lanes are dropped so the scarce line budget goes to lanes with work; legacy ids keep their familiar labels and order, unknown ids sort after them alphabetically so output is deterministic. `counts` itself is untouched — the route returns it as the API body and consumers still see every key.

## Revert proof

Restoring only `cards.ts` fails all three new cases, printing the defect verbatim:

```
AssertionError: expected 'Triage 0 Todo 0 Doing 0 Review 0 Done…' to contain 'backlog 2'
AssertionError: expected 'Triage 0 Todo 1 Doing 0 Review 0 Done…' not to match /Triage/
AssertionError: expected 'Triage 0 Todo 0 Doing 0 Review 0 Done…' to be 'No active work'
      Tests  3 failed | 5 passed (8)
```

## Verification (measured)

- `cards.test.ts` — **8/8 passed**
- full plugin suite — **180 passed**, 19 files
- `eslint`, `tsc --noEmit` — clean
- `lifecycle-column-census --strict`, `check-sql-column-literals`, `check-fnxc-future-dates` — green

No changeset: `@fusion-plugin-examples/even-realities-glasses` is `private: true` and is not bundled into the published CLI.

## Pre-existing failure, NOT from this change

The plugin suite also has **15 failures in `src/__tests__/agent-actions.test.ts`**. They reproduce identically on clean `origin/main` with this branch stashed (`15 failed | 41 passed`), so they are not caused by this PR and are not fixed by it. Flagging separately — this suite is outside the merge gate, which is why it has been red unnoticed.
