### PR TITLE
fix(core): the merge result reported a column the finaliser did not write (merge-queue-ops 3 → 0)

### DIFF
--- a/packages/core/src/__tests__/merge-blocker-renamed-review-lane.test.ts
+++ b/packages/core/src/__tests__/merge-blocker-renamed-review-lane.test.ts
@@ -183,3 +183,78 @@ pgDescribe("mergeTask resolves the review lane from the task's own workflow", ()
     expect(message).toContain("signoff");
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-15:45:
+THE MERGE RESULT ASSERTED A COLUMN IT DID NOT SET.
+
+`moveToDoneImpl` resolves the board's completion lane and WRITES it onto the task object
+(`task.column = completeColumn`). `mergeTaskImpl` then did
+
+    result.task = { ...task, column: "done" };
+
+putting the literal back over what the writer had just set. Every `task:merged` listener — GitHub
+tracking, the auto-merge handoff — was therefore told the card landed in `done` while the persisted
+row said `shipped`. The row was right and the event was wrong, which is the worse direction: the
+listeners act on the event.
+
+The companion defect is the already-complete short-circuit at the top of the same function, which
+asked `task.column === "done"` while the finaliser it guards asks the RESOLVED question. On a renamed
+board they disagreed, so a card already resting in the completion lane fell through and the merge ran
+again against a branch that was already landed and deleted.
+
+Reached without any git fixture: with no branch present, `git rev-parse --verify` fails and the
+function takes its documented "branch not found — moving to done without merge" path, which is the
+one that calls `moveToDone` and then builds the result.
+*/
+pgDescribe("the merge result reports the column the finaliser actually wrote", () => {
+  let harness: PgTestHarness;
+  let store: TaskStore;
+
+  beforeEach(async () => {
+    harness = await createTaskStoreForTest({ prefix: "fusion_merge_result_lane" });
+    store = harness.store;
+  });
+
+  afterEach(async () => {
+    await harness?.teardown();
+  });
+
+  async function cardInReviewLane(description: string) {
+    const created = await store.createWorkflowDefinition({ name: "renamed merge lanes", ir: RENAMED_IR as never });
+    const task = await store.createTask({ description });
+    await store.selectTaskWorkflow(task.id, created.id);
+    for (const lane of ["backlog", "building", "checking"]) {
+      await store.moveTask(task.id, lane as never, { moveSource: "user" } as never);
+    }
+    expect((await store.getTask(task.id)).column).toBe("checking");
+    return task.id;
+  }
+
+  it("reports the board's completion lane, not the `done` literal", async () => {
+    const id = await cardInReviewLane("merge result column");
+
+    const result = await store.mergeTask(id);
+
+    /* The persisted row and the emitted result must agree. Before the fix the row said `shipped`
+       and this said `done`. */
+    expect((await store.getTask(id)).column).toBe("shipped");
+    expect(result.task.column).toBe("shipped");
+  });
+
+  it("short-circuits a card already resting in the renamed completion lane", async () => {
+    const id = await cardInReviewLane("already complete");
+    await store.mergeTask(id);
+    expect((await store.getTask(id)).column).toBe("shipped");
+
+    /*
+    Second call. Keyed on the `done` literal this guard did not fire on a renamed board, so the card
+    fell through to the merge-blocker check and the operator saw a refusal for a card that had
+    already merged.
+    */
+    const second = await store.mergeTask(id);
+
+    expect(second.merged).toBe(false);
+    expect(second.task.column).toBe("shipped");
+  });
+});

--- a/packages/core/src/task-store/merge-queue-ops.ts
+++ b/packages/core/src/task-store/merge-queue-ops.ts
@@ -13,7 +13,7 @@ import {assertNotWorkspaceTaskMerge} from "../types.js";
 import "../builtin-traits.js";
 import {getTaskMergeBlocker, resolveTaskMergeTarget} from "../task-merge.js";
 import {resolveWorkflowIrForTask} from "../workflow-ir-resolver.js";
-import {resolveReviewColumns} from "../workflow-lifecycle-traits.js";
+import {resolveReviewColumns, resolveTaskLifecycleColumns} from "../workflow-lifecycle-traits.js";
 import {__setTaskActivityLogLimitsForTesting} from "../task-store/comments.js";
 import {assertSafeGitBranchName, assertSafeAbsolutePath} from "../task-store/shell-safety.js";
 import {acquireMergeQueueLease as acquireMergeQueueLeaseAsync} from "../task-store/async-merge-coordination.js";
@@ -349,7 +349,20 @@ export async function mergeTaskImpl(store: TaskStore, id: string): Promise<Merge
       // but assert as defense-in-depth against future id-format changes.
       assertSafeGitBranchName(branch);
 
-      if (task.column === "done") {
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-15:30:
+      THE GUARD MUST AGREE WITH THE WRITER. `moveToDoneImpl` short-circuits on
+      `task.column === completeColumn`, resolved from the task's own workflow; this guard asked the
+      same question with the `done` literal. On a renamed board they DISAGREED — the guard said "not
+      finished" for a card already resting in the board's completion lane, so the merge path ran
+      again against a branch that was already landed and deleted.
+
+      Same resolution, same shape (a single first-match column, not membership), because the point is
+      that these two answers cannot differ. A workflow declaring no complete lane resolves to
+      `undefined`, which matches no column — the finaliser below refuses such a board explicitly.
+      */
+      const alreadyCompleteColumn = (await resolveTaskLifecycleColumns(store, id))?.complete ?? "done";
+      if (task.column === alreadyCompleteColumn) {
         const result: MergeResult = {
           task,
           branch,
@@ -470,7 +483,17 @@ export async function mergeTaskImpl(store: TaskStore, id: string): Promise<Merge
           mergeTargetSource: mergeTarget.source,
         };
         await store.moveToDone(task, dir);
-        result.task = { ...task, column: "done" };
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-15:30:
+        `moveToDone` already WROTE the resolved completion column onto this object
+        (`task.column = completeColumn` in `moveToDoneImpl`). The `column: "done"` override put the
+        literal back, so every `task:merged` listener — GitHub tracking, the auto-merge handoff —
+        was told the card landed in `done` while the persisted row said `shipped`.
+
+        Nothing to resolve here: read back what the writer set. A second resolution would be a second
+        chance to disagree with it.
+        */
+        result.task = { ...task };
         store.emit("task:merged", result);
         return result;
       }
@@ -529,7 +552,9 @@ export async function mergeTaskImpl(store: TaskStore, id: string): Promise<Merge
 
       // 5. Move task to done
       await store.moveToDone(task, dir);
-      result.task = { ...task, column: "done" };
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-15:30: read back what `moveToDone` wrote — see the
+         same override on the no-branch path above. */
+      result.task = { ...task };
 
       store.emit("task:merged", result);
       return result;

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -21,7 +21,6 @@
     "packages/core/src/task-store/audit-ops.ts": 1,
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
-    "packages/core/src/task-store/merge-queue-ops.ts": 1,
     "packages/core/src/task-store/task-artifacts-ops.ts": 1,
     "packages/core/src/task-store/task-id-integrity.ts": 1,
     "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1,
@@ -138,7 +137,6 @@
   },
   "queryByFile": {
     "packages/core/src/task-store/async-persistence.ts": 2,
-    "packages/core/src/task-store/merge-queue-ops.ts": 2,
     "packages/core/src/task-store/archive-lifecycle-2.ts": 1,
     "packages/core/src/task-store/async-archive-lineage.ts": 1,
     "packages/core/src/task-store/async-self-healing.ts": 1,


### PR DESCRIPTION
Largest unclaimed census cluster in `packages/core` — three `done` literals in `mergeTaskImpl`. Two of them produced **wrong state**, not merely a guard that stopped firing.

## 1. The result overrode the writer

`moveToDoneImpl` resolves the board's completion lane and writes it onto the task object:

```ts
task.column = completeColumn;   // task-artifacts-ops.ts
```

Both merge call sites then did:

```ts
result.task = { ...task, column: "done" };
```

putting the literal back over what the writer had just set. Every `task:merged` listener — GitHub tracking, the auto-merge handoff — was told the card landed in `done` while the persisted row said `shipped`.

The row was right and the event was wrong, which is the worse direction: the listeners act on the event, not the row.

Fixed by reading back what the writer set (`{ ...task }`). Deliberately **not** a second resolution — that would only be a second chance to disagree with the finaliser.

## 2. The guard disagreed with the writer

The already-complete short-circuit asked `task.column === "done"`, while the finaliser it guards short-circuits on the resolved `task.column === completeColumn`. On a renamed board those two answers differ, so a card already resting in the board's completion lane fell through and the merge ran again against a branch that was already landed and deleted.

Converted with the **same resolution and the same shape** — a single first-match column, not membership — because the whole point is that these two answers cannot differ. A workflow declaring no complete lane resolves to `undefined`, which matches no column; the finaliser refuses such a board explicitly one function later.

## Census

| | before | after |
|---|---|---|
| `merge-queue-ops.ts` | 3 | **0** |

## Measured

- Two new cases added to `merge-blocker-renamed-review-lane.test.ts` (same renamed-board fixture, same PG harness) — file **5/5 pass**.
- **MUTATION**: restoring either literal fails **both** new cases and leaves the three pre-existing ones green.
- Reached with **no git fixture**: with no branch present, `git rev-parse --verify` fails and the function takes its own documented *"branch not found — moving to done without merge"* path — which is exactly the path that calls `moveToDone` and then builds the result. No repo setup, no flake surface.
- `packages/core` targeted run: **38 tests pass**.
- `tsc --noEmit -p packages/core` clean; census `--strict`, `check-lane-wiring` ("none added"), `check-fnxc-future-dates` clean.

## Not done here (flagged, not guessed)

The other `done`/`archived` literals still in the core census are each blocked for a *different* documented reason, so sweeping them into this PR would have meant guessing:

- `agent-store.ts:236` — a pure formatter over `Pick<Task,"column">` that prints the column for a human; degrades gracefully and has no store to resolve from.
- `async-mission-store-queries.ts` — already converted with caller-threaded lane sets.
- `taskRevert.ts:119` — classifies a **neighbour** task; the only flags in scope describe the modal's own task, so wiring them would answer the question for the wrong row. Needs per-neighbour flags.
- `moves.ts:310` — a **refusal**, where a legacy-seeded superset is the documented hazard rather than the safe direction. Wants its own change with its own test.
- `mission-store.ts:2332` — a sync SQLite path with no async seam.

Each is real debt; none is a mechanical conversion.