### PR TITLE
test(ci): record the third PG gate canary — the policy ledger has been red since #2759

### DIFF
--- a/scripts/__tests__/engine-vitest-gate-policy.test.mjs
+++ b/scripts/__tests__/engine-vitest-gate-policy.test.mjs
@@ -110,9 +110,29 @@ test("pg gate canaries remain a subset of the enabled non-blocking PG suite", ()
       .map((file) => `src/__tests__/postgres/${file}`),
   );
   const gateMembers = core.scripts?.["test:pg-gate"]?.match(/src\/__tests__\/postgres\/[^ ]+\.pg\.test\.ts/g) ?? [];
+  /*
+  FNXC:TestInfrastructure 2026-07-31-20:30:
+  The third canary is RECORDED here, not approved here — and the distinction is the point.
+
+  #2759 (`ae4ff9c111`) added `sync-workflow-ir-is-always-default.pg.test.ts` and its gate entry in one
+  commit without updating this list, so the assertion has been red on `main` since. A red policy test
+  protects nothing: while it fails, the NEXT gate admission is invisible too, which is the opposite of
+  what a narrow-canary ledger is for. Restoring it re-arms that protection.
+
+  The admission carries the evidence of value AGENTS.md requires, which is why recording it is not a
+  rubber stamp. It pins that `resolveTaskWorkflowIrSync` returns the DEFAULT IR for every task in
+  production — so a guard written as `resolveLifecycleColumns(store.resolveTaskWorkflowIrSync(id))?.hold`
+  reads as converted, counts as census progress, and is silently wrong for every custom workflow
+  because the non-optional return type hides the substitution. Ten call sites depend on that fact
+  today. A whole class of inert conversions is cheaper to catch at the gate than in review.
+
+  If the gate's owner disagrees with a third canary, the fix is to remove it from
+  `packages/core`'s `test:pg-gate` script and shorten this list again — not to leave the ledger red.
+  */
   const expectedCanaries = [
     "src/__tests__/postgres/handoff-to-review-atomicity.pg.test.ts",
     "src/__tests__/postgres/task-lifecycle-e2e.pg.test.ts",
+    "src/__tests__/postgres/sync-workflow-ir-is-always-default.pg.test.ts",
   ];
   const formerGateMembers = [
     ...expectedCanaries,


### PR DESCRIPTION
## The PG gate ledger has been red since #2759

```
AssertionError: the PG gate must stay a narrow, explicit canary list
+   'src/__tests__/postgres/sync-workflow-ir-is-always-default.pg.test.ts'
```

#2759 (`ae4ff9c111`) added that test **and** its entry in `packages/core`'s `test:pg-gate` script in one commit, without updating the ledger this assertion compares against.

## Recorded, not approved — and that distinction is why I touched it carefully

My first instinct was to leave it: ratifying someone else's gate admission is exactly the "make it green" move I have refused elsewhere in this sweep.

What changed my mind is that **a red policy test protects nothing**. While it fails, the *next* gate admission is invisible too — which is the opposite of what a narrow-canary ledger exists for. The admission is already live; the gate runs three tests today whatever this file says. Restoring the ledger re-arms the guard for everything after it.

And the admission does carry the evidence of value AGENTS.md requires, so recording it is not a rubber stamp. The test pins that `resolveTaskWorkflowIrSync` returns the **default** IR for every task in production, which means a guard written as:

```ts
resolveLifecycleColumns(store.resolveTaskWorkflowIrSync(id))?.hold
```

reads as converted, counts as census progress, and is **silently wrong for every custom workflow** — the non-optional return type hides the substitution from every caller. Ten call sites depend on that fact today. Catching that class at the gate is cheaper than catching it in review; I would have argued for admission had I been asked.

**If the gate's owner disagrees with a third canary, the fix is to remove it from `test:pg-gate` and shorten this ledger again — not to leave the assertion red.** I have said so in the code comment too, so the next reader gets the choice rather than the fait accompli.

## The guard is bidirectional — verified against the gate, not the ledger

A ledger synced to whatever the gate currently says would be worthless, so I mutated the **gate script**:

```
removed a canary from packages/core test:pg-gate  →  ℹ pass 3   ℹ fail 1
restored                                          →  ℹ pass 4   ℹ fail 0
```

So it still catches silent gate **shrinkage** as well as growth — a canary quietly dropping out of the merge gate would fail here. `package.json` is restored; the diff is the test file only.

## One thing worth passing on

That test names a *class*, not a single bug: ten call sites resolve lanes through the sync resolver and read as converted while always getting the default IR. I checked where they live — **all in `packages/core` and `packages/engine`, none in `packages/cli` or `plugins`** — so my own territory is clear of it, but whoever owns those two packages may want the list.

## Verification (measured)

- this suite — **4 passed / 0 failed** (was 1 failed)
- `eslint` — clean

Fourth of the red `scripts/__tests__` suites. Test-only. No changeset.
