### PR TITLE
docs(core): resolveLifecycleColumns returns one id per role, not a set

### DIFF
--- a/packages/core/src/workflow-lifecycle-traits.ts
+++ b/packages/core/src/workflow-lifecycle-traits.ts
@@ -337,6 +337,25 @@ const LIFECYCLE_ROLE_FLAGS: Record<keyof LifecycleColumns, keyof TraitFlags> = {
  *
  * Returns `undefined` for a v1 / column-less IR: there is no column vocabulary
  * to resolve, so the caller has no workflow-derived answer to act on.
+ *
+ * FNXC:WorkflowResolvedColumns 2026-07-31-19:40: THIS ANSWERS "WHERE SHOULD A CARD GO", NOT
+ * "IS THIS CARD ALREADY THERE".
+ *
+ * Each field is a SINGLE id — the first column carrying that trait. A board may declare several
+ * columns with one role (two pre-review working lanes, a review lane plus a merge-blocked lane),
+ * and every one after the first is invisible here. Using a field for MEMBERSHIP therefore reads as
+ * a working check while silently ignoring lanes: a card resting in the second hold column is
+ * classified as not-held, and the guard that depends on it never fires.
+ *
+ * That misreading has now landed in three separate places — the `hold` guard in `self-healing.ts`
+ * (#3084), the progressed-lane check in `notification-service.ts` (#3096), and the review-set
+ * mismatch in #3088 — so it is a property of this signature, not three unlucky authors.
+ *
+ * For membership, use one of:
+ *   - `columnsWithFlag(ir, role)` — every column with the role on ONE board
+ *   - `resolveProjectColumnsForRoles(store, roles)` — the union across a project's workflows
+ *
+ * Rule of thumb: a routing/move target wants this function; a `.has(task.column)` test does not.
  */
 export function resolveLifecycleColumns(ir: WorkflowIr): LifecycleColumns | undefined {
   const columns = columnsOf(ir);


### PR DESCRIPTION
Comment-only. No behaviour change. `tsc` 0 errors, eslint clean, `census --strict` and `check:fnxc-future-dates` exit 0.

## Why this is worth a PR

Three fleet PRs have independently read this function's fields as **membership**:

| where | finding |
|---|---|
| `self-healing.ts` `hold` guard | **#3084**, `Major` — *"resolve `hold` by membership, not first-per-role"* |
| `notification-service.ts` progressed-lane check | **#3096** — reads `?.hold / ?.wip / ?.complete / ?.archived` |
| sync vs async review set | **#3088** — same shape, different symptom |

Each field is a **single id**: the first column carrying that trait. A board may declare several columns with one role — two pre-review working lanes, or a review lane plus a merge-blocked lane — and every one after the first is invisible.

Used for membership, that reads as a working check while silently ignoring lanes: a card resting in the second hold column classifies as **not-held**, and the guard depending on it never fires. It is the quiet direction of wrong, which is why it survives review three times.

**Three occurrences of one misreading is a property of the signature, not three unlucky authors.** Fixing it at the call sites one at a time leaves the next author to rediscover it, so this documents the contract where the mistake is made — at the definition — and names the alternatives:

- `columnsWithFlag(ir, role)` — every column with the role on one board
- `resolveProjectColumnsForRoles(store, roles)` — the union across a project's workflows

Rule of thumb recorded in the doc: **a routing/move target wants this function; a `.has(task.column)` test does not.**

## What this does not do

It does not fix the three call sites. #3084's is a live `Major` and needs a real fix with mutation verification; #3096's needs its author to resolve a two-implementation conflict first; #3088's is flagged and open. This only stops the fourth occurrence.

A stronger version would rename the fields (`firstHoldColumn`) or return branded single-id types so misuse fails to compile. That is a wider change across every caller and belongs to whoever owns the helper's API — worth considering once the current fleet PRs land, since doing it now would conflict with all three.