### PR TITLE
fix(self-healing): resolve the FN-5256 liveness cluster (self-healing 11 → 5)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -369,3 +369,55 @@ describe("self-healing pause-abort requeue target vocabulary", () => {
     expect(vi.mocked(moveTask).mock.calls[0]?.[1]).toBe("todo");
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-17:10 (fleet — active/terminal membership):
+Two multi-id membership guards, both asking "is this card live or finished?" and both matching NOTHING
+on a renamed board.
+
+`reconcilePreExecutionWorktrees` is the destructive one: a renamed board made every working card look
+parked, so the sweep would have SEIZED a worktree from live work. That is why over-inclusion is the
+acceptable failure direction for it and the project union is the right scope — a column wrongly counted
+as active only leaves a worktree alone.
+*/
+describe("self-healing active/terminal membership vocabulary", () => {
+  function releaseStoreFor(ir: WorkflowIr | undefined, tasks: Task[]) {
+    return {
+      ...storeFor(ir),
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false })),
+      listTasks: vi.fn(async () => tasks),
+      getProjectWorkflowIds: vi.fn(async () => (ir ? ["custom:renamed"] : [])),
+      listWorkflowDefinitions: vi.fn(async () => (ir ? [{ id: "custom:renamed", ir }] : [])),
+      logEntry: vi.fn(async () => undefined),
+      recordRunAuditEvent: vi.fn(async () => undefined),
+    } as unknown as TaskStore;
+  }
+
+  const withWorktree = (id: string, column: string): Task => ({
+    id,
+    column,
+    worktree: `/tmp/wt/${id}`,
+    updatedAt: "2020-01-01T00:00:00.000Z",
+    columnMovedAt: "2020-01-01T00:00:00.000Z",
+  } as unknown as Task);
+
+  it("does not seize the worktree of a card in a RENAMED working lane", async () => {
+    const store = releaseStoreFor(RENAMED_WITH_REVIEW, [withWorktree("FN-9300", "building")]);
+    const release = vi.fn(async () => true);
+    const manager = Object.create(SelfHealingManager.prototype) as SelfHealingManager;
+    (manager as unknown as Record<string, unknown>).store = store;
+    (manager as unknown as Record<string, unknown>).options = { releasePreExecutionWorktree: release };
+    await (manager as unknown as { reconcilePreExecutionWorktrees(): Promise<number> }).reconcilePreExecutionWorktrees();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it("does not seize the worktree of a card in a RENAMED review lane", async () => {
+    const store = releaseStoreFor(RENAMED_WITH_REVIEW, [withWorktree("FN-9301", "signoff")]);
+    const release = vi.fn(async () => true);
+    const manager = Object.create(SelfHealingManager.prototype) as SelfHealingManager;
+    (manager as unknown as Record<string, unknown>).store = store;
+    (manager as unknown as Record<string, unknown>).options = { releasePreExecutionWorktree: release };
+    await (manager as unknown as { reconcilePreExecutionWorktrees(): Promise<number> }).reconcilePreExecutionWorktrees();
+    expect(release).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import "@fusion/core"; // register built-in traits
-import type { Task, TaskStore, WorkflowIr } from "@fusion/core";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
 import { SelfHealingManager } from "../self-healing.js";
 
 /*
@@ -160,5 +160,97 @@ describe("self-healing pre-WIP column vocabulary", () => {
       cache,
     );
     expect(vi.mocked(store.getWorkflowDefinition)).toHaveBeenCalledTimes(1);
+  });
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet — pause-abort router vocabulary):
+The pause-abort recovery router routed on three literals: `in-review` twice (review progress, manual
+merge hold) and `todo || in-progress` (active work). On a renamed board all three stopped matching, so
+a parked card in a renamed lane fell through to `no-action` and was never recovered — silently, and with
+every existing test still green, because they all use the legacy ids.
+
+Each case below asserts the RENAMED lane routes correctly. Reverting any of the three conversions turns
+its case into `no-action`, so these fail if the guards go back to literals.
+
+Note the ACTIVE-WORK set is hold + countsTowardWip, NOT the intake + hold that `resolvePreWipColumns`
+above returns: a card in intake is not mid-flight and must not be requeued as active work. The two sets
+overlap on `hold`, which is exactly why using the wrong one would look right in a legacy-id test.
+*/
+const RENAMED_WITH_REVIEW: WorkflowIr = {
+  version: "v2",
+  name: "renamed-lifecycle-review",
+  columns: [
+    { id: "inbox", name: "Inbox", traits: [{ trait: "intake" }] },
+    { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+    /* Trait names are kebab (`merge`); `mergeOrchestration` is the FLAG that trait sets. */
+    { id: "signoff", name: "Signoff", traits: [{ trait: "merge" }, { trait: "human-review" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+  ],
+  nodes: [],
+  edges: [],
+} as unknown as WorkflowIr;
+
+const PARK_ERROR =
+  "Workflow graph failure surfaced after paused engine abort during pause/resume in 'todo' at node 'execute' — operator action required; retry or explicitly unpause/resume after inspecting the task";
+
+type PauseAbortInternals = {
+  resolveActiveWorkColumnsFor(taskId: string, cache: Map<string, unknown>): Promise<ReadonlySet<string>>;
+  resolvePauseAbortColumnsFor(taskId: string, cache: Map<string, unknown>): Promise<{ review: ReadonlySet<string>; activeWork: ReadonlySet<string> }>;
+  classifyPausedAbortWorkflowRecovery(
+    task: Task,
+    settings: unknown,
+    isExecuting: boolean,
+    columns: { review: ReadonlySet<string>; activeWork: ReadonlySet<string> },
+  ): { kind: string; reason: string };
+};
+
+const parked = (column: string, steps: Array<{ status: string }> = []): Task => ({
+  id: "FN-9100",
+  column,
+  status: "failed",
+  error: PARK_ERROR,
+  steps,
+} as unknown as Task);
+
+describe("self-healing pause-abort router column vocabulary", () => {
+  const settings = { autoMerge: true } as unknown as Settings;
+
+  it("resolves ACTIVE WORK as hold + wip on a renamed board, excluding intake", async () => {
+    const manager = managerFor(storeFor(RENAMED_WITH_REVIEW)) as unknown as PauseAbortInternals;
+    const active = await manager.resolveActiveWorkColumnsFor("FN-9100", new Map());
+    expect(active.has("backlog")).toBe(true);
+    expect(active.has("building")).toBe(true);
+    // Intake is NOT active work — this is the distinction from resolvePreWipColumns.
+    expect(active.has("inbox")).toBe(false);
+  });
+
+  it("requeues a park sitting in a RENAMED wip lane", async () => {
+    const manager = managerFor(storeFor(RENAMED_WITH_REVIEW)) as unknown as PauseAbortInternals;
+    const columns = await manager.resolvePauseAbortColumnsFor("FN-9100", new Map());
+    const route = manager.classifyPausedAbortWorkflowRecovery(parked("building"), settings, false, columns);
+    expect(route).toEqual({ kind: "node-requeue", reason: "pause-abort-active-work" });
+  });
+
+  it("resumes a completed park sitting in a RENAMED review lane", async () => {
+    const manager = managerFor(storeFor(RENAMED_WITH_REVIEW)) as unknown as PauseAbortInternals;
+    const columns = await manager.resolvePauseAbortColumnsFor("FN-9100", new Map());
+    const task = parked("signoff", [{ status: "done" }, { status: "done" }]);
+    const route = manager.classifyPausedAbortWorkflowRecovery(task, settings, false, columns);
+    expect(route).toEqual({ kind: "work-item-resume", reason: "pause-abort-review-progress" });
+  });
+
+  /*
+  The degraded path is the reason both resolvers union the legacy ids: an unreadable workflow must keep
+  its former recovery behaviour rather than resolve an empty set and go inert.
+  */
+  it("keeps recovering legacy-id boards when the workflow is unresolvable", async () => {
+    const manager = managerFor(storeFor(undefined)) as unknown as PauseAbortInternals;
+    const columns = await manager.resolvePauseAbortColumnsFor("FN-9100", new Map());
+    expect(manager.classifyPausedAbortWorkflowRecovery(parked("in-progress"), settings, false, columns).kind)
+      .toBe("node-requeue");
+    expect(manager.classifyPausedAbortWorkflowRecovery(parked("todo"), settings, false, columns).kind)
+      .toBe("node-requeue");
   });
 });

--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -326,3 +326,46 @@ describe("self-healing task:moved fan-out column vocabulary", () => {
     expect(reconcile).not.toHaveBeenCalled();
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (fleet — pause-abort requeue TARGET):
+The recovery requeued to a hardcoded "todo". A hardcoded target is a worse failure than a stale guard:
+a stale guard stops matching, but a move to a column the board does not declare is a write into nowhere.
+Asserted on `moveTask`, because the target is the whole point of this conversion — a test that only
+checked the guards would pass with the write still hardcoded.
+*/
+describe("self-healing pause-abort requeue target vocabulary", () => {
+  function recoveryStoreFor(ir: WorkflowIr | undefined, parkedTask: Task) {
+    const moveTask = vi.fn(async () => undefined);
+    const store = {
+      ...storeFor(ir),
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false, autoMerge: true })),
+      listTasks: vi.fn(async () => [parkedTask]),
+      getTask: vi.fn(async () => parkedTask),
+      updateTask: vi.fn(async () => ({})),
+      moveTask,
+      logEntry: vi.fn(async () => undefined),
+      recordRunAuditEvent: vi.fn(async () => undefined),
+      getRootDir: vi.fn(() => "/tmp/test-project"),
+    } as unknown as TaskStore;
+    return { store, moveTask };
+  }
+
+  it("requeues to the board's own HOLD lane, not a hardcoded todo", async () => {
+    const parkedInWip = parked("building");
+    const { store, moveTask } = recoveryStoreFor(RENAMED_WITH_REVIEW, parkedInWip);
+    const manager = managerFor(store) as unknown as { recoverPausedAbortFailures(): Promise<number> };
+    await manager.recoverPausedAbortFailures();
+    expect(moveTask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(moveTask).mock.calls[0]?.[1]).toBe("backlog");
+  });
+
+  it("still requeues to todo when the workflow will not resolve", async () => {
+    const parkedInWip = parked("in-progress");
+    const { store, moveTask } = recoveryStoreFor(undefined, parkedInWip);
+    const manager = managerFor(store) as unknown as { recoverPausedAbortFailures(): Promise<number> };
+    await manager.recoverPausedAbortFailures();
+    expect(moveTask).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(moveTask).mock.calls[0]?.[1]).toBe("todo");
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -254,3 +254,75 @@ describe("self-healing pause-abort router column vocabulary", () => {
       .toBe("node-requeue");
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet — task:moved fan-out vocabulary):
+The fan-out routed on five literals. On a renamed board all of it went inert at once — the board-stall
+counter stopped counting, in-review rebind stopped firing, completed-task reconciliation stopped running
+— and none of that fails a test, because the move itself still happens.
+
+The sync/async split below is asserted deliberately. The counter MUST increment synchronously:
+`runBoardStallAutoRecoverySweep` makes its own recovery moves and then reads the counter in the same
+pass, so an increment deferred behind an await is read as a stale zero and a real recovery is reported
+as unrecovered. That is not hypothetical — it is what board-stall-auto-recovery.test.ts caught when this
+conversion first put the whole listener behind one await.
+*/
+describe("self-healing task:moved fan-out column vocabulary", () => {
+  type FanoutInternals = {
+    resolveMoveFanoutColumnsSync(taskId: string): { wip: ReadonlySet<string>; review: ReadonlySet<string>; complete: ReadonlySet<string>; archived: ReadonlySet<string>; hold: ReadonlySet<string> };
+    handleTaskMovedFanout(task: Task, from: string, to: string): Promise<void>;
+    reconcileInReviewBranchRebind: unknown;
+    reconcileCompletedTask: unknown;
+  };
+
+  function syncStoreFor(ir?: WorkflowIr): TaskStore {
+    return {
+      ...storeFor(ir),
+      resolveTaskWorkflowIrSync: vi.fn(() => ir),
+    } as unknown as TaskStore;
+  }
+
+  it("resolves every fan-out lane from a renamed board", () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const c = manager.resolveMoveFanoutColumnsSync("FN-9200");
+    expect(c.wip.has("building")).toBe(true);
+    expect(c.review.has("signoff")).toBe(true);
+    expect(c.complete.has("shipped")).toBe(true);
+    expect(c.hold.has("backlog")).toBe(true);
+  });
+
+  it("keeps legacy ids when the store cannot resolve synchronously", () => {
+    const manager = managerFor(storeFor(undefined)) as unknown as FanoutInternals;
+    const c = manager.resolveMoveFanoutColumnsSync("FN-9200");
+    expect(c.wip.has("in-progress")).toBe(true);
+    expect(c.review.has("in-review")).toBe(true);
+    expect(c.complete.has("done")).toBe(true);
+  });
+
+  it("fires the in-review rebind for a move into a RENAMED review lane", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const rebind = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = rebind;
+    manager.reconcileCompletedTask = vi.fn(async () => undefined);
+    await manager.handleTaskMovedFanout(task("FN-9200", "signoff"), "building", "signoff");
+    expect(rebind).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles completion across RENAMED review -> complete and complete -> archived", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const reconcile = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = vi.fn(async () => undefined);
+    manager.reconcileCompletedTask = reconcile;
+    await manager.handleTaskMovedFanout(task("FN-9200", "shipped"), "signoff", "shipped");
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reconcile completion on an unrelated renamed move", async () => {
+    const manager = managerFor(syncStoreFor(RENAMED_WITH_REVIEW)) as unknown as FanoutInternals;
+    const reconcile = vi.fn(async () => undefined);
+    manager.reconcileInReviewBranchRebind = vi.fn(async () => undefined);
+    manager.reconcileCompletedTask = reconcile;
+    await manager.handleTaskMovedFanout(task("FN-9200", "building"), "backlog", "building");
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
+++ b/packages/engine/src/__tests__/self-healing-prewip-role-vocabulary.test.ts
@@ -421,3 +421,43 @@ describe("self-healing active/terminal membership vocabulary", () => {
     expect(release).not.toHaveBeenCalled();
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-17:45 (fleet — FN-5256 liveness protection):
+FN-5256 exists because nulling a live task's worktree metadata yanks the worktree from a still-running
+shell. The guard that enforces it compared `task.column` against "in-progress"/"in-review", so on a
+renamed board it protected NOTHING and the very incident it was written to prevent came back.
+
+Asserted on `updateTask` NOT being called: the protection is the absence of a write, so a test that only
+counted the return value would pass while the metadata was being cleared.
+*/
+describe("self-healing FN-5256 liveness protection vocabulary", () => {
+  it("does not clear worktree metadata for a card in a RENAMED working lane", async () => {
+    const live = {
+      id: "FN-9400",
+      column: "building",
+      worktree: "/tmp/wt/FN-9400-missing",
+      branch: "fusion/FN-9400",
+    } as unknown as Task;
+    const updateTask = vi.fn(async () => undefined);
+    const store = {
+      ...storeFor(RENAMED_WITH_REVIEW),
+      getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false })),
+      listTasks: vi.fn(async () => [live]),
+      getTask: vi.fn(async () => live),
+      updateTask,
+      logEntry: vi.fn(async () => undefined),
+      recordRunAuditEvent: vi.fn(async () => undefined),
+      getRootDir: vi.fn(() => "/tmp/test-project"),
+      getProjectWorkflowIds: vi.fn(async () => ["custom:renamed"]),
+      listWorkflowDefinitions: vi.fn(async () => [{ id: "custom:renamed", ir: RENAMED_WITH_REVIEW }]),
+    } as unknown as TaskStore;
+
+    const manager = Object.create(SelfHealingManager.prototype) as SelfHealingManager;
+    (manager as unknown as Record<string, unknown>).store = store;
+    (manager as unknown as Record<string, unknown>).options = { rootDir: "/tmp/test-project", getExecutingTaskIds: () => new Set() };
+
+    await (manager as unknown as { reconcileTaskWorktreeMetadata(o?: unknown): Promise<number> }).reconcileTaskWorktreeMetadata();
+    expect(updateTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/engine/src/__tests__/self-healing-starved-refinement.test.ts
+++ b/packages/engine/src/__tests__/self-healing-starved-refinement.test.ts
@@ -77,6 +77,60 @@ describe("SelfHealingManager.recoverStarvedRefinementTriageTasks", () => {
     vi.useRealTimers();
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-16:40 (fleet — peer-progress vocabulary):
+  "Peer progress" was `peer.column === "todo"` in two places: the candidate filter and the count written
+  into the log line and audit metadata. On a renamed board both stopped matching, so peer progress read
+  as zero and starved refinements were never escalated — silently, since a zero count is indistinguishable
+  from a genuinely quiet board.
+
+  The board below separates intake from hold on purpose. The candidate rests in INTAKE (`inbox`) and its
+  peers in HOLD (`backlog`), so a conversion that reached for the wrong role set — or that left either
+  site on the literal — resolves no peers and escalates nothing.
+  */
+  it("counts peer progress in the board's own HOLD lane on a renamed board", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T11:00:00.000Z"));
+
+    const RENAMED_IR = {
+      version: "v2",
+      name: "renamed-starvation",
+      columns: [
+        { id: "inbox", name: "Inbox", traits: [{ trait: "intake" }] },
+        { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+        { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+      ],
+      nodes: [],
+      edges: [],
+    };
+
+    const tasks: Task[] = [
+      task({ id: "FN-R9", column: "inbox", sourceType: "task_refine", createdAt: "2026-05-15T10:00:00.000Z", updatedAt: "2026-05-15T10:00:00.000Z", priority: "low" }),
+      task({ id: "FN-Q1", column: "backlog", sourceType: "dashboard_ui", updatedAt: "2026-05-15T10:15:00.000Z" }),
+      task({ id: "FN-Q2", column: "backlog", sourceType: "dashboard_ui", updatedAt: "2026-05-15T10:16:00.000Z" }),
+      task({ id: "FN-Q3", column: "backlog", sourceType: "dashboard_ui", updatedAt: "2026-05-15T10:17:00.000Z" }),
+    ];
+
+    const updateTask = vi.fn(async () => undefined);
+    const store: any = {
+      getSettings: vi.fn().mockResolvedValue({ globalPause: false, enginePaused: false }),
+      listTasks: vi.fn().mockResolvedValue(tasks),
+      updateTask,
+      logEntry: vi.fn().mockResolvedValue(undefined),
+      recordRunAuditEvent: vi.fn().mockResolvedValue(undefined),
+      getTaskWorkflowSelection: vi.fn(() => ({ workflowId: "custom:renamed", stepIds: [] })),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => ({ workflowId: "custom:renamed", stepIds: [] })),
+      getWorkflowDefinition: vi.fn(async () => ({ ir: RENAMED_IR })),
+      on: () => {},
+      removeListener: () => {},
+    };
+
+    const manager = new SelfHealingManager(store, { rootDir: process.cwd(), getPlanningTaskIds: () => new Set() });
+    await expect(manager.recoverStarvedRefinementTriageTasks()).resolves.toBe(1);
+    expect(updateTask).toHaveBeenCalledWith("FN-R9", { priority: "normal" });
+    vi.useRealTimers();
+  });
+
   it("does not escalate non-refinement triage tasks", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-15T11:00:00.000Z"));

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -30,7 +30,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, columnsWithFlag, resolveLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+import { resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, resolveReboundTargetForTask, columnsWithFlag, resolveLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
   LEGACY_COLUMN_IDS_BY_ROLE,
   TERMINAL_ROLES,
   resolveProjectColumnsForRoles,
@@ -12291,6 +12291,19 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             continue;
           }
 
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (fleet):
+          The requeue TARGET, resolved rather than hardcoded to "todo". This is the KTD-10 ordering
+          (`hold` -> `intake` -> first column) that `resolveReboundTarget` already defines and that L745
+          in this file already uses for the same kind of repair.
+
+          A hardcoded target is a different and worse failure than a stale guard: a stale guard stops
+          matching, whereas a move to a column the board does not declare is a write into nowhere. The
+          helper falls back to "todo" itself when the workflow will not resolve, so the degraded case
+          keeps today's behaviour.
+          */
+          const reboundTarget = await resolveReboundTargetForTask(this.store, fresh.id);
+
           const workflowTransitionNotification = route.kind === "node-requeue"
             ? {
                 /*
@@ -12301,7 +12314,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                  * later task movement.
                  */
                 kind: "recovery-requeue" as const,
-                column: "todo" as const,
+                column: reboundTarget,
                 transitionId: `recovery-requeue:${task.id}:pause-abort-active-work`,
                 nodeId: "pause-abort-recovery-router",
                 reason: route.reason,
@@ -12311,12 +12324,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.updateTask(task.id, {
             status: null,
             error: null,
-            ...(fresh.column === "todo" && workflowTransitionNotification
+            ...(fresh.column === reboundTarget && workflowTransitionNotification
               ? { workflowTransitionNotification }
               : {}),
           });
-          if (route.kind === "node-requeue" && fresh.column !== "todo") {
-            await this.store.moveTask(task.id, "todo", {
+          if (route.kind === "node-requeue" && fresh.column !== reboundTarget) {
+            await this.store.moveTask(task.id, reboundTarget, {
               preserveProgress: true,
               moveSource: "engine",
               recoveryRehome: true,
@@ -12354,7 +12367,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
           await this.store.logEntry(
             task.id,
-            fresh.column === "in-review"
+            freshColumns.review.has(fresh.column)
               ? "Auto-recovered: in-review pause-abort park cleared — preserved for normal review progression"
               : "Auto-recovered: pause-abort park cleared — requeued for normal scheduling",
           );
@@ -12388,7 +12401,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
 
       if (recovered > 0) {
-        log.log(`Recovered ${recovered} pause-abort park(s) → requeued to todo or preserved in review`);
+        // FNXC:WorkflowResolvedColumns 2026-07-31-16:05 (fleet): the target is resolved now, so the
+        // summary must not name "todo" — on a renamed board that line described a move that never happened.
+        log.log(`Recovered ${recovered} pause-abort park(s) → requeued to the hold lane or preserved in review`);
       }
       return recovered;
     } catch (err: unknown) { const errorMessage = err instanceof Error ? err.message : String(err);

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -949,10 +949,49 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     super();
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet):
+  `columns` is REQUIRED, not optional-with-a-literal-fallback. This router is called from exactly two
+  places — the candidate filter and the post-re-read re-verify — and they must agree: an optional
+  parameter lets one caller resolve and the other default, and the disagreement shows up as a recovery
+  that selects a card and then declines to act on it, with nothing logged. Requiring it makes that
+  divergence a compile error instead of a silent no-op. Degraded resolution is handled inside the two
+  resolvers, which union the legacy ids, so "required" never means "callers must invent a column set".
+  */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet):
+  The column-FREE half of the pause-abort predicate, split out so the sweep can identify candidate rows
+  without reading a workflow IR for every task on the board. It tests only the two error markers, which
+  is what makes it safe to run over the full list.
+
+  Deliberately NOT the whole guard: it omits the paused/executing checks as well as the column routing,
+  because it is a prefilter and `classifyPausedAbortWorkflowRecovery` remains the single authority on
+  whether a row is actually recoverable. Widening it into a second authority is how the filter and the
+  re-verify drift apart.
+  */
+  private isPauseAbortParkCandidate(task: Task): boolean {
+    return task.status === "failed"
+      && typeof task.error === "string"
+      && task.error.includes(PAUSE_ABORT_PARK_OPERATOR_MARKER)
+      && task.error.includes(PAUSE_ABORT_PARK_ERROR_MARKER);
+  }
+
+  /** The review + active-work sets the pause-abort router needs, resolved together over one IR cache. */
+  private async resolvePauseAbortColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<{ review: ReadonlySet<string>; activeWork: ReadonlySet<string> }> {
+    return {
+      review: await this.resolveReviewColumnsFor(taskId, cache),
+      activeWork: await this.resolveActiveWorkColumnsFor(taskId, cache),
+    };
+  }
+
   private classifyPausedAbortWorkflowRecovery(
     task: Task,
     settings: Settings,
     isExecuting: boolean,
+    columns: { review: ReadonlySet<string>; activeWork: ReadonlySet<string> },
   ): WorkflowRecoveryRoute {
     const isPausedAbortPark =
       task.status === "failed" &&
@@ -973,13 +1012,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.steps.every((step) => step.status === "done" || step.status === "skipped");
     const sharedBranchMember = isSharedBranchGroupMemberIntegration(task);
     const hasReviewProgress =
-      task.column === "in-review"
+      columns.review.has(task.column)
       && allowsAutoMergeProcessing(task, settings)
       && task.mergeDetails?.mergeConfirmed !== true
       && !isTerminalMergePark
       && completedSteps;
     const hasManualMergeHoldProgress =
-      task.column === "in-review"
+      columns.review.has(task.column)
       && (!allowsAutoMergeProcessing(task, settings) || resolveEffectiveAutoMerge(task, settings) === false)
       && !sharedBranchMember
       && task.mergeDetails?.mergeConfirmed !== true
@@ -1002,7 +1041,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     if (hasReviewProgress) {
       return { kind: "work-item-resume", reason: "pause-abort-review-progress" };
     }
-    if (task.column === "todo" || task.column === "in-progress") {
+    if (columns.activeWork.has(task.column)) {
       return { kind: "node-requeue", reason: "pause-abort-active-work" };
     }
     return { kind: "no-action", reason: "unsafe-or-not-routable" };
@@ -3106,6 +3145,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
     } catch {
       /* degraded: the legacy id alone, matching resolvePreWipColumns' catch */
+    }
+    return columns;
+  }
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet — the active-work sibling of `resolveReviewColumnsFor`):
+  MEMBERSHIP for the same arity reason its review sibling documents: a board may declare more than one
+  pre-review working lane, and first-per-role would silently ignore the second.
+
+  "Active work" is deliberately hold + countsTowardWip, NOT `resolvePreWipColumns`' intake + hold. The
+  pause-abort router asks "is this card mid-flight, so a requeue is the right recovery?", and an intake
+  lane is not mid-flight while a WIP lane is. Reusing the intake-shaped helper here would have widened the
+  requeue to triage rows and dropped in-progress ones — the same set, wrong members.
+
+  Unioned with the legacy ids because `resolveWorkflowIrForTask` answers a missing/corrupt workflow with the
+  BUILT-IN IR rather than throwing: without the union, a degraded board resolves a set excluding its own
+  working lanes and this recovery goes inert exactly when it is most needed.
+  */
+  private async resolveActiveWorkColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<ReadonlySet<string>> {
+    const columns = new Set<string>(["todo", "in-progress"]);
+    try {
+      const ir = await resolveWorkflowIrForTask(this.store, taskId, cache);
+      if (ir) {
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.hold) columns.add(lifecycle.hold);
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) columns.add(id);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching resolveReviewColumnsFor's catch */
     }
     return columns;
   }
@@ -12045,9 +12116,26 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
       const tasks = await this.store.listTasks({ slim: true });
 
-      const parked = tasks.filter((t) =>
-        this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id)).kind !== "no-action",
-      );
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-14:20 (fleet):
+      Resolution is per task (each card may run a different workflow), so it cannot hoist out of the
+      loop — but it also must not run for every row on the board. The pause-abort park is identified by
+      error MARKERS, which are column-independent, so the marker test stays a cheap synchronous prefilter
+      and the IR is read only for the handful of rows that pass it. The shared `cache` then makes the
+      re-verify below free for those same rows.
+
+      `parked` keeps its exact former membership, so the count in the log line below still means what it
+      said before this conversion.
+      */
+      const columnCache = new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>();
+      const parked: Task[] = [];
+      for (const t of tasks) {
+        if (!this.isPauseAbortParkCandidate(t)) continue;
+        const columns = await this.resolvePauseAbortColumnsFor(t.id, columnCache);
+        if (this.classifyPausedAbortWorkflowRecovery(t, settings, executingIds.has(t.id), columns).kind !== "no-action") {
+          parked.push(t);
+        }
+      }
 
       if (parked.length === 0) return 0;
 
@@ -12083,7 +12171,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             log.debug(`[self-healing] deferring pause-abort recovery for ${fresh.id}: a live session surface is registered`);
             continue;
           }
-          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id));
+          const freshColumns = await this.resolvePauseAbortColumnsFor(fresh.id, columnCache);
+          const route = this.classifyPausedAbortWorkflowRecovery(fresh, settings, latestExecutingIds.has(fresh.id), freshColumns);
           if (route.kind === "no-action") {
             continue;
           }

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -5473,9 +5473,30 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
       let repaired = 0;
 
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:45 (fleet — FN-5256 liveness cluster):
+      The four lane comparisons in this loop, resolved once per sweep as the PROJECT union. Board-wide
+      loop, so per-task resolution is one IR read per row on a recurring sweep, and the union needs no
+      per-task workflow selection — the same trade `reconcilePreExecutionWorktrees` makes.
+
+      Over-inclusion is the safe direction for EVERY use here, which is what makes the union sound:
+        - terminal (below): a wider terminal set skips more rows, i.e. repairs less. Benign.
+        - wip / review in the scopeOverride bypass: a wider set means FEWER rows take the bypass that
+          CLEARS worktree metadata.
+        - wip / review in the FN-5256 guard: a wider set PROTECTS more rows from having their worktree
+          nulled out.
+      A missed column, by contrast, yanks a worktree from a still-running shell — which is the exact
+      incident FN-5256 exists to prevent, and on a renamed board the literals missed every column.
+      */
+      const laneUnions = {
+        terminal: await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES),
+        wip: await resolveProjectColumnsForRoles(this.store, ["countsTowardWip"]),
+        review: await resolveProjectColumnsForRoles(this.store, REVIEW_ROLES),
+      };
+
       for (const task of allTasks) {
         if (!task.worktree) continue;
-        if (!options?.includeTaskIds?.has(task.id) && (task.column === "done" || task.column === "archived")) {
+        if (!options?.includeTaskIds?.has(task.id) && laneUnions.terminal.has(task.column)) {
           continue;
         }
 
@@ -5512,8 +5533,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const scopeOverrideMergeActiveSafe =
           task.scopeOverride === true
-          && task.column !== "in-progress"
-          && (task.column !== "in-review" || (typeof task.status === "string" && RECONCILE_SCOPE_OVERRIDE_MERGE_ACTIVE_STATUS_SET.has(task.status)));
+          && !laneUnions.wip.has(task.column)
+          && (!laneUnions.review.has(task.column) || (typeof task.status === "string" && RECONCILE_SCOPE_OVERRIDE_MERGE_ACTIVE_STATUS_SET.has(task.status)));
         if (scopeOverrideMergeActiveSafe) {
           /*
           FNXC:MissingWorktreeRecovery 2026-07-10-18:23:
@@ -5541,7 +5562,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         // live task's worktree looks stale here (and we couldn't rebind to a live
         // fusion/<id>), the executor's own recovery paths will detect and recreate
         // it. Clearing here yanks the worktree from a still-running shell.
-        if (task.column === "in-progress" || task.column === "in-review") {
+        if (laneUnions.wip.has(task.column) || laneUnions.review.has(task.column)) {
           await this.emitWorktreeMetadataAuditEvent({
             taskId: task.id,
             mutationType: "task:auto-recover-worktree-metadata-skipped-active",

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -9967,12 +9967,33 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
       const now = Date.now();
       const parked = await this.store.listTasks({ slim: true });
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:10 (fleet):
+      "Active or queued to become active" asked by id skipped every renamed board, so this sweep would
+      have judged a working card parked and TAKEN ITS WORKTREE — the destructive direction.
+
+      Resolved as the PROJECT union rather than per task. This filter runs over every card on the board,
+      so per-task resolution is one IR read per row on a recurring sweep; the union needs no per-task
+      workflow selection. Over-inclusion is the SAFE direction here and that is why the union is
+      acceptable: a column wrongly counted as active only means a worktree is left alone, whereas a
+      missed column means one is seized from live work
+      (docs/solutions/workflow-learnings/project-union-versus-per-task-lanes.md).
+
+      `archived` is deliberately absent, matching the literals this replaces: an archived card's
+      pre-execution worktree is reclaimable.
+      */
+      const activeOrQueuedColumns = await resolveProjectColumnsForRoles(this.store, [
+        "hold",
+        "countsTowardWip",
+        ...REVIEW_ROLES,
+        "complete",
+      ]);
       const candidates = parked.filter((task) => {
         if (!task.worktree || task.deletedAt) return false;
         // Execution evidence — the worktree may hold real work; only the merge/archive lifecycle owns it.
         if (task.firstExecutionAt || task.executionStartedAt) return false;
         // Columns where a card is active or queued to become active.
-        if (task.column === "todo" || task.column === "in-progress" || task.column === "in-review" || task.column === "done") return false;
+        if (activeOrQueuedColumns.has(task.column)) return false;
         /*
         WAITING is not PARKED. A card paused for an operator decision, carrying any status (planning,
         needs-replan, awaiting-*), blocked on another task, or scheduled for a recovery attempt is
@@ -13116,6 +13137,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
     const now = Date.now();
     const recoveredAgentIds = new Set<string>();
+    const linkedTaskColumnCache = new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>();
     const runningAgents = await agentStore.listAgents({ state: "running", includeEphemeral: true });
 
     for (const agent of runningAgents) {
@@ -13124,7 +13146,28 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       }
 
       const linkedTask = await this.store.getTask(agent.taskId);
-      if (linkedTask && (linkedTask.column === "in-progress" || linkedTask.column === "in-review" || linkedTask.column === "done" || linkedTask.column === "archived")) {
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-17:10 (fleet):
+      "The linked card is still live or already finished, so leave this agent alone." Asked by id, a
+      renamed board matched none of the four and every healthy agent looked stranded — this sweep then
+      recovers agents that are working normally.
+
+      Per task here, not the project union: the loop has already awaited `getTask`, so the card's own
+      workflow is the natural and correct scope, and the cache keeps it to one IR read per workflow
+      across the agent list. Over-inclusion stays the safe direction — an extra column means an agent is
+      left running rather than recovered out from under live work.
+      */
+      const linkedColumns = linkedTask
+        ? await this.resolveMoveFanoutColumnsFor(linkedTask.id, linkedTaskColumnCache)
+        : undefined;
+      if (
+        linkedTask
+        && linkedColumns
+        && (linkedColumns.wip.has(linkedTask.column)
+          || linkedColumns.review.has(linkedTask.column)
+          || linkedColumns.complete.has(linkedTask.column)
+          || linkedColumns.archived.has(linkedTask.column))
+      ) {
         continue;
       }
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -976,6 +976,84 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       && task.error.includes(PAUSE_ABORT_PARK_ERROR_MARKER);
   }
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:05 (fleet — task:moved fan-out vocabulary):
+  The lane sets the `task:moved` fan-out routes on. MEMBERSHIP throughout, for the arity reason
+  `resolveReviewColumnsFor` documents, and unioned with the legacy ids so a degraded IR keeps the
+  fan-out firing rather than silently resolving empty sets.
+
+  `wip` is `countsTowardWip` rather than the `wip` trait: the counter it feeds measures cards LEAVING the
+  working lane, which is the same population the WIP cap governs. A board declaring a second working lane
+  outside the cap should not have exits from it counted as board progress.
+  */
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet):
+  The synchronous twin of `resolveMoveFanoutColumnsFor`, for the one caller that cannot await: the
+  board-stall counter, whose increment must be visible to a sweep already in progress.
+
+  `resolveTaskWorkflowIrSync` is the same seam `scheduler.ts` uses for its own sync lane resolution. A
+  store that does not implement it, or a workflow that will not resolve, yields the legacy ids — the
+  degraded answer every resolver in this file gives, and the one that keeps the counter counting rather
+  than silently flat-lining board-stall detection.
+  */
+  private resolveMoveFanoutColumnsSync(taskId: string): {
+    wip: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+    hold: ReadonlySet<string>;
+  } {
+    const wip = new Set<string>(["in-progress"]);
+    const review = new Set<string>(["in-review"]);
+    const complete = new Set<string>(["done"]);
+    const archived = new Set<string>(["archived"]);
+    const hold = new Set<string>(["todo"]);
+    try {
+      const ir = this.store.resolveTaskWorkflowIrSync?.(taskId);
+      if (ir) {
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) wip.add(id);
+        for (const id of columnsWithFlag(ir, "mergeOrchestration")) review.add(id);
+        for (const id of columnsWithFlag(ir, "humanReview")) review.add(id);
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.complete) complete.add(lifecycle.complete);
+        if (lifecycle?.archived) archived.add(lifecycle.archived);
+        if (lifecycle?.hold) hold.add(lifecycle.hold);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching the async siblings' catch */
+    }
+    return { wip, review, complete, archived, hold };
+  }
+
+  private async resolveMoveFanoutColumnsFor(
+    taskId: string,
+    cache: Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>,
+  ): Promise<{
+    wip: ReadonlySet<string>;
+    review: ReadonlySet<string>;
+    complete: ReadonlySet<string>;
+    archived: ReadonlySet<string>;
+    hold: ReadonlySet<string>;
+  }> {
+    const wip = new Set<string>(["in-progress"]);
+    const complete = new Set<string>(["done"]);
+    const archived = new Set<string>(["archived"]);
+    const hold = new Set<string>(["todo"]);
+    try {
+      const ir = await resolveWorkflowIrForTask(this.store, taskId, cache);
+      if (ir) {
+        for (const id of columnsWithFlag(ir, "countsTowardWip")) wip.add(id);
+        const lifecycle = resolveLifecycleColumns(ir);
+        if (lifecycle?.complete) complete.add(lifecycle.complete);
+        if (lifecycle?.archived) archived.add(lifecycle.archived);
+        if (lifecycle?.hold) hold.add(lifecycle.hold);
+      }
+    } catch {
+      /* degraded: the legacy ids alone, matching the sibling resolvers' catch */
+    }
+    return { wip, review: await this.resolveReviewColumnsFor(taskId, cache), complete, archived, hold };
+  }
+
   /** The review + active-work sets the pause-abort router needs, resolved together over one IR cache. */
   private async resolvePauseAbortColumnsFor(
     taskId: string,
@@ -1523,28 +1601,32 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     };
     this.store.on("settings:updated", this.settingsListener);
 
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-15:20 (fleet):
+    Split deliberately by OBSERVABILITY, not by convenience.
+
+    The board-stall counter is incremented SYNCHRONOUSLY, because it is not merely read by a later
+    periodic sweep — `runBoardStallAutoRecoverySweep` performs its own recovery moves and then evaluates
+    progress in the SAME pass, so the increment must land before that read. Deferring it behind an await
+    made the sweep read a stale zero and report a real recovery as unrecovered (caught by
+    board-stall-auto-recovery.test.ts, which is why the sync resolver is used here).
+
+    The two reconcile branches were already fire-and-forget before this change, so they keep that shape
+    and resolve asynchronously.
+    */
     this.taskMovedFanoutListener = ({ task, from, to }) => {
+      const sync = this.resolveMoveFanoutColumnsSync(task.id);
       if (
-        from === "in-progress"
-        && (to === "todo" || to === "in-review" || to === "done" || to === "archived")
+        sync.wip.has(from)
+        && (sync.hold.has(to) || sync.review.has(to) || sync.complete.has(to) || sync.archived.has(to))
         && this.boardStallWindow
       ) {
         // In-memory only counter; resets on engine restart.
         this.boardStallWindow.transitionsOutOfInProgressInWindow++;
       }
-      if (to === "in-review") {
-        void this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) }).catch((err: unknown) => {
-          const errorMessage = err instanceof Error ? err.message : String(err);
-          log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
-        });
-      }
-      const shouldReconcile =
-        (from === "in-review" && to === "done") ||
-        (from === "done" && to === "archived");
-      if (!shouldReconcile) return;
-      void this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined }).catch((err: unknown) => {
+      void this.handleTaskMovedFanout(task, from, to).catch((err: unknown) => {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        log.warn(`[self-healing] task:moved completion fan-out failed for ${task.id}: ${errorMessage}`);
+        log.warn(`[self-healing] task:moved fan-out failed for ${task.id}: ${errorMessage}`);
       });
     };
     this.store.on("task:moved", this.taskMovedFanoutListener);
@@ -1553,6 +1635,38 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     this.startMaintenance();
 
     log.debug("Started");
+  }
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:05 (fleet):
+  The `task:moved` fan-out, routed on the moving task's own resolved lanes instead of the five literals
+  it used to compare against. On a renamed board every branch here went inert at once: the board-stall
+  counter stopped counting, in-review rebind stopped firing, and completed-task reconciliation stopped
+  running -- none of which fails a test, because the move still happens.
+
+  One IR read per move event, not per branch: the three branches share a cache.
+  */
+  private async handleTaskMovedFanout(task: Task, from: string, to: string): Promise<void> {
+    const columns = await this.resolveMoveFanoutColumnsFor(task.id, new Map());
+
+    if (columns.review.has(to)) {
+      try {
+        await this.reconcileInReviewBranchRebind({ includeTaskIds: new Set([task.id]) });
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.warn(`[self-healing] task:moved in-review rebind failed for ${task.id}: ${errorMessage}`);
+      }
+    }
+    const shouldReconcile =
+      (columns.review.has(from) && columns.complete.has(to)) ||
+      (columns.complete.has(from) && columns.archived.has(to));
+    if (!shouldReconcile) return;
+    try {
+      await this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined });
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.warn(`[self-healing] task:moved completion fan-out failed for ${task.id}: ${errorMessage}`);
+    }
   }
 
   /**

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -14356,10 +14356,22 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       const now = Date.now();
 
       // FNXC:WorkflowColumns 2026-07-29-09:30 (Phase B): intake role.
-      const intakeCandidates = await this.filterByPreWipRole(
-        tasks,
-        ["intake"],
-        new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>(),
+      const preWipCache = new Map<string, Awaited<ReturnType<typeof resolveWorkflowIrForTask>>>();
+      const intakeCandidates = await this.filterByPreWipRole(tasks, ["intake"], preWipCache);
+
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-16:40 (fleet):
+      "Peer progress" means peers sitting in their own board's HOLD lane, which was `peer.column ===
+      "todo"` in two places — once in the candidate filter, once again when computing the number recorded
+      in the log line and the audit metadata. Duplicated predicates that must agree are how a converted
+      guard ends up feeding an unconverted one, so both now read the same precomputed set.
+
+      Resolved ONCE for the whole board rather than per peer: this is an N-squared scan (every candidate
+      counts over every task), so a per-peer resolve would multiply IR reads by the candidate count. The
+      shared cache means one read per distinct workflow.
+      */
+      const holdPeerIds = new Set(
+        (await this.filterByPreWipRole(tasks, ["hold"], preWipCache)).map((peer) => peer.id),
       );
       const candidates = intakeCandidates.filter((task) => {
         if (task.sourceType !== "task_refine") return false;
@@ -14375,7 +14387,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         const peerProgressCount = tasks.filter((peer) =>
           peer.id !== task.id &&
-          peer.column === "todo" &&
+          holdPeerIds.has(peer.id) &&
           peer.sourceType !== "task_refine" &&
           new Date(peer.updatedAt).getTime() > createdAtMs,
         ).length;
@@ -14396,7 +14408,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const createdAtMs = new Date(task.createdAt).getTime();
           const peerProgressCount = tasks.filter((peer) =>
             peer.id !== task.id &&
-            peer.column === "todo" &&
+            holdPeerIds.has(peer.id) &&
             peer.sourceType !== "task_refine" &&
             new Date(peer.updatedAt).getTime() > createdAtMs,
           ).length;


### PR DESCRIPTION
Sixth cut into `self-healing.ts`. **Stacked on #3075 → #3080 → #3083 → #3084 → #3086.**

## Census

| Metric | Session start | Now |
|---|---:|---:|
| COLUMN guards (backlog) | 88 | **53** |
| `self-healing.ts` | 38 | **5** |

## The bug

FN-5256 exists because nulling a live task's worktree metadata **yanks the worktree from a still-running shell**. The guard enforcing it compared `task.column` against `"in-progress"`/`"in-review"` — so on a renamed board it protected **nothing**, and the incident it was written to prevent came back.

Revert the guard and the sweep writes `{ worktree: null, branch: null, sessionFile: null }` onto a live card in a working lane. The test asserts on `updateTask` **not** being called, because here the protection *is* the absence of a write — a test counting only the return value would pass while metadata was being cleared.

## Why the project union is sound here

All four comparisons live in one board-wide loop, resolved once per sweep. Over-inclusion is the safe direction for **every** use:

| Site | Wider set means | Direction |
|---|---|---|
| terminal skip | repairs less | benign |
| wip/review in scopeOverride bypass | **fewer** rows take the bypass that clears metadata | safe |
| wip/review in FN-5256 guard | **more** rows protected | safe |

A *missed* column is what does the damage — and the literals missed every one on a renamed board.

## Verification

- **Revert-proof on the write:** reverting the FN-5256 guard alone clears `branch: null` on a live renamed-lane card.
- 7 suites, **483 tests green**; tsc and eslint clean

## Remaining

5, down from 38. I have not read these closely yet — flagging them as **unread**, not blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-healing workflows on boards with renamed or custom workflow lanes.
  * Ensured paused and aborted tasks are recovered and requeued to the correct workflow lane.
  * Improved task fan-out, agent recovery, parked-task cleanup, and peer-progress detection.
  * Preserved support for legacy workflow identifiers when custom workflow details cannot be resolved.
  * Preserved live worktree information during recovery.
  * Improved starved refinement recovery and priority handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->