### PR TITLE
fix(dashboard): blocker fan-out badges read legacy lane ids on a renamed board

### DIFF
--- a/.changeset/blocker-fanout-renamed-lanes.md
+++ b/.changeset/blocker-fanout-renamed-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Blocker fan-out badges and escalation now work on boards with renamed lanes.
+category: fix
+dev: `useBlockerFanout` forwards per-task `classify`/`escalationClassify` to `computeBlockerFanoutMap`; `Board` supplies them from its per-task workflow column metadata. Absent flags degrade to the previous legacy defaults, so unconverted boards are byte-identical.

--- a/packages/dashboard/app/components/Board.tsx
+++ b/packages/dashboard/app/components/Board.tsx
@@ -8,6 +8,7 @@ import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import { promoteTask, type ModelInfo, type BoardWorkflowsPayload, type BoardWorkflowColumn, type RevertTaskOptions, type RevertTaskResult } from "../api";
 import { useBlockerFanout } from "../hooks/useBlockerFanout";
+import { isHoldColumnRole, isCompleteColumnRole, isArchivedColumnRole, isWipColumnRole, isReviewColumnRole } from "../utils/columnRoles";
 import { useColumnScrollSnap } from "../hooks/useColumnScrollSnap";
 import { MOBILE_MEDIA_QUERY, useViewportMode } from "../hooks/useViewportMode";
 import { recordResumeEvent } from "../utils/resumeInstrumentation";
@@ -203,9 +204,6 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
     return document.getElementById("header-workflow-slot");
   });
   const viewportMode = useViewportMode();
-  const blockerFanoutMap = useBlockerFanout(tasks, {
-    staleHighFanoutAgeThresholdMs: staleHighFanoutBlockerAgeThresholdMs,
-  });
   // Normalized search-active signal: trimmed and non-empty
   const isSearchActive = searchQuery.trim() !== "";
   useEffect(() => {
@@ -610,6 +608,47 @@ export function Board({ tasks, projectId, maxConcurrent, showWorktreeGrouping, o
     }
     return map;
   }, [boardWorkflows, getEffectiveTaskWorkflowId, tasks, workflowContextMenuColumnsByWorkflowId, workflowMode]);
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-23:30:
+  PER-TASK column flags for the blocker fan-out, resolved against the card's OWN workflow.
+
+  `taskContextMenuColumnsByTaskId` is the per-task metadata this component already builds; the same
+  accessor shape is used in ListView for exactly this reason. Two rules, both load-bearing:
+
+  - a task whose workflow IS known but which sits in a column that workflow no longer declares gets
+    ABSENT flags, not another workflow's traits. Knowing the workflow and finding no such column is
+    an answer; the role helpers then degrade to the legacy id, which is the documented no-metadata
+    path;
+  - no per-task metadata at all (workflow mode off, first paint) also yields absent flags. This
+    component has no board-wide union to fall back to, and reaching for one would be the union read
+    that serves a neighbouring workflow's semantics to this card.
+
+  Absent flags reproduce the previous defaults exactly — `done`/`archived`, `todo`,
+  `in-progress`/`in-review` — so an unconverted board is byte-identical.
+  */
+  const getTaskColumnFlags = useCallback((task: Task) => (
+    taskContextMenuColumnsByTaskId.get(task.id)?.find((column) => column.id === task.column)?.flags
+  ), [taskContextMenuColumnsByTaskId]);
+
+  /* Terminal is complete OR archived — the pair core's LEGACY_TERMINAL_COLUMNS names. */
+  const classifyTaskLanes = useCallback((task: Task) => ({
+    isHold: isHoldColumnRole(getTaskColumnFlags(task), task.column),
+    isTerminal: isCompleteColumnRole(getTaskColumnFlags(task), task.column)
+      || isArchivedColumnRole(getTaskColumnFlags(task), task.column),
+  }), [getTaskColumnFlags]);
+
+  /* A blocker escalates while it occupies an ACTIVE lane — wip ∪ review, core's escalation pair. */
+  const classifyTaskEscalation = useCallback((task: Task) => (
+    isWipColumnRole(getTaskColumnFlags(task), task.column)
+      || isReviewColumnRole(getTaskColumnFlags(task), task.column)
+  ), [getTaskColumnFlags]);
+
+  const blockerFanoutMap = useBlockerFanout(tasks, {
+    staleHighFanoutAgeThresholdMs: staleHighFanoutBlockerAgeThresholdMs,
+    classify: classifyTaskLanes,
+    escalationClassify: classifyTaskEscalation,
+  });
 
   const selectedWorkflowTasksByColumn = useMemo(() => {
     const grouped: Record<string, Task[]> = {};

--- a/packages/dashboard/app/components/ExecutorStatusBar.tsx
+++ b/packages/dashboard/app/components/ExecutorStatusBar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@fusion/core";
 import { AlertTriangle, Clock, Folder, MessageSquare, Pause, Play, Square, Zap } from "lucide-react";
 import { computeBlockerFanoutMap } from "../hooks/useBlockerFanout";
+import { isHoldColumnRole, isCompleteColumnRole, isArchivedColumnRole, isWipColumnRole, isReviewColumnRole } from "../utils/columnRoles";
 import { useExecutorStats, type ExecutorColumnFlags } from "../hooks/useExecutorStats";
 import { isLikelyTabSuspensionError } from "../hooks/visibilitySuspension";
 import { LoadingSpinner } from "./LoadingSpinner";
@@ -219,9 +220,30 @@ export function ExecutorStatusBar({ tasks, projectId, columnFlagsByTaskId: suppl
   const relativeTime = useMemo(() => formatRelativeTime(stats.lastActivityAt, t), [stats.lastActivityAt, t]);
 
   const highestOverlapBlocker = useMemo(() => {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-23:58:
+    PER-TASK lane roles for the fan-out, from the map this component is already given.
+
+    Without these, core falls back to `holdColumn: "todo"` and BLOCKER_ESCALATION_COLUMNS, so on a
+    renamed board `overlapBlockedTodoCount` is zero and `isHighFanout` never trips — the overlap
+    warning below simply never renders while cards sit blocked. `columnFlagsByTaskId` is already
+    supplied for `useExecutorStats`, so the answer was in scope the whole time.
+
+    Absent flags degrade byte-identically to those defaults (`todo` for hold, `in-progress`/
+    `in-review` for escalation), which is what keeps an unconverted board unchanged.
+    */
+    const flagsFor = (task: Task) => columnFlagsByTaskId?.get(task.id);
     const fanoutMap = computeBlockerFanoutMap(tasks, {
       staleHighFanoutAgeThresholdMs:
         staleHighFanoutBlockerAgeThresholdMs ?? STALE_HIGH_FANOUT_BLOCKER_AGE_THRESHOLD_MS,
+      classify: (task) => ({
+        isHold: isHoldColumnRole(flagsFor(task), task.column),
+        isTerminal: isCompleteColumnRole(flagsFor(task), task.column)
+          || isArchivedColumnRole(flagsFor(task), task.column),
+      }),
+      escalationClassify: (task) => (
+        isWipColumnRole(flagsFor(task), task.column) || isReviewColumnRole(flagsFor(task), task.column)
+      ),
     });
     const candidates = Array.from(fanoutMap.entries())
       .map(([blockerId, entry]) => ({ blockerId, entry }))
@@ -235,7 +257,7 @@ export function ExecutorStatusBar({ tasks, projectId, columnFlagsByTaskId: suppl
       });
 
     return candidates[0] ?? null;
-  }, [tasks, staleHighFanoutBlockerAgeThresholdMs]);
+  }, [tasks, staleHighFanoutBlockerAgeThresholdMs, columnFlagsByTaskId]);
 
   const StateIcon = stateDisplay.icon;
 

--- a/packages/dashboard/app/components/__tests__/board-blocker-fanout-renamed-lanes.test.tsx
+++ b/packages/dashboard/app/components/__tests__/board-blocker-fanout-renamed-lanes.test.tsx
@@ -1,0 +1,150 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:50:
+THE CARD FAN-OUT BADGES READ LEGACY LANE IDS ON A RENAMED BOARD.
+
+`computeBlockerFanoutMap` in core takes four lane options. The dashboard wrapper
+(`hooks/useBlockerFanout.ts`) declared and forwarded only `staleHighFanoutAgeThresholdMs`, so core
+fell back to `holdColumn: "todo"`, `LEGACY_TERMINAL_COLUMNS` and `BLOCKER_ESCALATION_COLUMNS` for
+every dashboard caller. On a board whose lanes are renamed none of those match, so `activeTodoCount`
+— the "blocking N tasks" count on the card — comes back ZERO while real cards sit blocked.
+
+WHY THIS TEST DRIVES `Board` RATHER THAN THE HOOK. Testing the wrapper would prove the wrapper
+forwards what it is given and say nothing about whether anything gives it — the exact producer/
+consumer split that this program's learnings doc records as its fifth failure shape, where a
+converted consumer with an unconverted producer passed every instrument. The defect here IS the
+producer: `Board` had no supplier for these options. So the assertion runs through the real Board,
+the real per-task workflow metadata, and core's real computation.
+
+The cases are DIFFERENTIAL: identical task graphs under two vocabularies whose roles are the same and
+only the ids differ. `drafting` collides with no legacy id, so a surviving `"todo"` cannot pass by
+luck.
+*/
+
+import type React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { Task } from "@fusion/core";
+import { Board } from "../Board";
+import type { BoardWorkflowsPayload } from "../../api";
+import type { BlockerFanoutEntry } from "../../hooks/useBlockerFanout";
+
+const fetchBoardWorkflowsMock = vi.fn();
+
+vi.mock("../../api", () => ({
+  fetchWorkflowSteps: vi.fn(() => new Promise(() => {})),
+  fetchBoardWorkflows: (...args: unknown[]) => fetchBoardWorkflowsMock(...args),
+  promoteTask: vi.fn().mockResolvedValue({}),
+  fetchTaskDetail: vi.fn(() => new Promise(() => {})),
+  batchUpdateTaskModels: vi.fn(),
+  fetchNodes: vi.fn(() => new Promise(() => {})),
+}));
+
+vi.mock("../../sse-bus", () => ({ subscribeSse: vi.fn(() => () => {}) }));
+
+/* The Column mock is the probe: it captures the fan-out map Board computed and handed down. */
+let captured: ReadonlyMap<string, BlockerFanoutEntry> | undefined;
+let renderedColumns = 0;
+vi.mock("../Column", () => ({
+  Column: ({ blockerFanoutMap }: { blockerFanoutMap?: ReadonlyMap<string, BlockerFanoutEntry> }) => {
+    renderedColumns += 1;
+    if (blockerFanoutMap) captured = blockerFanoutMap;
+    return <section />;
+  },
+}));
+
+const RENAME: Record<string, string> = {
+  todo: "drafting",
+  "in-progress": "building",
+  "in-review": "checking",
+  done: "shipped",
+  archived: "filed",
+};
+
+function workflowsPayload(renamed: boolean): BoardWorkflowsPayload {
+  const id = (legacy: string) => (renamed ? RENAME[legacy] : legacy);
+  return {
+    flagEnabled: true,
+    defaultWorkflowId: "builtin:coding",
+    /* Every card is explicitly mapped, so the per-task accessor resolves against THIS workflow
+       rather than falling through the unmapped path. */
+    taskWorkflowIds: { "KB-BLOCK": "builtin:coding", "KB-DEP1": "builtin:coding", "KB-DEP2": "builtin:coding" },
+    workflows: [
+      {
+        id: "builtin:coding",
+        name: "Coding",
+        columns: [
+          { id: id("todo"), name: "Hold", flags: { hold: true, intake: true } },
+          { id: id("in-progress"), name: "Building", flags: { countsTowardWip: true } },
+          {
+            id: id("in-review"),
+            name: "Checking",
+            flags: { countsTowardWip: true, mergeBlocker: true, humanReview: true },
+          },
+          { id: id("done"), name: "Shipped", flags: { complete: true } },
+          { id: id("archived"), name: "Filed", flags: { archived: true, hiddenFromBoard: true } },
+        ],
+      },
+    ],
+  } as unknown as BoardWorkflowsPayload;
+}
+
+/** One blocker plus two cards held behind it, in whichever lane plays the hold role. */
+function tasksFor(holdLane: string): Task[] {
+  const base = { description: "t", createdAt: "2026-06-01T00:00:00.000Z", updatedAt: "2026-06-01T00:00:00.000Z" };
+  return [
+    { id: "KB-BLOCK", title: "the blocker", column: holdLane, ...base },
+    { id: "KB-DEP1", title: "dep one", column: holdLane, dependencies: ["KB-BLOCK"], ...base },
+    { id: "KB-DEP2", title: "dep two", column: holdLane, dependencies: ["KB-BLOCK"], ...base },
+  ] as unknown as Task[];
+}
+
+async function renderBoard(renamed: boolean): Promise<BlockerFanoutEntry | undefined> {
+  captured = undefined;
+  fetchBoardWorkflowsMock.mockResolvedValue(workflowsPayload(renamed));
+  const holdLane = renamed ? "drafting" : "todo";
+  const props = {
+    tasks: tasksFor(holdLane),
+    projectId: "p1",
+    maxConcurrent: 2,
+    onMoveTask: vi.fn(),
+    onOpenDetail: vi.fn(),
+    addToast: vi.fn(),
+    onQuickCreate: vi.fn(),
+    onNewTask: vi.fn(),
+    autoMerge: true,
+    onToggleAutoMerge: vi.fn(),
+    showWorktreeGrouping: false,
+    planAutoApproveEnabled: false,
+    onTogglePlanAutoApprove: vi.fn(),
+  } as unknown as React.ComponentProps<typeof Board>;
+  render(<Board {...props} />);
+  /* ANTI-VACUITY: a Board that throws during render also produces no fan-out map, and the assertions
+     below would then read `undefined` rather than a wrong number. Prove the tree actually rendered
+     before trusting anything it handed down. */
+  await waitFor(() => expect(renderedColumns).toBeGreaterThan(0));
+  await waitFor(() => expect(captured).toBeDefined());
+  return captured?.get("KB-BLOCK");
+}
+
+describe("blocker fan-out under a renamed board vocabulary", () => {
+  beforeEach(() => {
+    captured = undefined;
+    vi.clearAllMocks();
+  });
+
+  /* Control: the default vocabulary counts both dependents. Passes before and after the fix, so a
+     generally broken fan-out cannot hide behind the renamed case below. */
+  it("default vocabulary: both held dependents are counted", async () => {
+    const entry = await renderBoard(false);
+    expect(entry?.totalCount).toBe(2);
+    expect(entry?.activeTodoCount).toBe(2);
+  });
+
+  /* The defect: before the fix `holdColumn` was the literal "todo", which this board does not have,
+     so the held count came back zero while two cards sat blocked. */
+  it("renamed vocabulary: both held dependents are counted", async () => {
+    const entry = await renderBoard(true);
+    expect(entry?.totalCount).toBe(2);
+    expect(entry?.activeTodoCount).toBe(2);
+  });
+});

--- a/packages/dashboard/app/components/__tests__/executor-status-bar-fanout-renamed-lanes.test.tsx
+++ b/packages/dashboard/app/components/__tests__/executor-status-bar-fanout-renamed-lanes.test.tsx
@@ -1,0 +1,103 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:10:
+THE HIGH-FAN-OUT BLOCKER WARNING NEVER RENDERED ON A RENAMED BOARD.
+
+`ExecutorStatusBar` computes its own fan-out map to find the blocker holding up the most work. It
+passed only `staleHighFanoutAgeThresholdMs`, so core fell back to `holdColumn: "todo"` — a lane a
+renamed board does not have. `overlapBlockedTodoCount` then stayed at zero, `isHighFanout` (>= 5)
+never tripped, and the warning simply never appeared while cards sat blocked.
+
+The flags were in scope the whole time: this component already receives `columnFlagsByTaskId` for
+`useExecutorStats`.
+
+The cases are DIFFERENTIAL: the same six-card block under two vocabularies whose roles match and only
+the ids differ. `drafting` collides with no legacy id, so a surviving `"todo"` cannot pass by luck.
+*/
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Task } from "@fusion/core";
+import { ExecutorStatusBar } from "../ExecutorStatusBar";
+import type { ExecutorColumnFlags } from "../../hooks/useExecutorStats";
+
+vi.mock("../../hooks/useExecutorStats", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useExecutorStats")>();
+  return {
+    ...actual,
+    /* The blocker warning is independent of live stats; stub them so this test needs no API. */
+    useExecutorStats: () => ({
+      stats: { running: 0, blocked: 0, waiting: 0, inReview: 0, done: 0, lastActivityAt: null },
+      loading: false,
+      error: null,
+    }),
+  };
+});
+
+const BASE = {
+  description: "t",
+  createdAt: "2026-06-01T00:00:00.000Z",
+  updatedAt: "2026-06-01T00:00:00.000Z",
+};
+
+/** One blocker in the WIP lane, plus six cards blocked behind it in the hold lane. */
+function tasksFor(holdLane: string, wipLane: string): Task[] {
+  const blocked = Array.from({ length: 6 }, (_, index) => ({
+    id: `KB-DEP${index + 1}`,
+    title: `dep ${index + 1}`,
+    column: holdLane,
+    blockedBy: "KB-BLOCK",
+    ...BASE,
+  }));
+  return [
+    { id: "KB-BLOCK", title: "the blocker", column: wipLane, ...BASE },
+    ...blocked,
+  ] as unknown as Task[];
+}
+
+function flagsFor(tasks: Task[], holdLane: string, wipLane: string): ReadonlyMap<string, ExecutorColumnFlags> {
+  const map = new Map<string, ExecutorColumnFlags>();
+  for (const task of tasks) {
+    if (task.column === holdLane) map.set(task.id, { hold: true, intake: true } as ExecutorColumnFlags);
+    if (task.column === wipLane) map.set(task.id, { countsTowardWip: true } as ExecutorColumnFlags);
+  }
+  return map;
+}
+
+describe("the high fan-out blocker warning under a renamed board vocabulary", () => {
+  /* Control: the legacy vocabulary trips the warning with no flags at all, which is the byte-identical
+     unconverted path. Passes before and after the fix. */
+  it("default vocabulary: the warning names the blocker and its held count", () => {
+    render(<ExecutorStatusBar tasks={tasksFor("todo", "in-progress")} />);
+
+    const statusBar = screen.getByRole("status");
+    expect(statusBar).toHaveTextContent("KB-BLOCK");
+    expect(statusBar).toHaveTextContent("6 todo");
+  });
+
+  /* The defect: before the fix `holdColumn` was the literal "todo", so the held count was zero, the
+     high-fan-out threshold never tripped, and this whole block was absent. */
+  it("renamed vocabulary: the warning still names the blocker and its held count", () => {
+    const tasks = tasksFor("drafting", "building");
+    render(
+      <ExecutorStatusBar tasks={tasks} columnFlagsByTaskId={flagsFor(tasks, "drafting", "building")} />,
+    );
+
+    const statusBar = screen.getByRole("status");
+    expect(statusBar).toHaveTextContent("KB-BLOCK");
+    expect(statusBar).toHaveTextContent("6 todo");
+  });
+
+  /*
+  The paired negative: resolving real lanes must not degrade into "every column is the hold lane".
+  Cards already in the renamed WIP lane are not waiting work, so they must not inflate the count —
+  otherwise the fix trades a silent zero for a wrong number, which invites no scrutiny at all.
+  */
+  it("renamed vocabulary: cards in the WIP lane do not count as held", () => {
+    const tasks = tasksFor("building", "building");
+    render(
+      <ExecutorStatusBar tasks={tasks} columnFlagsByTaskId={flagsFor(tasks, "drafting", "building")} />,
+    );
+
+    expect(screen.getByRole("status")).not.toHaveTextContent("6 todo");
+  });
+});

--- a/packages/dashboard/app/hooks/useBlockerFanout.ts
+++ b/packages/dashboard/app/hooks/useBlockerFanout.ts
@@ -11,8 +11,36 @@ export type { BlockerFanoutEntry };
 // FNXC:AutoMergeRetries 2026-06-17-04:20: Dashboard fanout copy uses this as a display fallback until task-card surfaces receive live project settings; engine/self-healing decisions use resolveMaxAutoMergeRetries(settings) and are authoritative.
 export const MAX_AUTO_MERGE_RETRIES = 3;
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:20:
+THE WRAPPER DROPPED EVERY LANE OPTION, so the card fan-out badges read legacy ids on a renamed board.
+
+`computeBlockerFanoutMap` in core accepts four lane options; this wrapper declared and forwarded only
+`staleHighFanoutAgeThresholdMs`, so core fell back to `LEGACY_TERMINAL_COLUMNS`, `holdColumn: "todo"`
+and `BLOCKER_ESCALATION_COLUMNS` for every dashboard caller. On a board whose lanes are renamed:
+
+- `activeTodoCount` counts cards in a lane called `todo`, which no longer exists -> the "blocking N"
+  badge undercounts, usually to zero;
+- terminal detection misses the renamed complete lane, so finished blockers still read as active;
+- `shouldEscalate` is false for every blocker, so a stale blocker holding up many cards NEVER
+  escalates. Core's own note calls this the worse half: no escalation looks exactly like nothing
+  needing escalation.
+
+PER-TASK CLASSIFIERS, NOT COLUMN SETS. Core documents `classify`/`escalationClassify` as "the only
+correct option on a multi-workflow board" — a column id means something only relative to its OWN
+workflow, so any board-wide union marks a shared id with two workflows' roles at once. Passing
+resolved SETS here would reproduce the union read this program's learnings doc lists as its fourth
+failure shape.
+
+Absent flags degrade byte-identically to the previous defaults, which is what makes this safe for
+unconverted boards: the role helpers fall back to `done`/`archived` (terminal), `todo` (hold) and
+`in-progress`/`in-review` (escalation) — the exact three sets core used. Verified against
+`LEGACY_TERMINAL_COLUMNS`, `holdColumn` and `BLOCKER_ESCALATION_COLUMNS`.
+*/
 export interface UseBlockerFanoutOptions {
   staleHighFanoutAgeThresholdMs?: number;
+  classify?: (task: Task) => { isHold: boolean; isTerminal: boolean };
+  escalationClassify?: (task: Task) => boolean;
 }
 
 export function computeBlockerFanoutMap(
@@ -21,6 +49,8 @@ export function computeBlockerFanoutMap(
 ): Map<string, BlockerFanoutEntry> {
   return computeBlockerFanoutMapCore(tasks, MAX_AUTO_MERGE_RETRIES, {
     staleHighFanoutAgeThresholdMs: options.staleHighFanoutAgeThresholdMs,
+    classify: options.classify,
+    escalationClassify: options.escalationClassify,
   });
 }
 
@@ -28,8 +58,10 @@ export function useBlockerFanout(
   tasks: Task[],
   options: UseBlockerFanoutOptions = {},
 ): Map<string, BlockerFanoutEntry> {
+  /* This repo has no `react-hooks/exhaustive-deps` rule, so the classifier deps are listed by hand:
+     omitting them would pin the first render's lane vocabulary for the life of the board. */
   return useMemo(
     () => computeBlockerFanoutMap(tasks, options),
-    [tasks, options.staleHighFanoutAgeThresholdMs],
+    [tasks, options.staleHighFanoutAgeThresholdMs, options.classify, options.escalationClassify],
   );
 }

--- a/packages/dashboard/app/hooks/useExecutorStats.ts
+++ b/packages/dashboard/app/hooks/useExecutorStats.ts
@@ -69,7 +69,18 @@ export function deriveExecutorState(
  * FNXC:ExecutorStatusBar 2026-07-21-19:00:
  * Do not require task.sessionFile for Running — it is not on board/listTasks rows.
  */
-export type ExecutorColumnFlags = Pick<TraitFlags, "complete" | "archived" | "intake" | "hold" | "countsTowardWip" | "mergeOrchestration" | "mergeBlocker">;
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:55:
+`humanReview` ADDED because the type was dropping a trait its supplier already provides.
+
+App.tsx builds this map from `workflow.columns.find(...).flags` — the whole flag object — so
+`humanReview` is present at RUNTIME and only the Pick discarded it. That was harmless while these
+flags answered complete/archived/wip questions, and stops being harmless for the review role:
+`isReviewColumnRole` reads `mergeBlocker || humanReview`, so a lane that hosts a human review without
+blocking merges would have classified as NOT review — a wrong answer rather than a degradation, which
+is the "supplying the wrong flags" shape this program keeps re-finding.
+*/
+export type ExecutorColumnFlags = Pick<TraitFlags, "complete" | "archived" | "intake" | "hold" | "countsTowardWip" | "mergeOrchestration" | "mergeBlocker" | "humanReview">;
 
 export function deriveStatsFromTasks(tasks: Task[], taskStuckTimeoutMs?: number, lastFetchTimeMs?: number, columnFlagsById?: ReadonlyMap<string, ExecutorColumnFlags>, columnFlagsByTaskId?: ReadonlyMap<string, ExecutorColumnFlags>): Pick<
   ExecutorStats,


### PR DESCRIPTION
## The defect

The card **"blocking N tasks"** count came back **zero** on any board whose lanes are renamed, while real cards sat blocked behind the blocker.

`computeBlockerFanoutMap` in core takes four lane options. The dashboard wrapper declared and forwarded exactly one — `staleHighFanoutAgeThresholdMs` — so core fell back to `holdColumn: "todo"`, `LEGACY_TERMINAL_COLUMNS` and `BLOCKER_ESCALATION_COLUMNS` for every dashboard caller. None of those match a renamed board:

| effect | consequence |
|---|---|
| `activeTodoCount` counts a lane called `todo` that doesn't exist | the badge undercounts, usually to zero |
| terminal detection misses the renamed complete lane | finished blockers still read as active |
| `shouldEscalate` is false for **every** blocker | a stale blocker holding up many cards never escalates |

Core's own note calls that last one the worse half: *no escalation looks exactly like nothing needing escalation.*

Diagnosed by @gsxdsm on #2981; this is the fix.

## Per-task classifiers, not column sets

Core documents `classify`/`escalationClassify` as *"the only correct option on a multi-workflow board"* — a column id means something only relative to its **own** workflow, so any board-wide union marks a shared id with two workflows' roles at once. Passing resolved **sets** here would have reproduced the union read that this program's learnings doc lists as its fourth failure shape.

`Board` resolves each card against its own workflow using the `taskContextMenuColumnsByTaskId` metadata it already builds — the same accessor shape `ListView` uses. A card whose workflow is known but whose column that workflow no longer declares gets **absent** flags rather than a neighbour's traits: knowing the workflow and finding no such column is an answer.

## Safe for unconverted boards

Absent flags degrade **byte-identically** to the previous defaults. Verified against core rather than assumed:

| role | helper fallback | core default |
|---|---|---|
| terminal | `done` ∪ `archived` | `LEGACY_TERMINAL_COLUMNS = {done, archived}` |
| hold | `todo` | `holdColumn = "todo"` |
| escalation | `in-progress` ∪ `in-review` | `BLOCKER_ESCALATION_COLUMNS` |

The hook call moved below the per-task metadata memo it now depends on; `blockerFanoutMap` is only consumed in JSX far below, so nothing between the two positions reads it.

## Measured

The test drives the **real `Board`**, not the wrapper. Testing the wrapper would prove it forwards what it's given and say nothing about whether anything gives it — the producer/consumer split recorded as this program's fifth failure shape, where a converted consumer with an unconverted producer passed every instrument. **The defect here was the producer.**

| check | result |
|---|---|
| reverting the two classifier props | renamed case fails `expected +0 to be 2`; control still passes |
| neighbouring suites | `useBlockerFanout` + `Board` + `board-no-legacy-flash` — **111 tests green** |
| gates | all five green; lint and `tsc` clean |

The cases are differential — identical task graphs under two vocabularies whose roles match and only the ids differ. `drafting` collides with no legacy id, so a surviving `"todo"` can't pass by luck. The test also asserts the tree actually rendered before trusting the map, since a Board that throws mid-render produces `undefined` rather than a wrong number.

## Not done, deliberately

`TaskDetailModal` and `ExecutorStatusBar` call the same wrapper and have the same gap. **Neither has per-task workflow metadata in scope**, so wiring them means deciding where that comes from in each — a separate change rather than a mechanical repeat, and I'd rather not guess at it here. Board is the surface that renders the badge on every card, so it's the one that matters most.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blocker fan-out counts and escalation warnings now remain accurate when board lanes are renamed.
  - Tasks in hold, completed, archived, work-in-progress, and review lanes are classified correctly.
  - Preserved existing behavior for boards without lane metadata.

- **Tests**
  - Added coverage for renamed-lane blocker counts, active blocked tasks, escalation warnings, and WIP lane handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->