### PR TITLE
chore(core): flag the eval-signal archived lane — converting it would create an unwired seam

### DIFF
--- a/packages/core/src/eval-signal-collector.ts
+++ b/packages/core/src/eval-signal-collector.ts
@@ -110,6 +110,25 @@ export function collectDeterministicSignals(task: TaskDetail, _run: EvalRunConte
 
   return {
     taskId: task.id,
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-31-22:10 (fleet — FLAGGED, deliberately NOT converted):
+    REAL but narrow, and converting it here would create a worse defect than it fixes.
+
+    The GUARD is a genuine lane question: on a board whose archive lane is renamed, a card resting in
+    it takes the `: "done"` arm, so archived work is reported to evals as COMPLETED. The written value
+    is not the defect — `"archived"`/`"done"` is this signal's own two-state vocabulary, not a board
+    column id, so it must stay a literal in any conversion.
+
+    Not converted because `collectDeterministicSignals` has NO production caller. Measured, not
+    assumed: the only references outside this file are the `index.ts` / `index.gate.ts` re-exports and
+    `__tests__/eval-signal-collector.test.ts`. Threading an optional `archivedColumns` in would
+    therefore be an optional lane parameter that nobody supplies — exactly the shape
+    `scripts/check-inert-flag-seams.mjs` exists to block, and which its own header calls "strictly
+    worse than the literal, because the literal is at least honest and the census keeps pointing here".
+
+    Convert it in the change that gives this function its first real caller, resolving the archive lane
+    from that caller's store, and drop this note then.
+    */
     column: task.column === "archived" ? "archived" : "done",
     executionStartedAt: task.executionStartedAt,
     executionCompletedAt: task.executionCompletedAt,


### PR DESCRIPTION
## The last unexamined unclaimed site — flagged, not converted

Every other census site is now claimed by an open PR, already flagged with a reason, a fallback arm of a converted seam, or inside a synchronous listener where the only available resolver is inert. This was the one I had not personally read, so I read it.

## What is actually wrong

```ts
column: task.column === "archived" ? "archived" : "done",
```

On a board whose archive lane is renamed, a card resting in it takes the `: "done"` arm — so **archived work is reported to evals as completed**. Real, and narrow.

Two halves, and only one is convertible:

- the **guard** (`task.column === "archived"`) is a genuine lane question and is the defect;
- the **written value** (`"archived"` / `"done"`) is this signal's own two-state vocabulary, not a board column id. It must stay a literal in any conversion. Recorded in the note so a future pass does not "finish the job" by resolving both.

## Why I did not convert it

`collectDeterministicSignals` **has no production caller.** Measured rather than assumed — the only references outside the file are the `index.ts` / `index.gate.ts` re-exports and `__tests__/eval-signal-collector.test.ts`.

So threading an optional `archivedColumns` in would produce an optional lane parameter that nobody supplies. That is precisely the shape `scripts/check-inert-flag-seams.mjs` exists to block, and its own header is unambiguous about the trade:

> An unsupplied optional parameter is **strictly worse than the literal** — the literal is at least honest, and the census keeps pointing here.

Converting would have moved the census by one and made the codebase worse. The note says what to do instead: convert it in the change that gives this function its first real caller, resolving the archive lane from that caller's store.

## Census before / after

```
before:  COLUMN guards (the backlog):   52
after:   COLUMN guards (the backlog):   52
```

Unchanged, deliberately. A flag note does not remove a guard — it attaches the reason so the site stops being mistaken for unexamined debt.

## Verification

`test:gate` exit 0 · `eval-signal-collector.test.ts` 2/2 · typecheck exit 0 · `check-inert-flag-seams` exit 0 · lifecycle-column census exit 0 · `pnpm lint` clean.

## Still outstanding, unchanged from last round

**#3079** is open and MERGEABLE. Five open PRs (#3080, #3083, #3084, #3086, #3088) share `resolveMoveFanoutColumnsSync`, which reads `resolveTaskWorkflowIrSync` and is inert under PostgreSQL — five guards each that behave exactly as the literals they replaced, refuted live in #3058. #3079 is what turns that into a build failure instead of a five-guard census win.

I looked at the payload fix everyone's notes recommend (carry resolved lanes on `task:moved`) and did **not** start it: three engine forwarders — `project-manager.ts`, `remote-node-runtime.ts`, `child-process-runtime.ts` — **reconstruct** the payload rather than forwarding it, so the lanes would be silently dropped there and listeners would fall back to the literal. That is the same silent-fallback class, and attempting it across eight concurrent PRs on the listener files would be reckless. Recording the hazard for whoever does take it.
