### PR TITLE
test(engine): pin the agent-link-drift terminal check on a renamed board (an agent stayed linked to finished work)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-agent-link-drift.test.ts
+++ b/packages/engine/src/__tests__/self-healing-agent-link-drift.test.ts
@@ -200,4 +200,65 @@ describe("FN-4296: self-healing agent link drift", () => {
     expect((agentStore as any).syncExecutionTaskLink).toHaveBeenCalledTimes(1);
     manager.stop();
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-19:20:
+  #3078 converted this sweep's terminal check to the role pair and merged before any test covered it.
+  Measured then: with the conversion reverted, all 204 self-healing tests still passed — every case in
+  this file uses `done`/`archived`, where the literal is correct, so none of them could see it.
+
+  What the literal cost on a renamed board: a durable agent stayed LINKED to a finished task forever.
+  The agent is not free to pick up new work while it is linked, so the drift this sweep exists to
+  clear is exactly the drift it stopped clearing.
+  */
+  const RENAMED_IR = {
+    version: "v2", id: "custom:renamed", nodes: [], edges: [],
+    columns: [
+      { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "shipped", name: "shipped", traits: [{ trait: "complete" }] },
+    ],
+  };
+
+  function buildRenamedManager(agents: Agent[], tasks: Record<string, Task | null>) {
+    const store = {
+      getTask: vi.fn(async (taskId: string) => tasks[taskId] ?? null),
+      recordRunAuditEvent: vi.fn(async () => {}),
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
+    } as any;
+    const agentStore = {
+      listAgents: vi.fn(async (filter?: { includeEphemeral?: boolean }) =>
+        filter?.includeEphemeral === false ? agents.filter((a) => !isEphemeralAgent(a)) : agents),
+      getActiveHeartbeatRun: vi.fn(async () => null),
+      updateAgentState: vi.fn(async (agentId: string, state: Agent["state"]) => {
+        const agent = agents.find((candidate) => candidate.id === agentId);
+        if (agent) agent.state = state;
+      }),
+      syncExecutionTaskLink: vi.fn(async (agentId: string, taskId?: string) => {
+        const agent = agents.find((candidate) => candidate.id === agentId);
+        if (agent) agent.taskId = taskId;
+      }),
+    } as unknown as AgentStore;
+    return new SelfHealingManager(store, { rootDir: "/tmp/test-project", agentStore });
+  }
+
+  it("clears a durable agent linked to a task in a RENAMED complete lane", async () => {
+    const agents = [makeAgent("agent-1", "FN-9")];
+    const manager = buildRenamedManager(agents, { "FN-9": { id: "FN-9", column: "shipped" } as Task });
+
+    await manager.recoverDriftedAgentTaskLinks();
+
+    expect(agents[0].taskId).toBeUndefined();
+    manager.stop();
+  });
+
+  it("leaves a durable agent linked to a task still in a RENAMED wip lane", async () => {
+    /* The sweep must narrow, not widen: an agent on live work keeps its link. */
+    const agents = [makeAgent("agent-1", "FN-8")];
+    const manager = buildRenamedManager(agents, { "FN-8": { id: "FN-8", column: "building" } as Task });
+
+    await manager.recoverDriftedAgentTaskLinks();
+
+    expect(agents[0].taskId).toBe("FN-8");
+    manager.stop();
+  });
 });


### PR DESCRIPTION
Second of the two uncovered sweeps I flagged when #3078 merged. Not a conversion — the conversion is already on main (`driftedTerminalColumns`, landed by another fleet PR). This is the coverage it shipped without.

## What was unprotected

Every existing case in this file uses `done` or `archived`, where the literal is correct. So the terminal check had **no renamed-board case at all**, and the same measurement that caught #3078 applies: a green file proves nothing about a conversion whose fixtures can't express the failure.

What the literal cost on a renamed board: **a durable agent stayed linked to a finished task forever.** A linked agent is not free to pick up new work, so the drift this sweep exists to clear is exactly the drift it stopped clearing.

## Measured, both directions

| case | result |
|---|---|
| agent linked to a task in a RENAMED complete lane is cleared | **fails on revert** — `taskId` still `"FN-9"`, agent pinned to finished work |
| agent linked to a task still in a RENAMED wip lane keeps its link | passes either way — the sweep must narrow, not widen |

14 pass on current main; reverting the terminal check to the id pair fails exactly one.

## Note on the fleet

This sweep was converted by someone else's PR while I was writing the test for it — I found out because my revert probe hit `driftedTerminalColumns`, a name I did not write. That is the collision pattern working in a *useful* direction for once: their conversion, my coverage, no duplicated code.

It also means the two of us independently chose the same sweep from a 7-PR pileup on this file. Assigning files from the census list would still be cheaper than discovering the overlap in a test harness.

## Verification

`self-healing-agent-link-drift` **14 passed** · `pnpm test:gate` 13 + 161 + 487 + 71 · lint — green.
