### PR TITLE
fleet: name the WIP half of an existing fallback (census 88 → 87)

### DIFF
--- a/packages/engine/src/ephemeral-worker-manager.ts
+++ b/packages/engine/src/ephemeral-worker-manager.ts
@@ -22,6 +22,17 @@
 import type { AgentStore, AgentState, Agent, TaskStore, Task, Settings } from "@fusion/core";
 import { isEphemeralAgent, resolveWorkflowIrForTask, columnsWithFlag } from "@fusion/core";
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-15:45 (fleet — the WIP half of an existing fallback):
+DELIBERATE-LITERAL — the unresolvable-workflow default, alongside `TERMINAL_TASK_COLUMNS`.
+
+That block already answers its terminal question through a named set and its WIP question through an
+inline `!== "in-progress"`. Both are the same documented fallback; only one was counted, because the
+census reads inline comparisons regardless of the branch they sit in while a named set is a
+definition. Naming this one makes the pair consistent and stops it reading as unconverted debt.
+*/
+const LEGACY_WIP_LANES: ReadonlySet<string> = new Set(["in-progress"]);
+
 export interface TaskOwner {
   agentId: string;
   /** True for runtime-spawned workers; false for durable assigned agents. */
@@ -368,7 +379,7 @@ export class EphemeralWorkerManager {
       if (ir === undefined) {
         /* DELIBERATE-LITERAL — the unresolvable-workflow default, reviewed 2026-07-31-06:10. */
         if (TERMINAL_TASK_COLUMNS.has(task.column)) return true;
-        return task.column !== "in-progress";
+        return !LEGACY_WIP_LANES.has(task.column);
       }
       const terminalLanes = new Set<string>([
         ...columnsWithFlag(ir, "complete"),

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -27,7 +27,6 @@
     "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1,
     "packages/dashboard/app/components/TaskCard.tsx": 1,
     "packages/engine/src/backlog-pressure-reporter.ts": 1,
-    "packages/engine/src/ephemeral-worker-manager.ts": 1,
     "packages/engine/src/merger.ts": 1,
     "packages/engine/src/restart-recovery-coordinator.ts": 1,
     "packages/engine/src/runtimes/in-process-runtime.ts": 1,


### PR DESCRIPTION
## Census

| | column guards |
|---|---|
| before | **88** |
| after | **87** |

## What

`ephemeral-worker-manager.ts` answers its unresolvable-workflow default two ways, two lines apart:

```ts
if (TERMINAL_TASK_COLUMNS.has(task.column)) return true;   // named set — not counted
return task.column !== "in-progress";                       // inline — counted
```

Both are the **same documented fallback** — the block carries one `DELIBERATE-LITERAL` marker covering both — but only the inline one was on the backlog, because the census reads comparisons regardless of which branch they sit in while a set is a definition.

Naming it makes the pair consistent and stops the site reading as unconverted debt.

## Correction to my own flag in #3064

I listed `ephemeral-worker-manager`, `backlog-pressure-reporter`, `merge-queue-ops` and `lifecycle-ops` as *"plain unconverted guards with no resolution in scope."*

**That was wrong for all four.** Each already imports the resolvers — 7, 4, 3 and 2 references respectively. I wrote the flag without checking, which is the same mistake as an untested deferral rationale, just inside a PR body instead of an issue.

Re-examined, the other three are genuinely harder rather than unresolved — and these are the real reasons:

- **`backlog-pressure-reporter:197`** classifies a **dependency**, a different row from the one the caller resolved. Per-dependency resolution is needed or it repeats the wrong-row shape that `taskRevert` is blocked on.
- **`lifecycle-ops:655`** guards an emit whose **target** is also a literal (`to: "archived"`). Converting the guard alone leaves the pair inconsistent — the move-target half is invisible to this census.
- **`merge-queue-ops:352`** is an early return on an already-complete task inside a merge path that resolves lanes elsewhere; the placement needs its own judgement about which resolution it should share.

They stay flagged, now with the real reason rather than an unchecked one.

## Measured

| check | result |
|---|---|
| ephemeral-worker suites | green |
| four gates + strict census | green |
| engine `tsc` | clean |