### PR TITLE
fix(dashboard): the high fan-out blocker warning never rendered on a renamed board

### DIFF
--- a/packages/dashboard/app/components/ExecutorStatusBar.tsx
+++ b/packages/dashboard/app/components/ExecutorStatusBar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@fusion/core";
 import { AlertTriangle, Clock, Folder, MessageSquare, Pause, Play, Square, Zap } from "lucide-react";
 import { computeBlockerFanoutMap } from "../hooks/useBlockerFanout";
+import { isHoldColumnRole, isCompleteColumnRole, isArchivedColumnRole, isWipColumnRole, isReviewColumnRole } from "../utils/columnRoles";
 import { useExecutorStats, type ExecutorColumnFlags } from "../hooks/useExecutorStats";
 import { isLikelyTabSuspensionError } from "../hooks/visibilitySuspension";
 import { LoadingSpinner } from "./LoadingSpinner";
@@ -219,9 +220,30 @@ export function ExecutorStatusBar({ tasks, projectId, columnFlagsByTaskId: suppl
   const relativeTime = useMemo(() => formatRelativeTime(stats.lastActivityAt, t), [stats.lastActivityAt, t]);
 
   const highestOverlapBlocker = useMemo(() => {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-30-23:58:
+    PER-TASK lane roles for the fan-out, from the map this component is already given.
+
+    Without these, core falls back to `holdColumn: "todo"` and BLOCKER_ESCALATION_COLUMNS, so on a
+    renamed board `overlapBlockedTodoCount` is zero and `isHighFanout` never trips — the overlap
+    warning below simply never renders while cards sit blocked. `columnFlagsByTaskId` is already
+    supplied for `useExecutorStats`, so the answer was in scope the whole time.
+
+    Absent flags degrade byte-identically to those defaults (`todo` for hold, `in-progress`/
+    `in-review` for escalation), which is what keeps an unconverted board unchanged.
+    */
+    const flagsFor = (task: Task) => columnFlagsByTaskId?.get(task.id);
     const fanoutMap = computeBlockerFanoutMap(tasks, {
       staleHighFanoutAgeThresholdMs:
         staleHighFanoutBlockerAgeThresholdMs ?? STALE_HIGH_FANOUT_BLOCKER_AGE_THRESHOLD_MS,
+      classify: (task) => ({
+        isHold: isHoldColumnRole(flagsFor(task), task.column),
+        isTerminal: isCompleteColumnRole(flagsFor(task), task.column)
+          || isArchivedColumnRole(flagsFor(task), task.column),
+      }),
+      escalationClassify: (task) => (
+        isWipColumnRole(flagsFor(task), task.column) || isReviewColumnRole(flagsFor(task), task.column)
+      ),
     });
     const candidates = Array.from(fanoutMap.entries())
       .map(([blockerId, entry]) => ({ blockerId, entry }))
@@ -235,7 +257,7 @@ export function ExecutorStatusBar({ tasks, projectId, columnFlagsByTaskId: suppl
       });
 
     return candidates[0] ?? null;
-  }, [tasks, staleHighFanoutBlockerAgeThresholdMs]);
+  }, [tasks, staleHighFanoutBlockerAgeThresholdMs, columnFlagsByTaskId]);
 
   const StateIcon = stateDisplay.icon;
 

--- a/packages/dashboard/app/components/__tests__/executor-status-bar-fanout-renamed-lanes.test.tsx
+++ b/packages/dashboard/app/components/__tests__/executor-status-bar-fanout-renamed-lanes.test.tsx
@@ -1,0 +1,103 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:10:
+THE HIGH-FAN-OUT BLOCKER WARNING NEVER RENDERED ON A RENAMED BOARD.
+
+`ExecutorStatusBar` computes its own fan-out map to find the blocker holding up the most work. It
+passed only `staleHighFanoutAgeThresholdMs`, so core fell back to `holdColumn: "todo"` — a lane a
+renamed board does not have. `overlapBlockedTodoCount` then stayed at zero, `isHighFanout` (>= 5)
+never tripped, and the warning simply never appeared while cards sat blocked.
+
+The flags were in scope the whole time: this component already receives `columnFlagsByTaskId` for
+`useExecutorStats`.
+
+The cases are DIFFERENTIAL: the same six-card block under two vocabularies whose roles match and only
+the ids differ. `drafting` collides with no legacy id, so a surviving `"todo"` cannot pass by luck.
+*/
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Task } from "@fusion/core";
+import { ExecutorStatusBar } from "../ExecutorStatusBar";
+import type { ExecutorColumnFlags } from "../../hooks/useExecutorStats";
+
+vi.mock("../../hooks/useExecutorStats", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useExecutorStats")>();
+  return {
+    ...actual,
+    /* The blocker warning is independent of live stats; stub them so this test needs no API. */
+    useExecutorStats: () => ({
+      stats: { running: 0, blocked: 0, waiting: 0, inReview: 0, done: 0, lastActivityAt: null },
+      loading: false,
+      error: null,
+    }),
+  };
+});
+
+const BASE = {
+  description: "t",
+  createdAt: "2026-06-01T00:00:00.000Z",
+  updatedAt: "2026-06-01T00:00:00.000Z",
+};
+
+/** One blocker in the WIP lane, plus six cards blocked behind it in the hold lane. */
+function tasksFor(holdLane: string, wipLane: string): Task[] {
+  const blocked = Array.from({ length: 6 }, (_, index) => ({
+    id: `KB-DEP${index + 1}`,
+    title: `dep ${index + 1}`,
+    column: holdLane,
+    blockedBy: "KB-BLOCK",
+    ...BASE,
+  }));
+  return [
+    { id: "KB-BLOCK", title: "the blocker", column: wipLane, ...BASE },
+    ...blocked,
+  ] as unknown as Task[];
+}
+
+function flagsFor(tasks: Task[], holdLane: string, wipLane: string): ReadonlyMap<string, ExecutorColumnFlags> {
+  const map = new Map<string, ExecutorColumnFlags>();
+  for (const task of tasks) {
+    if (task.column === holdLane) map.set(task.id, { hold: true, intake: true } as ExecutorColumnFlags);
+    if (task.column === wipLane) map.set(task.id, { countsTowardWip: true } as ExecutorColumnFlags);
+  }
+  return map;
+}
+
+describe("the high fan-out blocker warning under a renamed board vocabulary", () => {
+  /* Control: the legacy vocabulary trips the warning with no flags at all, which is the byte-identical
+     unconverted path. Passes before and after the fix. */
+  it("default vocabulary: the warning names the blocker and its held count", () => {
+    render(<ExecutorStatusBar tasks={tasksFor("todo", "in-progress")} />);
+
+    const statusBar = screen.getByRole("status");
+    expect(statusBar).toHaveTextContent("KB-BLOCK");
+    expect(statusBar).toHaveTextContent("6 todo");
+  });
+
+  /* The defect: before the fix `holdColumn` was the literal "todo", so the held count was zero, the
+     high-fan-out threshold never tripped, and this whole block was absent. */
+  it("renamed vocabulary: the warning still names the blocker and its held count", () => {
+    const tasks = tasksFor("drafting", "building");
+    render(
+      <ExecutorStatusBar tasks={tasks} columnFlagsByTaskId={flagsFor(tasks, "drafting", "building")} />,
+    );
+
+    const statusBar = screen.getByRole("status");
+    expect(statusBar).toHaveTextContent("KB-BLOCK");
+    expect(statusBar).toHaveTextContent("6 todo");
+  });
+
+  /*
+  The paired negative: resolving real lanes must not degrade into "every column is the hold lane".
+  Cards already in the renamed WIP lane are not waiting work, so they must not inflate the count —
+  otherwise the fix trades a silent zero for a wrong number, which invites no scrutiny at all.
+  */
+  it("renamed vocabulary: cards in the WIP lane do not count as held", () => {
+    const tasks = tasksFor("building", "building");
+    render(
+      <ExecutorStatusBar tasks={tasks} columnFlagsByTaskId={flagsFor(tasks, "drafting", "building")} />,
+    );
+
+    expect(screen.getByRole("status")).not.toHaveTextContent("6 todo");
+  });
+});

--- a/packages/dashboard/app/hooks/useExecutorStats.ts
+++ b/packages/dashboard/app/hooks/useExecutorStats.ts
@@ -69,7 +69,18 @@ export function deriveExecutorState(
  * FNXC:ExecutorStatusBar 2026-07-21-19:00:
  * Do not require task.sessionFile for Running — it is not on board/listTasks rows.
  */
-export type ExecutorColumnFlags = Pick<TraitFlags, "complete" | "archived" | "intake" | "hold" | "countsTowardWip" | "mergeOrchestration" | "mergeBlocker">;
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:55:
+`humanReview` ADDED because the type was dropping a trait its supplier already provides.
+
+App.tsx builds this map from `workflow.columns.find(...).flags` — the whole flag object — so
+`humanReview` is present at RUNTIME and only the Pick discarded it. That was harmless while these
+flags answered complete/archived/wip questions, and stops being harmless for the review role:
+`isReviewColumnRole` reads `mergeBlocker || humanReview`, so a lane that hosts a human review without
+blocking merges would have classified as NOT review — a wrong answer rather than a degradation, which
+is the "supplying the wrong flags" shape this program keeps re-finding.
+*/
+export type ExecutorColumnFlags = Pick<TraitFlags, "complete" | "archived" | "intake" | "hold" | "countsTowardWip" | "mergeOrchestration" | "mergeBlocker" | "humanReview">;
 
 export function deriveStatsFromTasks(tasks: Task[], taskStuckTimeoutMs?: number, lastFetchTimeMs?: number, columnFlagsById?: ReadonlyMap<string, ExecutorColumnFlags>, columnFlagsByTaskId?: ReadonlyMap<string, ExecutorColumnFlags>): Pick<
   ExecutorStats,


### PR DESCRIPTION
> **Stacked on #2989** — that PR adds the `classify`/`escalationClassify` passthrough this one uses. Review/merge #2989 first; the base will retarget to `main` automatically.

## The defect

`ExecutorStatusBar` computes its **own** fan-out map to find the blocker holding up the most work. It passed only `staleHighFanoutAgeThresholdMs`, so core fell back to `holdColumn: "todo"` — a lane a renamed board doesn't have. `overlapBlockedTodoCount` stayed at zero, the high-fan-out threshold (`>= 5`) never tripped, and the warning **simply never appeared** while cards sat blocked behind one card.

The flags were in scope the whole time: this component already receives `columnFlagsByTaskId` and hands it to `useExecutorStats`. It just never reached the fan-out.

## One type fix rides along, and it isn't cosmetic

`ExecutorColumnFlags` was a `Pick` that dropped `humanReview`, while its supplier in `App.tsx` builds the map from `workflow.columns.find(...).flags` — the whole object. So the trait is present at **runtime** and only the type discarded it.

That was harmless while these flags answered complete/archived/wip questions. It stops being harmless for the review role: `isReviewColumnRole` reads `mergeBlocker || humanReview`, so a lane hosting a human review **without** blocking merges would have classified as not-review. That's a wrong answer rather than a degradation — the "supplying the wrong flags" shape this program keeps re-finding — so the `Pick` now declares what the data already carries.

I'd rather flag this than let it pass as a one-word type tweak: it's the kind of narrowing that reads as tidy and answers incorrectly.

## Measured

| check | result |
|---|---|
| removing the two classifiers | renamed case fails; control **and** negative both pass |
| `ExecutorStatusBar` suite + both new fan-out suites | **76 tests green** |
| gates | all five green; lint and `tsc` clean |

The negative case is the one worth keeping: cards already in the renamed WIP lane must not count as held, or the fix trades a silent zero for a wrong number — which invites no scrutiny at all.

## Still not done: TaskDetailModal

The third caller stays unfixed, and for a different reason than this one. It holds `detailColumnFlags` for the **open task only**, while the fan-out needs a role answer for every **dependent**. So unlike `ExecutorStatusBar`, where the data was merely unthreaded, here it is genuinely absent — wiring it means deciding where per-task workflow metadata comes from in a modal, which is a design call rather than a mechanical repeat.

That leaves the surface enumeration at 2 of 3 closed, stated rather than implied.