### PR TITLE
fix(plugins): the dependency graph's stuck indicator asked the legacy question

### DIFF
--- a/.changeset/dependency-graph-stuck-lanes.md
+++ b/.changeset/dependency-graph-stuck-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: The dependency graph's stuck indicator now uses the board's own lane names.
+category: fix
+dev: Plugin view context gains `columnFlagsByTaskId`; the plugin's hand-maintained `dashboard-interop.d.ts` had drifted to the pre-conversion three-argument `isTaskStuck`.

--- a/docs/solutions/workflow-learnings/lifecycle-conversions-that-score-as-wins.md
+++ b/docs/solutions/workflow-learnings/lifecycle-conversions-that-score-as-wins.md
@@ -343,6 +343,35 @@ tool and a bad ratchet; the distinction is worth keeping.
 The triage that does work is cheap: run the scan, then for each hit ask the two questions above. Nine
 of the nineteen survive question 1; hand-checking those is an afternoon, not a project.
 
+### A deferral's stated blocker is a claim, and it decays the same way a measurement does
+
+Two pieces of work were filed rather than fixed in one session, each with a specific technical reason.
+Both reasons were wrong, and in both cases the real obstacle was smaller than the stated one.
+
+- **"The plugin has no scaffolding for faking its stores."** It had `_harness.ts`, building a real
+  `PluginContext` over a live PostgreSQL layer. The gap was two missing readers on a stub — additive,
+  and inert for every existing suite. The filed issue was a pipeline that stalls forever on a renamed
+  board, so the cost of that excuse was a real stall sitting open behind a plausible-sounding note.
+- **"Supplying this needs a published-API change."** The type was dashboard-internal and the SDK
+  package is `private: true`. Every consumer was in-repo. Building the chain took minutes and
+  surfaced a different, smaller obstacle: the plugin compiles against stale dashboard type
+  declarations, which is build plumbing rather than an API decision.
+
+The shape is the same both times: **the blocker was asserted from the shape of the problem rather than
+tested.** "This needs infrastructure that does not exist" and "this crosses a published boundary" are
+both checkable in about five minutes, and neither was checked before writing a paragraph explaining
+why the work could not proceed.
+
+Filing is often right — someone else owns the contract, the fix needs a decision, the data genuinely
+is not there. What makes it wrong is filing on an *untested* blocker, because a filed issue with a
+confident rationale is the one thing nobody re-derives. It reads as settled. That is the same
+mechanism as a stale "do not re-probe" note, one level up: there a measurement went stale, here a
+decision did.
+
+The rule that costs nothing: **before writing the blocker down, spend five minutes trying to hit it.**
+If it is real you will hit it immediately and can describe it precisely, which makes the issue more
+useful. If it is not, you have the fix instead of the issue.
+
 ### The probe harness lies more often than the gate does
 
 Probing four gates with unimagined shapes in one session produced **two rounds of silently invalid

--- a/packages/dashboard/app/components/dashboard/MainContent.tsx
+++ b/packages/dashboard/app/components/dashboard/MainContent.tsx
@@ -368,6 +368,8 @@ export function MainContent({
           context={{
             projectId: currentProject?.id,
             tasks: pluginContextTasks,
+            /* The per-task trait index already threaded to this component's other children. */
+            columnFlagsByTaskId,
             workflowSteps,
             subscribePluginEvents,
             openTaskDetail: openPluginTaskDetail,

--- a/packages/dashboard/app/plugins/types.ts
+++ b/packages/dashboard/app/plugins/types.ts
@@ -37,6 +37,23 @@ export interface PluginDashboardViewContext {
   openTaskDetail: (task: Task | TaskDetail, initialTab?: DetailTaskTab) => void;
   /** Open a project-relative file in the dashboard's built-in file viewer. */
   openFile: (path: string, options?: { workspace?: string; line?: number; col?: number }) => void;
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-06:15:
+  PER-TASK lane traits, so a plugin view can ask role questions about the cards it draws.
+
+  Without it a plugin view had no trait source at all and every lifecycle question it asked answered
+  for the legacy vocabulary. Keyed by TASK id because a column id means something only relative to
+  its own workflow, and a board can render several. The host already builds this index.
+  */
+  columnFlagsByTaskId?: ReadonlyMap<string, {
+    readonly intake?: boolean;
+    readonly hold?: boolean;
+    readonly countsTowardWip?: boolean;
+    readonly mergeBlocker?: boolean;
+    readonly humanReview?: boolean;
+    readonly complete?: boolean;
+    readonly archived?: boolean;
+  }>;
   renderTaskCard?: (task: Task | TaskDetail) => ReactNode;
   addToast?: (message: string, type?: PluginToastType) => void;
   /**

--- a/plugins/fusion-plugin-dependency-graph/src/DependencyGraph.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/DependencyGraph.tsx
@@ -19,6 +19,16 @@ const NARROW_VIEWPORT_WIDTH = 768;
 export interface DependencyGraphProps {
   tasks: Task[];
   projectId?: string;
+  /** Per-task lane traits from the host; absent means fall back to the legacy ids. */
+  columnFlagsByTaskId?: ReadonlyMap<string, {
+    readonly intake?: boolean;
+    readonly hold?: boolean;
+    readonly countsTowardWip?: boolean;
+    readonly mergeBlocker?: boolean;
+    readonly humanReview?: boolean;
+    readonly complete?: boolean;
+    readonly archived?: boolean;
+  }>;
   onOpenTaskDetail?: (taskId: string) => void;
   onOpenDetail?: (task: Task) => void;
   addToast?: (message: string, type?: "success" | "error" | "info" | "warning") => void;
@@ -56,7 +66,7 @@ export function DependencyGraph({
   onMoveTask,
   lastFetchTimeMs,
   workflowStepNameLookup,
-}: DependencyGraphProps) {
+  columnFlagsByTaskId,}: DependencyGraphProps) {
   const viewportRef = useRef<HTMLDivElement | null>(null);
   const pointerDownRef = useRef<{ x: number; y: number } | null>(null);
   const pointerDraggedRef = useRef(false);
@@ -470,6 +480,7 @@ export function DependencyGraph({
                   <GraphTaskNode
                     key={node.task.id}
                     task={node.task}
+                    taskColumnFlags={columnFlagsByTaskId?.get(node.task.id)}
                     projectId={projectId}
                     isSelected={selectedTaskId === node.task.id}
                     style={{ minHeight: `${NODE_HEIGHT}px`, left: `${position.x}px`, top: `${position.y}px` }}

--- a/plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx
@@ -27,6 +27,9 @@ type TaskCardBridgeProps = Pick<
   | "onMoveTask"
   | "lastFetchTimeMs"
   | "workflowStepNameLookup"
+  /* FNXC:WorkflowResolvedColumns 2026-07-31-06:25: the card's resolved lane traits — a Pick that
+     omits them is why the stuck indicator could only ask the legacy question. */
+  | "taskColumnFlags"
 >;
 
 export interface GraphTaskNodeProps extends TaskCardBridgeProps, Pick<HTMLAttributes<HTMLDivElement>, "onMouseEnter" | "onMouseLeave" | "onClick"> {
@@ -66,10 +69,22 @@ export function GraphTaskNode({
   onNodeDragEnd,
   ...taskCardProps
 }: GraphTaskNodeProps) {
-  const { task, globalPaused, taskStuckTimeoutMs, lastFetchTimeMs, onOpenDetail } = taskCardProps;
+  const { task, globalPaused, taskStuckTimeoutMs, lastFetchTimeMs, onOpenDetail, taskColumnFlags } = taskCardProps;
   const isFailed = task.status === "failed";
   const isPaused = task.paused === true;
-  const isStuck = isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs);
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-06:20:
+  The card's OWN resolved traits, now that the host supplies them through the plugin view context.
+
+  Six of the seven other `isTaskStuck` call sites in the tree already passed this; the graph's stuck
+  indicator answered for the legacy vocabulary on every board. It was exempted in the inert-seam gate
+  on the grounds that supplying it needed a published-API change, then that it needed build plumbing.
+  Both were wrong: the blocker was a hand-maintained interop declaration that had drifted to the
+  pre-conversion three-argument signature.
+
+  Absent flags still degrade to the legacy id, the documented no-metadata path.
+  */
+  const isStuck = isTaskStuck(task, taskStuckTimeoutMs, lastFetchTimeMs, taskColumnFlags);
   /*
   FNXC:PluginLifecycleColumns 2026-07-30-03:40 (U11 #2515 audit):
   Keyed on `column === "triage"`, this went permanently FALSE for default-lineage

--- a/plugins/fusion-plugin-dependency-graph/src/__tests__/GraphTaskNode.stuck-lanes.test.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/__tests__/GraphTaskNode.stuck-lanes.test.tsx
@@ -1,0 +1,89 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-06:35:
+THE GRAPH'S STUCK INDICATOR ASKED THE LEGACY QUESTION ON EVERY BOARD.
+
+`GraphTaskNode` called `isTaskStuck(task, timeoutMs, lastFetchMs)` with no resolved traits, while six
+of the seven other call sites in the tree supplied them. Stuck detection is a lane question — a card
+is stuck only in an executing lane — so on a renamed board the answer came from `in-progress`, a
+column that board does not have.
+
+WHY IT SAT SO LONG. The gate that flags exactly this shape did not scan `plugins/` until #3002, and
+the exemption added there justified itself first as a published-API change and then as build
+plumbing. Both were wrong. The actual blocker was `dashboard-interop.d.ts`, a hand-maintained mirror
+of the dashboard surfaces this plugin uses, which still declared the pre-conversion three-argument
+`isTaskStuck` — so the argument could not be passed even deliberately.
+
+The assertion is on the ARGUMENT the component hands the predicate, not on rendered output: the
+defect is a dropped argument, and rendering asserts what the predicate does with it.
+*/
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type React from "react";
+import type { Task } from "@fusion/core";
+import { GraphTaskNode } from "../GraphTaskNode";
+
+const stuckCalls: unknown[][] = [];
+vi.mock("@fusion/dashboard/app/utils/taskStuck", () => ({
+  isTaskStuck: (...args: unknown[]) => {
+    stuckCalls.push(args);
+    return false;
+  },
+}));
+
+vi.mock("@fusion/dashboard/app/hooks/useToast", () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn(), toasts: [] }),
+  useOptionalToast: () => ({ addToast: vi.fn(), removeToast: vi.fn(), toasts: [] }),
+}));
+
+function task(column: string): Task {
+  return { id: "FN-1", description: "FN-1", column, dependencies: [], steps: [], currentStep: 0, log: [] } as unknown as Task;
+}
+
+function props(overrides: Partial<React.ComponentProps<typeof GraphTaskNode>> = {}): React.ComponentProps<typeof GraphTaskNode> {
+  return {
+    task: task("building"),
+    projectId: "p1",
+    position: { x: 0, y: 0 },
+    scale: 1,
+    isSelected: false,
+    isHighlighted: false,
+    isDimmed: false,
+    onNodePositionChange: vi.fn(),
+    onNodeDragStateChange: vi.fn(),
+    onOpenDetail: vi.fn(),
+    addToast: vi.fn(),
+    onUpdateTask: vi.fn(),
+    onArchiveTask: vi.fn(),
+    onUnarchiveTask: vi.fn(),
+    onDeleteTask: vi.fn(),
+    onRetryTask: vi.fn(),
+    onOpenDetailWithTab: vi.fn(),
+    onMoveTask: vi.fn(),
+    onOpenMission: vi.fn(),
+    taskStuckTimeoutMs: 1000,
+    lastFetchTimeMs: Date.now(),
+    workflowStepNameLookup: new Map<string, string>(),
+    ...overrides,
+  } as React.ComponentProps<typeof GraphTaskNode>;
+}
+
+describe("the graph node's stuck check under a renamed board vocabulary", () => {
+  afterEach(() => { cleanup(); stuckCalls.length = 0; });
+
+  it("hands the card's resolved traits to the stuck predicate", () => {
+    render(<GraphTaskNode {...props({ taskColumnFlags: { countsTowardWip: true } })} />);
+
+    expect(stuckCalls.length).toBeGreaterThan(0);
+    expect(stuckCalls[0]?.[3]).toEqual({ countsTowardWip: true });
+  });
+
+  /* The documented degraded path: no traits resolved is an ANSWER — the predicate falls back to the
+     legacy id rather than receiving a fabricated set. */
+  it("passes undefined when the host resolved no traits for the card", () => {
+    render(<GraphTaskNode {...props()} />);
+
+    expect(stuckCalls.length).toBeGreaterThan(0);
+    expect(stuckCalls[0]?.[3]).toBeUndefined();
+  });
+});

--- a/plugins/fusion-plugin-dependency-graph/src/dashboard-interop.d.ts
+++ b/plugins/fusion-plugin-dependency-graph/src/dashboard-interop.d.ts
@@ -1,7 +1,30 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-06:10:
+THIS FILE IS A HAND-MAINTAINED MIRROR of the dashboard surfaces this plugin uses, wired in via
+tsconfig `paths`. It drifts silently: the real `isTaskStuck` grew a fourth `columnFlags` parameter
+during the lane conversion and this declaration kept the three-argument shape, so the plugin could
+not have supplied the argument even if someone tried — the compiler said it did not exist.
+
+That drift is what made this look like a build-plumbing problem from outside. Any future dashboard
+surface added here needs the same update, and there is no check that notices.
+*/
 declare module "@fusion/dashboard/app/utils/taskStuck" {
   import type { Task } from "@fusion/core";
 
-  export function isTaskStuck(task: Task, taskStuckTimeoutMs?: number, lastFetchTimeMs?: number): boolean;
+  export function isTaskStuck(
+    task: Task,
+    taskStuckTimeoutMs?: number,
+    lastFetchTimeMs?: number,
+    columnFlags?: {
+    readonly intake?: boolean;
+    readonly hold?: boolean;
+    readonly countsTowardWip?: boolean;
+    readonly mergeBlocker?: boolean;
+    readonly humanReview?: boolean;
+    readonly complete?: boolean;
+    readonly archived?: boolean;
+  },
+  ): boolean;
 }
 
 declare module "@fusion/dashboard/app/plugins/types" {
@@ -17,6 +40,16 @@ declare module "@fusion/dashboard/app/plugins/types" {
     tasks: Task[];
     workflowSteps: WorkflowStep[];
     openTaskDetail: (task: Task | TaskDetail, initialTab?: DetailTaskTab) => void;
+    /** Per-task lane traits; absent means fall back to the legacy ids. */
+    columnFlagsByTaskId?: ReadonlyMap<string, {
+    readonly intake?: boolean;
+    readonly hold?: boolean;
+    readonly countsTowardWip?: boolean;
+    readonly mergeBlocker?: boolean;
+    readonly humanReview?: boolean;
+    readonly complete?: boolean;
+    readonly archived?: boolean;
+  }>;
     renderTaskCard?: (task: Task | TaskDetail) => ReactNode;
     addToast?: (message: string, type?: PluginToastType) => void;
   }
@@ -49,6 +82,15 @@ declare module "@fusion/dashboard/app/components/TaskCard" {
     lastFetchTimeMs?: number;
     workflowStepNameLookup?: ReadonlyMap<string, string>;
     disableDrag?: boolean;
+    taskColumnFlags?: {
+    readonly intake?: boolean;
+    readonly hold?: boolean;
+    readonly countsTowardWip?: boolean;
+    readonly mergeBlocker?: boolean;
+    readonly humanReview?: boolean;
+    readonly complete?: boolean;
+    readonly archived?: boolean;
+  };
   }
 
   export function TaskCard(props: TaskCardProps): ReactElement;

--- a/plugins/fusion-plugin-dependency-graph/src/dashboard-view.tsx
+++ b/plugins/fusion-plugin-dependency-graph/src/dashboard-view.tsx
@@ -11,6 +11,8 @@ export function DependencyGraphDashboardView({ context }: { context?: PluginDash
   return createElement(DependencyGraph, {
     tasks: context?.tasks ?? [],
     projectId: context?.projectId,
+    /* Per-task lane traits, so the graph's stuck indicator is a role question. */
+    columnFlagsByTaskId: context?.columnFlagsByTaskId,
     workflowStepNameLookup: createWorkflowStepNameLookup(context?.workflowSteps),
     onOpenDetail: context?.openTaskDetail as ((task: Task | TaskDetail) => void) | undefined,
   });

--- a/scripts/check-inert-flag-seams.mjs
+++ b/scripts/check-inert-flag-seams.mjs
@@ -140,17 +140,6 @@ An omission earns an entry only when supplying the argument would be WRONG, not 
 */
 const ALLOWED_OMISSIONS = new Map([
   [
-    "plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx::isTaskStuck",
-    { count: 1, reason: "Surfaced the moment this gate started scanning `plugins/` (2026-07-31). The plugin has NO "
-      + "lane-trait source anywhere: it is mounted as a dashboard view through `PluginDashboardViewContext`, "
-      + "and `DependencyGraph` receives `tasks: Task[]` and nothing else. Supplying the argument here would "
-      + "pass `undefined` — an unsupplied optional parameter, which this document's first failure shape says "
-      + "is strictly worse than the literal it replaces, because it reads as converted and answers legacy "
-      + "forever. Correct supply needs the plugin VIEW CONTEXT to carry per-task flags: a published-API "
-      + "change, not local wiring, which is the same 'needs a data change' category as the entry below. "
-      + "Filed for the plugin-API owner rather than bodged here." },
-  ],
-  [
     "packages/dashboard/app/components/TaskDetailModal.tsx::isNearDuplicateCanonicalInactive",
     { count: 1, reason: "The flags in scope describe the MODAL'S task; the canonical is a different task on a column this "
       + "component never resolves. Passing them would type-check, read as a conversion, and answer "

--- a/scripts/lib/lane-wiring-baseline.json
+++ b/scripts/lib/lane-wiring-baseline.json
@@ -14,7 +14,6 @@
     "packages/dashboard/app/hooks/useBlockerFanout.ts": 1,
     "packages/cli/src/commands/dashboard-tui/app.tsx": 1,
     "packages/cli/src/commands/dashboard-tui/bucket-mapping.ts": 1,
-    "plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx": 1,
     "plugins/fusion-plugin-even-realities-glasses/src/routes/board-routes.ts": 1
   }
 }


### PR DESCRIPTION
Closes #3003 — the **third** deferral rationale of mine to fail on contact this session, and the one I'd already written a docs entry about (#3026) before applying the rule to it.

## The defect

`GraphTaskNode` called `isTaskStuck(task, timeoutMs, lastFetchMs)` with no resolved traits, while **six of the seven** other call sites in the tree supplied them. Stuck detection is a lane question — a card is stuck only in an executing lane — so on a renamed board the answer came from `in-progress`, a column that board doesn't have.

## The blocker was neither thing I claimed

| my claim | reality |
|---|---|
| "needs a published-API change" (#3003) | `PluginDashboardViewContext` is dashboard-internal; `@fusion/plugin-sdk` is `private: true` |
| "build plumbing between packages" (#3025) | no — `dashboard-interop.d.ts`, a **hand-maintained mirror** wired in via tsconfig `paths`, still declared the pre-conversion **three-argument** `isTaskStuck` |

The argument couldn't be passed even deliberately, because the compiler said it didn't exist. Five minutes of *trying to hit* the blocker found it; two paragraphs of reasoning *about* it did not.

That mirror is worth knowing about independently of this fix: **a private copy of another package's API surface, with no test tying them together.** It drifted through the entire lane conversion and nothing noticed.

## The chain

host supplies `columnFlagsByTaskId` on the view context (the index `MainContent` already threads to its other children) → the view maps it to a prop → the graph threads it per node → the node hands the card's own traits to the predicate. **Per task, not board-wide** — a column id means something only relative to its own workflow.

## Measured

| check | result |
|---|---|
| the #3002 exemption | **deleted**, and the gate is green without it — the check that flagged this seam now passes with no waiver |
| reverting the argument | fails the new test **and** turns that gate red again |
| `check-lane-wiring` | independently observed it: unwired **1 → 0**, baseline re-recorded here as its ratchet requires |
| dependency-graph suite | 19 → **20 files, 179 tests green** |
| `dashboard/__tests__` | 34 green |
| census · FNXC · lint · both `tsc` projects | clean |

The first row is the one I'd point at: an exemption removed and the gate still green is a stronger statement than any test I could write for it.