### PR TITLE
fix(census): surface files where a conversion may be INERT

### DIFF
--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -177,6 +177,57 @@ if (!json) {
   }
 }
 
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-20:10 (fleet — the census could not see an INERT conversion):
+
+`resolveTaskWorkflowIrSync` returns the DEFAULT workflow IR for every task in production (PostgreSQL
+mode's sync selection reader answers `undefined` unconditionally; see
+`sync-workflow-ir-callsite-allowlist.test.ts` and `postgres/sync-workflow-ir-is-always-default.pg.test.ts`).
+
+A guard whose lane comes from that resolver behaves EXACTLY as the literal it replaced — but this
+census scored it as converted, so the backlog fell while nothing changed in production. The call-site
+allow-list stops that class GROWING; it does not stop it COUNTING, because an allow-listed site still
+looks converted from here.
+
+MEASURED when added: `scheduler.ts` holds 10 guards fed by its allow-listed sync resolver, all already
+subtracted from the backlog by earlier PRs. Two conversions of mine were in this class and only one was
+caught — by the ratchet, not by this tool.
+
+A WARNING, not a subtraction: attributing individual guards to the resolver needs dataflow this parser
+does not do, so the honest output is "this file contains a sync call site, so conversions in it may be
+inert" rather than a precise number that would be wrong the other way.
+*/
+if (!json) {
+  const SYNC_RESOLVER = "resolveTaskWorkflowIrSync";
+  const syncCall = new RegExp(SYNC_RESOLVER + "\\s*\\??\\.?\\s*\\(");
+  const remainingByFile = new Map(summary.byFile);
+  const suspect = [];
+  /* Every censused file, not only those with remaining guards: a file converted ENTIRELY through the
+     sync resolver has zero remaining literals and would otherwise be invisible — the case most worth
+     surfacing, because it reads as 100% done and is inert. */
+  for (const file of files) {
+    let source;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    if (!syncCall.test(source)) continue;
+    suspect.push({ file, count: remainingByFile.get(file) ?? 0 });
+  }
+  if (suspect.length > 0) {
+    suspect.sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+    console.log("\n  SYNC-RESOLVED files (conversions here may be INERT): " + suspect.length);
+    console.log("  `" + SYNC_RESOLVER + "` answers with the DEFAULT workflow in production, so a guard");
+    console.log("  resolved through it behaves exactly as the literal did. Counts are REMAINING literals;");
+    console.log("  a count of 0 is the WORST case, not the best — the file reads as fully converted.");
+    for (const entry of suspect.slice(0, 10)) {
+      console.log("    " + String(entry.count).padStart(4) + "  " + entry.file);
+    }
+    if (suspect.length > 10) console.log("    … and " + (suspect.length - 10) + " more");
+  }
+}
+
 if (compare) {
   /*
   FNXC:WorkflowLifecycleColumns 2026-07-30-23:05:


### PR DESCRIPTION
Tooling fix for a measurement gap **I created and then found.** Independent of my other branches.

## The gap

`resolveTaskWorkflowIrSync` returns the **default** workflow IR for every task under PostgreSQL — the shipped backend — because the sync selection reader answers `undefined` unconditionally. A guard resolved through it behaves **exactly as the literal it replaced**, yet the census scored it as converted. The backlog number fell; production did not change.

I did this twice. One was caught by the new call-site ratchet (`self-healing.ts`, since reverted to an honest literal). The other — `scheduler.ts` in my merged #3051 — was not, because it has an allow-list entry.

**The allow-list stops the class growing. It does not stop it counting.** `scheduler.ts` alone holds **10 guards** fed by its allow-listed sync resolver, all already subtracted from the backlog by earlier PRs.

## What this adds

```
  SYNC-RESOLVED files (conversions here may be INERT): 5
  `resolveTaskWorkflowIrSync` answers with the DEFAULT workflow in production, so a guard
  resolved through it behaves exactly as the literal did. Counts are REMAINING literals;
  a count of 0 is the WORST case, not the best — the file reads as fully converted.
       2  packages/engine/src/scheduler.ts
       0  packages/core/src/store.ts
       0  packages/core/src/task-store/task-store-helpers.ts
       0  packages/core/src/task-store/workflow-task-create-ops.ts
       0  packages/engine/src/replan-target.ts
```

Two deliberate choices:

- **Scans every censused file, not just those with remaining literals.** A file converted *entirely* through the sync resolver has zero remaining and would be invisible — which is exactly the case worth surfacing, because it reads as 100% done. Four of the five are at zero, including `replan-target.ts`, which the ratchet's own notes record as found only by the ratchet.
- **A warning, not a subtraction.** Attributing individual guards to the resolver needs dataflow this parser doesn't do, so the honest output is "this file contains a sync call site, conversions in it may be inert" rather than a precise number wrong in the other direction.

## Verification

- Totals and `--json` **byte-identical** before/after (stash-compare: 47 guards, 132 deliberate both ways) — the section is purely additive
- Census suites green: 53 tests + the node-test fallback suite
- Regex requires a *call*, not a mention, so the many files discussing this in prose don't trip it

## Why it matters to the program

You steer by the backlog number. Right now a real conversion and an inert one are indistinguishable in it, and my own reports of "20 / 45 / 74 sites resolved" were computed that way. This makes the ambiguity visible at the point of measurement instead of relying on a reviewer remembering the PG caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)