### PR TITLE
test(core): re-green the archived-gate parity ratchet (main is red)

### DIFF
--- a/packages/core/src/__tests__/archived-column-gate-parity.test.ts
+++ b/packages/core/src/__tests__/archived-column-gate-parity.test.ts
@@ -107,10 +107,24 @@ const AUDITED_TS_SITES: Readonly<Record<string, number>> = {
  * to exist. Invisible to the column census (not a comparison) and invisible to the Drizzle scan below
  * (not an `eq`/`ne` call), so before this inventory nothing in the repo counted them at all.
  */
+/*
+FNXC:ArchivedGateParity 2026-07-31-17:45 (re-recorded — main was RED on this ratchet):
+Both movements below are REAL removals in the direction this file wants, and both landed without the
+same-commit inventory update the failure message demands. Because this test is not in the merge gate,
+main went red without blocking anything and stayed that way.
+
+  async-mission-store.ts          2 -> 0 (drops out)   #3046 CONVERTED both raw predicates to
+                                                       `archivedLanesFor(...)`, a resolved lane set.
+  task-store/async-archive-lineage.ts  3 -> 2          #3042 DELETED `liveParentFilter` outright — no
+                                                       caller, and it carried `column != 'archived'`.
+
+Verified before re-recording rather than assumed: a count that falls because a gate was silently
+DROPPED looks identical here to one that falls because a gate was converted, and only the first is a
+defect. #3046 replaced its comparisons; #3042 removed a function nothing called.
+*/
 const AUDITED_RAW_SQL_SITES: Readonly<Record<string, number>> = {
   "packages/core/src/async-mission-store-queries.ts": 1,
-  "packages/core/src/async-mission-store.ts": 2,
-  "packages/core/src/task-store/async-archive-lineage.ts": 3,
+  "packages/core/src/task-store/async-archive-lineage.ts": 2,
   "packages/core/src/task-store/async-maintenance.ts": 1,
   "packages/core/src/task-store/reads.ts": 1,
 };
@@ -345,7 +359,18 @@ describe("the archived-state gate is enforced in TypeScript AND in SQL", () => {
     must be counted. An assertion of absence here would have to be deleted by whoever added the next
     raw template, and deleting a red guard is how a class of sites stops being tracked.
     */
+    /*
+    FNXC:ArchivedGateParity 2026-07-31-17:45 (8 -> 5, and why the number is allowed to move):
+    Three raw templates left the tree legitimately — #3046 converted two to a resolved lane set, #3042
+    deleted a dead function carrying a third. The total is a headstone for "this encoding exists and is
+    counted", not a floor; pinning it at a stale 8 would keep main red until someone re-added raw SQL,
+    which is the opposite of the pressure this file wants to apply.
+
+    Lowered only after checking each movement individually — a total that falls because a gate was
+    silently DROPPED is indistinguishable here from one that falls because a gate was CONVERTED, and
+    only the first is a defect. The per-file inventory above records which was which.
+    */
     expect(Object.keys(AUDITED_RAW_SQL_SITES).length).toBeGreaterThan(0);
-    expect(Object.values(AUDITED_RAW_SQL_SITES).reduce((a, b) => a + b, 0)).toBe(8);
+    expect(Object.values(AUDITED_RAW_SQL_SITES).reduce((a, b) => a + b, 0)).toBe(5);
   });
 });


### PR DESCRIPTION
## Main is red on this ratchet, and has been for a while

Scope reduced: this PR now does **one thing**. The `merge-queue-ops.ts` conversion it originally carried is dropped — **#3071** converts that same guard plus two more in the file, and catches a `column: "done"` override in the merge result that mine did not. Superseded; the file is theirs, and I said so on their PR along with one substantive point (their `resolveTaskLifecycleColumns(...).complete` is first-per-role, which misses a second complete lane — the exact class #3065 is fixing one file over).

## What is wrong

`archived-column-gate-parity.test.ts` fails on a **clean checkout of main**. I hit it while doing something unrelated and confirmed it against a stashed tree before touching anything.

Two merged PRs removed raw-SQL `archived` comparisons without the same-commit inventory update the failure message explicitly demands:

| file | move | cause |
|---|---|---|
| `async-mission-store.ts` | 2 → 0 (drops out) | **#3046** converted both raw predicates to `archivedLanesFor(...)`, a resolved lane set |
| `task-store/async-archive-lineage.ts` | 3 → 2 | **#3042** deleted `liveParentFilter` outright — no caller, carried `column != 'archived'` |

Both moved in the direction the ratchet wants. Neither re-recorded.

## Why it went unnoticed

**`pnpm test:gate` passes.** This test is outside the merge gate, so main went red and stayed red without blocking a single PR — during a phase where a dozen PRs are actively editing lane guards.

That is worth a separate decision by whoever owns the gate composition: a parity ratchet whose entire purpose is to catch a split-brain between three encodings of the archived gate is exactly the kind of check that is worthless if nothing consults it. I have not moved it into the gate here — that is a gate-composition change and not mine to make unilaterally.

## What I did, and the part that took the time

Re-recorded the inventory **after verifying each movement individually**. That verification is the entire job, because:

> a count that falls because a gate was silently **dropped** is indistinguishable, from inside this test, from one that falls because a gate was **converted** — and only the first is a defect.

- #3046 **replaced** its two comparisons with a resolved lane set. Legitimate.
- #3042 **deleted** a function nothing called. Legitimate.

Had either been a gate quietly removed from a live path, the correct action would have been to restore it, not to re-record the number.

The companion assertion pinning the raw-SQL total moves **8 → 5**, with the reasoning recorded in place. That total is a headstone for "this encoding exists and is counted", not a floor — leaving it stale would hold main red until somebody re-added raw SQL, which is the opposite of the pressure the file is designed to apply.

## Census before / after

```
before:  COLUMN guards (the backlog):   84
after:   COLUMN guards (the backlog):   84
```

Unchanged — this converts nothing. It restores a red lane to green.

## Verification

`test:gate` exit 0 · `archived-column-gate-parity` **2/2 passed** (was 1 failed / 1 passed on main) · typecheck exit 0 · lifecycle-column census exit 0.

Diff is one test file, 28 insertions. No production file touched.
