### PR TITLE
fix(self-healing): route the task:moved fan-out on resolved lanes (self-healing 34 → 24)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -254,3 +254,75 @@ describe("self-healing pause-abort router column vocabulary", () => {
       .toBe("node-requeue");
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet — task:moved fan-out vocabulary):
+The fan-out routed on five literals. On a renamed board all of it went inert at once — the board-stall
+counter stopped counting, in-review rebind stopped firing, completed-task reconciliation stopped running
+— and none of that fails a test, because the move itself still happens.
+
+The sync/async split below is asserted deliberately. The counter MUST increment synchronously:
+`runBoardStallAutoRecoverySweep` makes its own recovery moves and then reads the counter in the same
+pass, so an increment deferred behind an await is read as a stale zero and a real recovery is reported
+as unrecovered. That is not hypothetical — it is what board-stall-auto-recovery.test.ts caught when this
+conversion first put the whole listener behind one await.
+*/
+describe("self-healing task:moved fan-out column vocabulary", () => {
+  type FanoutInternals = {
+    resolveMoveFanoutColumnsSync(taskId: string): { wip: ReadonlySet<string>; review: ReadonlySet<string>; complete: ReadonlySet<string>; archived: ReadonlySet<string>; hold: ReadonlySet<string> };
+    handleTaskMovedFanout(task: Task, from: string, to: string): Promise<void>;
+    reconcileInReviewBranchRebind: unknown;
+    reconcileCompletedTask: unknown;
+  };
+
+  function syncStoreFor(ir?: WorkflowIr): TaskStore {
+    return {
+      ...storeFor(ir),
+      resolveTaskWorkflowIrSync: vi.fn(() => ir),
+    } as unknown as TaskStore;
+  }
+
+  it("resolves every fan-out lane from a renamed board", () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const c = manager.resolveMoveFanoutColumnsSync("FN-9200");
+    expect(c.wip.has("building")).toBe(true);
+    expect(c.review.has("signoff")).toBe(true);
+    expect(c.complete.has("shipped")).toBe(true);
+    expect(c.hold.has("backlog")).toBe(true);
+  });
+
+  it("keeps legacy ids when the store cannot resolve synchronously", () => {
+    const manager = managerFor(storeFor(undefined)) as unknown as FanoutInternals;
+    const c = manager.resolveMoveFanoutColumnsSync("FN-9200");
+    expect(c.wip.has("in-progress")).toBe(true);
+    expect(c.review.has("in-review")).toBe(true);
+    expect(c.complete.has("done")).toBe(true);
+  });
+
+  it("fires the in-review rebind for a move into a RENAMED review lane", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const rebind = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = rebind;
+    manager.reconcileCompletedTask = vi.fn(async () => undefined);
+    await manager.handleTaskMovedFanout(task("FN-9200", "signoff"), "building", "signoff");
+    expect(rebind).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles completion across RENAMED review -> complete and complete -> archived", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const reconcile = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = vi.fn(async () => undefined);
+    manager.reconcileCompletedTask = reconcile;
+    await manager.handleTaskMovedFanout(task("FN-9200", "shipped"), "signoff", "shipped");
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconcile completion on an unrelated renamed move", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const reconcile = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = vi.fn(async () => undefined);
+    manager.reconcileCompletedTask = reconcile;
+    await manager.handleTaskMovedFanout(task("FN-9200", "building"), "backlog", "building");
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -976,6 +976,84 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.error.includes(PAUSE_ABORT_PARK_ERROR_MARKER);
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:05 (fleet — task:moved fan-out vocabulary):
+  The lane sets the `task:moved` fan-out routes on. MEMBERSHIP throughout, for the arity reason
+  `resolveReviewColumnsFor` documents, and unioned with the legacy ids so a degraded IR keeps the
+  fan-out firing rather than silently resolving empty sets.
+
+  `wip` is `countsTowardWip` rather than the `wip` trait: the counter it feeds measures cards LEAVING the
+  working lane, which is the same population the WIP cap governs. A board declaring a second working lane
+  outside the cap should not have exits from it counted as board progress.
+  */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet):
+  The synchronous twin of `resolveMoveFanoutColumnsFor`, for the one caller that cannot await: the
+  board-stall counter, whose increment must be visible to a sweep already in progress.
+
+  `resolveTaskWorkflowIrSync` is the same seam `scheduler.ts` uses for its own sync lane resolution. A
+  store that does not implement it, or a workflow that will not resolve, yields the legacy ids — the
+  degraded answer every resolver in this file gives, and the one that keeps the counter counting rather
+  than silently flat-lining board-stall detection.
+  */
+  private resolveMoveFanoutColumnsSync(taskId: string): {
+    wip: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+    hold: ReadonlySet<string>;
+  } {
+    const wip = new Set<string>(["in-progress"]);
+    const review = new Set<string>(["in-review"]);
+    const complete = new Set<string>(["done"]);
+    const archived = new Set<string>(["archived"]);
+    const hold = new Set<string>(["todo"]);
+    try {
+      const ir = this.store.resolveTaskWorkflowIrSync?.(taskId);
+      if (ir) {
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) wip.add(id);
+        for (const id of columnsWithFlag(ir, "mergeOrchestration")) review.add(id);
+        for (const id of columnsWithFlag(ir, "humanReview")) review.add(id);
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.complete) complete.add(lifecycle.complete);
+        if (lifecycle?.archived) archived.add(lifecycle.archived);
+        if (lifecycle?.hold) hold.add(lifecycle.hold);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching the async siblings' catch */
+    }
+    return { wip, review, complete, archived, hold };
+  }
+
+  private async resolveMoveFanoutColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<{
+    wip: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+    hold: ReadonlySet<string>;
+  }> {
+    const wip = new Set<string>(["in-progress"]);
+    const complete = new Set<string>(["done"]);
+    const archived = new Set<string>(["archived"]);
+    const hold = new Set<string>(["todo"]);
+    try {
+      const ir = await resolveWorkflowIrForTask(this.store, taskId, cache);
+      if (ir) {
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) wip.add(id);
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.complete) complete.add(lifecycle.complete);
+        if (lifecycle?.archived) archived.add(lifecycle.archived);
+        if (lifecycle?.hold) hold.add(lifecycle.hold);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching the sibling resolvers' catch */
+    }
+    return { wip, review: await this.resolveReviewColumnsFor(taskId, cache), complete, archived, hold };
+  }
+
   /** The review + active-work sets the pause-abort router needs, resolved together over one IR cache. */
   private async resolvePauseAbortColumnsFor(
     taskId: string,
@@ -1523,28 +1601,32 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     };
     this.store.on("settings:updated", this.settingsListener);
 
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet):
+    Split deliberately by OBSERVABILITY, not by convenience.
+
+    The board-stall counter is incremented SYNCHRONOUSLY, because it is not merely read by a later
+    periodic sweep — `runBoardStallAutoRecoverySweep` performs its own recovery moves and then evaluates
+    progress in the SAME pass, so the increment must land before that read. Deferring it behind an await
+    made the sweep read a stale zero and report a real recovery as unrecovered (caught by
+    board-stall-auto-recovery.test.ts, which is why the sync resolver is used here).
+
+    The two reconcile branches were already fire-and-forget before this change, so they keep that shape
+    and resolve asynchronously.
+    */
     this.taskMovedFanoutListener = ({ task, from, to }) => {
+      const sync = this.resolveMoveFanoutColumnsSync(task.id);
       if (
-        from === "in-progress"
-        && (to === "todo" || to === "in-review" || to === "done" || to === "archived")
+        sync.wip.has(from)
+        && (sync.hold.has(to) || sync.review.has(to) || sync.complete.has(to) || sync.archived.has(to))
         && this.boardStallWindow
       ) {
         // In-memory only counter; resets on engine restart.
         this.boardStallWindow.transitionsOutOfInProgressInWindow++;
       }
-      if (to === "in-review") {
-        void this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) }).catch((err: unknown) => {
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
-        });
-      }
-      const shouldReconcile =
-        (from === "in-review" && to === "done") ||
-        (from === "done" && to === "archived");
-      if (!shouldReconcile) return;
-      void this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined }).catch((err: unknown) => {
+      void this.handleTaskMovedFanout(task, from, to).catch((err: unknown) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        log.warn(`[self-healing] task:moved completion fan-out failed for ${task.id}: ${errorMessage}`);
+        log.warn(`[self-healing] task:moved fan-out failed for ${task.id}: ${errorMessage}`);
       });
     };
     this.store.on("task:moved", this.taskMovedFanoutListener);
@@ -1553,6 +1635,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     this.startMaintenance();
 
     log.debug("Started");
+  }
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:05 (fleet):
+  The `task:moved` fan-out, routed on the moving task's own resolved lanes instead of the five literals
+  it used to compare against. On a renamed board every branch here went inert at once: the board-stall
+  counter stopped counting, in-review rebind stopped firing, and completed-task reconciliation stopped
+  running -- none of which fails a test, because the move still happens.
+
+  One IR read per move event, not per branch: the three branches share a cache.
+  */
+  private async handleTaskMovedFanout(task: Task, from: string, to: string): Promise<void> {
+    const columns = await this.resolveMoveFanoutColumnsFor(task.id, new Map());
+
+    if (columns.review.has(to)) {
+      try {
+        await this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) });
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
+      }
+    }
+    const shouldReconcile =
+      (columns.review.has(from) && columns.complete.has(to)) ||
+      (columns.complete.has(from) && columns.archived.has(to));
+    if (!shouldReconcile) return;
+    try {
+      await this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined });
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.warn(`[self-healing] task:moved completion fan-out failed for ${task.id}: ${errorMessage}`);
+    }
   }
 
   /**


### PR DESCRIPTION
Second cut into `self-healing.ts`. **Stacked on #3075** — review that first; this diff is only the fan-out.

## Census

| Metric | Start of session | Now |
|---|---:|---:|
| COLUMN guards (backlog) | 88 | **72** |
| `self-healing.ts` | 38 | **24** |

## The bug

The `task:moved` fan-out compared against five literals. On a renamed board the whole listener goes inert at once — board-stall counter stops counting, in-review rebind stops firing, completed-task reconciliation stops running. **None of it fails a test, because the move itself still happens.**

## The part worth reading: split by observability

My first attempt put the entire listener behind one `await`, on this stated premise:

> the counter is read only by a later periodic sweep, never synchronously after a move

**That was wrong.** `runBoardStallAutoRecoverySweep` performs its own recovery moves and *then* evaluates progress **in the same pass**. The deferred increment was read as a stale zero, so a genuine recovery was reported as unrecovered. `board-stall-auto-recovery.test.ts` caught it — 4 failures against a green base, which is how I knew it was mine and not pre-existing.

The shipped version splits by what is synchronously observed:
- **counter → sync**, via `resolveTaskWorkflowIrSync` (the seam `scheduler.ts` already uses for sync lane resolution)
- **the two reconcile branches → async**, keeping the fire-and-forget shape they already had

Worth flagging for the rest of this file: I had previously listed this listener as *blocked* on "needs async conversion first." That was half right — the blocker was real but narrower than stated, and it applies to the counter alone, not the listener.

## Verification

- **Revert-proof:** reverting the guards to literals fails 2 cases. The others exercise the new resolvers directly, so they cannot fail on revert — stated, not counted as evidence.
- 5 suites, **449 tests green**; tsc and eslint clean
- Degraded-resolution case included: an unresolvable workflow must keep the fan-out firing rather than flat-line board-stall detection

## Still flagged (not guessed)

24 remain. The sweeps at L2894/3297/8948/9089 depend on the unowned `listTasks({ column })` decision; L5430/5364 sit under the FN-5256 liveness guard whose own comment says those columns can be live when the heuristic calls them stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)