### PR TITLE
fix(dependency-graph): an allowlist of four legacy lanes rendered a blank graph on a renamed board

### DIFF
--- a/plugins/fusion-plugin-dependency-graph/src/__tests__/filters.test.ts
+++ b/plugins/fusion-plugin-dependency-graph/src/__tests__/filters.test.ts
@@ -67,6 +67,40 @@ describe("filterGraphTasks", () => {
     expect(filterGraphTasks([invalidTask])).toEqual([]);
   });
 
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-30-23:05:
+  THE INVARIANT: a card in a lane this filter has never heard of is still a graph node.
+
+  Reverted to the `INCLUDED_COLUMNS` allowlist, this case returns `[]` for three live cards — which is
+  what a renamed board got: an entirely blank dependency graph, indistinguishable from "no dependencies".
+
+  Every case above stays green either way, which is the point: they only ever enumerate the six legacy
+  ids, so the allowlist and the denylist agree on all of them. Nothing here could see the blackout.
+  */
+  it("renders cards from lanes it does not recognise, instead of blanking the graph", () => {
+    const renamed = [
+      createTask("FN-1", "backlog" as Task["column"]),
+      createTask("FN-2", "building" as Task["column"]),
+      createTask("FN-3", "checking" as Task["column"]),
+    ];
+
+    expect(filterGraphTasks(renamed).map((task) => task.id)).toEqual(["FN-1", "FN-2", "FN-3"]);
+  });
+
+  it("still drops finished lanes when the rest of the board is renamed", () => {
+    const mixed = [
+      createTask("FN-1", "building" as Task["column"]),
+      createTask("FN-2", "done"),
+      createTask("FN-3", "archived"),
+    ];
+
+    expect(filterGraphTasks(mixed).map((task) => task.id)).toEqual(["FN-1"]);
+  });
+
+  it("excludes an empty-string column, which names no lane at all", () => {
+    expect(filterGraphTasks([createTask("FN-1", "" as Task["column"])])).toEqual([]);
+  });
+
   it("preserves task object identity", () => {
     const taskA = createTask("FN-1", "todo");
     const taskB = createTask("FN-2", "in-review");

--- a/plugins/fusion-plugin-dependency-graph/src/filters.ts
+++ b/plugins/fusion-plugin-dependency-graph/src/filters.ts
@@ -1,8 +1,40 @@
 import type { ColumnId, Task } from "@fusion/core";
 
+/**
+ * The legacy default board's active lanes.
+ *
+ * Retained as the documented default-board vocabulary (and used by tests to enumerate it), but it is
+ * NO LONGER the gate — see {@link filterGraphTasks} for why an allowlist was the wrong shape here.
+ */
 export const INCLUDED_COLUMNS: ReadonlySet<ColumnId> = new Set(["triage", "todo", "in-progress", "in-review"]);
+
+/** Lanes whose cards are finished, and so are not dependency-graph nodes. */
 export const EXCLUDED_COLUMNS: ReadonlySet<ColumnId> = new Set(["done", "archived"]);
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-30-23:05:
+Gate on the FINISHED lanes, not on a fixed list of active ones — an allowlist blacked out the graph.
+
+This filtered `INCLUDED_COLUMNS.has(task.column)`, an allowlist of four legacy ids. On a board whose
+lanes are named anything else — `backlog`, `building`, `checking` — NO task matches and the dependency
+graph renders COMPLETELY EMPTY. Not a mislabelled node or a missing edge: the whole feature is blank,
+and it reads as "this project has no dependencies" rather than as a bug.
+
+Inverting to a denylist makes the default the safe one. An unrecognised lane is active work by
+assumption, so a renamed or custom lane renders; only lanes that genuinely mean "finished" drop out.
+An allowlist fails closed (hide everything unknown), a denylist fails open (show it) — and for a
+graph, showing a node that could have been omitted is a far smaller error than showing nothing.
+
+`EXCLUDED_COLUMNS` is still two literals: this is a client React component that receives plain `Task`
+rows as a prop and has no async seam to resolve a workflow IR, so a board that renames its DONE lane
+still shows finished cards here. That is the residual, and it is deliberately the mild failure — the
+direction of the remaining error is "one extra node", not "no graph".
+
+The invalid-column guard is now explicit. Under the allowlist, `column: undefined` was excluded as a
+side effect of not being in the set; under a denylist it would sail through, so it is checked directly.
+*/
 export function filterGraphTasks(tasks: Task[]): Task[] {
-  return tasks.filter((task) => INCLUDED_COLUMNS.has(task.column));
+  return tasks.filter(
+    (task) => typeof task.column === "string" && task.column.length > 0 && !EXCLUDED_COLUMNS.has(task.column),
+  );
 }


### PR DESCRIPTION
## A renamed board gets a blank dependency graph

`filterGraphTasks` gated on an allowlist of four legacy lane ids:

```ts
export const INCLUDED_COLUMNS = new Set(["triage", "todo", "in-progress", "in-review"]);
export function filterGraphTasks(tasks: Task[]): Task[] {
  return tasks.filter((task) => INCLUDED_COLUMNS.has(task.column));
}
```

On a board whose lanes are named anything else — `backlog`, `building`, `checking` — **no card matches and the graph renders completely empty**. This is not a mislabelled node or a missing edge: the entire feature is blank, and it reads as *"this project has no dependencies"* rather than as a bug. `triage` is in that allowlist too, a lane U11 (#2515) deleted.

## Fix: gate on the finished lanes instead

Inverted to a denylist, so the **default is the safe one**. An unrecognised lane is active work by assumption and renders; only lanes that genuinely mean "finished" drop out.

An allowlist fails **closed** — hide everything unknown. A denylist fails **open** — show it. For a graph, an extra node is a far smaller error than no graph.

## The residual, named rather than hidden

`EXCLUDED_COLUMNS` is still two literals. `DependencyGraph.tsx` is a client React component handed plain `Task` rows as a prop, with no async seam to resolve a workflow IR — so a board that renames its DONE lane still shows finished cards here. That is deliberately the mild failure direction: "one extra node", not "no graph". It is documented in the code rather than papered over with an optional resolved-lanes parameter no caller could fill.

The invalid-column guard is now **explicit**. Under the allowlist, `column: undefined` was excluded as a side effect of not being in the set; under a denylist it would sail through, so it is checked directly and covered.

## Revert proof

Restoring only `filters.ts`:

```
AssertionError: expected [] to deeply equal [ 'FN-1', 'FN-2', 'FN-3' ]
AssertionError: expected [] to deeply equal [ 'FN-1' ]
      Tests  2 failed | 13 passed (15)
```

Worth noting explicitly: **every pre-existing case passes either way.** They only ever enumerate the six legacy ids, so the allowlist and the denylist agree on all of them — no existing test could have seen this blackout. (The new empty-string case also passes both ways; it guards the new implementation rather than proving the fix, and I am not claiming it as coverage of the defect.)

## Verification (measured)

- plugin suite — **183 passed / 20 files**
- `tsc --noEmit`, `eslint` — clean
- `lifecycle-column-census --strict`, `check-fnxc-future-dates` — green

## Checked and deliberately not changed

`GraphTaskNode.tsx` holds `column === "in-progress"` and `column === "in-review"`. Both are already audited with an in-code note, and both degrade mildly rather than blanking anything — `hasExecutionSignal` also ORs on `ACTIVE_STATUSES`, so a renamed WIP lane still reads as active via status. Converting them needs column traits this component is not given, so they stay noted rather than half-converted.

No changeset: `fusion-plugin-dependency-graph` is `private: true`.
