### PR TITLE
fleet(engine): self-healing lane guards 17 → 1 — the sync seams

### DIFF
--- a/packages/engine/src/__tests__/self-healing-fanout-renamed-lanes.test.ts
+++ b/packages/engine/src/__tests__/self-healing-fanout-renamed-lanes.test.ts
@@ -1,0 +1,180 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-14:45:
+THE `task:moved` FAN-OUT ANSWERED EVERY LANE QUESTION WITH A LITERAL.
+
+`taskMovedFanoutListener` decided three things by comparing column ids:
+
+  - a move OUT of `in-progress` into `todo`/`in-review`/`done`/`archived` increments the
+    board-stall transition counter,
+  - a move INTO `in-review` triggers the branch-rebind reconciliation,
+  - `in-review -> done` and `done -> archived` trigger the completion fan-out (worktree removal,
+    dependent `blockedBy` clearing).
+
+On a board that names its lanes anything else, all three stopped firing. Nothing errors: the
+counter silently reads zero, worktrees are never reclaimed, and dependents keep a `blockedBy`
+pointing at a blocker that already finished.
+
+WHY A SYNC RESOLVER. `task:moved` is emitted synchronously, so an `await` in this listener defers
+everything after it to a microtask and reorders this handler against every other subscriber — the
+hazard the scheduler's own `resolveTaskParkedColumnsSync` header documents. The conversion uses the
+store's sync IR path for that reason, which is a different seam from the `resolveProjectColumnsForRoles`
+used by the async sweeps and needs its own coverage.
+
+Driven through the REAL listener via `start()` + a real `task:moved` emit, not by calling the
+private resolver: the contract is that the fan-out fires, not that a helper returns a set.
+*/
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+const { logger } = vi.hoisted(() => ({
+  logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../logger.js", () => ({ createLogger: vi.fn(() => logger) }));
+
+import { SelfHealingManager } from "../self-healing.js";
+
+/** Hold `drafting`, wip `building`, review `reviewing`, complete `shipped`, archived `filed`. */
+function renamedIr(): WorkflowIr {
+  return {
+    version: "v2",
+    id: "custom:wf",
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: "drafting", name: "drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "reviewing", name: "reviewing", traits: [{ trait: "merge" }] },
+      { id: "shipped", name: "shipped", traits: [{ trait: "complete" }] },
+      { id: "filed", name: "filed", traits: [{ trait: "archived" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+function makeTask(id: string, column: string): Task {
+  return {
+    id,
+    title: id,
+    description: id,
+    column,
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  } as unknown as Task;
+}
+
+function createStore(tasks: Task[], ir: WorkflowIr | null): TaskStore & EventEmitter {
+  const map = new Map(tasks.map((t) => [t.id, t]));
+  const emitter = new EventEmitter();
+  const cfg = { globalPause: false, enginePaused: false } as Settings;
+  return Object.assign(emitter, {
+    getSettings: vi.fn(async () => cfg),
+    listTasks: vi.fn(async () => [...map.values()]),
+    getTask: vi.fn(async (id: string) => map.get(id) ?? null),
+    updateTask: vi.fn(async () => undefined),
+    logEntry: vi.fn(async () => undefined),
+    /* The sync seam under test. `null` stands for a workflow that cannot be resolved. */
+    resolveTaskWorkflowIrSync: vi.fn(() => {
+      if (!ir) throw new Error("no workflow selection");
+      return ir;
+    }),
+  }) as unknown as TaskStore & EventEmitter;
+}
+
+/** Starts the manager with its periodic maintenance suppressed — only the listener is under test. */
+function startManager(store: TaskStore & EventEmitter) {
+  const mgr = new SelfHealingManager(store, { rootDir: "/repo" });
+  vi.spyOn(mgr as unknown as { startMaintenance: () => void }, "startMaintenance").mockImplementation(() => {});
+  const reconcile = vi.spyOn(mgr, "reconcileCompletedTask").mockResolvedValue({
+    blockedByCleared: 0, worktreeRemoved: false, branchRemoved: false,
+  });
+  const rebind = vi.spyOn(mgr, "reconcileInReviewBranchRebind").mockResolvedValue(0 as never);
+  mgr.start();
+  return { mgr, reconcile, rebind };
+}
+
+/** `task:moved` is synchronous; the handlers it starts are not, so let the microtasks drain. */
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("the self-healing task:moved fan-out on a renamed board", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("runs the completion fan-out for reviewing -> shipped", async () => {
+    const task = makeTask("KB-1", "shipped");
+    const store = createStore([task], renamedIr());
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "reviewing", to: "shipped", source: "engine" });
+    await settle();
+
+    /* Keyed on `in-review -> done` this never fired: the worktree is never reclaimed and every
+       dependent keeps a `blockedBy` pointing at a blocker that has already finished. */
+    expect(reconcile).toHaveBeenCalledWith("KB-1", expect.anything());
+    mgr.stop();
+  });
+
+  it("runs the completion fan-out for shipped -> filed", async () => {
+    const task = makeTask("KB-2", "filed");
+    const store = createStore([task], renamedIr());
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "shipped", to: "filed", source: "engine" });
+    await settle();
+
+    expect(reconcile).toHaveBeenCalledWith("KB-2", expect.anything());
+    mgr.stop();
+  });
+
+  it("triggers the branch rebind on a move into the renamed review lane", async () => {
+    const task = makeTask("KB-3", "reviewing");
+    const store = createStore([task], renamedIr());
+    const { mgr, rebind } = startManager(store);
+
+    store.emit("task:moved", { task, from: "building", to: "reviewing", source: "engine" });
+    await settle();
+
+    expect(rebind).toHaveBeenCalledWith({ includeTaskIds: new Set(["KB-3"]) });
+    mgr.stop();
+  });
+
+  /*
+  The paired negative. The conversion widens membership, so it must not turn EVERY move into a
+  fan-out — a `building -> drafting` requeue is not a completion, and reconciling it would remove
+  the worktree of a card that is about to run again.
+  */
+  it("does NOT run the completion fan-out for a requeue into the hold lane", async () => {
+    const task = makeTask("KB-4", "drafting");
+    const store = createStore([task], renamedIr());
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "building", to: "drafting", source: "engine" });
+    await settle();
+
+    expect(reconcile).not.toHaveBeenCalled();
+    mgr.stop();
+  });
+
+  /*
+  CONTROL + fail-soft. A store that cannot resolve a workflow must answer with exactly the legacy
+  ids — this is the path every unconverted board and every `synthesizeDefaultColumns` v1 upgrade
+  takes, and an unseeded resolved set would switch the whole fan-out off for them.
+  */
+  it("still fires on the legacy ids when the workflow cannot be resolved", async () => {
+    const task = makeTask("KB-5", "done");
+    const store = createStore([task], null);
+    const { mgr, reconcile } = startManager(store);
+
+    store.emit("task:moved", { task, from: "in-review", to: "done", source: "engine" });
+    await settle();
+
+    expect(reconcile).toHaveBeenCalledWith("KB-5", expect.anything());
+    mgr.stop();
+  });
+});

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -949,11 +949,35 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     super();
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:10:
+  THE LANE ANSWERS ARRIVE AS PARAMETERS WITH LEGACY DEFAULTS, because this classifier is SYNC and
+  must stay sync: it runs inside `tasks.filter(...)` at its first call site, and an `await` there
+  turns a predicate into a promise that filters nothing away.
+
+  Its only caller already resolves both sets once per sweep, so the resolution is paid where an
+  await is legal and passed down. REQUIRED, not optional-with-a-literal-default: an optional
+  parameter leaves the legacy ids in the file as a silent fallback, and the next caller gets the
+  pre-conversion behaviour by writing nothing. `resolveProjectColumnsForRoles` seeds the legacy ids
+  itself, so an unconverted board still answers exactly as it did.
+
+  MEMBERSHIP, not a target. The routing question is "is this card resting in a review / an active
+  lane", which a renamed board can answer with more than one column; `resolveLifecycleColumns`'
+  first match would silently route only the first.
+  */
   private classifyPausedAbortWorkflowRecovery(
     task: Task,
     settings: Settings,
     isExecuting: boolean,
+    lanes: {
+      /** Review MEMBERSHIP — replaces the `in-review` literal. */
+      reviewColumns: ReadonlySet<string>;
+      /** Waiting ∪ wip MEMBERSHIP — replaces the `todo`/`in-progress` pair. */
+      activeWorkColumns: ReadonlySet<string>;
+    },
   ): WorkflowRecoveryRoute {
+    const isReviewLane = (column: string): boolean => lanes.reviewColumns.has(column);
+    const isActiveWorkLane = (column: string): boolean => lanes.activeWorkColumns.has(column);
     const isPausedAbortPark =
       task.status === "failed" &&
       typeof task.error === "string" &&
@@ -973,13 +997,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.steps.every((step) => step.status === "done" || step.status === "skipped");
     const sharedBranchMember = isSharedBranchGroupMemberIntegration(task);
     const hasReviewProgress =
-      task.column === "in-review"
+      isReviewLane(task.column)
       && allowsAutoMergeProcessing(task, settings)
       && task.mergeDetails?.mergeConfirmed !== true
       && !isTerminalMergePark
       && completedSteps;
     const hasManualMergeHoldProgress =
-      task.column === "in-review"
+      isReviewLane(task.column)
       && (!allowsAutoMergeProcessing(task, settings) || resolveEffectiveAutoMerge(task, settings) === false)
       && !sharedBranchMember
       && task.mergeDetails?.mergeConfirmed !== true
@@ -1002,7 +1026,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     if (hasReviewProgress) {
       return { kind: "work-item-resume", reason: "pause-abort-review-progress" };
     }
-    if (task.column === "todo" || task.column === "in-progress") {
+    if (isActiveWorkLane(task.column)) {
       return { kind: "node-requeue", reason: "pause-abort-active-work" };
     }
     return { kind: "no-action", reason: "unsafe-or-not-routable" };
@@ -1126,9 +1150,20 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
   this. (Distinct from `isWorkspaceTaskLive`, which probes the session REGISTRY; this probes the
   task ROW lifecycle.)
   */
-  private isWorkspaceOwnerLive(owner: Task | null | undefined): boolean {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:35:
+  `completeColumns` is REQUIRED and resolved by the caller, because this predicate is sync and its
+  caller is not — it runs inside the lease sweep's loop where the await is already paid once.
+
+  MEMBERSHIP of `complete` ONLY, deliberately: the literal it replaces was `done` alone, and the
+  comment above spells out that every non-terminal state must read LIVE. Adding `archived` here
+  would widen what counts as terminal and reclaim leases the old code kept — a behaviour change
+  riding in a column conversion, which is exactly what this program forbids. If archived owners
+  should also be reclaimable that is its own change, with its own test.
+  */
+  private isWorkspaceOwnerLive(owner: Task | null | undefined, completeColumns: ReadonlySet<string>): boolean {
     if (!owner) return false; // not found / deleted → terminal.
-    if (owner.column === "done") return false;
+    if (completeColumns.has(owner.column)) return false;
     if (owner.status === "failed") return false;
     return true;
   }
@@ -1358,11 +1393,20 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    * FN-7566: the FN-6736 liveness gate (`agentPresent` heartbeat, `checkedOutBy` lease, `hasRecentRunAudit`) is structurally blind to EPHEMERAL EXECUTOR agents (`agentId: "executor"`): they never emit heartbeat runs (so `activeHeartbeatTaskIds` never contains them), never acquire a checkout lease (`checkedOutBy` stays null), and normal execution activity (sandbox:run / task:log / verification) writes no `runAuditEvents` rows (so `getRecentRunAuditActivityAgeMs` stays null). With all three permanently false, the ONLY surviving gate was age > graceMs*3 (~30 min), so any ephemeral executor task running longer than 30 minutes — a heavy foreach workflow, a slow model — was killed mid-flight on the next self-healing sweep and hard-moved to `todo`, corrupting overlapping-worktree/task-link state.
    * The fix adds the in-process live-session truth that DOES track ephemeral executors: a worktree path registered as active in `activeSessionRegistry` (the executor/step-session/workflow-step session holds it for the whole run), the `executingTaskLock`, or `isTaskActive`. This mirrors the canonical `isWorkspaceTaskLive` / `sessionDead` predicate. A genuinely leaked binding (FN-6736) still has an EMPTY registry / no lock / inactive task, so legitimate phantom recovery is preserved; a live ephemeral executor now vetoes the phantom verdict regardless of the durable-agent signals.
    */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-13:35:
+  `wipColumns` is REQUIRED and supplied by the caller, which resolved the same set one line earlier
+  to decide whether to call this at all (`lanesOfReclaim(task.id).wip`). Two reads of one board,
+  one resolved and one literal, is the shape this program keeps finding — here they were three
+  lines apart.
+  */
   private isPhantomExecutorBinding(task: Task, options: {
     executionAgeMs: number | null;
     graceMs: number;
     activeHeartbeatTaskIds: Set<string>;
     lastActivityMs: number | null;
+    /** Wip MEMBERSHIP — replaces the `in-progress` literal. */
+    wipColumns: ReadonlySet<string>;
   }): { phantom: boolean; metadata: Record<string, unknown> } {
     const normalizedId = task.id.toUpperCase();
     const agentPresent = options.activeHeartbeatTaskIds.has(normalizedId);
@@ -1395,7 +1439,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     };
 
     return {
-      phantom: task.column === "in-progress"
+      phantom: options.wipColumns.has(task.column)
         && worktreeExists
         && options.executionAgeMs !== null
         && options.executionAgeMs > safeAgeMs
@@ -1475,6 +1519,50 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     log.debug(`[${stage}] ${task.id}: false-positive requeue suppressed (${reason})`);
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:05:
+  SYNC lane membership for the `task:moved` fan-out listener, mirroring the scheduler's
+  `resolveTaskParkedColumnsSync`. The listener body must stay synchronous: `task:moved` is emitted
+  synchronously, so an `await` before its existing work defers everything after it to a microtask
+  and reorders this handler against every other subscriber. Resolution therefore uses the store's
+  sync IR path, never `resolveProjectColumnsForRoles`.
+
+  Every set is SEEDED with the legacy id it replaces. Two reasons, and the second is the load-bearing
+  one: an inclusion-widened superset can only make the fan-out fire on a transition it used to
+  ignore, and `synthesizeDefaultColumns` emits trait-less placeholder columns for v1-upgraded
+  workflows — on those boards `columnsWithFlag` returns EMPTY for every trait, so an unseeded set
+  would silently switch the whole fan-out off (see the hazard note in `workflow-lifecycle-traits.ts`).
+
+  Fail-soft: an unresolvable workflow answers with exactly the legacy ids, i.e. today's behaviour.
+  */
+  private resolveFanoutLanesSync(taskId: string): {
+    wip: ReadonlySet<string>;
+    waiting: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+  } {
+    const legacy = {
+      wip: new Set(["in-progress"]),
+      waiting: new Set(["todo"]),
+      review: new Set(["in-review"]),
+      complete: new Set(["done"]),
+      archived: new Set(["archived"]),
+    };
+    try {
+      const ir = this.store.resolveTaskWorkflowIrSync(taskId);
+      return {
+        wip: new Set([...legacy.wip, ...columnsWithFlag(ir, "countsTowardWip")]),
+        waiting: new Set([...legacy.waiting, ...columnsWithFlag(ir, "hold"), ...columnsWithFlag(ir, "intake")]),
+        review: new Set([...legacy.review, ...columnsWithFlag(ir, "mergeOrchestration"), ...columnsWithFlag(ir, "mergeBlocker"), ...columnsWithFlag(ir, "humanReview")]),
+        complete: new Set([...legacy.complete, ...columnsWithFlag(ir, "complete")]),
+        archived: new Set([...legacy.archived, ...columnsWithFlag(ir, "archived")]),
+      };
+    } catch {
+      return legacy;
+    }
+  }
+
   // ── Lifecycle ───────────────────────────────────────────────────────
 
   start(): void {
@@ -1485,23 +1573,25 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     this.store.on("settings:updated", this.settingsListener);
 
     this.taskMovedFanoutListener = ({ task, from, to }) => {
+      /* One sync resolution per move, reused by all three guards below. */
+      const lanes = this.resolveFanoutLanesSync(task.id);
       if (
-        from === "in-progress"
-        && (to === "todo" || to === "in-review" || to === "done" || to === "archived")
+        lanes.wip.has(from)
+        && (lanes.waiting.has(to) || lanes.review.has(to) || lanes.complete.has(to) || lanes.archived.has(to))
         && this.boardStallWindow
       ) {
         // In-memory only counter; resets on engine restart.
         this.boardStallWindow.transitionsOutOfInProgressInWindow++;
       }
-      if (to === "in-review") {
+      if (lanes.review.has(to)) {
         void this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) }).catch((err: unknown) => {
           const errorMessage = err instanceof Error ? err.message : String(err);
           log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
         });
       }
       const shouldReconcile =
-        (from === "in-review" && to === "done") ||
-        (from === "done" && to === "archived");
+        (lanes.review.has(from) && lanes.complete.has(to)) ||
+        (lanes.complete.has(from) && lanes.archived.has(to));
       if (!shouldReconcile) return;
       void this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined }).catch((err: unknown) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -3885,6 +3975,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               executionAgeMs,
               graceMs: STALE_ACTIVE_BRANCH_EXECUTION_GRACE_MS,
               activeHeartbeatTaskIds: activeTaskIds,
+              wipColumns: lanesOfReclaim(task.id).wip,
               lastActivityMs,
             });
 
@@ -9718,6 +9809,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const entries = activeSessionRegistry.entriesByKind("workspace-repo-land");
       if (entries.length === 0) return 0;
 
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-13:35: resolved once per sweep, AFTER the early
+         return above, so a board with no leases still pays nothing. See `isWorkspaceOwnerLive`. */
+      const leaseOwnerCompleteColumns = await resolveProjectColumnsForRoles(this.store, ["complete"]);
+
       const graceMs = settings.taskStuckTimeoutMs ?? STALE_ACTIVE_BRANCH_EXECUTION_GRACE_MS;
       const staleFloorMs = graceMs * PHANTOM_EXECUTOR_BINDING_AGE_MULTIPLIER;
       const activeMergeTaskId = this.options.getActiveMergeTaskId?.() ?? null;
@@ -9747,7 +9842,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const owner = await this.store.getTask(entry.taskId).catch(() => null);
           const ownerColumn = owner?.column ?? "deleted";
           // Only a DEMONSTRABLY TERMINAL owner's lease is reclaimed (review C fix).
-          if (this.isWorkspaceOwnerLive(owner)) continue;
+          if (this.isWorkspaceOwnerLive(owner, leaseOwnerCompleteColumns)) continue;
 
           activeSessionRegistry.unregisterPath(entry.path);
           await createRunAuditor(this.store, {
@@ -12067,6 +12162,21 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       /* Waiting MEMBERSHIP (hold u intake) for the notification guard below; the requeue TARGET is a
          single column and resolves per task at its call site. */
       const pausedAbortWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-13:10:
+      "Active work" for the ROUTER is waiting ∪ wip, matching the `todo`/`in-progress` pair it
+      replaces: a card parked in the queue and a card parked mid-execution both route to a node
+      requeue. Resolved here, where an await is legal, and passed into the sync classifier.
+      */
+      const pausedAbortWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const pausedAbortActiveWorkColumns: ReadonlySet<string> = new Set([
+        ...pausedAbortWaitingColumns,
+        ...pausedAbortWipColumns,
+      ]);
+      const pausedAbortLanes = {
+        reviewColumns: pausedAbortReviewColumns,
+        activeWorkColumns: pausedAbortActiveWorkColumns,
+      };
     try {
       // FNXC:WorkflowLifecycle 2026-06-20-00:00: self-guard against global/engine
       // pause at the method entry, not just the batch-2 runner. This method is
@@ -12080,7 +12190,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const tasks = await this.store.listTasks({ slim: true });
 
       const parked = tasks.filter((t) =>
-        this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id)).kind !== "no-action",
+        this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id), pausedAbortLanes).kind !== "no-action",
       );
 
       if (parked.length === 0) return 0;
@@ -12117,7 +12227,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             log.debug(`[self-healing] deferring pause-abort recovery for ${fresh.id}: a live session surface is registered`);
             continue;
           }
-          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id));
+          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id), pausedAbortLanes);
           if (route.kind === "no-action") {
             continue;
           }
@@ -12959,6 +13069,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     swallowed that case — `self-healing.test.ts` "recovers durable running agents linked to todo
     tasks" caught it immediately.
     */
+    /* FNXC:WorkflowResolvedColumns 2026-07-31-14:20: the parked pair (`todo`/`triage`) this sweep
+       hands `evaluateParkedAgentTaskLink`; legacy-seeded, so unconverted boards are unchanged. */
+    const agentParkedColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
     const inactiveAgentLifecycleColumns = await resolveProjectColumnsForRoles(
       this.store,
       ["countsTowardWip", ...REVIEW_ROLES, "complete", "archived"],
@@ -12984,7 +13097,23 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const activeRun = await agentStore.getActiveHeartbeatRun(agent.id);
       const proof = evaluateParkedAgentTaskLink({
         agent,
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-14:20:
+        The synthetic stand-in for a MISSING task stays the legacy id ON PURPOSE, and it is now
+        correct rather than merely unconverted: `parkedColumns` below is resolved through
+        `resolveProjectColumnsForRoles`, which SEEDS the legacy ids, so `todo` is a member on every
+        board. There is also no task left to resolve a workflow from — a deleted row has no
+        selection — so any "renamed" placeholder would be a guess about which lane a task that no
+        longer exists belonged to.
+        */
         linkedTask: linkedTask ?? { column: "todo" } as Pick<Task, "column">,
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-14:20:
+        Previously omitted, so this call fell back to `LEGACY_PARKED_COLUMNS` (`todo`/`triage`) and
+        a live agent linked to a card resting in a RENAMED hold lane read as not-parked — the
+        safeguard that preserves its task link never applied, and the link was dropped.
+        */
+        parkedColumns: [...agentParkedColumns],
         activeRun,
         hasActiveAgentExecution: this.options.hasActiveAgentExecution,
         now,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,6 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 17,
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/executor.ts": 4,
     "packages/engine/src/restart-recovery-coordinator.ts": 4,
@@ -33,6 +32,7 @@
     "packages/engine/src/ephemeral-worker-manager.ts": 1,
     "packages/engine/src/merger.ts": 1,
     "packages/engine/src/runtimes/in-process-runtime.ts": 1,
+    "packages/engine/src/self-healing.ts": 1,
     "packages/engine/src/triage.ts": 1
   },
   "deliberateByFile": {


### PR DESCRIPTION
Stacked on #3055. Base is `fleet/self-healing-lane-roles`; retarget to `main` once that merges.

## Why these were left for last

Everything remaining in `self-healing.ts` after the sweep conversions was a **sync** site. `resolveProjectColumnsForRoles` is async and cannot be used inside a synchronous `task:moved` listener, nor inside a predicate invoked from `Array.filter` — an `await` there turns a predicate into a promise, and every element passes.

Two shapes cover it, both already used elsewhere in the codebase.

### 1. Sync IR resolution — the `task:moved` fan-out

New `resolveFanoutLanesSync`, mirroring the scheduler's `resolveTaskParkedColumnsSync` and using the same store sync IR path for the same documented reason: `task:moved` is emitted synchronously, so an `await` in the listener defers everything after it to a microtask and reorders this handler against every other subscriber.

Converts three guards that were silently dead on a renamed board — the board-stall transition counter read zero, worktrees were never reclaimed, and dependents kept a `blockedBy` pointing at a blocker that had already finished.

**Every set is seeded with the legacy id**, and the second reason is the load-bearing one:
- an inclusion-widened superset can only make the fan-out fire on a transition it used to ignore;
- `synthesizeDefaultColumns` emits **trait-less placeholder columns** for v1-upgraded workflows, so `columnsWithFlag` returns empty for every trait on those boards. An unseeded set would switch the whole fan-out off for them. (The hazard is documented at the top of `workflow-lifecycle-traits.ts`; this is a live instance of it.)

### 2. Resolved lanes as required parameters

`classifyPausedAbortWorkflowRecovery`, `isWorkspaceOwnerLive`, `isPhantomExecutorBinding` — each sync, each with a single caller in an async sweep that already resolves (or can resolve) the set once.

**Required, not optional-with-a-literal-default.** An optional parameter leaves the legacy ids in the file as a silent fallback, and the next caller gets pre-conversion behaviour by writing nothing. `resolveProjectColumnsForRoles` seeds the legacy ids itself, so unconverted boards answer exactly as before.

`isPhantomExecutorBinding` is the sharpest case: its caller resolved `lanesOfReclaim(task.id).wip` **three lines above the call**, then passed a task whose column the predicate compared against the `in-progress` literal. Two reads of one board, one resolved and one not — the shape this program keeps finding.

### Also fixed: an unwired `evaluateParkedAgentTaskLink`

The call in `recoverAgentsRunningOnInactiveTasks` omitted `parkedColumns`, so it fell back to `LEGACY_PARKED_COLUMNS` (`todo`/`triage`). A live durable agent linked to a card resting in a **renamed hold lane** read as not-parked, so the safeguard that preserves its task link never applied and the link was dropped.

## Flagged, not guessed

- **`isWorkspaceOwnerLive` keeps `complete` membership ONLY.** The literal it replaces was `done` alone, and its own header states that every non-terminal state must read LIVE so a lease is never yanked from a task that could still be running. Adding `archived` would make more owners terminal and reclaim leases the old code kept — a behaviour change riding inside a column conversion. If archived owners should be reclaimable, that is its own change with its own test.
- **The synthetic `{ column: "todo" }`** for a *missing* task stays a legacy id, and is now correct rather than merely unconverted: `parkedColumns` is legacy-seeded, so `todo` is a member on every board. A deleted row has no workflow selection, so any "renamed" placeholder would be a guess about which lane a task that no longer exists belonged to.
- **The last remaining count (line ~5991)** is the pre-existing flagged log-dedup closure, left counted by an earlier PR because it sits before the lane prefetch it would need and only decides whether to re-log an already-logged blocker.

## Census

| | before | after |
|---|---|---|
| `self-healing.ts` | 17 | **1** |
| repo backlog | 70 | **54** |

(Across the two stacked PRs: `self-healing.ts` 56 → 1.)

## Measured

- new `self-healing-fanout-renamed-lanes.test.ts` — **5 pass**
- **MUTATION**: restoring the two literal fan-out guards fails **3 of 5** — the renamed positives — while the negative case (`building → drafting` requeue must NOT reconcile) and the legacy-fallback control stay green. That split is the point: the tests fail for the conversion and not for "anything moved".
- `src/__tests__/self-healing*` + `task-agent*` — **43 files / 837 tests pass**
- `tsc --noEmit -p packages/engine` clean
- census `--strict`, `check-lane-wiring` ("none added"), `check-fnxc-future-dates` clean

## Coverage I did not add

The three parameter-threaded predicates are covered for **legacy** behaviour by the existing 822-test self-healing suite (required parameters mean tsc proves every caller passes a set, and the resolved sets are legacy-seeded). I did not add renamed-board cases driven end-to-end through `recoverPausedAbortFailures` / `reclaimPhantomWorkspaceLandLeases` — each needs a full workspace-lease or pause-abort fixture, which is a larger harness than this PR should carry. Stating it rather than implying the new test file covers all five conversions.