### PR TITLE
chore(core): delete liveParentFilter — no caller, and it carried a legacy lane literal

### DIFF
--- a/packages/core/src/task-store/async-archive-lineage.ts
+++ b/packages/core/src/task-store/async-archive-lineage.ts
@@ -40,26 +40,6 @@ import {
 import type { ArchivedTaskEntry } from "../types.js";
 
 /**
- * FNXC:TaskStoreArchiveLineage 2026-06-24-07:05:
- * The "live parent" predicate for the document/artifact visibility gate
- * (VAL-CROSS-015). Documents and artifacts scoped to a task are surfaced in
- * live views only when their parent task is live: `deleted_at IS NULL` (not
- * soft-deleted) AND `column != 'archived'` (not archived). When the parent is
- * archived or soft-deleted, the rows are retained but filtered out of live
- * views — they remain for an unarchive/restore.
- *
- * This predicate is the join condition for `task_documents` / `artifacts` →
- * `tasks`. It is the async equivalent of the sync
- * `taskExists && taskExists.column !== 'archived'` check in
- * `upsertTaskDocument` and the `hasActiveTask` gate in `getTaskDocument`.
- */
-export function liveParentFilter(taskIdColumn: ReturnType<typeof eq>) {
-  // The caller passes an equality fragment like eq(schema.project.tasks.id, taskId).
-  // We compose the live-parent conditions on top.
-  return and(taskIdColumn, ACTIVE_TASK_FILTER, sql`${schema.project.tasks.column} != 'archived'`);
-}
-
-/**
  * FNXC:TaskStoreArchiveLineage 2026-06-24-07:10:
  * Upsert an archived-task snapshot into the cold-storage archive schema
  * (`archive.archived_tasks`). This is the async equivalent of

--- a/scripts/lib/sql-column-literals-baseline.json
+++ b/scripts/lib/sql-column-literals-baseline.json
@@ -5,7 +5,7 @@
   "packages/core/src/gitlab-issue-analytics.ts": 1,
   "packages/core/src/mission-store.ts": 1,
   "packages/core/src/productivity-analytics.ts": 1,
-  "packages/core/src/task-store/async-archive-lineage.ts": 3,
+  "packages/core/src/task-store/async-archive-lineage.ts": 2,
   "packages/core/src/task-store/async-maintenance.ts": 1,
   "packages/core/src/task-store/async-merge-coordination.ts": 1,
   "packages/core/src/task-store/reads.ts": 1,


### PR DESCRIPTION
Found while enumerating archive-exclusion sites for #3041.

## Unambiguously dead

`liveParentFilter` has exactly **one** reference in the repo: its own definition.

- not exported from `index.ts` or `index.gate.ts`
- no test imports it
- no production code calls it

It nonetheless contained `column != 'archived'`, so it was one of the 22 sites the SQL column-literal gate tracks.

## Why delete rather than convert

Converting it would mean adding lane resolution to code nothing runs — risk with no behaviour. That's the same argument #3041 makes for *not* converting the other two dead sites; deleting is the version of it that also removes the literal.

## The gate it documents is not being deleted

Its docblock describes the document/artifact visibility gate (VAL-CROSS-015). That gate is real and still enforced — by the inline conditions inside `listLiveTaskDocuments` and `listLiveArtifacts`, which is presumably why this helper was never wired up in the first place. Only the unused composition goes.

## Measured

| check | result |
|---|---|
| SQL literal population | **22 → 21**; the gate ratcheted its own baseline down and asked for the commit, included here |
| `taskstore-remaining.test.ts` (archive-lineage suite) | **27 tests green** |
| six gates + `tsc` | green |

## Not deleted, deliberately

`listLiveTaskDocuments` and `listLiveArtifacts` are referenced **only** by that test file. That's a weaker signal than zero references — someone may have written them ahead of a consumer. Their literals stay counted, which is the honest state for code whose intent I can't read from the repo.