### PR TITLE
chore(core): mark the dead sync-path lane literal DELIBERATE-LITERAL (census 104→102)

### DIFF
--- a/packages/core/src/task-store/project-store-ops.ts
+++ b/packages/core/src/task-store/project-store-ops.ts
@@ -515,6 +515,11 @@ It is the SQLite-mode twin. The live path is `dequeueMergeQueueOnColumnExitInTra
 throws in PostgreSQL backend mode, so a renamed board never gets far enough to be mis-dequeued.
 
 Converting it would mean threading a lane set into a function whose first statement cannot execute.
+DELIBERATE-LITERAL — marked, not merely described. The audit note below already said "do not
+convert", but a prose note is invisible to the census, so this stayed in `byFile` as apparent debt
+and the next fleet pass re-derives the same conclusion. The marker moves it to `deliberateByFile`,
+which is where a reviewed-and-kept literal belongs.
+
 Recorded instead, so the census entry is not mistaken for unconverted debt — and so that whoever
 finally deletes the sync SQLite residue can take this with it.
 */

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -3,7 +3,6 @@
   "byFile": {
     "packages/engine/src/self-healing.ts": 22,
     "packages/engine/src/executor.ts": 4,
-    "packages/core/src/task-store/project-store-ops.ts": 2,
     "packages/dashboard/app/utils/taskRevert.ts": 2,
     "packages/engine/src/auto-merge-finalization.ts": 2,
     "packages/engine/src/scheduler.ts": 2,
@@ -31,6 +30,7 @@
     "packages/core/src/task-merge.ts\u0000archived": 2,
     "packages/core/src/task-merge.ts\u0000done": 2,
     "packages/core/src/task-merge.ts\u0000in-review": 2,
+    "packages/core/src/task-store/project-store-ops.ts\u0000in-review": 2,
     "packages/core/src/task-store/task-artifacts-ops.ts\u0000archived": 2,
     "packages/dashboard/app/components/TaskCard.tsx\u0000todo": 2,
     "packages/dashboard/app/components/TaskCard.tsx\u0000triage": 2,


### PR DESCRIPTION
Fleet phase. Claimed `packages/core/src/task-store/project-store-ops.ts` — the largest census file with no branch, worktree, or open PR against it. Claim published by pushing the branch **before** starting work.

## Census before / after

| | total | this file | deliberate |
|---|---|---|---|
| before | **104** | 2 | 130 |
| after | **102** | 0 | 130 |

`--strict` exits 0, baseline re-recorded in the same commit. **Reclassification, not conversion** — the line is unchanged.

## The site was already audited today, in prose the tool cannot read

```
FNXC:WorkflowLifecycleColumns 2026-07-31-02:45 (audited — DEAD SYNC PATH, do not convert):
… It is the SQLite-mode twin. The live path is `dequeueMergeQueueOnColumnExitInTransaction`
… and it is ALREADY converted … This body reaches for `store.db.prepare`, which throws in
   PostgreSQL backend mode …
```

The reasoning is sound and I did not second-guess it: the live path is converted, this twin cannot execute in production, and converting it would mean threading a lane set into a function whose first statement throws.

The problem is purely mechanical — **the note is prose, and the census reads markers.** So the site stayed in `byFile` looking like unconverted debt, and each fleet pass pays to re-derive the same conclusion. Adding `DELIBERATE-LITERAL` moves it to `deliberateByFile`, where a reviewed-and-kept literal belongs.

## This is the second one, which makes it a pattern

Same shape as #3056 (`async-mission-store-queries.ts`, fallback arms). Across the files I have checked this phase — `agent-store`, `github-tracking-state`, `planner-overseer`, `auto-merge-finalization`, `async-mission-store-queries`, and this one — **every site was either a fallback arm or an already-documented deliberate leave**, and `agent-store.ts:236` carries its own "FLAGGED AND LEFT COUNTED" note from today.

So the count is not a work queue, and the gap is not judgement — previous passes reached the right answer. They recorded it where only a human reader would find it. Two lines of marker per site closes that, and the number then means "conversions owed", which is how every worker reads it when picking a cluster.

## Verification

- `census --strict` exit 0; `tsc --noEmit` **0 errors**
- `check:fnxc-future-dates`, `check:lane-wiring`, `check:sql-column-literals`, `check:inert-flag-seams` — all exit 0
- No behaviour change: only a comment added