### PR TITLE
fix(census): commit the tightened baseline — main is red on two census tests

### DIFF
--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/engine/src/self-healing.ts": 26,
+    "packages/engine/src/self-healing.ts": 22,
     "packages/engine/src/notification/notification-service.ts": 5,
     "packages/engine/src/executor.ts": 4,
     "packages/core/src/task-store/project-store-ops.ts": 2,


### PR DESCRIPTION
## `main` is red

`lifecycle-column-census.test.ts` fails on clean `origin/main`:

```
AssertionError: expected 22 to be 26
```

Committing the baseline the gate has been asking for takes that suite from **38/40 to 40/40**.

## The drift

The committed baseline allows `self-healing.ts` **26** guards. The tree has **22**. A fleet PR took it down without re-recording.

That's easy to miss, and the reason is by design: the census **exits 0 on a drop**, deliberately, so one worker's merge can't redden the gate for everyone else.

## The cost that design has, now visible

The baseline goes stale **invisibly**. Every local run rewrites the file, prints `COMMIT IT`, and exits 0 — so nothing blocks, and the only thing that eventually notices is the tighten test, which asserts `allowedAfter === inflatedFrom - 3` against a real file and fails the moment the recorded number stops matching the tree.

Both failing cases share that root cause. Neither is about the code under test.

## Worth a decision separately

That fixture pins arithmetic against whichever real file has the largest allowance, so **it will re-break on the next unrecorded drop** — and with a fleet actively converting `self-healing.ts`, that's likely soon.

Deriving the fixture from the tree rather than the committed baseline would make it self-maintaining, but that changes what the test guards. Noted rather than done, since it's the owner's call.

## Measured

| check | result |
|---|---|
| census suite | **38/40 → 40/40** |
| `--strict` after commit | exits 0 and leaves the file unmodified — no residual drift |
| five gates | green |