### PR TITLE
fix(self-healing): route pause-abort recovery on resolved columns (self-healing 38 → 34)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import "@fusion/core"; // register built-in traits
-import type { Task, TaskStore, WorkflowIr } from "@fusion/core";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
 import { SelfHealingManager } from "../self-healing.js";
 
 /*
@@ -160,5 +160,97 @@ describe("self-healing pre-WIP column vocabulary", () => {
       cache,
     );
     expect(vi.mocked(store.getWorkflowDefinition)).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet — pause-abort router vocabulary):
+The pause-abort recovery router routed on three literals: `in-review` twice (review progress, manual
+merge hold) and `todo || in-progress` (active work). On a renamed board all three stopped matching, so
+a parked card in a renamed lane fell through to `no-action` and was never recovered — silently, and with
+every existing test still green, because they all use the legacy ids.
+
+Each case below asserts the RENAMED lane routes correctly. Reverting any of the three conversions turns
+its case into `no-action`, so these fail if the guards go back to literals.
+
+Note the ACTIVE-WORK set is hold + countsTowardWip, NOT the intake + hold that `resolvePreWipColumns`
+above returns: a card in intake is not mid-flight and must not be requeued as active work. The two sets
+overlap on `hold`, which is exactly why using the wrong one would look right in a legacy-id test.
+*/
+const RENAMED_WITH_REVIEW: WorkflowIr = {
+  version: "v2",
+  name: "renamed-lifecycle-review",
+  columns: [
+    { id: "inbox", name: "Inbox", traits: [{ trait: "intake" }] },
+    { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+    /* Trait names are kebab (`merge`); `mergeOrchestration` is the FLAG that trait sets. */
+    { id: "signoff", name: "Signoff", traits: [{ trait: "merge" }, { trait: "human-review" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+  nodes: [],
+  edges: [],
+} as unknown as WorkflowIr;
+
+const PARK_ERROR =
+  "Workflow graph failure surfaced after paused engine abort during pause/resume in 'todo' at node 'execute' — operator action required; retry or explicitly unpause/resume after inspecting the task";
+
+type PauseAbortInternals = {
+  resolveActiveWorkColumnsFor(taskId: string, cache: Map<string, unknown>): Promise<ReadonlySet<string>>;
+  resolvePauseAbortColumnsFor(taskId: string, cache: Map<string, unknown>): Promise<{ review: ReadonlySet<string>; activeWork: ReadonlySet<string> }>;
+  classifyPausedAbortWorkflowRecovery(
+    task: Task,
+    settings: unknown,
+    isExecuting: boolean,
+    columns: { review: ReadonlySet<string>; activeWork: ReadonlySet<string> },
+  ): { kind: string; reason: string };
+};
+
+const parked = (column: string, steps: Array<{ status: string }> = []): Task => ({
+  id: "FN-9100",
+  column,
+  status: "failed",
+  error: PARK_ERROR,
+  steps,
+} as unknown as Task);
+
+describe("self-healing pause-abort router column vocabulary", () => {
+  const settings = { autoMerge: true } as unknown as Settings;
+
+  it("resolves ACTIVE WORK as hold + wip on a renamed board, excluding intake", async () => {
+    const manager = managerFor(storeFor(RENAMED_WITH_REVIEW)) as unknown as PauseAbortInternals;
+    const active = await manager.resolveActiveWorkColumnsFor("FN-9100", new Map());
+    expect(active.has("backlog")).toBe(true);
+    expect(active.has("building")).toBe(true);
+    // Intake is NOT active work — this is the distinction from resolvePreWipColumns.
+    expect(active.has("inbox")).toBe(false);
+  });
+
+  it("requeues a park sitting in a RENAMED wip lane", async () => {
+    const manager = managerFor(storeFor(RENAMED_WITH_REVIEW)) as unknown as PauseAbortInternals;
+    const columns = await manager.resolvePauseAbortColumnsFor("FN-9100", new Map());
+    const route = manager.classifyPausedAbortWorkflowRecovery(parked("building"), settings, false, columns);
+    expect(route).toEqual({ kind: "node-requeue", reason: "pause-abort-active-work" });
+  });
+
+  it("resumes a completed park sitting in a RENAMED review lane", async () => {
+    const manager = managerFor(storeFor(RENAMED_WITH_REVIEW)) as unknown as PauseAbortInternals;
+    const columns = await manager.resolvePauseAbortColumnsFor("FN-9100", new Map());
+    const task = parked("signoff", [{ status: "done" }, { status: "done" }]);
+    const route = manager.classifyPausedAbortWorkflowRecovery(task, settings, false, columns);
+    expect(route).toEqual({ kind: "work-item-resume", reason: "pause-abort-review-progress" });
+  });
+
+  /*
+  The degraded path is the reason both resolvers union the legacy ids: an unreadable workflow must keep
+  its former recovery behaviour rather than resolve an empty set and go inert.
+  */
+  it("keeps recovering legacy-id boards when the workflow is unresolvable", async () => {
+    const manager = managerFor(storeFor(undefined)) as unknown as PauseAbortInternals;
+    const columns = await manager.resolvePauseAbortColumnsFor("FN-9100", new Map());
+    expect(manager.classifyPausedAbortWorkflowRecovery(parked("in-progress"), settings, false, columns).kind)
+      .toBe("node-requeue");
+    expect(manager.classifyPausedAbortWorkflowRecovery(parked("todo"), settings, false, columns).kind)
+      .toBe("node-requeue");
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -949,10 +949,49 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     super();
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet):
+  `columns` is REQUIRED, not optional-with-a-literal-fallback. This router is called from exactly two
+  places — the candidate filter and the post-re-read re-verify — and they must agree: an optional
+  parameter lets one caller resolve and the other default, and the disagreement shows up as a recovery
+  that selects a card and then declines to act on it, with nothing logged. Requiring it makes that
+  divergence a compile error instead of a silent no-op. Degraded resolution is handled inside the two
+  resolvers, which union the legacy ids, so "required" never means "callers must invent a column set".
+  */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet):
+  The column-FREE half of the pause-abort predicate, split out so the sweep can identify candidate rows
+  without reading a workflow IR for every task on the board. It tests only the two error markers, which
+  is what makes it safe to run over the full list.
+
+  Deliberately NOT the whole guard: it omits the paused/executing checks as well as the column routing,
+  because it is a prefilter and `classifyPausedAbortWorkflowRecovery` remains the single authority on
+  whether a row is actually recoverable. Widening it into a second authority is how the filter and the
+  re-verify drift apart.
+  */
+  private isPauseAbortParkCandidate(task: Task): boolean {
+    return task.status === "failed"
+      && typeof task.error === "string"
+      && task.error.includes(PAUSE_ABORT_PARK_OPERATOR_MARKER)
+      && task.error.includes(PAUSE_ABORT_PARK_ERROR_MARKER);
+  }
+
+  /** The review + active-work sets the pause-abort router needs, resolved together over one IR cache. */
+  private async resolvePauseAbortColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<{ review: ReadonlySet<string>; activeWork: ReadonlySet<string> }> {
+    return {
+      review: await this.resolveReviewColumnsFor(taskId, cache),
+      activeWork: await this.resolveActiveWorkColumnsFor(taskId, cache),
+    };
+  }
+
   private classifyPausedAbortWorkflowRecovery(
     task: Task,
     settings: Settings,
     isExecuting: boolean,
+    columns: { review: ReadonlySet<string>; activeWork: ReadonlySet<string> },
   ): WorkflowRecoveryRoute {
     const isPausedAbortPark =
       task.status === "failed" &&
@@ -973,13 +1012,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.steps.every((step) => step.status === "done" || step.status === "skipped");
     const sharedBranchMember = isSharedBranchGroupMemberIntegration(task);
     const hasReviewProgress =
-      task.column === "in-review"
+      columns.review.has(task.column)
       && allowsAutoMergeProcessing(task, settings)
       && task.mergeDetails?.mergeConfirmed !== true
       && !isTerminalMergePark
       && completedSteps;
     const hasManualMergeHoldProgress =
-      task.column === "in-review"
+      columns.review.has(task.column)
       && (!allowsAutoMergeProcessing(task, settings) || resolveEffectiveAutoMerge(task, settings) === false)
       && !sharedBranchMember
       && task.mergeDetails?.mergeConfirmed !== true
@@ -1002,7 +1041,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     if (hasReviewProgress) {
       return { kind: "work-item-resume", reason: "pause-abort-review-progress" };
     }
-    if (task.column === "todo" || task.column === "in-progress") {
+    if (columns.activeWork.has(task.column)) {
       return { kind: "node-requeue", reason: "pause-abort-active-work" };
     }
     return { kind: "no-action", reason: "unsafe-or-not-routable" };
@@ -3106,6 +3145,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
     } catch {
       /* degraded: the legacy id alone, matching resolvePreWipColumns' catch */
+    }
+    return columns;
+  }
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet — the active-work sibling of `resolveReviewColumnsFor`):
+  MEMBERSHIP for the same arity reason its review sibling documents: a board may declare more than one
+  pre-review working lane, and first-per-role would silently ignore the second.
+
+  "Active work" is deliberately hold + countsTowardWip, NOT `resolvePreWipColumns`' intake + hold. The
+  pause-abort router asks "is this card mid-flight, so a requeue is the right recovery?", and an intake
+  lane is not mid-flight while a WIP lane is. Reusing the intake-shaped helper here would have widened the
+  requeue to triage rows and dropped in-progress ones — the same set, wrong members.
+
+  Unioned with the legacy ids because `resolveWorkflowIrForTask` answers a missing/corrupt workflow with the
+  BUILT-IN IR rather than throwing: without the union, a degraded board resolves a set excluding its own
+  working lanes and this recovery goes inert exactly when it is most needed.
+  */
+  private async resolveActiveWorkColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<ReadonlySet<string>> {
+    const columns = new Set<string>(["todo", "in-progress"]);
+    try {
+      const ir = await resolveWorkflowIrForTask(this.store, taskId, cache);
+      if (ir) {
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.hold) columns.add(lifecycle.hold);
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) columns.add(id);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching resolveReviewColumnsFor's catch */
     }
     return columns;
   }
@@ -12045,9 +12116,26 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const tasks = await this.store.listTasks({ slim: true });
 
-      const parked = tasks.filter((t) =>
-        this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id)).kind !== "no-action",
-      );
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet):
+      Resolution is per task (each card may run a different workflow), so it cannot hoist out of the
+      loop — but it also must not run for every row on the board. The pause-abort park is identified by
+      error MARKERS, which are column-independent, so the marker test stays a cheap synchronous prefilter
+      and the IR is read only for the handful of rows that pass it. The shared `cache` then makes the
+      re-verify below free for those same rows.
+
+      `parked` keeps its exact former membership, so the count in the log line below still means what it
+      said before this conversion.
+      */
+      const columnCache = new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>();
+      const parked: Task[] = [];
+      for (const t of tasks) {
+        if (!this.isPauseAbortParkCandidate(t)) continue;
+        const columns = await this.resolvePauseAbortColumnsFor(t.id, columnCache);
+        if (this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id), columns).kind !== "no-action") {
+          parked.push(t);
+        }
+      }
 
       if (parked.length === 0) return 0;
 
@@ -12083,7 +12171,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             log.debug(`[self-healing] deferring pause-abort recovery for ${fresh.id}: a live session surface is registered`);
             continue;
           }
-          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id));
+          const freshColumns = await this.resolvePauseAbortColumnsFor(fresh.id, columnCache);
+          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id), freshColumns);
           if (route.kind === "no-action") {
             continue;
           }


### PR DESCRIPTION
First real cut into `self-healing.ts`, the last large cluster. Converts the **pause-abort recovery router** — a coherent unit with one owner, rather than a scattered pass.

## Census before/after

| Metric | Before | After |
|---|---:|---:|
| COLUMN guards (backlog) | 86 | **82** |
| `self-healing.ts` | 38 | **34** |

## The bug this was hiding

The router keyed on three literals — `in-review` twice (review progress, manual merge hold) and `todo || in-progress` (active work). On a renamed board **all three stop matching**, so a parked card in a renamed lane falls through to `no-action` and is never recovered — silently, no log line, and with every existing test still green because they all use legacy ids.

## Conversion

Used the file's own resolvers. `resolveReviewColumnsFor` already existed; added `resolveActiveWorkColumnsFor` as its sibling from the same `columnsWithFlag` / `resolveLifecycleColumns` helpers — no new vocabulary.

**ACTIVE WORK is hold + `countsTowardWip`, deliberately NOT the intake + hold that the neighbouring `resolvePreWipColumns` returns.** The router asks *"is this card mid-flight, so a requeue is right?"* — an intake lane is not mid-flight; a WIP lane is. Reusing the intake-shaped helper would have widened the requeue to triage rows and dropped in-progress ones. Because the two sets **overlap on `hold`**, that mistake looks correct in every legacy-id test. This is the trap worth knowing about for the rest of the file: it has several resolvers, and picking the nearest one is not the same as picking the right one.

**`columns` is required, not optional-with-a-fallback.** The router has exactly two callers — the candidate filter and the post-re-read re-verify — and they must agree. An optional parameter lets one resolve and the other default, and that divergence surfaces as a sweep that selects a card and then declines to act on it, writing nothing. Required makes it a compile error. (Same reasoning as #3059; safe here because both resolvers union the legacy ids internally, so "required" never means callers invent a column set.)

**On the filter/re-verify hazard I flagged earlier:** both call sites are the *same function*, so converting it once keeps them consistent by construction — no split-CAS risk. Per-task resolution can't hoist out of the loop but must not read an IR per row, so the marker test (column-independent) stays a cheap sync prefilter and the IR is read only for rows that pass it, over a shared cache. `parked` keeps its exact former membership, so the log count still means what it said.

## Verification

- **Revert-proof:** reverting the three guards to literals fails 2 of 3 routing cases. The third exercises the new resolver directly, so it cannot fail on revert — stated rather than counted as evidence.
- 4 self-healing suites, **437 tests green**
- `tsc --noEmit` clean; eslint clean
- Degraded-resolution case included, since the legacy-id union is what keeps recovery alive on an unreadable workflow

## Still flagged in this file (not guessed)

34 remain. They are not one batch: the sweeps around L2855/3297/8877/9018 depend on the unowned `listTasks({ column })` decision, and L5330/5359 sit under the FN-5256 liveness guard whose own comment says those columns can be live when the heuristic calls them stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)