### PR TITLE
fix(self-healing): resolve starved-refinement peer progress (self-healing 21 → 19)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -326,3 +326,46 @@ describe("self-healing task:moved fan-out column vocabulary", () => {
     expect(reconcile).not.toHaveBeenCalled();
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (fleet — pause-abort requeue TARGET):
+The recovery requeued to a hardcoded "todo". A hardcoded target is a worse failure than a stale guard:
+a stale guard stops matching, but a move to a column the board does not declare is a write into nowhere.
+Asserted on `moveTask`, because the target is the whole point of this conversion — a test that only
+checked the guards would pass with the write still hardcoded.
+*/
+describe("self-healing pause-abort requeue target vocabulary", () => {
+  function recoveryStoreFor(ir: WorkflowIr | undefined, parkedTask: Task) {
+    const moveTask = vi.fn(async () => undefined);
+    const store = {
+      ...storeFor(ir),
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false, autoMerge: true })),
+      listTasks: vi.fn(async () => [parkedTask]),
+      getTask: vi.fn(async () => parkedTask),
+      updateTask: vi.fn(async () => ({})),
+      moveTask,
+      logEntry: vi.fn(async () => undefined),
+      recordRunAuditEvent: vi.fn(async () => undefined),
+      getRootDir: vi.fn(() => "/tmp/test-project"),
+    } as unknown as TaskStore;
+    return { store, moveTask };
+  }
+
+  it("requeues to the board's own HOLD lane, not a hardcoded todo", async () => {
+    const parkedInWip = parked("building");
+    const { store, moveTask } = recoveryStoreFor(RENAMED_WITH_REVIEW, parkedInWip);
+    const manager = managerFor(store) as unknown as { recoverPausedAbortFailures(): Promise<number> };
+    await manager.recoverPausedAbortFailures();
+    expect(moveTask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(moveTask).mock.calls[0]?.[1]).toBe("backlog");
+  });
+
+  it("still requeues to todo when the workflow will not resolve", async () => {
+    const parkedInWip = parked("in-progress");
+    const { store, moveTask } = recoveryStoreFor(undefined, parkedInWip);
+    const manager = managerFor(store) as unknown as { recoverPausedAbortFailures(): Promise<number> };
+    await manager.recoverPausedAbortFailures();
+    expect(moveTask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(moveTask).mock.calls[0]?.[1]).toBe("todo");
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -254,3 +254,75 @@ describe("self-healing pause-abort router column vocabulary", () => {
       .toBe("node-requeue");
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet — task:moved fan-out vocabulary):
+The fan-out routed on five literals. On a renamed board all of it went inert at once — the board-stall
+counter stopped counting, in-review rebind stopped firing, completed-task reconciliation stopped running
+— and none of that fails a test, because the move itself still happens.
+
+The sync/async split below is asserted deliberately. The counter MUST increment synchronously:
+`runBoardStallAutoRecoverySweep` makes its own recovery moves and then reads the counter in the same
+pass, so an increment deferred behind an await is read as a stale zero and a real recovery is reported
+as unrecovered. That is not hypothetical — it is what board-stall-auto-recovery.test.ts caught when this
+conversion first put the whole listener behind one await.
+*/
+describe("self-healing task:moved fan-out column vocabulary", () => {
+  type FanoutInternals = {
+    resolveMoveFanoutColumnsSync(taskId: string): { wip: ReadonlySet<string>; review: ReadonlySet<string>; complete: ReadonlySet<string>; archived: ReadonlySet<string>; hold: ReadonlySet<string> };
+    handleTaskMovedFanout(task: Task, from: string, to: string): Promise<void>;
+    reconcileInReviewBranchRebind: unknown;
+    reconcileCompletedTask: unknown;
+  };
+
+  function syncStoreFor(ir?: WorkflowIr): TaskStore {
+    return {
+      ...storeFor(ir),
+      resolveTaskWorkflowIrSync: vi.fn(() => ir),
+    } as unknown as TaskStore;
+  }
+
+  it("resolves every fan-out lane from a renamed board", () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const c = manager.resolveMoveFanoutColumnsSync("FN-9200");
+    expect(c.wip.has("building")).toBe(true);
+    expect(c.review.has("signoff")).toBe(true);
+    expect(c.complete.has("shipped")).toBe(true);
+    expect(c.hold.has("backlog")).toBe(true);
+  });
+
+  it("keeps legacy ids when the store cannot resolve synchronously", () => {
+    const manager = managerFor(storeFor(undefined)) as unknown as FanoutInternals;
+    const c = manager.resolveMoveFanoutColumnsSync("FN-9200");
+    expect(c.wip.has("in-progress")).toBe(true);
+    expect(c.review.has("in-review")).toBe(true);
+    expect(c.complete.has("done")).toBe(true);
+  });
+
+  it("fires the in-review rebind for a move into a RENAMED review lane", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const rebind = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = rebind;
+    manager.reconcileCompletedTask = vi.fn(async () => undefined);
+    await manager.handleTaskMovedFanout(task("FN-9200", "signoff"), "building", "signoff");
+    expect(rebind).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles completion across RENAMED review -> complete and complete -> archived", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const reconcile = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = vi.fn(async () => undefined);
+    manager.reconcileCompletedTask = reconcile;
+    await manager.handleTaskMovedFanout(task("FN-9200", "shipped"), "signoff", "shipped");
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconcile completion on an unrelated renamed move", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const reconcile = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = vi.fn(async () => undefined);
+    manager.reconcileCompletedTask = reconcile;
+    await manager.handleTaskMovedFanout(task("FN-9200", "building"), "backlog", "building");
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-starved-refinement.test.ts
+++ b/packages/engine/src/__tests__/self-healing-starved-refinement.test.ts
@@ -77,6 +77,60 @@ describe("SelfHealingManager.recoverStarvedRefinementTriageTasks", () => {
     vi.useRealTimers();
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-16:40 (fleet — peer-progress vocabulary):
+  "Peer progress" was `peer.column === "todo"` in two places: the candidate filter and the count written
+  into the log line and audit metadata. On a renamed board both stopped matching, so peer progress read
+  as zero and starved refinements were never escalated — silently, since a zero count is indistinguishable
+  from a genuinely quiet board.
+
+  The board below separates intake from hold on purpose. The candidate rests in INTAKE (`inbox`) and its
+  peers in HOLD (`backlog`), so a conversion that reached for the wrong role set — or that left either
+  site on the literal — resolves no peers and escalates nothing.
+  */
+  it("counts peer progress in the board's own HOLD lane on a renamed board", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T11:00:00.000Z"));
+
+    const RENAMED_IR = {
+      version: "v2",
+      name: "renamed-starvation",
+      columns: [
+        { id: "inbox", name: "Inbox", traits: [{ trait: "intake" }] },
+        { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+        { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+      ],
+      nodes: [],
+      edges: [],
+    };
+
+    const tasks: Task[] = [
+      task({ id: "FN-R9", column: "inbox", sourceType: "task_refine", createdAt: "2026-05-15T10:00:00.000Z", updatedAt: "2026-05-15T10:00:00.000Z", priority: "low" }),
+      task({ id: "FN-Q1", column: "backlog", sourceType: "dashboard_ui", updatedAt: "2026-05-15T10:15:00.000Z" }),
+      task({ id: "FN-Q2", column: "backlog", sourceType: "dashboard_ui", updatedAt: "2026-05-15T10:16:00.000Z" }),
+      task({ id: "FN-Q3", column: "backlog", sourceType: "dashboard_ui", updatedAt: "2026-05-15T10:17:00.000Z" }),
+    ];
+
+    const updateTask = vi.fn(async () => undefined);
+    const store: any = {
+      getSettings: vi.fn().mockResolvedValue({ globalPause: false, enginePaused: false }),
+      listTasks: vi.fn().mockResolvedValue(tasks),
+      updateTask,
+      logEntry: vi.fn().mockResolvedValue(undefined),
+      recordRunAuditEvent: vi.fn().mockResolvedValue(undefined),
+      getTaskWorkflowSelection: vi.fn(() => ({ workflowId: "custom:renamed", stepIds: [] })),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => ({ workflowId: "custom:renamed", stepIds: [] })),
+      getWorkflowDefinition: vi.fn(async () => ({ ir: RENAMED_IR })),
+      on: () => {},
+      removeListener: () => {},
+    };
+
+    const manager = new SelfHealingManager(store, { rootDir: process.cwd(), getPlanningTaskIds: () => new Set() });
+    await expect(manager.recoverStarvedRefinementTriageTasks()).resolves.toBe(1);
+    expect(updateTask).toHaveBeenCalledWith("FN-R9", { priority: "normal" });
+    vi.useRealTimers();
+  });
+
   it("does not escalate non-refinement triage tasks", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-15T11:00:00.000Z"));

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -14381,10 +14381,22 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const now = Date.now();
 
       // FNXC:WorkflowColumns 2026-07-29-09:30 (Phase B): intake role.
-      const intakeCandidates = await this.filterByPreWipRole(
-        tasks,
-        ["intake"],
-        new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>(),
+      const preWipCache = new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>();
+      const intakeCandidates = await this.filterByPreWipRole(tasks, ["intake"], preWipCache);
+
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-16:40 (fleet):
+      "Peer progress" means peers sitting in their own board's HOLD lane, which was `peer.column ===
+      "todo"` in two places — once in the candidate filter, once again when computing the number recorded
+      in the log line and the audit metadata. Duplicated predicates that must agree are how a converted
+      guard ends up feeding an unconverted one, so both now read the same precomputed set.
+
+      Resolved ONCE for the whole board rather than per peer: this is an N-squared scan (every candidate
+      counts over every task), so a per-peer resolve would multiply IR reads by the candidate count. The
+      shared cache means one read per distinct workflow.
+      */
+      const holdPeerIds = new Set(
+        (await this.filterByPreWipRole(tasks, ["hold"], preWipCache)).map((peer) => peer.id),
       );
       const candidates = intakeCandidates.filter((task) => {
         if (task.sourceType !== "task_refine") return false;
@@ -14400,7 +14412,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const peerProgressCount = tasks.filter((peer) =>
           peer.id !== task.id &&
-          peer.column === "todo" &&
+          holdPeerIds.has(peer.id) &&
           peer.sourceType !== "task_refine" &&
           new Date(peer.updatedAt).getTime() > createdAtMs,
         ).length;
@@ -14421,7 +14433,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const createdAtMs = new Date(task.createdAt).getTime();
           const peerProgressCount = tasks.filter((peer) =>
             peer.id !== task.id &&
-            peer.column === "todo" &&
+            holdPeerIds.has(peer.id) &&
             peer.sourceType !== "task_refine" &&
             new Date(peer.updatedAt).getTime() > createdAtMs,
           ).length;

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -30,7 +30,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, resolveReboundTargetForTask, columnsWithFlag, resolveLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
   LEGACY_COLUMN_IDS_BY_ROLE,
   TERMINAL_ROLES,
   resolveProjectColumnsForRoles,
@@ -12309,6 +12309,19 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             continue;
           }
 
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (fleet):
+          The requeue TARGET, resolved rather than hardcoded to "todo". This is the KTD-10 ordering
+          (`hold` -> `intake` -> first column) that `resolveReboundTarget` already defines and that L745
+          in this file already uses for the same kind of repair.
+
+          A hardcoded target is a different and worse failure than a stale guard: a stale guard stops
+          matching, whereas a move to a column the board does not declare is a write into nowhere. The
+          helper falls back to "todo" itself when the workflow will not resolve, so the degraded case
+          keeps today's behaviour.
+          */
+          const reboundTarget = await resolveReboundTargetForTask(this.store, fresh.id);
+
           const workflowTransitionNotification = route.kind === "node-requeue"
             ? {
                 /*
@@ -12319,7 +12332,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                  * later task movement.
                  */
                 kind: "recovery-requeue" as const,
-                column: "todo" as const,
+                column: reboundTarget,
                 transitionId: `recovery-requeue:${task.id}:pause-abort-active-work`,
                 nodeId: "pause-abort-recovery-router",
                 reason: route.reason,
@@ -12329,12 +12342,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.updateTask(task.id, {
             status: null,
             error: null,
-            ...(fresh.column === "todo" && workflowTransitionNotification
+            ...(fresh.column === reboundTarget && workflowTransitionNotification
               ? { workflowTransitionNotification }
               : {}),
           });
-          if (route.kind === "node-requeue" && fresh.column !== "todo") {
-            await this.store.moveTask(task.id, "todo", {
+          if (route.kind === "node-requeue" && fresh.column !== reboundTarget) {
+            await this.store.moveTask(task.id, reboundTarget, {
               preserveProgress: true,
               moveSource: "engine",
               recoveryRehome: true,
@@ -12372,7 +12385,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
           await this.store.logEntry(
             task.id,
-            fresh.column === "in-review"
+            freshColumns.review.has(fresh.column)
               ? "Auto-recovered: in-review pause-abort park cleared — preserved for normal review progression"
               : "Auto-recovered: pause-abort park cleared — requeued for normal scheduling",
           );
@@ -12406,7 +12419,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
 
       if (recovered > 0) {
-        log.log(`Recovered ${recovered} pause-abort park(s) → requeued to todo or preserved in review`);
+        // FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (fleet): the target is resolved now, so the
+        // summary must not name "todo" — on a renamed board that line described a move that never happened.
+        log.log(`Recovered ${recovered} pause-abort park(s) → requeued to the hold lane or preserved in review`);
       }
       return recovered;
     } catch (err: unknown) { const errorMessage = err instanceof Error ? err.message : String(err);

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -976,6 +976,84 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.error.includes(PAUSE_ABORT_PARK_ERROR_MARKER);
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:05 (fleet — task:moved fan-out vocabulary):
+  The lane sets the `task:moved` fan-out routes on. MEMBERSHIP throughout, for the arity reason
+  `resolveReviewColumnsFor` documents, and unioned with the legacy ids so a degraded IR keeps the
+  fan-out firing rather than silently resolving empty sets.
+
+  `wip` is `countsTowardWip` rather than the `wip` trait: the counter it feeds measures cards LEAVING the
+  working lane, which is the same population the WIP cap governs. A board declaring a second working lane
+  outside the cap should not have exits from it counted as board progress.
+  */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet):
+  The synchronous twin of `resolveMoveFanoutColumnsFor`, for the one caller that cannot await: the
+  board-stall counter, whose increment must be visible to a sweep already in progress.
+
+  `resolveTaskWorkflowIrSync` is the same seam `scheduler.ts` uses for its own sync lane resolution. A
+  store that does not implement it, or a workflow that will not resolve, yields the legacy ids — the
+  degraded answer every resolver in this file gives, and the one that keeps the counter counting rather
+  than silently flat-lining board-stall detection.
+  */
+  private resolveMoveFanoutColumnsSync(taskId: string): {
+    wip: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+    hold: ReadonlySet<string>;
+  } {
+    const wip = new Set<string>(["in-progress"]);
+    const review = new Set<string>(["in-review"]);
+    const complete = new Set<string>(["done"]);
+    const archived = new Set<string>(["archived"]);
+    const hold = new Set<string>(["todo"]);
+    try {
+      const ir = this.store.resolveTaskWorkflowIrSync?.(taskId);
+      if (ir) {
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) wip.add(id);
+        for (const id of columnsWithFlag(ir, "mergeOrchestration")) review.add(id);
+        for (const id of columnsWithFlag(ir, "humanReview")) review.add(id);
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.complete) complete.add(lifecycle.complete);
+        if (lifecycle?.archived) archived.add(lifecycle.archived);
+        if (lifecycle?.hold) hold.add(lifecycle.hold);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching the async siblings' catch */
+    }
+    return { wip, review, complete, archived, hold };
+  }
+
+  private async resolveMoveFanoutColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<{
+    wip: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+    hold: ReadonlySet<string>;
+  }> {
+    const wip = new Set<string>(["in-progress"]);
+    const complete = new Set<string>(["done"]);
+    const archived = new Set<string>(["archived"]);
+    const hold = new Set<string>(["todo"]);
+    try {
+      const ir = await resolveWorkflowIrForTask(this.store, taskId, cache);
+      if (ir) {
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) wip.add(id);
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.complete) complete.add(lifecycle.complete);
+        if (lifecycle?.archived) archived.add(lifecycle.archived);
+        if (lifecycle?.hold) hold.add(lifecycle.hold);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching the sibling resolvers' catch */
+    }
+    return { wip, review: await this.resolveReviewColumnsFor(taskId, cache), complete, archived, hold };
+  }
+
   /** The review + active-work sets the pause-abort router needs, resolved together over one IR cache. */
   private async resolvePauseAbortColumnsFor(
     taskId: string,
@@ -1523,28 +1601,32 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     };
     this.store.on("settings:updated", this.settingsListener);
 
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet):
+    Split deliberately by OBSERVABILITY, not by convenience.
+
+    The board-stall counter is incremented SYNCHRONOUSLY, because it is not merely read by a later
+    periodic sweep — `runBoardStallAutoRecoverySweep` performs its own recovery moves and then evaluates
+    progress in the SAME pass, so the increment must land before that read. Deferring it behind an await
+    made the sweep read a stale zero and report a real recovery as unrecovered (caught by
+    board-stall-auto-recovery.test.ts, which is why the sync resolver is used here).
+
+    The two reconcile branches were already fire-and-forget before this change, so they keep that shape
+    and resolve asynchronously.
+    */
     this.taskMovedFanoutListener = ({ task, from, to }) => {
+      const sync = this.resolveMoveFanoutColumnsSync(task.id);
       if (
-        from === "in-progress"
-        && (to === "todo" || to === "in-review" || to === "done" || to === "archived")
+        sync.wip.has(from)
+        && (sync.hold.has(to) || sync.review.has(to) || sync.complete.has(to) || sync.archived.has(to))
         && this.boardStallWindow
       ) {
         // In-memory only counter; resets on engine restart.
         this.boardStallWindow.transitionsOutOfInProgressInWindow++;
       }
-      if (to === "in-review") {
-        void this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) }).catch((err: unknown) => {
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
-        });
-      }
-      const shouldReconcile =
-        (from === "in-review" && to === "done") ||
-        (from === "done" && to === "archived");
-      if (!shouldReconcile) return;
-      void this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined }).catch((err: unknown) => {
+      void this.handleTaskMovedFanout(task, from, to).catch((err: unknown) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        log.warn(`[self-healing] task:moved completion fan-out failed for ${task.id}: ${errorMessage}`);
+        log.warn(`[self-healing] task:moved fan-out failed for ${task.id}: ${errorMessage}`);
       });
     };
     this.store.on("task:moved", this.taskMovedFanoutListener);
@@ -1553,6 +1635,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     this.startMaintenance();
 
     log.debug("Started");
+  }
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:05 (fleet):
+  The `task:moved` fan-out, routed on the moving task's own resolved lanes instead of the five literals
+  it used to compare against. On a renamed board every branch here went inert at once: the board-stall
+  counter stopped counting, in-review rebind stopped firing, and completed-task reconciliation stopped
+  running -- none of which fails a test, because the move still happens.
+
+  One IR read per move event, not per branch: the three branches share a cache.
+  */
+  private async handleTaskMovedFanout(task: Task, from: string, to: string): Promise<void> {
+    const columns = await this.resolveMoveFanoutColumnsFor(task.id, new Map());
+
+    if (columns.review.has(to)) {
+      try {
+        await this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) });
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
+      }
+    }
+    const shouldReconcile =
+      (columns.review.has(from) && columns.complete.has(to)) ||
+      (columns.complete.has(from) && columns.archived.has(to));
+    if (!shouldReconcile) return;
+    try {
+      await this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined });
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.warn(`[self-healing] task:moved completion fan-out failed for ${task.id}: ${errorMessage}`);
+    }
   }
 
   /**


### PR DESCRIPTION
Fourth cut into `self-healing.ts`. **Stacked on #3075 → #3080 → #3083.**

## Census

| Metric | Session start | Now |
|---|---:|---:|
| COLUMN guards (backlog) | 88 | **67** |
| `self-healing.ts` | 38 | **19** |

## The bug

"Peer progress" was `peer.column === "todo"` in **two** places — the candidate filter, and the count written into the log line and audit metadata. On a renamed board both stopped matching, so peer progress read as **zero** and starved refinements were never escalated. Silently: a zero count is indistinguishable from a genuinely quiet board.

## De-duplication was part of the fix

Both sites now read one precomputed `holdPeerIds` set. Two copies of a predicate that must agree is exactly how a converted guard ends up feeding an unconverted one — the mixed-vocabulary failure the census warns about — so collapsing them belongs in this change rather than a tidy-up later.

Resolved **once for the whole board, not per peer.** This is an N-squared scan (every candidate counts over every task), so a per-peer resolve would multiply IR reads by the candidate count. It reuses `filterByPreWipRole` — already the converted seam for the intake filter directly above — and shares its cache, so the cost is one read per distinct workflow.

## Verification

- **Revert-proof:** reverting both sites to the literal drops escalations **1 → 0**.
- The new fixture separates intake from hold deliberately — candidate in `inbox`, peers in `backlog` — so reaching for the wrong role set resolves no peers and escalates nothing. A fixture where the two lanes coincide would pass either way.
- 5 suites, **454 tests green**; tsc and eslint clean

## Still flagged (not guessed)

19 remain, still the two groups: the `listTasks({ column })` sweeps (L2894/3297/8948/9089) and the FN-5256 liveness guards (L5364/5430).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-healing recovery across workflows with renamed or customized board lanes.
  * Recovered tasks now move to the appropriate workflow hold or review lane instead of relying on fixed defaults.
  * Improved pause-abort routing, task-move handling, stall detection, and starved refinement recovery.
  * Added fallback behavior for legacy workflow configurations and more reliable recovery reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->