### PR TITLE
fix(gate): a lane id hoisted into a const evaded the SQL column-literal gate

### DIFF
--- a/scripts/__tests__/check-sql-column-literals.test.mjs
+++ b/scripts/__tests__/check-sql-column-literals.test.mjs
@@ -21,14 +21,17 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import ts from "typescript";
 
-import { COMPARISON, comparisonWeight, literalText } from "../check-sql-column-literals.mjs";
+import { COMPARISON, comparisonWeight, literalText, collectStringConsts } from "../check-sql-column-literals.mjs";
 
 /** Count forbidden comparisons the way the scanner does: over decoded literal text. */
 function hits(source) {
   const sf = ts.createSourceFile("t.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  /* The scanner resolves same-file constants before matching; the harness must too, or these tests
+     would exercise a scanner that does not exist. */
+  const consts = collectStringConsts(sf);
   let total = 0;
   const visit = (node) => {
-    const text = literalText(node);
+    const text = literalText(node, consts);
     if (text !== null) {
       COMPARISON.lastIndex = 0;
       /* Weighted exactly as the scanner counts: an IN list of two legacy ids is two sites. */
@@ -220,4 +223,54 @@ test("IS / IS NOT are caught", () => {
 
 test("IS DISTINCT FROM a NON-legacy id is not matched", () => {
   assert.equal(hits("const q = sql`${t.column} IS DISTINCT FROM 'shipped'`;"), 0);
+});
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-30-23:20:
+A LANE ID HOISTED INTO A CONST IS THE SAME DEFECT AS AN INLINE ONE.
+
+Both shapes below were MISSED by the shipped scanner: a non-column interpolation collapsed to the NUL
+sentinel, so the predicate dissolved before the matcher ran. Hoisting a repeated string to a named
+const reads as a cleanup, which makes it the likeliest way one of these gets rewritten.
+
+The negatives are the harder half. Resolving constants too eagerly double-counts SQL fragments that
+are already counted where they are written — the analytics files jumped 3->6 that way, which looked
+like a genuine find. Only BARE lane ids are resolved, and `sqlFragmentArray` below is the case that
+pins it.
+*/
+test("a legacy lane id hoisted into a const is counted", () => {
+  assert.equal(hits('const LANE = "done";\nconst q = sql`WHERE "column" = ${LANE}`;'), 1);
+});
+
+test("a hoisted const ARRAY is counted once per legacy id", () => {
+  assert.equal(
+    hits('const LANES = ["in-progress", "in-review"];\nconst q = sql`WHERE "column" IN (${sql.join(LANES)})`;'),
+    2,
+  );
+});
+
+test("the wrapper call around the const does not matter (inArray, as const)", () => {
+  assert.equal(
+    hits('const LANES = ["done"] as const;\nconst q = sql`WHERE "column" IN (${inArray(t.column, LANES)})`;'),
+    1,
+  );
+});
+
+test("a const of NON-legacy lane ids is not counted", () => {
+  assert.equal(hits('const LANES = ["drafting", "shipped"];\nconst q = sql`WHERE "column" IN (${sql.join(LANES)})`;'), 0);
+});
+
+test("a lane list produced by a resolver call is not counted", () => {
+  assert.equal(
+    hits('const LANES = resolveProjectColumnsForRoles(store, ["wip"]);\nconst q = sql`WHERE "column" IN (${sql.join(LANES)})`;'),
+    0,
+  );
+});
+
+test("an array of SQL FRAGMENTS is counted at its elements, never twice via the join", () => {
+  /* The double-count regression: each fragment is already a site where it is written. Resolving the
+     const re-injected it into the outer template, doubling every analytics query. */
+  const source = 'const CLAUSES = [`t."column" = \'done\'`, `t.deletedAt IS NULL`];\n'
+    + 'const q = sql`SELECT * FROM t WHERE ${CLAUSES.join(" AND ")}`;';
+  assert.equal(hits(source), 1);
 });

--- a/scripts/check-sql-column-literals.mjs
+++ b/scripts/check-sql-column-literals.mjs
@@ -215,13 +215,94 @@ it is the thing a reader checks instead of the code.
 */
 const COLUMN_PROPERTY = /(?:(?:^|\.)column|\[\s*["'`]column["'`]\s*\])[!?]*$/;
 
-export function literalText(node) {
+/*
+FNXC:LifecycleColumnCensus 2026-07-30-22:30:
+A LITERAL HOISTED INTO A NAMED CONST IS THE SAME DEFECT, and the span scan could not see it.
+
+    const LANE = "done";
+    sql`... WHERE "column" = ${LANE}`
+
+    const LANES = ["in-progress", "in-review"];
+    sql`... WHERE "column" IN (${sql.join(LANES)})`
+
+Both bind a query to the legacy vocabulary exactly as an inline 'done' does. Neither was counted: an
+interpolation that is not a column reference became the NUL sentinel, so the predicate dissolved
+before the matcher ever ran.
+
+THIS IS THE SHAPE A CLEANUP PRODUCES. Hoisting a repeated string to a named const reads as tidying,
+and is the most likely way one of these gets rewritten — the gate would go quiet on a file that
+changed only in punctuation, which is the failure this scanner has now had three times (the static
+span join, the element-access column reference, and this).
+
+The array form is not hypothetical: IN ('in-progress','in-review') was the live workflow-analytics
+defect, and hoisting that list is the obvious tidy-up.
+
+Found by mutation with shapes deliberately NOT in mind when the scanner was written, after arguing in
+#2979 that ratchets should be probed that way on the day they ship. Two of three probes got through.
+
+SCOPE: same-file const declarations holding a string or an array of strings. Cross-file imports are
+NOT resolved — that needs a type checker and a program-wide pass, and the honest boundary is worth
+more than a half-resolution that reads as coverage. A constant imported from another module is still
+invisible, and --list output is where that gets audited, not this comment.
+*/
+/*
+FNXC:LifecycleColumnCensus 2026-07-30-23:05:
+ONLY BARE LANE IDS ARE RESOLVED, and this restriction is load-bearing rather than cautious.
+
+The first version resolved any string-valued const. Several analytics files build their queries as
+`const completedClauses = [`t."column" = 'done'`, ...]` and then interpolate `clauses.join(" AND ")`
+— those elements are SQL FRAGMENTS that the scanner already counts where they are written, so
+resolving them re-injected each one into the outer template and counted it a second time. The three
+analytics files jumped from 3/3/1 to 6/5/2 with no new defect anywhere: pure double counting, and it
+read exactly like a real find.
+
+A hoisted lane id is a bare token — `done`, `in-progress`. Anything carrying quotes, spaces or SQL
+punctuation is a fragment, already covered at its own site, and must not be resolved here.
+*/
+const BARE_LANE_ID = /^[A-Za-z0-9_-]+$/;
+
+export function collectStringConsts(sf) {
+  const consts = new Map();
+  const unwrap = (n) => (n && (ts.isAsExpression(n) || ts.isParenthesizedExpression(n)) ? unwrap(n.expression) : n);
+  const isStr = (n) => ts.isStringLiteral(n) || ts.isNoSubstitutionTemplateLiteral(n);
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const init = unwrap(node.initializer);
+      if (isStr(init) && BARE_LANE_ID.test(init.text)) consts.set(node.name.text, [init.text]);
+      else if (ts.isArrayLiteralExpression(init)) {
+        const elements = init.elements.map(unwrap);
+        if (elements.length > 0 && elements.every((e) => isStr(e) && BARE_LANE_ID.test(e.text))) {
+          consts.set(node.name.text, elements.map((e) => e.text));
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return consts;
+}
+
+/**
+ * The SQL text an interpolation stands in for, when it resolves to a known constant.
+ * Any identifier in the expression is a candidate, so sql.join(LANES) and inArray(x, LANES) resolve
+ * the same way a bare ${LANES} does — the wrapper call does not change the vocabulary.
+ */
+function resolvedSpanText(expression, consts) {
+  for (const identifier of expression.match(/[A-Za-z_$][\w$]*/g) ?? []) {
+    const values = consts.get(identifier);
+    if (values) return values.map((value) => `'${value}'`).join(",");
+  }
+  return null;
+}
+
+export function literalText(node, consts = new Map()) {
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
   if (ts.isTemplateExpression(node)) {
     const parts = [node.head.text];
     for (const span of node.templateSpans) {
       const expression = span.expression.getText().trim();
-      parts.push(COLUMN_PROPERTY.test(expression) ? '"column"' : "\u0000");
+      if (COLUMN_PROPERTY.test(expression)) parts.push('"column"');
+      else parts.push(resolvedSpanText(expression, consts) ?? "\u0000");
       parts.push(span.literal.text);
     }
     return parts.join("");
@@ -248,9 +329,10 @@ function scan() {
   for (const file of walk(PACKAGES)) {
     const source = readFileSync(file, "utf8");
     const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    const consts = collectStringConsts(sf);
     let hits = 0;
     const visit = (node) => {
-      const text = literalText(node);
+      const text = literalText(node, consts);
       if (text !== null) {
         COMPARISON.lastIndex = 0;                         // a /g regex carries state between calls
         for (const match of text.match(COMPARISON) ?? []) {


### PR DESCRIPTION
## What

In #2979 I argued a ratchet should be mutation-probed with shapes its author did **not** have in mind, on the day it ships. Applying that to my own gate: two of three probes walked straight through.

```ts
const LANE = "done";
sql`... WHERE "column" = ${LANE}`                       // MISSED

const LANES = ["in-progress", "in-review"];
sql`... WHERE "column" IN (${sql.join(LANES)})`         // MISSED
```

Both bind the query to the legacy vocabulary exactly as an inline `'done'` does. An interpolation that wasn't a column reference collapsed to the NUL sentinel, so the predicate dissolved before the matcher ever ran.

**This is the shape a cleanup produces.** Hoisting a repeated string to a named const reads as tidying, which makes it the likeliest way one of these gets rewritten — and the gate would have gone quiet on a file that changed only in punctuation. Third time this scanner has had that failure (static-span join, element-access column ref, now this). The array form isn't hypothetical: `IN ('in-progress','in-review')` was the live workflow-analytics defect.

## The first version of this fix was wrong, and that's the useful part

Resolving *any* string-valued const double-counted the analytics files, which build queries as:

```ts
const completedClauses = [`t."column" = 'done'`, "t.columnMovedAt IS NOT NULL"];
```

Those elements are SQL fragments **already counted where they're written**. Resolving the const re-injected each into the outer template. The three analytics files went `3/3/1` → `6/5/2` — and it read exactly like a genuine find. Only **bare lane ids** are resolved now; the fragment-array case is pinned as a test.

I also nearly shipped that version on a bad probe: `node gate | tail` then `echo $?` reads *tail's* exit status, not the gate's. Every probe reported "caught" while the gate was actually failing on main for an unrelated reason. Worth repeating because the harness looked fine and agreed with what I expected.

## Measured

| check | result |
|---|---|
| clean `main` | **22 sites, exit 0, unchanged** — no false positives introduced |
| now caught | const string · const array via `sql.join` · as-const via `inArray` |
| correctly **not** flagged | resolver-produced lanes · non-legacy ids · SQL-fragment array |
| gate's own suite | **26 → 32 tests**, all green |
| blinding the resolution | fails **exactly** the 3 new positive tests; the 3 negatives still pass |

The negatives outnumber what feels necessary on purpose: eager resolution is how this went wrong the first time, and the fragment-array test is the one that would have caught it.

## Scope

Same-file `const` declarations only. Cross-file imports need a type checker and a program-wide pass — a constant imported from another module is **still invisible**, and `--list` output is where that gets audited. Stating the boundary rather than half-resolving it and calling the gate complete.