### PR TITLE
docs(engine): flag executor's four task:moved literals — the obvious conversion is provably inert

### DIFF
--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -3552,6 +3552,38 @@ export class TaskExecutor {
       return {removed, failed};
     });
 
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:20 (FLAGGED AND LEFT COUNTED — do NOT convert with
+    `resolveTaskWorkflowIrSync` / `resolvePlannerLanes`):
+
+    Four lifecycle literals live in this listener and they are genuinely wrong on a renamed board:
+    execution never starts on a move INTO the board's own wip lane, terminal session release never
+    runs on a move into its archive lane, and the two `from` guards never fire, so in-flight work is
+    not aborted when a card leaves implementation. Nothing errors; the engine simply stops reacting.
+
+    THE OBVIOUS FIX IS INERT, AND THAT IS NOW PROVED RATHER THAN ARGUED. `task:moved` is emitted
+    synchronously, so an await here reorders this handler against every other subscriber — which
+    points at the sync IR path. That path cannot answer for a renamed board, for TWO independent
+    reasons (`sync-workflow-ir-second-blocker.test.ts`):
+
+      1. `getTaskWorkflowSelectionImpl` returns `undefined` unconditionally under PostgreSQL, so
+         `resolveTaskWorkflowIrSync` always takes its `!workflowId` branch;
+      2. even with a selection, the CUSTOM-workflow branch loads its IR through `store.db`, whose
+         implementation is an unconditional throw — so it falls into the catch and returns the
+         DEFAULT IR anyway.
+
+    A renamed lane IS a custom workflow, so (2) alone is decisive: the sync path can never serve this
+    listener's case. `check-inert-sync-lane-conversions` already baselines twenty guards in exactly
+    that state in `scheduler.ts`; these four must not join them.
+
+    They stay literal and COUNTED, which is the honest state — an unconverted literal is visible to
+    the census, while an inert conversion leaves the backlog and takes the evidence with it.
+
+    UNBLOCKING needs the async resolver reachable from here, which means either an async listener
+    contract (a behaviour change to handler ordering, not a column conversion) or a sync reader that
+    answers for custom workflows AND survives a writer on another node — the three constraints are
+    written up in `sync-workflow-ir-second-blocker.test.ts`.
+    */
     store.on("task:moved", ({ task, from, to, source }) => {
       executorLog.log(`[event:task:moved] ${task.id}: ${from} → ${to}`);
       if (to === "in-progress") {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -3579,10 +3579,24 @@ export class TaskExecutor {
     They stay literal and COUNTED, which is the honest state — an unconverted literal is visible to
     the census, while an inert conversion leaves the backlog and takes the evidence with it.
 
-    UNBLOCKING needs the async resolver reachable from here, which means either an async listener
-    contract (a behaviour change to handler ordering, not a column conversion) or a sync reader that
-    answers for custom workflows AND survives a writer on another node — the three constraints are
-    written up in `sync-workflow-ir-second-blocker.test.ts`.
+    THE CRITERION IS NARROWER THAN "THE LISTENER IS SYNC", and I got this wrong first time elsewhere:
+    what blocks a guard is whether ITS ANSWER IS CONSUMED SYNCHRONOUSLY, not whether it happens to sit
+    inside a synchronous function. In `self-healing.ts`'s fan-out, three of four guards only gated work
+    the listener already `void`s, so they were reachable by the async resolver all along and are now
+    converted. These four are NOT that case, for two independent reasons:
+
+      A. `trackTaskDisposal` writes `pendingTaskDisposals` in THIS tick, and the `to === wip` branch
+         above READS that map to serialise a fast bounce (in-progress -> todo -> in-progress; the
+         FN-5256 note it carries). Deferring the branch selection to a microtask lets the second
+         event's prologue read the map before the first event's write lands — which reopens exactly
+         the race that comment exists to close.
+      B. This is an if / else-if CHAIN, so the guards are entangled: converting one changes which
+         branch a move falls into. They convert together or not at all, and (A) blocks the set.
+
+    UNBLOCKING therefore needs the async resolver reachable from a SYNCHRONOUS consumer, which means
+    either a sync reader that answers for custom workflows AND survives a writer on another node, or
+    restructuring the disposal bookkeeping so nothing is read in-tick — the constraints are written up
+    in `sync-workflow-ir-second-blocker.test.ts`.
     */
     store.on("task:moved", ({ task, from, to, source }) => {
       executorLog.log(`[event:task:moved] ${task.id}: ${from} → ${to}`);


### PR DESCRIPTION
The largest unclaimed census cluster. **Nothing in this file said why the sync-lane pass skipped it**, and that silence is the hazard: the obvious next move is to convert these the way `scheduler.ts`'s ten were converted, which would make them **inert rather than fixed**.

## The literals are genuinely wrong — this is not a "non-issue" flag

All four sit in one synchronous `task:moved` listener, and on a renamed board:

- execution **never starts** on a move into the board's own wip lane;
- terminal session release **never runs** on a move into its archive lane;
- both `from` guards never fire, so **in-flight work is not aborted** when a card leaves implementation.

Nothing errors. The engine simply stops reacting.

## Why the obvious fix is inert — proved, not argued

`task:moved` is emitted synchronously, so an `await` here reorders this handler against every other subscriber. That points at the sync IR path, which cannot answer for a renamed board for **two independent reasons** (`sync-workflow-ir-second-blocker.test.ts`, #3103):

1. `getTaskWorkflowSelectionImpl` returns `undefined` unconditionally under PostgreSQL, so `resolveTaskWorkflowIrSync` always takes its `!workflowId` branch.
2. Even **with** a selection, the custom-workflow branch loads its IR through `store.db`, whose implementation is an **unconditional throw** — so it falls into the catch and returns the default IR anyway.

**A renamed lane is a custom workflow, so (2) alone is decisive.** The sync path can never serve this listener's case, whatever the selection reader is fixed to do. That is the part the existing notes across this repo miss, and it is why flagging beats attempting here.

`check-inert-sync-lane-conversions` already baselines **twenty** guards in exactly that state in `scheduler.ts`. These four must not join them.

## Census

**Unchanged at 4, deliberately.**

Marking them DELIBERATE-LITERAL would buy a smaller number by asserting the code is *fine*. It is not fine — it is *blocked*. Those are different claims with different expiries, and the census should keep pointing here until the block is lifted. An unconverted literal is visible; an inert conversion leaves the backlog and takes the evidence with it.

## Measured

- Comment-only change.
- `src/__tests__/executor*` — **84 files / 853 tests pass**.
- `tsc --noEmit -p packages/engine` clean; census `--strict`, `check-inert-sync-lane-conversions`, `check-fnxc-future-dates` clean.

## Unblocking, for whoever takes it

Either an async listener contract — a behaviour change to handler ordering, not a column conversion — or a sync reader that answers for **custom** workflows *and* survives a writer on another node. All three constraints are written up in `sync-workflow-ir-second-blocker.test.ts` (#3103).
