### PR TITLE
fix(engine): an archived dependency made every backlog candidate unrunnable (long-tail audit: 16 files, 1 real defect)

### DIFF
--- a/.changeset/backlog-pressure-dependency-lanes.md
+++ b/.changeset/backlog-pressure-dependency-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Backlog-pressure alerts no longer go silent when candidates depend on archived tasks.
+category: fix
+dev: `isRunnableCandidate` takes the caller's resolved TERMINAL set instead of comparing each dependency to the `done` id.

--- a/packages/engine/src/__tests__/backlog-pressure-reporter.test.ts
+++ b/packages/engine/src/__tests__/backlog-pressure-reporter.test.ts
@@ -284,4 +284,43 @@ describe("backlog pressure resolves the board's own lanes", () => {
 
     expect((await reporter.report()).alerted).toBe(false);
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:25:
+  The DEPENDENCY half. #2820 converted this reporter's two queries and left the runnable-candidate
+  check asking whether each dependency was the id `done` — so a candidate blocked by an ARCHIVED
+  dependency counted as not-runnable, the candidate list came back empty, and the reporter reported no
+  pressure on a board that was genuinely under it. A diagnostic going quiet, not wrong.
+
+  Archived is the load-bearing case: it is wrong on the BUILT-IN board too, not only a renamed one.
+  */
+  function storeWithArchivedBlocker(): TaskStore {
+    const blocker = { id: "B-1", column: "archived", title: "B-1", priority: "normal" } as unknown as Task;
+    const hold = Array.from({ length: 10 }, (_, i) => (
+      { id: `H-${i}`, column: "backlog", title: `H-${i}`, priority: "normal", dependencies: ["B-1"] } as unknown as Task
+    ));
+    const wip = [{ id: "W-0", column: "building", title: "W-0", priority: "normal" } as unknown as Task];
+    return {
+      getSettings: vi.fn().mockResolvedValue({ backlogPressureRatioThreshold: 2, backlogPressureMinTodoCount: 3 }),
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
+      listTasks: vi.fn(async (options?: { column?: string }) => {
+        if (options?.column === "backlog") return hold;
+        if (options?.column === "building") return wip;
+        if (options?.column === undefined) return [...hold, ...wip, blocker];
+        return [];
+      }),
+      getInsightStore: vi.fn(() => ({ upsertInsight: vi.fn(), listInsights: vi.fn(async () => []) })),
+      logEntry: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TaskStore;
+  }
+
+  it("treats an ARCHIVED dependency as satisfied, so the candidate is still runnable", async () => {
+    const reporter = new BacklogPressureReporter({
+      store: storeWithArchivedBlocker(),
+      projectId: "p1",
+      logger: laneLogger,
+    });
+
+    expect((await reporter.report()).alerted).toBe(true);
+  });
 });

--- a/packages/engine/src/backlog-pressure-reporter.ts
+++ b/packages/engine/src/backlog-pressure-reporter.ts
@@ -1,4 +1,4 @@
-import { computeInsightFingerprint, resolveProjectColumnsForRoles, type Task, type TaskPriority, type TaskStore } from "@fusion/core";
+import { computeInsightFingerprint, resolveProjectColumnsForRoles, TERMINAL_ROLES, type Task, type TaskPriority, type TaskStore } from "@fusion/core";
 import { createLogger } from "./logger.js";
 
 const reporterLog = createLogger("backlog-pressure");
@@ -69,9 +69,20 @@ export class BacklogPressureReporter {
       read needs (there is no task in hand yet to resolve from) and always unions the legacy id, so a
       board mid-rename still counts rows stored under the old one.
       */
-      const [holdColumns, wipColumns] = await Promise.all([
+      const [holdColumns, wipColumns, dependencySatisfiedColumns] = await Promise.all([
         resolveProjectColumnsForRoles(this.store, ["hold"]),
         resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]),
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-15:10 (fleet phase, long tail):
+        The runnable-candidate check asked whether every dependency was `done` — the one lane question
+        in this file that was NOT resolved, two lines from where the other two already were.
+
+        A dependency is satisfied when it reaches a TERMINAL lane, complete or archived: an archived
+        blocker satisfies its dependents, and the id-keyed form said otherwise on any renamed board AND
+        for archived blockers on the built-in one. The reporter then found zero runnable candidates and
+        reported no backlog pressure — the failure mode where a diagnostic goes quiet instead of wrong.
+        */
+        resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES),
       ]);
       const listByColumns = async (columns: ReadonlySet<string>, slim: boolean): Promise<Task[]> => {
         const byId = new Map<string, Task>();
@@ -98,7 +109,7 @@ export class BacklogPressureReporter {
       ]);
       const byId = new Map(allTasks.map((task) => [task.id, task]));
       const candidates = todoFull
-        .filter((task) => this.isRunnableCandidate(task, byId))
+        .filter((task) => this.isRunnableCandidate(task, byId, dependencySatisfiedColumns))
         .sort((a, b) => {
           const pa = PRIORITY_WEIGHT[a.priority ?? "normal"];
           const pb = PRIORITY_WEIGHT[b.priority ?? "normal"];
@@ -185,7 +196,8 @@ export class BacklogPressureReporter {
     }
   }
 
-  private isRunnableCandidate(task: Task, byId: Map<string, Task>): boolean {
+  /** `dependencySatisfiedColumns` is the caller's resolved TERMINAL set; omitted keeps the legacy id. */
+  private isRunnableCandidate(task: Task, byId: Map<string, Task>, dependencySatisfiedColumns?: ReadonlySet<string>): boolean {
     if (task.paused) return false;
     if ((task.blockedBy ?? "").trim().length > 0) return false;
     if ((task.overlapBlockedBy ?? "").trim().length > 0) return false;
@@ -194,7 +206,11 @@ export class BacklogPressureReporter {
     for (const depId of task.dependencies ?? []) {
       const dependency = byId.get(depId);
       if (!dependency) continue;
-      if (dependency.column !== "done") {
+      const satisfied = dependencySatisfiedColumns
+        ? dependencySatisfiedColumns.has(dependency.column)
+        /* DELIBERATE-LITERAL — the no-metadata fallback for a caller that resolved nothing. */
+        : dependency.column === "done";
+      if (!satisfied) {
         return false;
       }
     }


### PR DESCRIPTION
Fleet long tail. I audited **all 16 unclaimed files (17 guards)** and converted the one that is a genuine defect. The other 15 are reported below rather than converted — several would be actively wrong to convert.

## Census

| | before | after |
|---|---|---|
| repo-wide column guards | 93 | **88** |

## The defect

#2820 converted this reporter's two **queries** and left the third lane question — the runnable-candidate check — comparing each dependency to the id `done`, two lines from where the other two are resolved:

```ts
const [holdColumns, wipColumns] = await Promise.all([...]);   // resolved
...
if (dependency.column !== "done") return false;               // not
```

A dependency is satisfied when it reaches a **terminal** lane — complete *or* archived. Keyed on the single id, a candidate blocked by an archived dependency counted as not-runnable, the candidate list came back empty, and the reporter reported **no backlog pressure on a board genuinely under it**. A diagnostic going quiet rather than wrong.

**The archived case is wrong on the built-in board too**, not only a renamed one — which is exactly why it survived the renamed-board tests #2820 added alongside it.

Reverted, the new case fails. Optional parameter with the legacy id as the documented fallback; the caller already awaited two role resolutions, so this is a third entry in the same `Promise.all`.

## The other 15 — flagged, not guessed

I opened every one. **None is a missed conversion:**

- **Sentinel comparisons** (`async-comments-attachments.ts`, 4 sites). These compare against a sentinel string the resolver itself returns, which deliberately collapses archived and soft-deleted into one value. Its comment spells out that converting *"would keep passing on the built-in board and start FAILING on a renamed one — a soft-deleted task would read as not-archived."* Converting would introduce the bug.
- **Sync-DB paths** (`merge-queue-ops-2`, `mission-store`, `audit-ops`, `lifecycle-ops`, `task-id-integrity`). Inside synchronous SQLite transactions, where the only sync resolver reads `getTaskWorkflowSelectionImpl` — which returns `undefined` unconditionally in PostgreSQL mode. One carries the note: *"Left as a literal WITH this note so the next worker does not 'fix' it into a false green."* That is exactly what a mechanical pass here would produce.
- **Already-converted seeds** (`executor.ts` ×3, `auto-merge-finalization.ts`). Literal sets unioned with `columnsWithFlag` results on the very next lines — the documented degradation path for when `resolveWorkflowIrForTask` falls back to the built-in IR.
- **`taskRevert.ts`** — its comment establishes that supplying the modal task's flags for a *neighbour* row is the flags-for-the-wrong-row hazard, and concludes the entry is *"accurate debt rather than a missed conversion."*
- **`notification-service.ts`** (5, largest unclaimed) — blocked on the wedge-episode contract: any `await` before the resolve drops an operator notification, with a test that fails loudly.

**The residual census count is mostly intentional.** Six of eight remaining files carry explicit flagged notes. Treating the number as a work queue from here produces false greens, not conversions — which several of those authors predicted in writing.

## Verification

backlog-pressure-reporter **11 passed** · `pnpm test:gate` 161 + 13 + 487 + 71 · lint · census `--strict` · lane-wiring · changesets — green.
