### PR TITLE
fleet(engine): self-healing 25 → 11 — four more async sweeps resolved by role

### DIFF
--- a/packages/engine/src/__tests__/self-healing-orphaned-pending-step-results.test.ts
+++ b/packages/engine/src/__tests__/self-healing-orphaned-pending-step-results.test.ts
@@ -58,7 +58,26 @@ function task(id: string, overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-function storeFor(tasks: Task[]): TaskStore & EventEmitter {
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-17:55:
+A board whose implementation lane is `building`. Supplied through `listWorkflowDefinitions`, which is
+the ONLY store read `resolveProjectColumnsForRoles` makes — a project-wide async read that works under
+PostgreSQL, unlike the sync workflow-SELECTION reader that makes `resolveTaskWorkflowIrSync`-based
+conversions inert. Using the async helper here is what makes the conversion real rather than decorative.
+*/
+const RENAMED_WIP_IR = {
+  version: "v2",
+  id: "custom:wf",
+  nodes: [],
+  edges: [],
+  columns: [
+    { id: "drafting", name: "drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "checking", name: "checking", traits: [{ trait: "merge" }] },
+  ],
+};
+
+function storeFor(tasks: Task[], workflowIr?: unknown): TaskStore & EventEmitter {
   const tasksById = new Map(tasks.map((entry) => [entry.id, entry]));
   return Object.assign(new EventEmitter(), {
     getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false } as Settings)),
@@ -70,6 +89,8 @@ function storeFor(tasks: Task[]): TaskStore & EventEmitter {
       return all.slice(offset, offset + limit);
     }),
     getTask: vi.fn(async (id: string) => tasksById.get(id)),
+    /* Absent → the helper keeps the legacy ids, which is every other case in this file. */
+    ...(workflowIr ? { listWorkflowDefinitions: vi.fn(async () => [{ ir: workflowIr }]) } : {}),
     updateTask: vi.fn(async (id: string, patch: Partial<Task>) => {
       const next = { ...tasksById.get(id)!, ...patch } as Task;
       tasksById.set(id, next);
@@ -255,5 +276,47 @@ describe("review-gate lease liveness (in-review gates)", () => {
     expect(await manager.reconcileOrphanedPendingStepResults()).toBe(1);
     const after = await store.getTask("FN-NO-OWNER");
     expect(after?.workflowStepResults?.[0]?.status).toBe("failed");
+  });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-17:55:
+  THE EXECUTOR-OWNED SKIP MUST FOLLOW A RENAMED IMPLEMENTATION LANE.
+
+  This sweep REWRITES `pending` step results to `failed`. It skips implementation-lane rows because
+  they are executor-owned and their liveness is unprovable here — a skip that was keyed on the
+  `in-progress` literal. On a board whose wip lane is named anything else the skip did not apply, so
+  the sweep rewrote a live executor's pending results out from under it, closing the merge gate on a
+  step that was still running.
+
+  Both legs are asserted: the page-snapshot guard and the re-read guard. They are separate `continue`s
+  and either one alone would let this pass while the other stayed literal.
+  */
+  it("skips an executor-owned row resting in a RENAMED implementation lane", async () => {
+    const live = task("FN-RENAMED-WIP", {
+      column: "building",
+      workflowStepResults: [stepResult({ status: "pending", startedAt: new Date().toISOString() })],
+    });
+    const store = storeFor([live], RENAMED_WIP_IR);
+    const manager = new SelfHealingManager(store, "/repo", {} as never);
+
+    expect(await manager.reconcileOrphanedPendingStepResults()).toBe(0);
+    expect((await store.getTask("FN-RENAMED-WIP"))?.workflowStepResults?.[0]?.status).toBe("pending");
+  });
+
+  /*
+  The paired negative. The conversion widens membership, so it must not turn every lane into a skip:
+  a card in the same board's REVIEW lane with a dead session is still an orphan and must still be
+  rewritten, or the fix trades one silent failure for another.
+  */
+  it("still rewrites an orphan in a renamed lane that is NOT the implementation lane", async () => {
+    const stranded = task("FN-RENAMED-REVIEW", {
+      column: "checking",
+      workflowStepResults: [stepResult({ status: "pending", startedAt: new Date().toISOString() })],
+    });
+    const store = storeFor([stranded], RENAMED_WIP_IR);
+    const manager = new SelfHealingManager(store, "/repo", {} as never);
+
+    expect(await manager.reconcileOrphanedPendingStepResults()).toBe(1);
+    expect((await store.getTask("FN-RENAMED-REVIEW"))?.workflowStepResults?.[0]?.status).toBe("failed");
   });
 });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -5347,6 +5347,19 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return 0;
 
       const allTasks = await this.store.listTasks({ slim: true, includeArchived: false });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:30:
+      Three resolved MEMBERSHIP sets for this sweep's three lane questions, resolved once through the
+      ASYNC helper (this method is async; nothing here needs the inert sync IR path).
+
+      All three are EXCLUSIONS — "skip a finished card", "skip an active card", "do not treat an
+      active card as scope-override-safe". Legacy seeding is safe in that direction: a superset skips
+      MORE, and skipping is this sweep's no-op. The opposite direction — a seeded set widening a
+      REFUSAL — is the documented hazard and does not apply here.
+      */
+      const worktreeFinishedColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
+      const worktreeWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
+      const worktreeReviewColumns = await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES);
       const branchMap = await getRegisteredWorktreeBranchMap(this.options.rootDir);
       // FN-5256: macOS git surfaces realpath-normalized worktree paths (/private/var/...)
       // while task.worktree may be persisted as the symlinked path. Compare on realpath
@@ -5366,7 +5379,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
       for (const task of allTasks) {
         if (!task.worktree) continue;
-        if (!options?.includeTaskIds?.has(task.id) && (task.column === "done" || task.column === "archived")) {
+        if (!options?.includeTaskIds?.has(task.id) && worktreeFinishedColumns.has(task.column)) {
           continue;
         }
 
@@ -5403,8 +5416,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const scopeOverrideMergeActiveSafe =
           task.scopeOverride === true
-          && task.column !== "in-progress"
-          && (task.column !== "in-review" || (typeof task.status === "string" && RECONCILE_SCOPE_OVERRIDE_MERGE_ACTIVE_STATUS_SET.has(task.status)));
+          && !worktreeWipColumns.has(task.column)
+          && (!worktreeReviewColumns.has(task.column) || (typeof task.status === "string" && RECONCILE_SCOPE_OVERRIDE_MERGE_ACTIVE_STATUS_SET.has(task.status)));
         if (scopeOverrideMergeActiveSafe) {
           /*
           FNXC:MissingWorktreeRecovery 2026-07-10-18:23:
@@ -5432,7 +5445,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         // live task's worktree looks stale here (and we couldn't rebind to a live
         // fusion/<id>), the executor's own recovery paths will detect and recreate
         // it. Clearing here yanks the worktree from a still-running shell.
-        if (task.column === "in-progress" || task.column === "in-review") {
+        if (worktreeWipColumns.has(task.column) || worktreeReviewColumns.has(task.column)) {
           await this.emitWorktreeMetadataAuditEvent({
             taskId: task.id,
             mutationType: "task:auto-recover-worktree-metadata-skipped-active",
@@ -7402,6 +7415,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
   async reconcileOrphanedPendingStepResults(): Promise<number> {
     try {
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:35:
+      Resolved WIP MEMBERSHIP for the two executor-owned skips below. Both are EXCLUSIONS — a card in
+      an implementation lane is executor-owned and this sweep must not touch it — so a legacy-seeded
+      superset skips more, which is this sweep's no-op. Keyed on the `in-progress` literal, a renamed
+      board let this sweep rewrite pending step results out from under a live executor.
+      */
+      const orphanedStepWipColumns = await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]);
       const pageSize = 500;
       let offset = 0;
       let recovered = 0;
@@ -7422,14 +7443,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           // An operator park is authoritative; this sweep must not reach through it.
           if (task.userPaused === true) continue;
           // Executor-owned rows: resume is deferred at startup, liveness unprovable here.
-          if (task.column === "in-progress") continue;
+          if (orphanedStepWipColumns.has(task.column)) continue;
           if (!task.workflowStepResults?.some((result) => result.status === "pending")) continue;
           if (isSessionLive(task.id)) continue;
 
           // Re-read the live row before mutating: the page snapshot can be stale against
           // a merger/planner that wrote a fresh pending lease after the page was fetched.
           const fresh = await this.store.getTask(task.id);
-          if (!fresh || fresh.userPaused === true || fresh.column === "in-progress") continue;
+          if (!fresh || fresh.userPaused === true || orphanedStepWipColumns.has(fresh.column)) continue;
           /*
           FNXC:WorkflowReviewGates 2026-07-26-15:50:
           Honor a LIVE review-gate lease, not just in-process session liveness.
@@ -9861,13 +9882,25 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (settings.globalPause || settings.enginePaused) return 0;
 
       const now = Date.now();
+      /* FNXC:WorkflowResolvedColumns 2026-07-31-17:40: resolved once per sweep — see the guard below. */
+      const preExecLiveColumns = await resolveProjectColumnsForRoles(
+        this.store,
+        ["intake", "hold", "countsTowardWip", ...REVIEW_ROLES, "complete"],
+      );
       const parked = await this.store.listTasks({ slim: true });
       const candidates = parked.filter((task) => {
         if (!task.worktree || task.deletedAt) return false;
         // Execution evidence — the worktree may hold real work; only the merge/archive lifecycle owns it.
         if (task.firstExecutionAt || task.executionStartedAt) return false;
-        // Columns where a card is active or queued to become active.
-        if (task.column === "todo" || task.column === "in-progress" || task.column === "in-review" || task.column === "done") return false;
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-17:40:
+        Columns where a card is active or queued to become active — resolved MEMBERSHIP, replacing
+        the four-id literal. This is an EXCLUSION from a destructive sweep, so a legacy-seeded
+        superset excludes MORE and can only be conservative; the literal's failure mode was the
+        dangerous direction, treating a live card on a renamed board as pre-execution and removing
+        its worktree.
+        */
+        if (preExecLiveColumns.has(task.column)) return false;
         /*
         WAITING is not PARKED. A card paused for an operator decision, carrying any status (planning,
         needs-replan, awaiting-*), blocked on another task, or scheduled for a recovery attempt is
@@ -14276,6 +14309,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       this.options.evictStaleTriageProcessing?.();
 
       const tasks = await this.store.listTasks({ slim: true, includeArchived: false });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:40:
+      Resolved WAITING membership for the two peer-progress counts below. The question is "are OTHER
+      queued cards moving while this refinement card starves", so it must include every lane a card
+      can wait in — hold and intake. Keyed on `todo` alone, a renamed board counted zero peers and
+      the starvation escalation never fired.
+      */
+      const starvedWaitingColumns = await resolveProjectColumnsForRoles(this.store, ["hold", "intake"]);
       const planningIds = this.options.getPlanningTaskIds?.() ?? new Set<string>();
       const now = Date.now();
 
@@ -14299,7 +14340,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const peerProgressCount = tasks.filter((peer) =>
           peer.id !== task.id &&
-          peer.column === "todo" &&
+          starvedWaitingColumns.has(peer.column) &&
           peer.sourceType !== "task_refine" &&
           new Date(peer.updatedAt).getTime() > createdAtMs,
         ).length;
@@ -14320,7 +14361,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const createdAtMs = new Date(task.createdAt).getTime();
           const peerProgressCount = tasks.filter((peer) =>
             peer.id !== task.id &&
-            peer.column === "todo" &&
+            starvedWaitingColumns.has(peer.column) &&
             peer.sourceType !== "task_refine" &&
             new Date(peer.updatedAt).getTime() > createdAtMs,
           ).length;

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 25,
+    "packages/engine/src/self-healing.ts": 11,
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/executor.ts": 4,
     "packages/core/src/task-store/moves.ts": 2,


### PR DESCRIPTION
Stacked on #3074. Retarget to `main` once that merges.

## The distinction that decides whether a conversion is real

`resolveProjectColumnsForRoles`' **only** store read is `listWorkflowDefinitions()` — a project-wide **async** read that works under PostgreSQL. Every conversion here goes through it.

That is the line #3058 drew and I re-verified: the **sync** `resolveTaskWorkflowIrSync` path cannot read a workflow selection (`getTaskWorkflowSelectionImpl` returns `undefined` unconditionally), so it answers with the default builtin IR and anything routed through it changes nothing. The new test in this PR supplies its renamed board through `listWorkflowDefinitions` specifically so it exercises the path production actually takes.

## Converted

| sweep | guards | what the literal cost |
|---|---|---|
| `reconcileTaskWorktreeMetadata` | 3 | finished-skip, scope-override merge-active predicate, active-card metadata-clear veto |
| `reconcileOrphanedPendingStepResults` | 2 | **rewrote a live executor's pending step results to `failed`** on any renamed board |
| `reconcilePreExecutionWorktrees` | 1 | a four-id literal in a sweep that **removes worktrees** |
| `recoverStarvedRefinementTriageTasks` | 2 | counted zero peers, so starvation escalation never fired |

The orphaned-step one is the sharpest. That sweep does not skip work — it **rewrites** `pending` results to `failed`. The implementation-lane skip exists because those rows are executor-owned and unprovable from here. Keyed on the `in-progress` literal, a renamed board bypassed the skip entirely and the sweep closed the merge gate on a step that was still running. **Both legs are converted** — the page-snapshot guard and the re-read guard are separate `continue`s, and either left literal would keep the hole open.

## Why legacy seeding is safe here

Every one of these is an **exclusion** — "skip a finished card", "skip an active card", "do not treat an active card as scope-override-safe", "this card is not pre-execution". A legacy-seeded superset skips *more*, and skipping is the no-op in all four sweeps. The hazardous direction — a seeded set widening a **refusal** so it blocks legitimate work, the shape `node-override-guard.ts` documents — does not apply.

## Census

| | before | after |
|---|---|---|
| `self-healing.ts` | 25 | **11** |
| repo backlog | 75 | **61** |

## Measured

- Two new cases in `self-healing-orphaned-pending-step-results.test.ts` — file **10/10 pass**.
- **MUTATION**: restoring the `in-progress` literal fails the renamed-lane case and leaves its paired negative green. The negative matters: a card in the same board's *review* lane with a dead session is still an orphan and must still be rewritten, so the fix cannot have simply turned the skip on for everything.
- `src/__tests__/self-healing*` + `task-agent*` — **42 files / 835 tests pass**.
- `tsc --noEmit -p packages/engine` clean; **`check-inert-sync-lane-conversions` exits 0**; census `--strict`, `check-lane-wiring`, `check-fnxc-future-dates` clean.

## What is left in this file (11), and why

- **4 — the `task:moved` fan-out.** Sync listener; the conversion is inert and was withdrawn in #3074 with the refutation recorded in place. Blocked on a sync-capable selection reader.
- **1 — the log-dedup closure (~line 5970).** Pre-existing flag: it sits before the lane prefetch it would need, and the degraded answer costs a duplicate log line, not a lifecycle decision.
- **1 — the synthetic `{ column: "todo" }`** for a *missing* task, deliberate and documented in #3074.
- The rest are status/deliberate classifications the census counts but that are not lane guards.