### PR TITLE
test(core): cover #3057's cold-storage conversion; audit two archived literals as dead sync

### DIFF
--- a/packages/core/src/__tests__/cold-storage-renamed-archive-lane.test.ts
+++ b/packages/core/src/__tests__/cold-storage-renamed-archive-lane.test.ts
@@ -1,0 +1,130 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-20:30:
+
+THE INVARIANT: cold storage is consulted for the BOARD'S OWN archive lane.
+
+COVERAGE FOR A LANDED, UNTESTED CONVERSION. #3057 converted this decision — `columnFilterIsArchive`
+replaced `columnFilter === "archived"` — and shipped no test. I had converted it independently and
+arrived after; rather than duplicate the change, this keeps the part main does not have.
+
+Why it is worth a test rather than a shrug. Archived rows do not live in `tasks`: `archiveTask`
+copies them into the archive store and removes them, so `listTasksImpl` decides whether to read that
+second store. Against the literal, a caller naming a RENAMED archive lane —
+`listTasks({ column: "filed", includeArchived: true })`, which is exactly what an archive view does —
+skipped cold storage and got an empty page.
+
+Note the shape: the UNFILTERED read (`!columnFilter`) was always correct, so this fails only for the
+caller that names the lane. It survives any board-level smoke test, and the symptom presents as "the
+archive is empty" rather than as a bug — which is precisely the class that regresses quietly once the
+conversion that fixed it has no test holding it.
+
+Driven through `listTasksImpl`, so the assertion is about the DECISION to consult cold storage.
+Whether the archive store returns the right rows is its own contract with its own tests; conflating
+them would make this pass for the wrong reason.
+*/
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { TaskStore } from "../store.js";
+
+/*
+The cold-storage read is a module function, not a store method, so the spy goes on the module. Only
+the two list entry points are replaced; everything else keeps its real export, because a bare factory
+would silently drop the other archive readers `reads.ts` imports from here.
+*/
+const { listArchivedTasksMock, listArchivedByCreatedOrderMock } = vi.hoisted(() => ({
+  listArchivedTasksMock: vi.fn(async () => []),
+  listArchivedByCreatedOrderMock: vi.fn(async () => []),
+}));
+vi.mock("../async-archive-db.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listArchivedTasks: listArchivedTasksMock,
+  listArchivedTasksByCreatedOrder: listArchivedByCreatedOrderMock,
+}));
+
+/*
+The LIVE read has to succeed for control flow to reach the cold-storage decision at all. My first
+version left it real against a fake `layer.db`, it threw, the `.catch` swallowed it, and ALL THREE
+cases "passed the negative" — including the legacy control, which is what exposed it. A test whose
+subject is never reached looks identical to a test whose subject answered no.
+*/
+vi.mock("../task-store/async-persistence.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  readLiveTaskRows: vi.fn(async () => []),
+}));
+
+const { listTasksImpl } = await import("../task-store/reads.js");
+
+/** Either entry point counts — which one runs depends on pagination, not on the lane decision. */
+function coldStorageConsulted(): boolean {
+  return listArchivedTasksMock.mock.calls.length > 0 || listArchivedByCreatedOrderMock.mock.calls.length > 0;
+}
+
+/** Hold `drafting`, complete `shipped`, archive `filed` — no legacy id anywhere. */
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "drafting", name: "Drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    { id: "filed", name: "Filed", traits: [{ trait: "archived" }] },
+  ],
+};
+
+/**
+ * The seam under test is "was cold storage consulted", so the archive reader is a spy over a fixed
+ * row set. `liveRows` stands in for the `tasks` table, which by construction holds no archived rows.
+ */
+function storeWith(definitions: unknown[]) {
+  return {
+    listWorkflowDefinitions: vi.fn(async () => definitions),
+    isWatching: true,
+    startupSlimListMemo: new Map(),
+    asyncLayer: { db: {}, projectId: "p1" },
+    getAsyncLayer: () => ({ db: {}, projectId: "p1" }),
+    getSettingsFast: vi.fn(async () => ({})),
+    getMergeQueuedTaskIdsAsync: vi.fn(async () => new Set<string>()),
+    archiveEntryToTask: vi.fn(() => ({})),
+  } as unknown as TaskStore;
+}
+
+describe("cold storage is consulted for the board's own archive lane", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("consults cold storage for a RENAMED archive lane", async () => {
+    const impl = storeWith([{ ir: RENAMED_IR }]);
+
+    await listTasksImpl(impl, { column: "filed" as never, includeArchived: true, slim: true })
+      .catch(() => undefined);
+
+    /* Keyed on the `archived` literal this was never called and the archive view rendered empty. */
+    expect(coldStorageConsulted()).toBe(true);
+  });
+
+  /*
+  CONTROL. The legacy id must keep opting in — `resolveProjectColumnsForRoles` seeds it, so an
+  unconverted board behaves exactly as before. Without this case a conversion that resolved the
+  renamed lane and DROPPED the legacy one would pass the case above while breaking every default
+  board, which is the seeding hazard in its other direction.
+  */
+  it("still consults cold storage for the legacy `archived` id", async () => {
+    const impl = storeWith([{ ir: RENAMED_IR }]);
+
+    await listTasksImpl(impl, { column: "archived" as never, includeArchived: true, slim: true })
+      .catch(() => undefined);
+
+    expect(coldStorageConsulted()).toBe(true);
+  });
+
+  /*
+  The paired negative. The conversion widens an inclusion, so it must not make EVERY filtered read
+  pay a cold-storage query — a board read for the wip lane has no archived rows to find, and turning
+  that into a second store round-trip on every board poll is a real cost.
+  */
+  it("does NOT consult cold storage for a lane that is not the archive lane", async () => {
+    const impl = storeWith([{ ir: RENAMED_IR }]);
+
+    await listTasksImpl(impl, { column: "drafting" as never, includeArchived: true, slim: true })
+      .catch(() => undefined);
+
+    expect(coldStorageConsulted()).toBe(false);
+  });
+});

--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -2329,6 +2329,17 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
       const linkedTask = this.db.prepare(
         `SELECT id, "column" FROM tasks WHERE id = ? AND "deletedAt" IS NULL`
       ).get(feature.taskId) as { id: string; column: string } | undefined;
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-20:15 (audited — DEAD SYNC PATH, do not convert):
+      On a renamed board this literal would call an archived card LIVE and refuse the unforced delete,
+      except that this class does not run in production. `getMissionStoreImpl` returns the
+      AsyncDataLayer-backed `AsyncMissionStore` in PostgreSQL backend mode; the sync `MissionStore`
+      (`this.db.prepare`, two lines up) is legacy SQLite only, and `store.db` throws under PG.
+
+      Same class as `dequeueMergeQueueOnColumnExitImpl` in `project-store-ops.ts`. Recorded rather
+      than converted so the census entry is not mistaken for unconverted debt, and so whoever deletes
+      the sync SQLite residue takes this with it.
+      */
       const linkedToLiveTask = linkedTask && linkedTask.column !== "archived";
 
       if (linkedToLiveTask && !force) {

--- a/packages/core/src/task-store/lifecycle-ops.ts
+++ b/packages/core/src/task-store/lifecycle-ops.ts
@@ -652,6 +652,18 @@ export async function checkForChangesImpl(store: TaskStore): Promise<void> {
               // Skip already-archived cache entries to avoid no-op emits.
               // Activity-log listeners skip polling emits; the originating
               // TaskStore instance wrote the row in-process.
+              /*
+              FNXC:WorkflowResolvedColumns 2026-07-31-20:15 (audited — DEAD SYNC PATH, do not convert):
+              Both the guard and the `to: "archived"` it emits are literals, so on a renamed board a
+              polling replica would emit a move to a column the board does not declare. It cannot:
+              `checkForChangesImpl` opens with `store.db.getLastModified()` and `store.db.prepare`,
+              which throw in PostgreSQL backend mode, so this whole polling replica path is legacy
+              SQLite only.
+
+              Recorded rather than converted, for the same reason as `mission-store.ts` and
+              `project-store-ops.ts`: an unconverted literal in dead code is not debt a fleet pass
+              should spend a signature change on, but it must not read as missed either.
+              */
               if (cached.column !== "archived") {
                 store.emit("task:moved", { task: cached, from: cached.column, to: "archived" as Column, source: "engine" });
               }


### PR DESCRIPTION
**Replaces #3085, which I am closing.** #3057 landed the same cold-storage conversion while that PR was open. Rather than argue about which spelling wins, this keeps only what `main` does not have: the coverage, and two audits.

## #3057 converted this and shipped no test

`listTasksImpl`'s `columnFilterIsArchive` replaced `columnFilter === "archived"`. Correct change — and the kind that needs a test more than most, because of how it fails.

Archived rows do not live in `tasks`; `archiveTask` copies them into the archive store and removes them. This decision is whether that second store is read **at all**. Against the literal, a caller naming a renamed archive lane — `listTasks({ column: "filed", includeArchived: true })`, which is what an archive view does — got an empty page from the only API that can reach those rows.

Note the shape: the **unfiltered** read (`!columnFilter`) was always correct. It fails only for the caller that names the lane, so it survives any board-level smoke test and presents as *"the archive is empty"* rather than as a bug. That is precisely the class that regresses quietly once the conversion that fixed it has nothing holding it.

Three cases, and each earns its place:

| case | what it stops |
|---|---|
| renamed archive lane | the regression itself |
| legacy `archived` id (**control**) | a future conversion that resolves the renamed lane and *drops* the legacy seed — the seeding hazard in its other direction |
| non-archive lane (**negative**) | the widening turning every filtered board read into a second-store round-trip |

**MUTATION**: restoring `columnFilter === "archived"` fails **only** the renamed case.

**A trap worth recording.** My first version left the LIVE read real against a fake `layer.db`. It threw, the `.catch` swallowed it, and all three cases passed the negative — *including the legacy control*, which is what exposed it. A test whose subject is never reached looks identical to one whose subject answered no. `readLiveTaskRows` is mocked now, and the control is what made it detectable.

## Audited, not converted — two dead sync paths

Both would be real defects if they ran. Neither runs.

| site | why it is dead |
|---|---|
| `mission-store.ts` (feature-delete link check) | `getMissionStoreImpl` returns the AsyncDataLayer-backed `AsyncMissionStore` under PostgreSQL; the sync `MissionStore` reached via `this.db.prepare` is legacy SQLite only |
| `lifecycle-ops.ts` (polling-replica archive emit) | `checkForChangesImpl` opens with `store.db.getLastModified()` / `store.db.prepare`, which throw in backend mode |

The second is the sharper one: **both** its guard and the `to: "archived"` it emits are literals, so a polling replica on a renamed board would emit a move to a column the board does not declare.

Recorded in place — the treatment `project-store-ops.ts`'s dequeue twin already has — so the census entries are not mistaken for unconverted debt, and whoever deletes the sync SQLite residue takes these with it.

**They stay COUNTED.** Marking them DELIBERATE-LITERAL would buy a smaller number by asserting the code is *correct*. It is not correct; it is unreachable. Those are different claims with different expiries, and the census should keep pointing here until the code is gone.

## Census

No movement — by design. This PR adds coverage and audits; it converts nothing that was not already converted on `main`.

## Measured

- 3 new cases pass; `src/__tests__/{cold-storage,archive,unarchive}*` — **6 files / 21 tests pass**
- `tsc --noEmit -p packages/core` clean; census `--strict` clean