### PR TITLE
fix(dashboard): the board's fan-out trait index never reached the memo

### DIFF
--- a/packages/dashboard/app/components/__tests__/board-blocker-fanout-renamed-lanes.test.tsx
+++ b/packages/dashboard/app/components/__tests__/board-blocker-fanout-renamed-lanes.test.tsx
@@ -1,0 +1,150 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-30-23:50:
+THE CARD FAN-OUT BADGES READ LEGACY LANE IDS ON A RENAMED BOARD.
+
+`computeBlockerFanoutMap` in core takes four lane options. The dashboard wrapper
+(`hooks/useBlockerFanout.ts`) declared and forwarded only `staleHighFanoutAgeThresholdMs`, so core
+fell back to `holdColumn: "todo"`, `LEGACY_TERMINAL_COLUMNS` and `BLOCKER_ESCALATION_COLUMNS` for
+every dashboard caller. On a board whose lanes are renamed none of those match, so `activeTodoCount`
+— the "blocking N tasks" count on the card — comes back ZERO while real cards sit blocked.
+
+WHY THIS TEST DRIVES `Board` RATHER THAN THE HOOK. Testing the wrapper would prove the wrapper
+forwards what it is given and say nothing about whether anything gives it — the exact producer/
+consumer split that this program's learnings doc records as its fifth failure shape, where a
+converted consumer with an unconverted producer passed every instrument. The defect here IS the
+producer: `Board` had no supplier for these options. So the assertion runs through the real Board,
+the real per-task workflow metadata, and core's real computation.
+
+The cases are DIFFERENTIAL: identical task graphs under two vocabularies whose roles are the same and
+only the ids differ. `drafting` collides with no legacy id, so a surviving `"todo"` cannot pass by
+luck.
+*/
+
+import type React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { Task } from "@fusion/core";
+import { Board } from "../Board";
+import type { BoardWorkflowsPayload } from "../../api";
+import type { BlockerFanoutEntry } from "../../hooks/useBlockerFanout";
+
+const fetchBoardWorkflowsMock = vi.fn();
+
+vi.mock("../../api", () => ({
+  fetchWorkflowSteps: vi.fn(() => new Promise(() => {})),
+  fetchBoardWorkflows: (...args: unknown[]) => fetchBoardWorkflowsMock(...args),
+  promoteTask: vi.fn().mockResolvedValue({}),
+  fetchTaskDetail: vi.fn(() => new Promise(() => {})),
+  batchUpdateTaskModels: vi.fn(),
+  fetchNodes: vi.fn(() => new Promise(() => {})),
+}));
+
+vi.mock("../../sse-bus", () => ({ subscribeSse: vi.fn(() => () => {}) }));
+
+/* The Column mock is the probe: it captures the fan-out map Board computed and handed down. */
+let captured: ReadonlyMap<string, BlockerFanoutEntry> | undefined;
+let renderedColumns = 0;
+vi.mock("../Column", () => ({
+  Column: ({ blockerFanoutMap }: { blockerFanoutMap?: ReadonlyMap<string, BlockerFanoutEntry> }) => {
+    renderedColumns += 1;
+    if (blockerFanoutMap) captured = blockerFanoutMap;
+    return <section />;
+  },
+}));
+
+const RENAME: Record<string, string> = {
+  todo: "drafting",
+  "in-progress": "building",
+  "in-review": "checking",
+  done: "shipped",
+  archived: "filed",
+};
+
+function workflowsPayload(renamed: boolean): BoardWorkflowsPayload {
+  const id = (legacy: string) => (renamed ? RENAME[legacy] : legacy);
+  return {
+    flagEnabled: true,
+    defaultWorkflowId: "builtin:coding",
+    /* Every card is explicitly mapped, so the per-task accessor resolves against THIS workflow
+       rather than falling through the unmapped path. */
+    taskWorkflowIds: { "KB-BLOCK": "builtin:coding", "KB-DEP1": "builtin:coding", "KB-DEP2": "builtin:coding" },
+    workflows: [
+      {
+        id: "builtin:coding",
+        name: "Coding",
+        columns: [
+          { id: id("todo"), name: "Hold", flags: { hold: true, intake: true } },
+          { id: id("in-progress"), name: "Building", flags: { countsTowardWip: true } },
+          {
+            id: id("in-review"),
+            name: "Checking",
+            flags: { countsTowardWip: true, mergeBlocker: true, humanReview: true },
+          },
+          { id: id("done"), name: "Shipped", flags: { complete: true } },
+          { id: id("archived"), name: "Filed", flags: { archived: true, hiddenFromBoard: true } },
+        ],
+      },
+    ],
+  } as unknown as BoardWorkflowsPayload;
+}
+
+/** One blocker plus two cards held behind it, in whichever lane plays the hold role. */
+function tasksFor(holdLane: string): Task[] {
+  const base = { description: "t", createdAt: "2026-06-01T00:00:00.000Z", updatedAt: "2026-06-01T00:00:00.000Z" };
+  return [
+    { id: "KB-BLOCK", title: "the blocker", column: holdLane, ...base },
+    { id: "KB-DEP1", title: "dep one", column: holdLane, dependencies: ["KB-BLOCK"], ...base },
+    { id: "KB-DEP2", title: "dep two", column: holdLane, dependencies: ["KB-BLOCK"], ...base },
+  ] as unknown as Task[];
+}
+
+async function renderBoard(renamed: boolean): Promise<BlockerFanoutEntry | undefined> {
+  captured = undefined;
+  fetchBoardWorkflowsMock.mockResolvedValue(workflowsPayload(renamed));
+  const holdLane = renamed ? "drafting" : "todo";
+  const props = {
+    tasks: tasksFor(holdLane),
+    projectId: "p1",
+    maxConcurrent: 2,
+    onMoveTask: vi.fn(),
+    onOpenDetail: vi.fn(),
+    addToast: vi.fn(),
+    onQuickCreate: vi.fn(),
+    onNewTask: vi.fn(),
+    autoMerge: true,
+    onToggleAutoMerge: vi.fn(),
+    showWorktreeGrouping: false,
+    planAutoApproveEnabled: false,
+    onTogglePlanAutoApprove: vi.fn(),
+  } as unknown as React.ComponentProps<typeof Board>;
+  render(<Board {...props} />);
+  /* ANTI-VACUITY: a Board that throws during render also produces no fan-out map, and the assertions
+     below would then read `undefined` rather than a wrong number. Prove the tree actually rendered
+     before trusting anything it handed down. */
+  await waitFor(() => expect(renderedColumns).toBeGreaterThan(0));
+  await waitFor(() => expect(captured).toBeDefined());
+  return captured?.get("KB-BLOCK");
+}
+
+describe("blocker fan-out under a renamed board vocabulary", () => {
+  beforeEach(() => {
+    captured = undefined;
+    vi.clearAllMocks();
+  });
+
+  /* Control: the default vocabulary counts both dependents. Passes before and after the fix, so a
+     generally broken fan-out cannot hide behind the renamed case below. */
+  it("default vocabulary: both held dependents are counted", async () => {
+    const entry = await renderBoard(false);
+    expect(entry?.totalCount).toBe(2);
+    expect(entry?.activeTodoCount).toBe(2);
+  });
+
+  /* The defect: before the fix `holdColumn` was the literal "todo", which this board does not have,
+     so the held count came back zero while two cards sat blocked. */
+  it("renamed vocabulary: both held dependents are counted", async () => {
+    const entry = await renderBoard(true);
+    expect(entry?.totalCount).toBe(2);
+    expect(entry?.activeTodoCount).toBe(2);
+  });
+});

--- a/packages/dashboard/app/hooks/useBlockerFanout.ts
+++ b/packages/dashboard/app/hooks/useBlockerFanout.ts
@@ -122,8 +122,21 @@ export function useBlockerFanout(
   tasks: Task[],
   options: UseBlockerFanoutOptions = {},
 ): Map<string, BlockerFanoutEntry> {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-30-23:45:
+  `columnFlagsByTaskId` MUST be a dependency, or the whole seam is inert on the board.
+
+  The board builds its trait index from `boardWorkflows`, which is null until an async fetch
+  resolves — so the FIRST computation always runs against an empty map and takes the documented
+  legacy fallback. When the index populates, neither `tasks` nor the threshold has changed, so a
+  memo keyed on those two never recomputes and the pre-load answer survives for the life of the
+  mount. Threaded end to end, correctly typed, and never arriving.
+
+  This repo has no `react-hooks/exhaustive-deps` rule, so a stale dep array here is invisible to
+  lint and a disable directive for that rule fails CI. The list is maintained by hand.
+  */
   return useMemo(
     () => computeBlockerFanoutMap(tasks, options),
-    [tasks, options.staleHighFanoutAgeThresholdMs],
+    [tasks, options.staleHighFanoutAgeThresholdMs, options.columnFlagsByTaskId],
   );
 }


### PR DESCRIPTION
> Against #2990's branch. This is me folding #2989 into yours rather than running two PRs over the same seam — see [my comment there](https://github.com/Runfusion/Fusion/pull/2990#issuecomment-5140075866).

## The Board half of #2990 is inert

`useBlockerFanout` memoizes on:

```ts
[tasks, options.staleHighFanoutAgeThresholdMs]
```

`columnFlagsByTaskId` isn't in the list. `Board` builds that index from `boardWorkflows`, which is **null until an async fetch resolves** — so the first computation runs against an empty map and takes the documented legacy fallback. When the index populates, neither dependency has changed, the memo never recomputes, and the pre-load answer survives for the life of the mount.

The `flagsByTaskId.size > 0` guard is right. It only ever ran against the empty map.

Threaded end to end, correctly typed, and never arriving — the first failure shape from the learnings doc, in the one place lint can't see it: **this repo has no `react-hooks/exhaustive-deps` rule**, and a disable directive for it fails CI, so the dep list is maintained by hand.

## Measured

| state | result |
|---|---|
| this branch before the commit | `expected +0 to be 2` |
| after | 2 passed |
| `useBlockerFanout` + `ExecutorStatusBar` + new Board suite | **87 tests green** |

Census and FNXC gates green; lint and `tsc` clean.

## The test is the point

It drives the **real `Board`** with a mocked `Column` that captures the map it was handed. The existing suites call `computeBlockerFanoutMap` directly and pass a populated map from the first call — so they exercise the pure function and never the memo, which is exactly where the value has to survive an async arrival. That's why a correct implementation and green tests coexisted with a board that read legacy lanes.

It also asserts the tree actually rendered before trusting the captured map: a Board that throws mid-render yields `undefined` rather than a wrong number, and I'd rather that fail loudly than read as a passing zero.

## What I'm dropping

#2989 and its stacked #2991 are superseded by yours — I'll close #2989 once you've taken what you want. Yours is broader (`reviewColumns`, the `mergeOrchestration` arm, scheduler parity, the census baseline), so this carries over only the two things it didn't have: the memo dep and the producer-level test.

Also withdrawn: I claimed on #2991 that the `ExecutorColumnFlags` `Pick` dropping `humanReview` produced a wrong answer. It doesn't — the sole supplier (`App.tsx:553`) passes the whole `column.flags` object, so the trait is there at runtime. Latent type-safety at most; your type is fine as-is.