### PR TITLE
chore(gate): drop the stale inert-seam exemption — the seam it covered is wired

### DIFF
--- a/scripts/check-inert-flag-seams.mjs
+++ b/scripts/check-inert-flag-seams.mjs
@@ -139,17 +139,6 @@ An omission earns an entry only when supplying the argument would be WRONG, not 
 "Awkward" means wire it; the check exists to make that the cheaper path.
 */
 const ALLOWED_OMISSIONS = new Map([
-  [
-    "plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx::isTaskStuck",
-    { count: 1, reason: "Surfaced the moment this gate started scanning `plugins/` (2026-07-31). The plugin has NO "
-      + "lane-trait source anywhere: it is mounted as a dashboard view through `PluginDashboardViewContext`, "
-      + "and `DependencyGraph` receives `tasks: Task[]` and nothing else. Supplying the argument here would "
-      + "pass `undefined` — an unsupplied optional parameter, which this document's first failure shape says "
-      + "is strictly worse than the literal it replaces, because it reads as converted and answers legacy "
-      + "forever. Correct supply needs the plugin VIEW CONTEXT to carry per-task flags: a published-API "
-      + "change, not local wiring, which is the same 'needs a data change' category as the entry below. "
-      + "Filed for the plugin-API owner rather than bodged here." },
-  ],
 ]);
 
 /*


### PR DESCRIPTION
The gate reports this itself:

```
[check-inert-flag-seams] STALE allow-list entries — supplied now, or no longer declared:

  plugins/fusion-plugin-dependency-graph/src/GraphTaskNode.tsx::isTaskStuck
    — no unsupplied call site remains; remove its ALLOWED_OMISSIONS entry
```

#3029 wired that call site. The entry now claims to tolerate something that doesn't exist.

The gate **warns rather than fails** here by design — failing would punish whoever fixed the seam — which is precisely why a stale entry has to be deleted deliberately instead of waiting for a red build to force it.

## The text is worth losing on its own account

That exemption justified the omission as needing *"a published-API change."* I later revised it to *"build plumbing."* **Both were wrong**: the blocker was a hand-maintained interop declaration frozen at the pre-conversion three-argument signature (#3003 → #3029).

An exemption whose stated reason has been disproven twice is worse than no exemption — it's a confident note that stops anyone re-deriving the answer. Same failure mode as the stale "do not re-probe" doc entry corrected in #3018, and the untested deferral rationales recorded in #3026.

## Measured

| check | result |
|---|---|
| inert-seam gate | **23 seams, all supplied**, exit 0 **with no waiver** |
| gate's own suite | 18/18 |
| lane-wiring · plugin-interop-drift · FNXC | green; lint clean |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of task status handling by removing an exception that could allow an incomplete call site to go undetected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->