### PR TITLE
fleet: executor.ts 7 → 4 lifecycle-column guards (3 converted, 4 flagged out of scope)

### DIFF
--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -14937,7 +14937,17 @@ export class TaskExecutor {
         const logMessage = `Task already moved from '${fromColumn}' — skipping transition to '${toColumn}'`;
         executorLog.log(`${task.id} ${logMessage}`);
         await this.store.logEntry(task.id, logMessage, errorMessage, this.getRunContextFor(task.id));
-        if (fromColumn === "in-review" && toColumn === "in-review") {
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-09:25 (fleet: executor lifecycle roles):
+        `fromColumn`/`toColumn` are parsed out of the store's rejection message, so they carry
+        whatever ids that workflow declares. Comparing them to the literal `in-review` meant a
+        renamed review lane never matched and the duplicate-handoff finalize never ran, leaving
+        the card mid-transition with nothing to complete it. Resolve the task's own review role;
+        an unresolvable workflow keeps the legacy literal, so behaviour is unchanged wherever the
+        vocabulary cannot be read.
+        */
+        const reviewLane = (await resolveTaskLifecycleColumns(this.store, task.id).catch(() => undefined))?.review ?? "in-review";
+        if (fromColumn === reviewLane && toColumn === reviewLane) {
           try {
             const finalizeResult = await this.finalizeAlreadyReviewedTask(task.id);
             executorLog.debug(`${task.id} duplicate in-review finalization result: ${finalizeResult}`);
@@ -17255,7 +17265,15 @@ export class TaskExecutor {
           latestColumn = wipTarget;
         }
 
-        if (latestColumn === "in-progress" && !hardPauseActive) {
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-09:20 (fleet: executor lifecycle roles):
+        The completed-task watchdog arms when the card is in its IMPLEMENTATION lane. Naming
+        `in-progress` literally meant a renamed wip column never armed it — a watchdog that
+        silently never fires, on exactly the boards this program converted. The branch directly
+        above already resolves that lane through `resolveWipTargetForTask`; this asks the same
+        question of the same resolver rather than of an id.
+        */
+        if (latestColumn === await resolveWipTargetForTask(store, taskId) && !hardPauseActive) {
           this.scheduleCompletedTaskWatchdog(taskId, "fn_task_done");
         }
 


### PR DESCRIPTION
Claiming `packages/engine/src/executor.ts` from the census work order.

## Census before/after

| File | Before | After |
|---|---:|---:|
| `packages/engine/src/executor.ts` | 7 | **4** |

Measured with `scripts/lifecycle-column-census.mjs` (kind `column` only), not grep.

## Converted (3)

**L17258 — the completed-task watchdog never armed on a renamed board.** It required the card to sit in a literal `in-progress`. This does not error; the watchdog simply never fires, which is the silent-guard class this program exists to remove. The branch immediately above already resolves the same lane through `resolveWipTargetForTask`, and there is even an FNXC note there saying `latestColumn` must come from that resolved value — so the comparison now asks the same resolver rather than an id.

**L14940 (×2) — the duplicate-handoff finalize never ran on a renamed review lane.** `fromColumn`/`toColumn` are parsed out of the store's rejection message (`Invalid transition: 'X' → 'Y'`), so they carry whatever ids that workflow declares. Comparing them to the literal `in-review` meant a renamed lane never matched and `finalizeAlreadyReviewedTask` was skipped, leaving the card mid-transition with nothing to complete it. Now resolves the task's own review role, falling back to the legacy literal when the workflow cannot be read — so behaviour is unchanged wherever the vocabulary is unreadable.

## Flagged, not converted (4) — per the fleet rule that behavior changes are out of scope

**L3557 / L3581 / L3632 / L3642** are branch conditions inside the **synchronous** `store.on("task:moved")` listener. Resolving a task's workflow requires an `await`, which is not available in a sync listener's condition. Moving the test into the deferred body would widen the branch to every non-forward move and then re-narrow it — a **behaviour change to the planning-evacuation path**, not a vocabulary conversion. Converting them properly means making the listener async, which wants its own commit and its own test.

I flagged rather than guessed, which is why this is 7 → 4 and not 7 → 0.

## On test coverage, stated plainly

Both converted sites are pure resolver swaps in `async` contexts, verified by tsc, the census delta, and the existing executor suites (48 tests green). I did **not** add new fixtures: this is the file where I twice wrote tests that passed against the *unconverted* code — `recoverCompletedTask`'s seven early-return guards make negative assertions succeed trivially — and reverted both times rather than claim coverage I did not have. A fixture that genuinely drives L17258 needs a satisfied `workflowStepResults` so the run does not divert into graph re-entry; that is worth doing, and it is worth doing honestly rather than as a green-looking placeholder.

## Verification

- census: `executor.ts` 7 → 4
- `tsc --noEmit` on `@fusion/engine` clean; `pnpm lint` clean
- `executor-graph-boundary`, `executor-task-done-summary`, `executor-triage-column-audit`, `executor-step-session` — 48 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)