### PR TITLE
fix(glasses): every card on a renamed board badged "todo", including cards in review

### DIFF
--- a/plugins/fusion-plugin-even-realities-glasses/src/__tests__/cards.test.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/__tests__/cards.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { boardSummaryCard, boardToDeck, notificationCard, taskToCard } from "../cards.js";
+import type { Task } from "@fusion/core";
+import { boardSummaryCard, boardToDeck, notificationCard, statusBadge, taskToCard } from "../cards.js";
 
 const task = {
   id: "FN-1",
@@ -105,5 +106,27 @@ describe("cards", () => {
     const deck = boardToDeck([row("FN-DONE", "done"), row("FN-ARCH", "archived"), row("FN-LIVE", "todo")], { maxCards: 5 });
 
     expect(deck.cards.map((c) => c.id)).toEqual(["summary", "FN-LIVE"]);
+  });
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-11:05:
+  THE INVARIANT: a card's badge names its OWN lane, and never asserts a lane it is not in.
+
+  `statusBadge` fell back to the literal `"todo"` whenever `COLUMN_BADGES` missed, so on a renamed
+  board EVERY card badged `todo` — a card in review told the wearer it was un-started. On a display
+  with room for one word, a confident wrong answer is worse than an unrecognised one.
+
+  Missed by #2968, which fixed the summary counts in this same file without looking one function
+  further at the badge those counts sit above.
+
+  Reverted, both cases below come back as "todo".
+  */
+  it("badges an unrecognised lane with its own name, not the legacy default", () => {
+    expect(statusBadge("checking" as Task["column"])).toBe("checking");
+    expect(taskToCard({ ...task, column: "building" } as Task).badge).toBe("building");
+  });
+
+  it("still badges the legacy ids exactly as before", () => {
+    expect(statusBadge("in-review")).toBe("in-review");
+    expect(statusBadge("done")).toBe("done");
   });
 });

--- a/plugins/fusion-plugin-even-realities-glasses/src/cards.ts
+++ b/plugins/fusion-plugin-even-realities-glasses/src/cards.ts
@@ -28,15 +28,6 @@ export type CardDeck = {
   summary: BoardSummary;
 };
 
-const COLUMN_BADGES: Record<string, string> = {
-  triage: "triage",
-  todo: "todo",
-  "in-progress": "in-progress",
-  "in-review": "in-review",
-  done: "done",
-  archived: "archived",
-};
-
 const COLUMN_ORDER: Array<Task["column"]> = ["triage", "todo", "in-progress", "in-review", "done", "archived"];
 
 export const DEFAULT_MAX_CHARS_PER_LINE = 24;
@@ -79,8 +70,30 @@ export function wrapLines(
   return lines;
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-11:05:
+An unrecognised lane shows its OWN name, not "todo" — the fallback was actively wrong, not merely blank.
+
+This read `COLUMN_BADGES[column] ?? "todo"`, where `COLUMN_BADGES` mapped the six legacy ids to
+themselves. On a board whose lanes are named anything else every lookup missed and the badge came back
+`"todo"` — a card sitting in review told the wearer it was un-started, and every card on the board
+carried the same badge. On a display with room for one word that is a confident wrong answer, which is
+worse than an unrecognised one.
+
+The badge IS the column id, so the function now says so. That also retires the map: once the fallback
+is the id, a table mapping each legacy id to itself decides nothing, and six lane literals were sitting
+in this file doing no work. Behaviour for legacy boards is byte-identical either way — the map was an
+identity — and it is deleted here rather than left as a decoy for the next reader of this file.
+
+Mirrors `columnLabel` in the CLI (`COLUMN_LABELS[column] ?? column`) for the same reason: a board that
+calls its lane `checking` should read `checking`, which is true and already what its operator
+recognises. No resolution needed — the id is in hand at the call site.
+
+Missed by #2968, which fixed the summary card's counts in this same file and did not look one function
+further at the per-card badge those counts sit above.
+*/
 export function statusBadge(column: Task["column"]): string {
-  return COLUMN_BADGES[column] ?? "todo";
+  return column;
 }
 
 export function formatRelativeAge(updatedAt: string, opts: { now?: () => Date } = {}): string {


### PR DESCRIPTION
## Every card on a renamed board badged `todo` — including cards in review

```ts
export function statusBadge(column: Task["column"]): string {
  return COLUMN_BADGES[column] ?? "todo";
}
```

`COLUMN_BADGES` maps the six legacy ids to themselves. On a board whose lanes are named anything else **every lookup misses**, so every card badges `todo` — a card sitting in review tells the wearer it is un-started, and the whole board carries one identical badge.

On a display with room for a single word, that is worse than an unrecognised lane: it is a *confident wrong answer* rather than a missing one.

Reached from `taskToCard` (the main card) and `notificationCard` (the notification badge).

## Fix, and the dead weight it exposed

The badge **is** the column id, so the function now says so:

```ts
export function statusBadge(column: Task["column"]): string {
  return column;
}
```

That also retires `COLUMN_BADGES`. Once the fallback is the id, a table mapping each legacy id to *itself* decides nothing — six lane literals sat in this file doing no work. It was module-private with `statusBadge` as its only consumer and it was a pure identity, so behaviour on legacy boards is byte-identical: this is not a behaviour change riding along with a cleanup, it is the dead weight the fix exposed, removed rather than left as a decoy.

Mirrors `columnLabel` in the CLI (`COLUMN_LABELS[column] ?? column`) for the same reason: a board that calls its lane `checking` should read `checking`. No resolution needed; the id is in hand at the call site.

Note the census count for this file does **not** move — those six were object keys, not comparisons, which is exactly the scope the census documents for itself.

## This is a miss in my own #2968

That PR fixed the summary card's counts **in this same file** and never looked one function further at the per-card badge those counts sit above. Worth saying plainly, because it is the practical reminder behind the census finding I have been repeating all run: *a file having had a defect fixed is not evidence about its neighbours* — and here the neighbour was nine lines away, in a function I had read.

## Revert proof

```
AssertionError: expected 'todo' to be 'checking'
      Tests  1 failed | 9 passed (10)
```

The paired case ("still badges the legacy ids exactly as before") passes both ways by design — it guards against the fallback change altering known boards, so I am not counting it as coverage of the defect.

## Verification (measured)

- plugin suite — **198 passed / 19 files**
- `tsc --noEmit`, `eslint` — clean
- `lifecycle-column-census --strict`, `check-lane-wiring`, `check-sql-column-literals`, `check-inert-flag-seams`, `check-fnxc-future-dates` — green

No changeset: the plugin is `private: true` and is not bundled into the published CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status badges now accurately display a card’s actual lane, including previously unrecognized lanes.
  * Preserved existing badge behavior for known lanes.
* **Tests**
  * Added coverage to verify accurate lane reporting and legacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->