### PR TITLE
gate: the inert-sync-lane check missed the Set-membership spelling

### DIFF
--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -63,8 +63,16 @@ const BASELINE_PATH = join(REPO, "scripts", "lib", "inert-sync-lane-baseline.jso
 /** The reader whose selection lookup is unconditionally `undefined` under PostgreSQL. */
 const SYNC_IR_READER = "resolveTaskWorkflowIrSync";
 
-/** Role fields a lifecycle resolution hands back. A guard on any of these is a lane guard. */
-const ROLE_FIELDS = new Set(["hold", "intake", "wip", "review", "complete", "archived", "plannerColumn", "mergedPlanningColumn"]);
+/** Role fields a lifecycle resolution hands back. A guard on any of these is a lane guard.
+ *
+ * FNXC:LifecycleColumnCensus 2026-07-31-16:05 (second evasion, found the same way as the first):
+ * `terminal` is a SET of lane ids rather than one id, and it is here because PR #3065 rewrote
+ * `to === parked.complete || to === parked.archived` into `parked.terminal.has(to)`. That is a real
+ * bug fix — a board may declare more than one complete-trait column — but the answer is still sourced
+ * from the same sync resolver, so the guard is exactly as inert while ceasing to be a `===`
+ * comparison. Counting only comparisons, this check would have watched its own subject shrink and
+ * called it progress. */
+const ROLE_FIELDS = new Set(["hold", "intake", "wip", "review", "complete", "archived", "plannerColumn", "mergedPlanningColumn", "terminal", "lanes", "columns"]);
 
 function sourceFiles(dir, out = []) {
   for (const entry of readdirSync(dir)) {
@@ -143,12 +151,24 @@ function countInertGuards(sf, locals, sources) {
     return undefined;
   };
   const visit = (node) => {
+    /* `to === parked.review` — one lane id, compared. */
     if (ts.isBinaryExpression(node)) {
       const op = node.operatorToken.kind;
       if (op === ts.SyntaxKind.EqualsEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken) {
         const hit = consumesLocal(node.left) ?? consumesLocal(node.right);
         if (hit) {
           hits.push({ line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1, expr: hit });
+        }
+      }
+    }
+    /* `parked.terminal.has(to)` — a SET of lane ids, tested for membership. Same source, same
+       inertness, no comparison node anywhere. See the note on ROLE_FIELDS. */
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const method = node.expression.name.getText(sf);
+      if (method === "has" || method === "includes") {
+        const hit = consumesLocal(node.expression.expression);
+        if (hit) {
+          hits.push({ line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1, expr: `${hit}.${method}(...)` });
         }
       }
     }


### PR DESCRIPTION
## The check I shipped in #3062 has a hole, and there is an open PR standing in it

#3062 counts `to === parked.complete`. **#3065 rewrites exactly that into `parked.terminal.has(to)`.**

#3065's change is **correct and should merge** — a board may declare more than one complete-trait column, so a single `parked.complete` was genuinely wrong, and the PR fixes a red main. But the answer still comes from `resolveTaskParkedColumnsSync`, which resolves through `store.resolveTaskWorkflowIrSync` and therefore always describes the default board. The guard is exactly as inert; it simply stopped being a comparison node, and my check only counted comparisons.

## Measured, both ways

Applying #3065's rewrite shape to `scheduler.ts`:

| | result |
|---|---|
| check as shipped in #3062 | **20 → 15**, exit 0, prints *"total fell — re-record with `--update-baseline`"* |
| this PR | **20 → 18**, the three `.has()` guards stay counted |

The shipped behaviour is the bad half: it does not merely miss them, it invites re-recording a smaller baseline, permanently retiring sites that are still inert.

And on the case the ratchet actually exists for — a **fresh literal** converted via the Set spelling:

| | result |
|---|---|
| check as shipped | **exit 0** — missed |
| this PR | **exit 1** — caught, `20 → 21` |

## What changed

- `terminal` (plus `lanes`, `columns`) added to the role-field vocabulary — Set-valued roles, not single ids.
- Membership calls counted alongside comparisons: `X.<role>.has(...)` / `.includes(...)` where `X` is sync-resolved, inline or via a local.

Neither exit code changes on current main: still 20, still exit 0.

## The pattern, stated plainly

This is the **second** evasion of this check, found the same way as the first. #3062's own body records the first: the initial draft matched only the local-variable spelling and a mutation run proved the inline `resolveX(...).review` walked straight past it.

Both times the guard was correct about the shape in front of it and blind to a trivially different spelling of the same defect. Worth generalising rather than patching a third time — the durable fix is to key on **the source** (any value derived from `resolveTaskWorkflowIrSync`) rather than enumerate the syntax that consumes it. That is a dataflow question and a larger change than this; recording it here as the known limit rather than claiming this version is complete.

Related and unresolved: the same "a rewrite makes the counter drop without the guard changing" shape is live in the census itself — see my comment on #3057 about `LEGACY_*` named sets, and #3058, where ten guards left the census for zero behaviour change.

## Census before / after

```
before:  COLUMN guards (the backlog):   88
after:   COLUMN guards (the backlog):   88
```

Unchanged — this converts nothing. It stops a counter from falling for the wrong reason.

## Verification

`pnpm check:inert-sync-lanes` exit 0 · `test:gate` exit 0 · lifecycle-column census exit 0 · `pnpm lint` clean. Gate-script only; no production file touched (`scheduler.ts` restored clean after every mutation run).
