### PR TITLE
chore(engine): mark the auto-merge-finalization reviewed literals DELIBERATE (census 47→45)

### DIFF
--- a/packages/engine/src/auto-merge-finalization.ts
+++ b/packages/engine/src/auto-merge-finalization.ts
@@ -27,6 +27,8 @@ async function resolveFinalizationColumns(
     return {
       completeColumn: "done",
       mergeColumn: "in-review",
+      /* DELIBERATE-LITERAL — the degraded fallback arm; the live arm above calls `columnHasFlag`.
+         Reached only when IR resolution throws, where the legacy id is the only answer left. */
       isCompleteColumn: (columnId: string) => columnId === "done",
     };
   }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -3,8 +3,8 @@
   "byFile": {
     "packages/engine/src/self-healing.ts": 22,
     "packages/engine/src/executor.ts": 4,
+    "packages/engine/src/auto-merge-finalization.ts": 3,
     "packages/dashboard/app/utils/taskRevert.ts": 2,
-    "packages/engine/src/auto-merge-finalization.ts": 2,
     "packages/engine/src/scheduler.ts": 2,
     "packages/core/src/eval-signal-collector.ts": 1,
     "packages/core/src/mission-store.ts": 1,
@@ -23,6 +23,7 @@
   "deliberateByFile": {
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 5,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
+    "packages/engine/src/auto-merge-finalization.ts\u0000done": 3,
     "packages/engine/src/self-healing.ts\u0000in-review": 3,
     "packages/core/src/live-agent-count.ts\u0000in-progress": 2,
     "packages/core/src/live-agent-count.ts\u0000in-review": 2,


### PR DESCRIPTION
Fleet phase. `packages/engine/src/auto-merge-finalization.ts` was the last census file with no branch, worktree, or open PR against it. Claim published by pushing the branch before starting.

## Census before / after

| | total | this file |
|---|---|---|
| before | **47** | 2 |
| after | **45** | 0 |

`--strict` exits 0, baseline re-recorded. **Reclassification, not conversion** — both lines are unchanged.

## Both sites were already reasoned, in a note that calls them non-defects

- **Line 30** is the resolver's **degraded fallback arm**, inside `catch`. The live arm two lines up calls `columnHasFlag(ir, columnId, "complete")`. The literal is reached only when IR resolution throws, where the legacy id is the only answer left — removing it would make a failed resolve return nothing.
- **Line 99** picks an **error string**. The note above it works through threading `isCompleteColumn` in and concludes the signature widening costs more than the sharper diagnostic buys.

I did not revisit either judgement. The gap was mechanical: prose the census cannot read, so both stayed in `byFile` as apparent debt for the next pass to re-derive.

## This is the fourth, and it closes the set

With #3056, #3060, and #3063, **every census file that was unclaimed during this phase has now been examined, and not one needed a conversion.** Each site was a three-state fallback arm, or a site a prior pass had already reviewed and kept.

The corollary is the finding I would most want carried forward: the remaining count is not a work queue. A worker told to "claim the largest cluster" reads the number, finds most of it already reasoned, and reaches for whatever moves it — which is how three PRs converted guards to a synchronous resolver that is inert under PostgreSQL.

One exception worth preserving: **`taskRevert.ts` should stay counted.** I claimed, inspected, and released it without marking. Converting it would classify a *neighbour* row using the modal task's flags — wrong on data, not merely stale on vocabulary — and its note correctly calls the entry **accurate debt** blocked on a per-neighbour flag map. Fallback arms and dead paths → mark. Placeholders awaiting a capability → leave counted.

## Verification

- `census --strict` exit 0; `tsc --noEmit` (engine) **0 errors**
- No dedicated test file for this module (`vitest` reports none), so no suite to run — comment-only diff, no behaviour change