### PR TITLE
fleet(engine): self-healing lane guards 56 → 19 (largest census cluster)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-fanout-renamed-lanes.test.ts
+++ b/packages/engine/src/__tests__/self-healing-fanout-renamed-lanes.test.ts
@@ -1,0 +1,180 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-14:45:
+THE `task:moved` FAN-OUT ANSWERED EVERY LANE QUESTION WITH A LITERAL.
+
+`taskMovedFanoutListener` decided three things by comparing column ids:
+
+  - a move OUT of `in-progress` into `todo`/`in-review`/`done`/`archived` increments the
+    board-stall transition counter,
+  - a move INTO `in-review` triggers the branch-rebind reconciliation,
+  - `in-review -> done` and `done -> archived` trigger the completion fan-out (worktree removal,
+    dependent `blockedBy` clearing).
+
+On a board that names its lanes anything else, all three stopped firing. Nothing errors: the
+counter silently reads zero, worktrees are never reclaimed, and dependents keep a `blockedBy`
+pointing at a blocker that already finished.
+
+WHY A SYNC RESOLVER. `task:moved` is emitted synchronously, so an `await` in this listener defers
+everything after it to a microtask and reorders this handler against every other subscriber — the
+hazard the scheduler's own `resolveTaskParkedColumnsSync` header documents. The conversion uses the
+store's sync IR path for that reason, which is a different seam from the `resolveProjectColumnsForRoles`
+used by the async sweeps and needs its own coverage.
+
+Driven through the REAL listener via `start()` + a real `task:moved` emit, not by calling the
+private resolver: the contract is that the fan-out fires, not that a helper returns a set.
+*/
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+const { logger } = vi.hoisted(() => ({
+  logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../logger.js", () => ({ createLogger: vi.fn(() => logger) }));
+
+import { SelfHealingManager } from "../self-healing.js";
+
+/** Hold `drafting`, wip `building`, review `reviewing`, complete `shipped`, archived `filed`. */
+function renamedIr(): WorkflowIr {
+  return {
+    version: "v2",
+    id: "custom:wf",
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "drafting", name: "drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "reviewing", name: "reviewing", traits: [{ trait: "merge" }] },
+      { id: "shipped", name: "shipped", traits: [{ trait: "complete" }] },
+      { id: "filed", name: "filed", traits: [{ trait: "archived" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+function makeTask(id: string, column: string): Task {
+  return {
+    id,
+    title: id,
+    description: id,
+    column,
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  } as unknown as Task;
+}
+
+function createStore(tasks: Task[], ir: WorkflowIr | null): TaskStore & EventEmitter {
+  const map = new Map(tasks.map((t) => [t.id, t]));
+  const emitter = new EventEmitter();
+  const cfg = { globalPause: false, enginePaused: false } as Settings;
+  return Object.assign(emitter, {
+    getSettings: vi.fn(async () => cfg),
+    listTasks: vi.fn(async () => [...map.values()]),
+    getTask: vi.fn(async (id: string) => map.get(id) ?? null),
+    updateTask: vi.fn(async () => undefined),
+    logEntry: vi.fn(async () => undefined),
+    /* The sync seam under test. `null` stands for a workflow that cannot be resolved. */
+    resolveTaskWorkflowIrSync: vi.fn(() => {
+      if (!ir) throw new Error("no workflow selection");
+      return ir;
+    }),
+  }) as unknown as TaskStore & EventEmitter;
+}
+
+/** Starts the manager with its periodic maintenance suppressed — only the listener is under test. */
+function startManager(store: TaskStore & EventEmitter) {
+  const mgr = new SelfHealingManager(store, { rootDir: "/repo" });
+  vi.spyOn(mgr as unknown as { startMaintenance: () => void }, "startMaintenance").mockImplementation(() => {});
+  const reconcile = vi.spyOn(mgr, "reconcileCompletedTask").mockResolvedValue({
+    blockedByCleared: 0, worktreeRemoved: false, branchRemoved: false,
+  });
+  const rebind = vi.spyOn(mgr, "reconcileInReviewBranchRebind").mockResolvedValue(0 as never);
+  mgr.start();
+  return { mgr, reconcile, rebind };
+}
+
+/** `task:moved` is synchronous; the handlers it starts are not, so let the microtasks drain. */
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("the self-healing task:moved fan-out on a renamed board", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("runs the completion fan-out for reviewing -> shipped", async () => {
+    const task = makeTask("KB-1", "shipped");
+    const store = createStore([task], renamedIr());
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "reviewing", to: "shipped", source: "engine" });
+    await settle();
+
+    /* Keyed on `in-review -> done` this never fired: the worktree is never reclaimed and every
+       dependent keeps a `blockedBy` pointing at a blocker that has already finished. */
+    expect(reconcile).toHaveBeenCalledWith("KB-1", expect.anything());
+    mgr.stop();
+  });
+
+  it("runs the completion fan-out for shipped -> filed", async () => {
+    const task = makeTask("KB-2", "filed");
+    const store = createStore([task], renamedIr());
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "shipped", to: "filed", source: "engine" });
+    await settle();
+
+    expect(reconcile).toHaveBeenCalledWith("KB-2", expect.anything());
+    mgr.stop();
+  });
+
+  it("triggers the branch rebind on a move into the renamed review lane", async () => {
+    const task = makeTask("KB-3", "reviewing");
+    const store = createStore([task], renamedIr());
+    const { mgr, rebind } = startManager(store);
+
+    store.emit("task:moved", { task, from: "building", to: "reviewing", source: "engine" });
+    await settle();
+
+    expect(rebind).toHaveBeenCalledWith({ includeTaskIds: new Set(["KB-3"]) });
+    mgr.stop();
+  });
+
+  /*
+  The paired negative. The conversion widens membership, so it must not turn EVERY move into a
+  fan-out — a `building -> drafting` requeue is not a completion, and reconciling it would remove
+  the worktree of a card that is about to run again.
+  */
+  it("does NOT run the completion fan-out for a requeue into the hold lane", async () => {
+    const task = makeTask("KB-4", "drafting");
+    const store = createStore([task], renamedIr());
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "building", to: "drafting", source: "engine" });
+    await settle();
+
+    expect(reconcile).not.toHaveBeenCalled();
+    mgr.stop();
+  });
+
+  /*
+  CONTROL + fail-soft. A store that cannot resolve a workflow must answer with exactly the legacy
+  ids — this is the path every unconverted board and every `synthesizeDefaultColumns` v1 upgrade
+  takes, and an unseeded resolved set would switch the whole fan-out off for them.
+  */
+  it("still fires on the legacy ids when the workflow cannot be resolved", async () => {
+    const task = makeTask("KB-5", "done");
+    const store = createStore([task], null);
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "in-review", to: "done", source: "engine" });
+    await settle();
+
+    expect(reconcile).toHaveBeenCalledWith("KB-5", expect.anything());
+    mgr.stop();
+  });
+});

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -949,11 +949,35 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     super();
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:10:
+  THE LANE ANSWERS ARRIVE AS PARAMETERS WITH LEGACY DEFAULTS, because this classifier is SYNC and
+  must stay sync: it runs inside `tasks.filter(...)` at its first call site, and an `await` there
+  turns a predicate into a promise that filters nothing away.
+
+  Its only caller already resolves both sets once per sweep, so the resolution is paid where an
+  await is legal and passed down. REQUIRED, not optional-with-a-literal-default: an optional
+  parameter leaves the legacy ids in the file as a silent fallback, and the next caller gets the
+  pre-conversion behaviour by writing nothing. `resolveProjectColumnsForRoles` seeds the legacy ids
+  itself, so an unconverted board still answers exactly as it did.
+
+  MEMBERSHIP, not a target. The routing question is "is this card resting in a review / an active
+  lane", which a renamed board can answer with more than one column; `resolveLifecycleColumns`'
+  first match would silently route only the first.
+  */
   private classifyPausedAbortWorkflowRecovery(
     task: Task,
     settings: Settings,
     isExecuting: boolean,
+    lanes: {
+      /** Review MEMBERSHIP — replaces the `in-review` literal. */
+      reviewColumns: ReadonlySet<string>;
+      /** Waiting ∪ wip MEMBERSHIP — replaces the `todo`/`in-progress` pair. */
+      activeWorkColumns: ReadonlySet<string>;
+    },
   ): WorkflowRecoveryRoute {
+    const isReviewLane = (column: string): boolean => lanes.reviewColumns.has(column);
+    const isActiveWorkLane = (column: string): boolean => lanes.activeWorkColumns.has(column);
     const isPausedAbortPark =
       task.status === "failed" &&
       typeof task.error === "string" &&
@@ -973,13 +997,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.steps.every((step) => step.status === "done" || step.status === "skipped");
     const sharedBranchMember = isSharedBranchGroupMemberIntegration(task);
     const hasReviewProgress =
-      task.column === "in-review"
+      isReviewLane(task.column)
       && allowsAutoMergeProcessing(task, settings)
       && task.mergeDetails?.mergeConfirmed !== true
       && !isTerminalMergePark
       && completedSteps;
     const hasManualMergeHoldProgress =
-      task.column === "in-review"
+      isReviewLane(task.column)
       && (!allowsAutoMergeProcessing(task, settings) || resolveEffectiveAutoMerge(task, settings) === false)
       && !sharedBranchMember
       && task.mergeDetails?.mergeConfirmed !== true
@@ -1002,7 +1026,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     if (hasReviewProgress) {
       return { kind: "work-item-resume", reason: "pause-abort-review-progress" };
     }
-    if (task.column === "todo" || task.column === "in-progress") {
+    if (isActiveWorkLane(task.column)) {
       return { kind: "node-requeue", reason: "pause-abort-active-work" };
     }
     return { kind: "no-action", reason: "unsafe-or-not-routable" };
@@ -1126,9 +1150,20 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   this. (Distinct from `isWorkspaceTaskLive`, which probes the session REGISTRY; this probes the
   task ROW lifecycle.)
   */
-  private isWorkspaceOwnerLive(owner: Task | null | undefined): boolean {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:35:
+  `completeColumns` is REQUIRED and resolved by the caller, because this predicate is sync and its
+  caller is not — it runs inside the lease sweep's loop where the await is already paid once.
+
+  MEMBERSHIP of `complete` ONLY, deliberately: the literal it replaces was `done` alone, and the
+  comment above spells out that every non-terminal state must read LIVE. Adding `archived` here
+  would widen what counts as terminal and reclaim leases the old code kept — a behaviour change
+  riding in a column conversion, which is exactly what this program forbids. If archived owners
+  should also be reclaimable that is its own change, with its own test.
+  */
+  private isWorkspaceOwnerLive(owner: Task | null | undefined, completeColumns: ReadonlySet<string>): boolean {
     if (!owner) return false; // not found / deleted → terminal.
-    if (owner.column === "done") return false;
+    if (completeColumns.has(owner.column)) return false;
     if (owner.status === "failed") return false;
     return true;
   }
@@ -1358,11 +1393,20 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    * FN-7566: the FN-6736 liveness gate (`agentPresent` heartbeat, `checkedOutBy` lease, `hasRecentRunAudit`) is structurally blind to EPHEMERAL EXECUTOR agents (`agentId: "executor"`): they never emit heartbeat runs (so `activeHeartbeatTaskIds` never contains them), never acquire a checkout lease (`checkedOutBy` stays null), and normal execution activity (sandbox:run / task:log / verification) writes no `runAuditEvents` rows (so `getRecentRunAuditActivityAgeMs` stays null). With all three permanently false, the ONLY surviving gate was age > graceMs*3 (~30 min), so any ephemeral executor task running longer than 30 minutes — a heavy foreach workflow, a slow model — was killed mid-flight on the next self-healing sweep and hard-moved to `todo`, corrupting overlapping-worktree/task-link state.
    * The fix adds the in-process live-session truth that DOES track ephemeral executors: a worktree path registered as active in `activeSessionRegistry` (the executor/step-session/workflow-step session holds it for the whole run), the `executingTaskLock`, or `isTaskActive`. This mirrors the canonical `isWorkspaceTaskLive` / `sessionDead` predicate. A genuinely leaked binding (FN-6736) still has an EMPTY registry / no lock / inactive task, so legitimate phantom recovery is preserved; a live ephemeral executor now vetoes the phantom verdict regardless of the durable-agent signals.
    */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:35:
+  `wipColumns` is REQUIRED and supplied by the caller, which resolved the same set one line earlier
+  to decide whether to call this at all (`lanesOfReclaim(task.id).wip`). Two reads of one board,
+  one resolved and one literal, is the shape this program keeps finding — here they were three
+  lines apart.
+  */
   private isPhantomExecutorBinding(task: Task, options: {
     executionAgeMs: number | null;
     graceMs: number;
     activeHeartbeatTaskIds: Set<string>;
     lastActivityMs: number | null;
+    /** Wip MEMBERSHIP — replaces the `in-progress` literal. */
+    wipColumns: ReadonlySet<string>;
   }): { phantom: boolean; metadata: Record<string, unknown> } {
     const normalizedId = task.id.toUpperCase();
     const agentPresent = options.activeHeartbeatTaskIds.has(normalizedId);
@@ -1395,7 +1439,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     };
 
     return {
-      phantom: task.column === "in-progress"
+      phantom: options.wipColumns.has(task.column)
         && worktreeExists
         && options.executionAgeMs !== null
         && options.executionAgeMs > safeAgeMs
@@ -1475,6 +1519,50 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     log.debug(`[${stage}] ${task.id}: false-positive requeue suppressed (${reason})`);
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:05:
+  SYNC lane membership for the `task:moved` fan-out listener, mirroring the scheduler's
+  `resolveTaskParkedColumnsSync`. The listener body must stay synchronous: `task:moved` is emitted
+  synchronously, so an `await` before its existing work defers everything after it to a microtask
+  and reorders this handler against every other subscriber. Resolution therefore uses the store's
+  sync IR path, never `resolveProjectColumnsForRoles`.
+
+  Every set is SEEDED with the legacy id it replaces. Two reasons, and the second is the load-bearing
+  one: an inclusion-widened superset can only make the fan-out fire on a transition it used to
+  ignore, and `synthesizeDefaultColumns` emits trait-less placeholder columns for v1-upgraded
+  workflows — on those boards `columnsWithFlag` returns EMPTY for every trait, so an unseeded set
+  would silently switch the whole fan-out off (see the hazard note in `workflow-lifecycle-traits.ts`).
+
+  Fail-soft: an unresolvable workflow answers with exactly the legacy ids, i.e. today's behaviour.
+  */
+  private resolveFanoutLanesSync(taskId: string): {
+    wip: ReadonlySet<string>;
+    waiting: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+  } {
+    const legacy = {
+      wip: new Set(["in-progress"]),
+      waiting: new Set(["todo"]),
+      review: new Set(["in-review"]),
+      complete: new Set(["done"]),
+      archived: new Set(["archived"]),
+    };
+    try {
+      const ir = this.store.resolveTaskWorkflowIrSync(taskId);
+      return {
+        wip: new Set([...legacy.wip, ...columnsWithFlag(ir, "countsTowardWip")]),
+        waiting: new Set([...legacy.waiting, ...columnsWithFlag(ir, "hold"), ...columnsWithFlag(ir, "intake")]),
+        review: new Set([...legacy.review, ...columnsWithFlag(ir, "mergeOrchestration"), ...columnsWithFlag(ir, "mergeBlocker"), ...columnsWithFlag(ir, "humanReview")]),
+        complete: new Set([...legacy.complete, ...columnsWithFlag(ir, "complete")]),
+        archived: new Set([...legacy.archived, ...columnsWithFlag(ir, "archived")]),
+      };
+    } catch {
+      return legacy;
+    }
+  }
+
   // ── Lifecycle ───────────────────────────────────────────────────────
 
   start(): void {
@@ -1485,23 +1573,25 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     this.store.on("settings:updated", this.settingsListener);
 
     this.taskMovedFanoutListener = ({ task, from, to }) => {
+      /* One sync resolution per move, reused by all three guards below. */
+      const lanes = this.resolveFanoutLanesSync(task.id);
       if (
-        from === "in-progress"
-        && (to === "todo" || to === "in-review" || to === "done" || to === "archived")
+        lanes.wip.has(from)
+        && (lanes.waiting.has(to) || lanes.review.has(to) || lanes.complete.has(to) || lanes.archived.has(to))
         && this.boardStallWindow
       ) {
         // In-memory only counter; resets on engine restart.
         this.boardStallWindow.transitionsOutOfInProgressInWindow++;
       }
-      if (to === "in-review") {
+      if (lanes.review.has(to)) {
         void this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) }).catch((err: unknown) => {
           const errorMessage = err instanceof Error ? err.message : String(err);
           log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
         });
       }
       const shouldReconcile =
-        (from === "in-review" && to === "done") ||
-        (from === "done" && to === "archived");
+        (lanes.review.has(from) && lanes.complete.has(to)) ||
+        (lanes.complete.has(from) && lanes.archived.has(to));
       if (!shouldReconcile) return;
       void this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined }).catch((err: unknown) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -3885,6 +3975,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               executionAgeMs,
               graceMs: STALE_ACTIVE_BRANCH_EXECUTION_GRACE_MS,
               activeHeartbeatTaskIds: activeTaskIds,
+              wipColumns: lanesOfReclaim(task.id).wip,
               lastActivityMs,
             });
 
@@ -9718,6 +9809,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const entries = activeSessionRegistry.entriesByKind("workspace-repo-land");
       if (entries.length === 0) return 0;
 
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-13:35: resolved once per sweep, AFTER the early
+         return above, so a board with no leases still pays nothing. See `isWorkspaceOwnerLive`. */
+      const leaseOwnerCompleteColumns = await resolveProjectColumnsForRoles(this.store, ["complete"]);
+
       const graceMs = settings.taskStuckTimeoutMs ?? STALE_ACTIVE_BRANCH_EXECUTION_GRACE_MS;
       const staleFloorMs = graceMs * PHANTOM_EXECUTOR_BINDING_AGE_MULTIPLIER;
       const activeMergeTaskId = this.options.getActiveMergeTaskId?.() ?? null;
@@ -9747,7 +9842,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const owner = await this.store.getTask(entry.taskId).catch(() => null);
           const ownerColumn = owner?.column ?? "deleted";
           // Only a DEMONSTRABLY TERMINAL owner's lease is reclaimed (review C fix).
-          if (this.isWorkspaceOwnerLive(owner)) continue;
+          if (this.isWorkspaceOwnerLive(owner, leaseOwnerCompleteColumns)) continue;
 
           activeSessionRegistry.unregisterPath(entry.path);
           await createRunAuditor(this.store, {
@@ -12067,6 +12162,21 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       /* Waiting MEMBERSHIP (hold u intake) for the notification guard below; the requeue TARGET is a
          single column and resolves per task at its call site. */
       const pausedAbortWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-13:10:
+      "Active work" for the ROUTER is waiting ∪ wip, matching the `todo`/`in-progress` pair it
+      replaces: a card parked in the queue and a card parked mid-execution both route to a node
+      requeue. Resolved here, where an await is legal, and passed into the sync classifier.
+      */
+      const pausedAbortWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const pausedAbortActiveWorkColumns: ReadonlySet<string> = new Set([
+        ...pausedAbortWaitingColumns,
+        ...pausedAbortWipColumns,
+      ]);
+      const pausedAbortLanes = {
+        reviewColumns: pausedAbortReviewColumns,
+        activeWorkColumns: pausedAbortActiveWorkColumns,
+      };
     try {
       // FNXC:WorkflowLifecycle 2026-06-20-00:00: self-guard against global/engine
       // pause at the method entry, not just the batch-2 runner. This method is
@@ -12080,7 +12190,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const tasks = await this.store.listTasks({ slim: true });
 
       const parked = tasks.filter((t) =>
-        this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id)).kind !== "no-action",
+        this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id), pausedAbortLanes).kind !== "no-action",
       );
 
       if (parked.length === 0) return 0;
@@ -12117,7 +12227,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             log.debug(`[self-healing] deferring pause-abort recovery for ${fresh.id}: a live session surface is registered`);
             continue;
           }
-          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id));
+          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id), pausedAbortLanes);
           if (route.kind === "no-action") {
             continue;
           }
@@ -12959,6 +13069,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     swallowed that case — `self-healing.test.ts` "recovers durable running agents linked to todo
     tasks" caught it immediately.
     */
+    /* FNXC:WorkflowResolvedColumns 2026-07-31-14:20: the parked pair (`todo`/`triage`) this sweep
+       hands `evaluateParkedAgentTaskLink`; legacy-seeded, so unconverted boards are unchanged. */
+    const agentParkedColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
     const inactiveAgentLifecycleColumns = await resolveProjectColumnsForRoles(
       this.store,
       ["countsTowardWip", ...REVIEW_ROLES, "complete", "archived"],
@@ -12984,7 +13097,23 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const activeRun = await agentStore.getActiveHeartbeatRun(agent.id);
       const proof = evaluateParkedAgentTaskLink({
         agent,
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-14:20:
+        The synthetic stand-in for a MISSING task stays the legacy id ON PURPOSE, and it is now
+        correct rather than merely unconverted: `parkedColumns` below is resolved through
+        `resolveProjectColumnsForRoles`, which SEEDS the legacy ids, so `todo` is a member on every
+        board. There is also no task left to resolve a workflow from — a deleted row has no
+        selection — so any "renamed" placeholder would be a guess about which lane a task that no
+        longer exists belonged to.
+        */
         linkedTask: linkedTask ?? { column: "todo" } as Pick<Task, "column">,
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-14:20:
+        Previously omitted, so this call fell back to `LEGACY_PARKED_COLUMNS` (`todo`/`triage`) and
+        a live agent linked to a card resting in a RENAMED hold lane read as not-parked — the
+        safeguard that preserves its task link never applied, and the link was dropped.
+        */
+        parkedColumns: [...agentParkedColumns],
         activeRun,
         hasActiveAgentExecution: this.options.hasActiveAgentExecution,
         now,

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -9796,13 +9796,26 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return 0;
 
       const now = Date.now();
+        /* Resolved once per sweep; also feeds the workspace-owner check below. */
+        const preExecLiveColumns = await resolveProjectColumnsForRoles(
+          this.store,
+          ["intake", "hold", "countsTowardWip", ...REVIEW_ROLES, "complete"],
+        );
       const parked = await this.store.listTasks({ slim: true });
       const candidates = parked.filter((task) => {
         if (!task.worktree || task.deletedAt) return false;
         // Execution evidence — the worktree may hold real work; only the merge/archive lifecycle owns it.
         if (task.firstExecutionAt || task.executionStartedAt) return false;
         // Columns where a card is active or queued to become active.
-        if (task.column === "todo" || task.column === "in-progress" || task.column === "in-review" || task.column === "done") return false;
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-31-06:45:
+          RESOLVED membership for "active or queued to become active" — intake, hold, wip, review and
+          complete. The literal list was todo/in-progress/in-review/done, i.e. every lane except
+          archived, so on a renamed board it matched nothing and this sweep considered LIVE cards'
+          worktrees reclaimable. Taking a worktree from a queued card is the failure this guard exists
+          to prevent, which is why it is converted rather than left.
+          */
+          if (preExecLiveColumns.has(task.column)) return false;
         /*
         WAITING is not PARKED. A card paused for an operator decision, carrying any status (planning,
         needs-replan, awaiting-*), blocked on another task, or scheduled for a recovery attempt is

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -5278,6 +5278,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
 
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:40: resolved once per sweep; the three guards below
+         ask finished / wip / review membership against these sets. */
+      const worktreeFinishedColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
+      const worktreeWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const worktreeReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
       const allTasks = await this.store.listTasks({ slim: true, includeArchived: false });
       const branchMap = await getRegisteredWorktreeBranchMap(this.options.rootDir);
       // FN-5256: macOS git surfaces realpath-normalized worktree paths (/private/var/...)
@@ -5298,7 +5303,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
       for (const task of allTasks) {
         if (!task.worktree) continue;
-        if (!options?.includeTaskIds?.has(task.id) && (task.column === "done" || task.column === "archived")) {
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-05:40: resolved FINISHED membership — a card in a
+           renamed complete/archive lane must be skipped here just as `done`/`archived` were. */
+        if (!options?.includeTaskIds?.has(task.id) && worktreeFinishedColumns.has(task.column)) {
           continue;
         }
 
@@ -5335,8 +5342,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const scopeOverrideMergeActiveSafe =
           task.scopeOverride === true
-          && task.column !== "in-progress"
-          && (task.column !== "in-review" || (typeof task.status === "string" && RECONCILE_SCOPE_OVERRIDE_MERGE_ACTIVE_STATUS_SET.has(task.status)));
+          && !worktreeWipColumns.has(task.column)
+          && (!worktreeReviewColumns.has(task.column) || (typeof task.status === "string" && RECONCILE_SCOPE_OVERRIDE_MERGE_ACTIVE_STATUS_SET.has(task.status)));
         if (scopeOverrideMergeActiveSafe) {
           /*
           FNXC:MissingWorktreeRecovery 2026-07-10-18:23:
@@ -5364,7 +5371,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         // live task's worktree looks stale here (and we couldn't rebind to a live
         // fusion/<id>), the executor's own recovery paths will detect and recreate
         // it. Clearing here yanks the worktree from a still-running shell.
-        if (task.column === "in-progress" || task.column === "in-review") {
+        /* Resolved ACTIVE membership (wip u review): clearing a live card's worktree yanks it from a
+           running shell, so a renamed active lane must be recognised here too. */
+        if (worktreeWipColumns.has(task.column) || worktreeReviewColumns.has(task.column)) {
           await this.emitWorktreeMetadataAuditEvent({
             taskId: task.id,
             mutationType: "task:auto-recover-worktree-metadata-skipped-active",

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -3446,7 +3446,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         limitMs: timeoutMs,
         status: task?.status ?? null,
       });
-      if (task && allowsAutoMergeProcessing(task, settings) && !task.paused && task.column === "in-review") {
+        if (task && allowsAutoMergeProcessing(task, settings) && !task.paused && (wedgedReviewColumns?.has(task.column) ?? false)) {
         try {
           this.options.enqueueMerge?.(activeId);
         } catch (enqueueErr: unknown) {
@@ -12897,6 +12897,21 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       return 0;
     }
 
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-06:15:
+    WIP u REVIEW u FINISHED — deliberately NOT intake/hold.
+
+    The literal list this replaces was `in-progress, in-review, done, archived`, and the omission of
+    `todo` is the whole point of the sweep: an agent still running against a card that fell back to a
+    WAITING lane is exactly the drift being recovered. My first conversion added intake/hold and
+    swallowed that case — `self-healing.test.ts` "recovers durable running agents linked to todo
+    tasks" caught it immediately.
+    */
+    const inactiveAgentLifecycleColumns = await resolveProjectColumnsForRoles(
+      this.store,
+      ["countsTowardWip", ...REVIEW_ROLES, "complete", "archived"],
+    );
+
     const now = Date.now();
     const recoveredAgentIds = new Set<string>();
     const runningAgents = await agentStore.listAgents({ state: "running", includeEphemeral: true });
@@ -12907,7 +12922,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
 
       const linkedTask = await this.store.getTask(agent.taskId);
-      if (linkedTask && (linkedTask.column === "in-progress" || linkedTask.column === "in-review" || linkedTask.column === "done" || linkedTask.column === "archived")) {
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:55: resolved LIFECYCLE membership — this skip covers
+         every column an agent may legitimately be linked to, so a renamed board dropped the whole set
+         and the sweep treated live agents as orphaned. */
+      if (linkedTask && inactiveAgentLifecycleColumns.has(linkedTask.column)) {
         continue;
       }
 
@@ -12950,6 +12968,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       return 0;
     }
 
+    /* FNXC:WorkflowResolvedColumns 2026-07-31-06:05: resolved once per sweep — see the guard below. */
+    const driftedFinishedColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
+
     const now = Date.now();
     const clearedAgentIds = new Set<string>();
     const durableAgents = await agentStore.listAgents({ includeEphemeral: false });
@@ -12969,7 +12990,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (!linkedTask) {
         shouldClear = true;
         reason = "linked task missing";
-      } else if (linkedTask.column === "done" || linkedTask.column === "archived") {
+        /* Resolved FINISHED membership — the drifted-link recovery must recognise a renamed
+           complete/archive lane as terminal. */
+        } else if (driftedFinishedColumns.has(linkedTask.column)) {
         shouldClear = true;
         reason = `linked task in terminal column ${linkedTask.column}`;
       } else if (linkedTask.assignedAgentId && linkedTask.assignedAgentId !== agent.id) {
@@ -14564,6 +14587,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   private async cleanupStaleTempMergeWorktrees(): Promise<number> {
     try {
       const settings = await this.store.getSettings();
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:55: resolved once per sweep — see the guard below. */
+      const tempWorktreeFinishedColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
       if (settings.worktrunk?.enabled === true) {
         log.debug("[self-healing] temp-dir sweep: worktrunk enabled — AI merge clean-room worktrees use Fusion's dedicated clean-room root, proceeding with native sweep");
       }
@@ -14607,7 +14632,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             if (taskId) {
               try {
                 const task = await this.store.getTask(taskId);
-                if (task.column === "done" || task.column === "archived") {
+                  /* FNXC:WorkflowResolvedColumns 2026-07-31-05:55: resolved FINISHED membership — a temp
+                     merge worktree belonging to a card in a renamed complete/archive lane is just as
+                     stale as one in `done`. */
+                  if (tempWorktreeFinishedColumns.has(task.column)) {
                   ageGateMs = DONE_TASK_TEMP_WORKTREE_GRACE_MS;
                   cleanupReason = "done-task-stale";
                 }

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -4488,6 +4488,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
   async reclaimStaleActiveBranches(): Promise<number> {
     try {
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:15: resolved once per sweep; the per-branch guard
+         below is the only lane question this method asks. */
+      const reclaimArchivedColumns = await resolveProjectColumnsForRoles(this.store, ["archived"]);
       const settings = await this.store.getSettings();
       if (settings.globalPause || settings.enginePaused) return 0;
 
@@ -4531,7 +4534,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (!derivedTaskId) continue;
 
         const task = taskById.get(derivedTaskId.toUpperCase());
-        if (!task || task.column === "archived" || task.checkedOutBy || task.userPaused) continue;
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-05:15: resolved ARCHIVED membership — a branch whose
+           card rests in a renamed archive lane must still read as reclaimable, not live. */
+        if (!task || reclaimArchivedColumns.has(task.column) || task.checkedOutBy || task.userPaused) continue;
         if (task.pausedReason === "worktrunk_operation_failed") {
           log.debug(`[self-healing] skipping worktrunk-paused task ${task.id}`);
           continue;
@@ -5065,7 +5070,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return result;
 
       const allTasks = await this.store.listTasks({ slim: true, includeArchived: false });
-      const tasks = allTasks.filter((task) => task.column === "in-review");
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-05:15:
+      RESOLVED review MEMBERSHIP — this filter is the sweep's entire candidate set. Keyed on the
+      literal it returns EMPTY on a renamed board, so the rebind never ran and stale `fusion/` refs
+      were never reconciled: a silent no-op rather than a wrong answer.
+      */
+      const rebindReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      const tasks = allTasks.filter((task) => rebindReviewColumns.has(task.column));
       const fusionRefOutput = await execAsync("git for-each-ref --format='%(refname:short)' refs/heads/fusion/", {
         cwd: this.options.rootDir,
         timeout: 30_000,
@@ -6138,6 +6150,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   async reconcileDependencyBlockingLeases(): Promise<number> {
     const settings = await this.store.getSettings();
     if (settings.globalPause || settings.enginePaused) return 0;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:25: resolved once per sweep — the holder's WIP lane
+         and the dependency's waiting lane are separate questions, so both sets are resolved here. */
+      const leaseWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const leaseWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
 
     let tasks: Task[] = [];
     try {
@@ -6172,7 +6188,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
     let recovered = 0;
     for (const holder of tasks) {
-      if (holder.column !== "in-progress") continue;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:25: resolved WIP membership for the lease holder. */
+      if (!leaseWipColumns.has(holder.column)) continue;
       if (holder.paused === true || holder.userPaused === true) continue;
 
       const unmetDeps = getUnmetSchedulingDependencies(holder, tasks, dependencyOptions);
@@ -6191,7 +6208,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           deadlockEvidence = "stale-overlap-blocker";
           break;
         }
-        if (dependency.column !== "todo") continue;
+        /* Resolved pre-implementation membership: hold ∪ intake, the pair `moves.ts` documents as the
+           board's waiting lane. A dependency parked in a renamed hold lane still blocks. */
+        if (!leaseWaitingColumns.has(dependency.column)) continue;
         const dependencyScope = await getFilteredFileScope(dependency.id);
         if (dependencyScope.length === 0 || isCoordinationOnlyTask(dependency, dependencyScope)) continue;
         if (pathsOverlap(holderScope, dependencyScope)) {
@@ -6388,6 +6407,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   async reconcileInReviewUnmetDependencies(): Promise<number> {
     const settings = await this.store.getSettings();
     if (settings.globalPause || settings.enginePaused) return 0;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:25: resolved once per sweep — see the guard below. */
+      const unmetDepReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
 
     let tasks: Task[] = [];
     try {
@@ -6411,7 +6432,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
     let recovered = 0;
     for (const task of tasks) {
-      if (task.column !== "in-review" || task.deletedAt) continue;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-05:25: resolved review MEMBERSHIP — the sweep's
+         candidate test. On the literal it matched nothing and the rebound never fired. */
+      if (!unmetDepReviewColumns.has(task.column) || task.deletedAt) continue;
 
       const unmetDeps = getUnmetSchedulingDependencies(task, tasks, dependencyOptions);
       if (unmetDeps.length === 0) continue;
@@ -7212,7 +7235,6 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     try {
       const settings = await this.store.getSettings().catch(() => undefined);
       if (settings?.globalPause === true || settings?.enginePaused === true) return 0;
-
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const now = Date.now();
       const tasks = await this.store.listTasks({ slim: true, includeArchived: false });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -5419,6 +5419,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   private async autoReboundPausedScopeDecayDetailed(options?: { ignoreAgeGate?: boolean }): Promise<{ count: number; reboundedIds: string[] }> {
     const settings = await this.store.getSettings();
     if (settings.globalPause || settings.enginePaused) return { count: 0, reboundedIds: [] };
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved once per sweep — see the guard(s) below. */
+      const scopeDecayWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
 
     const thresholdMs = Number(settings.pausedScopeDecayMs ?? 0);
     if (!options?.ignoreAgeGate && (!Number.isFinite(thresholdMs) || thresholdMs <= 0)) {
@@ -5435,7 +5437,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     const now = Date.now();
     const reboundedIds: string[] = [];
     for (const task of tasks) {
-      if (task.column !== "in-progress" || task.paused !== true) continue;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved WIP membership — a paused card in a
+         renamed build lane still decays. */
+      if (!scopeDecayWipColumns.has(task.column) || task.paused !== true) continue;
       if (SelfHealingManager.PAUSED_SCOPE_DECAY_EXCLUDED_REASONS.has(task.pausedReason ?? "")) continue;
       const followerCount = followersByHolder.get(task.id) ?? 0;
       if (followerCount <= 0) continue;
@@ -6326,6 +6330,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   async reconcileCompletedBlockedTasks(): Promise<number> {
     const settings = await this.store.getSettings();
     if (settings.globalPause || settings.enginePaused) return 0;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved once per sweep — see the guard(s) below. */
+      const completedBlockedWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
     if (!this.options.recoverCompletedTask) return 0;
 
     let tasks: Task[] = [];
@@ -6341,7 +6347,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     let recovered = 0;
     for (const snapshot of tasks) {
       if (snapshot.deletedAt) continue;
-      if (snapshot.column !== "todo") continue;
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved waiting membership (hold u intake) —
+         the pre-implementation pair `moves.ts` documents. */
+      if (!completedBlockedWaitingColumns.has(snapshot.column)) continue;
       if (snapshot.paused !== true || snapshot.pausedReason !== COMPLETED_BLOCKED_PAUSE_REASON) continue;
       if (snapshot.userPaused === true) continue;
       if (!allowsAutoMergeProcessing(snapshot, settings)) continue;
@@ -7329,6 +7337,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
   async reconcileOrphanedPendingStepResults(): Promise<number> {
     try {
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved once per sweep — see the guard(s) below. */
+      const orphanedStepWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
       const pageSize = 500;
       let offset = 0;
       let recovered = 0;
@@ -7349,14 +7359,16 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           // An operator park is authoritative; this sweep must not reach through it.
           if (task.userPaused === true) continue;
           // Executor-owned rows: resume is deferred at startup, liveness unprovable here.
-          if (task.column === "in-progress") continue;
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved WIP membership — an executor-owned
+           card in a renamed build lane must be skipped here too. */
+        if (orphanedStepWipColumns.has(task.column)) continue;
           if (!task.workflowStepResults?.some((result) => result.status === "pending")) continue;
           if (isSessionLive(task.id)) continue;
 
           // Re-read the live row before mutating: the page snapshot can be stale against
           // a merger/planner that wrote a fresh pending lease after the page was fetched.
           const fresh = await this.store.getTask(task.id);
-          if (!fresh || fresh.userPaused === true || fresh.column === "in-progress") continue;
+        if (!fresh || fresh.userPaused === true || orphanedStepWipColumns.has(fresh.column)) continue;
           /*
           FNXC:WorkflowReviewGates 2026-07-26-15:50:
           Honor a LIVE review-gate lease, not just in-process session liveness.
@@ -11277,7 +11289,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   }
 
   private async recoverApprovedStrandedAiMergeCommit(task: Task, settings: Settings): Promise<boolean> {
-    if (task.column !== "in-review") return false;
+    /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved review membership, per task — this is a
+       per-card predicate rather than a sweep, so it resolves for the task it is judging. */
+    const strandedAiMergeReviewColumns = await this.resolveReviewColumnsFor(task.id, new Map());
+    if (!strandedAiMergeReviewColumns.has(task.column)) return false;
     if (task.mergeDetails?.mergeConfirmed === true) return false;
     if (!this.hasApprovedAiMergeReview(task)) return false;
     if (!(task.steps ?? []).every((step) => step.status === "done" || step.status === "skipped")) return false;
@@ -12034,6 +12049,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    * paused, currently executing, or whose error is not the pause-abort park.
    */
   async recoverPausedAbortFailures(): Promise<number> {
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved once per sweep — see the guard(s) below. */
+      const pausedAbortReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
     try {
       // FNXC:WorkflowLifecycle 2026-06-20-00:00: self-guard against global/engine
       // pause at the method entry, not just the batch-2 runner. This method is
@@ -12152,7 +12169,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
           await this.store.logEntry(
             task.id,
-            fresh.column === "in-review"
+      pausedAbortReviewColumns.has(fresh.column)
               ? "Auto-recovered: in-review pause-abort park cleared — preserved for normal review progression"
               : "Auto-recovered: pause-abort park cleared — requeued for normal scheduling",
           );
@@ -14153,6 +14170,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    */
   async recoverStarvedRefinementTriageTasks(): Promise<number> {
     try {
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved once per sweep — see the guard(s) below. */
+      const starvedWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
       this.options.evictStaleTriageProcessing?.();
 
       const tasks = await this.store.listTasks({ slim: true, includeArchived: false });
@@ -14179,7 +14198,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const peerProgressCount = tasks.filter((peer) =>
           peer.id !== task.id &&
-          peer.column === "todo" &&
+      starvedWaitingColumns.has(peer.column) &&
           peer.sourceType !== "task_refine" &&
           new Date(peer.updatedAt).getTime() > createdAtMs,
         ).length;
@@ -14200,7 +14219,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const createdAtMs = new Date(task.createdAt).getTime();
           const peerProgressCount = tasks.filter((peer) =>
             peer.id !== task.id &&
-            peer.column === "todo" &&
+      starvedWaitingColumns.has(peer.column) &&
             peer.sourceType !== "task_refine" &&
             new Date(peer.updatedAt).getTime() > createdAtMs,
           ).length;

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -30,7 +30,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
   LEGACY_COLUMN_IDS_BY_ROLE,
   TERMINAL_ROLES,
   resolveProjectColumnsForRoles,
@@ -12064,6 +12064,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   async recoverPausedAbortFailures(): Promise<number> {
       /* FNXC:WorkflowResolvedColumns 2026-07-31-06:30: resolved once per sweep — see the guard(s) below. */
       const pausedAbortReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
+      /* Waiting MEMBERSHIP (hold u intake) for the notification guard below; the requeue TARGET is a
+         single column and resolves per task at its call site. */
+      const pausedAbortWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
     try {
       // FNXC:WorkflowLifecycle 2026-06-20-00:00: self-guard against global/engine
       // pause at the method entry, not just the batch-2 runner. This method is
@@ -12139,12 +12142,31 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.updateTask(task.id, {
             status: null,
             error: null,
-            ...(fresh.column === "todo" && workflowTransitionNotification
+            ...(pausedAbortWaitingColumns.has(fresh.column) && workflowTransitionNotification
               ? { workflowTransitionNotification }
               : {}),
           });
-          if (route.kind === "node-requeue" && fresh.column !== "todo") {
-            await this.store.moveTask(task.id, "todo", {
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-31-07:20:
+          THE GUARD AND ITS MOVE TARGET CONVERT TOGETHER — converting only the guard is worse than
+          converting neither, which is the property `self-healing-converted-sweeps-have-no-literal-
+          lane-guards` ratchets and which caught this exact partial state.
+
+          `moveTask` REJECTS a target the workflow does not declare, EXCEPT under `recoveryRehome`
+          with a legacy id (`moves.ts:570` — the #1411 escape hatch that stops a custom-workflow card
+          being unrescuable). A converted guard feeding the literal `"todo"` would therefore fire
+          correctly on a renamed board and then rehome the card into a column its workflow does not
+          declare: the undeclared-column state other reconcilers exist to repair.
+
+          MEMBERSHIP for the guard, a SINGLE column for the target. `resolveTaskLifecycleColumns` is
+          first-match per role — wrong for "is this card waiting?", exactly right for "where should it
+          land". Precedence hold -> intake -> legacy is the one `moves.ts:1296` documents, because a
+          workflow may declare intake and no hold.
+          */
+          const requeueLifecycle = await resolveTaskLifecycleColumns(this.store, task.id);
+          const requeueTarget = requeueLifecycle?.hold ?? requeueLifecycle?.intake ?? "todo";
+          if (route.kind === "node-requeue" && fresh.column !== requeueTarget) {
+            await this.store.moveTask(task.id, requeueTarget, {
               preserveProgress: true,
               moveSource: "engine",
               recoveryRehome: true,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,10 +1,9 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 51,
-    "packages/engine/src/scheduler.ts": 12,
-    "packages/engine/src/executor.ts": 7,
+    "packages/engine/src/self-healing.ts": 138,
     "packages/engine/src/notification/notification-service.ts": 5,
+    "packages/engine/src/executor.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
     "packages/core/src/agent-store.ts": 2,
     "packages/core/src/async-mission-store-queries.ts": 2,
@@ -16,6 +15,7 @@
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 2,
     "packages/engine/src/auto-merge-finalization.ts": 2,
     "packages/engine/src/planner-overseer.ts": 2,
+    "packages/engine/src/scheduler.ts": 2,
     "packages/core/src/eval-signal-collector.ts": 1,
     "packages/core/src/in-review-stall.ts": 1,
     "packages/core/src/mission-store.ts": 1,
@@ -36,9 +36,11 @@
     "packages/engine/src/triage.ts": 1
   },
   "deliberateByFile": {
+    "packages/engine/src/self-healing.ts\u0000in-review": 9,
+    "packages/engine/src/self-healing.ts\u0000done": 6,
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 5,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
-    "packages/engine/src/self-healing.ts\u0000in-review": 3,
+    "packages/engine/src/self-healing.ts\u0000archived": 3,
     "packages/core/src/live-agent-count.ts\u0000in-progress": 2,
     "packages/core/src/live-agent-count.ts\u0000in-review": 2,
     "packages/core/src/store.ts\u0000in-review": 2,
@@ -58,7 +60,6 @@
     "packages/engine/src/scheduler.ts\u0000done": 2,
     "packages/engine/src/scheduler.ts\u0000in-progress": 2,
     "packages/engine/src/scheduler.ts\u0000in-review": 2,
-    "packages/engine/src/self-healing.ts\u0000done": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000done": 2,
     "plugins/fusion-plugin-reports/src/store/report-store.ts\u0000archived": 2,
@@ -129,19 +130,17 @@
     "packages/engine/src/hold-release.ts\u0000in-review": 1,
     "packages/engine/src/project-engine.ts\u0000in-review": 1,
     "packages/engine/src/scheduler.ts\u0000todo": 1,
-    "packages/engine/src/self-healing.ts\u0000archived": 1,
     "packages/engine/src/triage.ts\u0000triage": 1,
     "plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts\u0000done": 1,
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
+    "packages/engine/src/self-healing.ts": 3,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
-    "packages/core/src/async-mission-store.ts": 1,
     "packages/core/src/task-store/archive-lifecycle-2.ts": 1,
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
-    "packages/engine/src/agent-tools.ts": 1,
-    "packages/engine/src/self-healing.ts": 1
+    "packages/engine/src/agent-tools.ts": 1
   }
 }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,25 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-    "packages/engine/src/self-healing.ts": 138,
-=======
-    "packages/engine/src/self-healing.ts": 40,
-=======
-    "packages/engine/src/self-healing.ts": 31,
->>>>>>> 04c4299026 (fleet(engine): convert the agent-link and merge-worktree lane guards (40 -> 31))
-=======
-    "packages/engine/src/self-healing.ts": 23,
->>>>>>> 4b3a28475a (fleet(engine): convert eight more sweep guards (31 -> 23))
-=======
-    "packages/engine/src/self-healing.ts": 19,
->>>>>>> 86c7c0bf13 (fleet(engine): convert reconcilePreExecutionWorktrees' live-lane guard (23 -> 19))
-    "packages/engine/src/scheduler.ts": 12,
-    "packages/engine/src/executor.ts": 7,
->>>>>>> bf30037f85 (fleet(engine): convert reconcileTaskWorktreeMetadata's lane guards (46 -> 40))
+    "packages/engine/src/self-healing.ts": 17,
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/executor.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
@@ -54,11 +36,9 @@
     "packages/engine/src/triage.ts": 1
   },
   "deliberateByFile": {
-    "packages/engine/src/self-healing.ts\u0000in-review": 9,
-    "packages/engine/src/self-healing.ts\u0000done": 6,
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 5,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
-    "packages/engine/src/self-healing.ts\u0000archived": 3,
+    "packages/engine/src/self-healing.ts\u0000in-review": 3,
     "packages/core/src/live-agent-count.ts\u0000in-progress": 2,
     "packages/core/src/live-agent-count.ts\u0000in-review": 2,
     "packages/core/src/store.ts\u0000in-review": 2,
@@ -78,6 +58,7 @@
     "packages/engine/src/scheduler.ts\u0000done": 2,
     "packages/engine/src/scheduler.ts\u0000in-progress": 2,
     "packages/engine/src/scheduler.ts\u0000in-review": 2,
+    "packages/engine/src/self-healing.ts\u0000done": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000done": 2,
     "plugins/fusion-plugin-reports/src/store/report-store.ts\u0000archived": 2,
@@ -148,17 +129,18 @@
     "packages/engine/src/hold-release.ts\u0000in-review": 1,
     "packages/engine/src/project-engine.ts\u0000in-review": 1,
     "packages/engine/src/scheduler.ts\u0000todo": 1,
+    "packages/engine/src/self-healing.ts\u0000archived": 1,
     "packages/engine/src/triage.ts\u0000triage": 1,
     "plugins/fusion-plugin-even-realities-glasses/src/notifications/diff.ts\u0000done": 1,
     "plugins/fusion-plugin-reports/src/store/report-types.ts\u0000archived": 1
   },
   "queryByFile": {
-    "packages/engine/src/self-healing.ts": 3,
     "packages/core/src/task-store/async-persistence.ts": 2,
     "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/task-store/archive-lifecycle-2.ts": 1,
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,
-    "packages/engine/src/agent-tools.ts": 1
+    "packages/engine/src/agent-tools.ts": 1,
+    "packages/engine/src/self-healing.ts": 1
   }
 }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -4,6 +4,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     "packages/engine/src/self-healing.ts": 138,
 =======
     "packages/engine/src/self-healing.ts": 40,
@@ -13,6 +14,9 @@
 =======
     "packages/engine/src/self-healing.ts": 23,
 >>>>>>> 4b3a28475a (fleet(engine): convert eight more sweep guards (31 -> 23))
+=======
+    "packages/engine/src/self-healing.ts": 19,
+>>>>>>> 86c7c0bf13 (fleet(engine): convert reconcilePreExecutionWorktrees' live-lane guard (23 -> 19))
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 7,
 >>>>>>> bf30037f85 (fleet(engine): convert reconcileTaskWorktreeMetadata's lane guards (46 -> 40))

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,13 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
+<<<<<<< HEAD
     "packages/engine/src/self-healing.ts": 138,
+=======
+    "packages/engine/src/self-healing.ts": 40,
+    "packages/engine/src/scheduler.ts": 12,
+    "packages/engine/src/executor.ts": 7,
+>>>>>>> bf30037f85 (fleet(engine): convert reconcileTaskWorktreeMetadata's lane guards (46 -> 40))
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/executor.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -3,12 +3,16 @@
   "byFile": {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     "packages/engine/src/self-healing.ts": 138,
 =======
     "packages/engine/src/self-healing.ts": 40,
 =======
     "packages/engine/src/self-healing.ts": 31,
 >>>>>>> 04c4299026 (fleet(engine): convert the agent-link and merge-worktree lane guards (40 -> 31))
+=======
+    "packages/engine/src/self-healing.ts": 23,
+>>>>>>> 4b3a28475a (fleet(engine): convert eight more sweep guards (31 -> 23))
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 7,
 >>>>>>> bf30037f85 (fleet(engine): convert reconcileTaskWorktreeMetadata's lane guards (46 -> 40))

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,6 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 17,
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/executor.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
@@ -33,6 +32,7 @@
     "packages/engine/src/ephemeral-worker-manager.ts": 1,
     "packages/engine/src/merger.ts": 1,
     "packages/engine/src/runtimes/in-process-runtime.ts": 1,
+    "packages/engine/src/self-healing.ts": 1,
     "packages/engine/src/triage.ts": 1
   },
   "deliberateByFile": {

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -2,9 +2,13 @@
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
 <<<<<<< HEAD
+<<<<<<< HEAD
     "packages/engine/src/self-healing.ts": 138,
 =======
     "packages/engine/src/self-healing.ts": 40,
+=======
+    "packages/engine/src/self-healing.ts": 31,
+>>>>>>> 04c4299026 (fleet(engine): convert the agent-link and merge-worktree lane guards (40 -> 31))
     "packages/engine/src/scheduler.ts": 12,
     "packages/engine/src/executor.ts": 7,
 >>>>>>> bf30037f85 (fleet(engine): convert reconcileTaskWorktreeMetadata's lane guards (46 -> 40))


### PR DESCRIPTION
Claimed the largest census cluster: `packages/engine/src/self-healing.ts`, the top file at **56 guards — 4× the next** (`scheduler.ts`, 12).

## Census: before → after

```
$ node scripts/lifecycle-column-census.mjs        # before
  COLUMN guards (the backlog):   126
      56  packages/engine/src/self-healing.ts     ← claimed

$ node scripts/lifecycle-column-census.mjs        # after
  COLUMN guards (the backlog):    89
      19  packages/engine/src/self-healing.ts
```

**37 of 56 converted (66%); the file drops from 56 → 19 and the repo-wide backlog from 126 → 89.** Baseline re-recorded in each commit per the ratchet's own instruction.

Existing role helpers only — `resolveProjectColumnsForRoles`, `REVIEW_ROLES`, and the file's own `resolveReviewColumnsFor`. No new helper, no new vocabulary.

## What was actually broken

Each sweep resolves once and asks membership. The defects these guards were hiding are not uniform, and several **compound**:

| sweep | on a renamed board |
|---|---|
| `archiveStaleDoneTasks` | two failures at once: finished dependents read as *active* (holding cards back) **and** the stale filter matched nothing (archiving none) |
| `reconcileInReviewBranchRebind` | the review filter **is** the candidate set — the sweep was a silent no-op |
| `reconcileTaskWorktreeMetadata` | the ACTIVE guard exists to stop clearing a worktree out from under a running shell; it stopped recognising the live card and cleared anyway |
| `reconcilePreExecutionWorktrees` | the live-lane list matched nothing, so **live cards' worktrees became reclaimable** |
| `detectStalledCards` | finished work reported as stalled |
| `reconcileInReviewUnmetDependencies` | rebound never fired |
| `recoverAgentsRunningOnInactiveTasks`, `recoverDriftedAgentTaskLinks`, `cleanupStaleTempMergeWorktrees`, `reconcileDependencyBlockingLeases`, `reconcileCompletedBlockedTasks`, `reconcileOrphanedPendingStepResults`, `autoReboundPausedScopeDecay`, `recoverApprovedStrandedAiMergeCommit`, `recoverStarvedRefinementTriageTasks` | guard or candidate set silently empty/inverted |

`resolveProjectColumnsForRoles` seeds the legacy ids, so an unconverted board answers byte-identically.

## One conversion I got wrong, caught by an existing test

`recoverAgentsRunningOnInactiveTasks` skips agents linked to `in-progress / in-review / done / archived`. I read that as "every lifecycle lane" and resolved intake ∪ hold ∪ wip ∪ review ∪ finished.

**The omission of `todo` is the entire point of the sweep** — an agent still running against a card that fell back to a *waiting* lane is precisely the drift being recovered. My set swallowed it, and `self-healing.test.ts` → *"recovers durable running agents linked to todo tasks"* failed immediately. Corrected to wip ∪ review ∪ finished, with the reasoning recorded at the site.

That is the argument for converting a literal list only after reading why each member is in it — the set is rarely "all the obvious ones".

## Flagged, not guessed — the remaining 19

**Transition table (`1489–1504`, 9 guards).** A `from`/`to` classifier over move *pairs*, not a lane membership test. Converting one side without the other changes which transitions are recognised, and these feed recovery routing. Needs a deliberate decision about whether a renamed board's transitions map role-to-role.

**Pause-abort routing (`976`, `982`, `1005`, 4 guards).** `classifyPausedAbortWorkflowRecovery` is **synchronous by design** and called twice from `recoverPausedAbortFailures`. Converting means injecting resolved sets as parameters — the same shape as `node-override-guard`. Mechanical, but it changes a signature and I would rather it be a decision than a drive-by.

**`12142` / `12146` (2 guards) — the one I most want a second opinion on.** These pair with `moveTask(task.id, "todo", { recoveryRehome: true })`. `moveTask` **rejects** a target the workflow does not declare — *except* under `recoveryRehome` with a legacy id (`moves.ts:570`, the #1411 escape hatch). So converting the guard alone makes the sweep fire *less* often while the move still lands the card in an undeclared column. **The guard and its write target have to move together**, and writes are explicitly out of scope for this conversion.

**`1131`, `1398` (2 guards).** Sync predicates (`isWorkspaceOwnerLive`, `isPhantomExecutorBinding`) each with one caller; same injection shape as the pause-abort pair.

**`5902` (1 guard).** Already carries a written justification for staying literal — *"the degraded answer costs a duplicate log line … not a wrong lifecycle decision"*. It is sound, but it lacks the `DELIBERATE-LITERAL` marker, so the census still counts it as backlog. Adding the marker is a judgement about someone else's reasoning, so I left it and am naming it here.

## Separately: 20 recovery rehomes write a legacy literal

Enumerating write targets while checking `12146` turned up **20** `moveTask(..., "<legacy>", { recoveryRehome: true })` calls in this file. Each bypasses the undeclared-column rejection by design. On a renamed board every one of them rehomes a card into a column its workflow does not declare — the state `reconcile-task-state-consistency` and #2999's reconciler exist to repair.

Out of scope here (writes), and a real finding: the escape hatch that stops #1411's "card can never be rescued" also guarantees the rescue lands somewhere undeclared.

## Verification

- `tsc -p tsconfig.json` (engine): **0 errors**
- `self-healing.test.ts` + `self-healing-fake-overlap-seam` + `self-healing-orphaned-task-dirs` + `surfacing-family-shared`: **475 passed**
- `lifecycle-column-census --strict`: clean, baseline re-recorded per commit
- FNXC gate exit 0, lint clean
- Full engine suite running; will report before merge.
