### PR TITLE
test(core): `archived` is renameable today — remove a wrong reason for the cheap parity option

### DIFF
--- a/packages/core/src/__tests__/archived-column-gate-parity.test.ts
+++ b/packages/core/src/__tests__/archived-column-gate-parity.test.ts
@@ -39,6 +39,16 @@ deliberate, are both real decisions with real blast radius. Neither is a fleet c
 templates are worse again: one of them is a hand-written `SELECT` string, so its comparison is not even
 a Drizzle expression that could take a bound value without rewriting the query.
 
+FNXC:WorkflowResolvedColumns 2026-07-31-23:50 (one wrong reason for picking the cheap option, removed):
+The second option looks like it has already been taken — `trait-types.ts` annotates the flag
+"RESTRICTED (built-in only)", which reads as "a custom board cannot have its own archive lane". It does
+not mean that. The restriction is over trait REGISTRATION: `trait-registry.ts` rejects a NON-BUILTIN
+(plugin-defined) trait that declares `archived` or `complete` (R22). A custom WORKFLOW may put the
+built-in `archived` trait on a column with any id, and the trait system resolves it — proved in
+`archived-lane-is-renameable-today.test.ts`. So option two is a capability REMOVAL that would silently
+break any board that has already renamed its archive lane, not the documentation of a constraint that
+already exists. That does not decide between the options; it removes a wrong reason for the cheap one.
+
 SO THIS FILE IS THE GUARD, NOT THE FIX. It fails when any of the three encodings stops matching its
 audited inventory below — which is exactly what a well-intentioned partial conversion does.
 

--- a/packages/core/src/__tests__/archived-lane-is-renameable-today.test.ts
+++ b/packages/core/src/__tests__/archived-lane-is-renameable-today.test.ts
@@ -1,0 +1,74 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:45:
+IS `archived` ALREADY A NON-RENAMEABLE SYSTEM COLUMN? NO — AND THE DOC COMMENT READS AS IF IT IS.
+
+`archived-column-gate-parity.test.ts` offers two ways to close its three-encoding split: convert all
+three encodings, or "declare `archived` a non-renameable system column and mark the sites deliberate".
+The second option is far cheaper, and the codebase looks like it has already been taken:
+
+    "Globally archived; hidden from the board. RESTRICTED (built-in only)."
+    archived?: boolean;                                    // trait-types.ts
+
+Read at a glance, "RESTRICTED (built-in only)" says a custom board cannot have an archive lane of its
+own — which would make every `archived` literal correct by construction and the whole family
+DELIBERATE rather than debt.
+
+That reading is wrong, and the two meanings point to opposite decisions. The restriction is on which
+traits may DECLARE the flag: `trait-registry.ts` rejects a NON-BUILTIN (plugin-defined) trait that
+declares `archived` or `complete` (R22). It says nothing about which COLUMN may carry the built-in
+`archived` trait, and a custom workflow may put it on a column with any id.
+
+Proved below rather than argued, because the distinction is invisible in the comment and a reviewer
+who takes the cheap option on the strength of it would be REMOVING a capability that exists today —
+silently breaking any board that already renamed its archive lane — while believing they were
+documenting a constraint that was already there.
+
+This file does not argue for either option. It removes one wrong reason for choosing between them.
+*/
+
+import { describe, expect, it } from "vitest";
+import { columnsWithFlag, resolveColumnFlags } from "../index.js";
+import { RESTRICTED_TRAIT_FLAGS } from "../trait-types.js";
+import "../builtin-traits.js";
+
+/** A custom workflow whose archive lane is `filed` and whose complete lane is `shipped`. */
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    { id: "filed", name: "Filed", traits: [{ trait: "archived" }] },
+  ],
+};
+
+describe("`archived` is a renameable lane today, whatever the flag comment suggests", () => {
+  it("resolves a custom workflow's renamed archive lane", () => {
+    /* If this ever returns [] or ["archived"], the cheap option has effectively been taken and the
+       parity test's framing should be revisited — that is the signal this case exists to give. */
+    expect(columnsWithFlag(RENAMED_IR as never, "archived")).toEqual(["filed"]);
+  });
+
+  it("gives that column the archived trait flags, so every role helper treats it as the archive lane", () => {
+    const flags = resolveColumnFlags({ id: "filed", name: "Filed", traits: [{ trait: "archived" }] } as never);
+
+    expect(flags.archived).toBe(true);
+    /* Carried with it, and worth pinning: the renamed lane is hidden from the board like the legacy
+       one, so a board that renames it does not gain a visible extra column by accident. */
+    expect(flags.hiddenFromBoard).toBe(true);
+  });
+
+  it("the same is true of `complete`, the other restricted flag", () => {
+    /* Both restricted flags behave identically, so the misreading is not specific to `archived` —
+       anyone reaching the same conclusion about `complete` would be wrong for the same reason. */
+    expect(columnsWithFlag(RENAMED_IR as never, "complete")).toEqual(["shipped"]);
+  });
+
+  /*
+  What the restriction ACTUALLY constrains, pinned so the correction cannot drift from the mechanism
+  it corrects. `RESTRICTED_TRAIT_FLAGS` is consumed by the trait REGISTRY when a trait is registered,
+  not by workflow validation when a column is declared.
+  */
+  it("the restriction is over trait REGISTRATION, not column naming", () => {
+    expect([...RESTRICTED_TRAIT_FLAGS]).toEqual(["complete", "archived"]);
+  });
+});


### PR DESCRIPTION
Follow-on from #3110, where the archived-gate parity test blocked my conversion and laid out two ways forward. This removes a **wrong reason** for picking the cheap one.

## The cheap option looks like it has already been taken

`archived-column-gate-parity.test.ts` offers: convert all three encodings, **or** *"declare `archived` a non-renameable system column and mark the sites deliberate"*.

The second is far cheaper — and the codebase reads as if it is already true:

> `"Globally archived; hidden from the board. RESTRICTED (built-in only)."` — `trait-types.ts`

At a glance that says a custom board cannot have an archive lane of its own, which would make all 52 sites correct by construction and the whole family **deliberate rather than debt**. That is a very attractive conclusion for anyone facing a 52-site conversion.

## It does not mean that

The restriction is over trait **registration**. `trait-registry.ts` rejects a **non-builtin** (plugin-defined) trait that declares `archived` or `complete` (R22). It says nothing about which **column** may carry the built-in trait, and a custom workflow may put it on a column with any id.

**Verified, not argued:**

| input | result |
|---|---|
| `columnsWithFlag(ir, "archived")` where the lane is named `filed` | `["filed"]` |
| `resolveColumnFlags` on that column | `{ archived: true, hiddenFromBoard: true }` |
| `columnsWithFlag(ir, "complete")` where the lane is named `shipped` | `["shipped"]` |

So option two is a **capability removal** — it would silently break any board that has already renamed its archive lane — not the documentation of a constraint that already exists.

## What this does and does not do

It **does not** decide between the two options; that is a product call with real blast radius either way. It removes the reason someone would most plausibly reach for after reading that flag comment, and it does so with an executable check rather than a claim.

The `complete` case is pinned alongside it, because both restricted flags behave identically — anyone reaching the same conclusion about `complete` would be wrong for the same reason.

The first case also doubles as a **tripwire**: if `columnsWithFlag(ir, "archived")` ever returns `[]` or `["archived"]` for that fixture, the cheap option has effectively been taken and the parity test's framing needs revisiting. That is the signal the case exists to give.

## Measured

- 4 new cases pass.
- The parity test still passes with its corrected framing — it excludes `__tests__` from its scan, so the added prose cannot move its own inventory. I checked that before editing it rather than after.
- `src/__tests__/{archived,trait,log-entry}*` — **3 files / 26 tests pass**.
- `tsc --noEmit -p packages/core` clean; census `--strict`, `check-fnxc-future-dates` clean.

## Census

**No movement — nothing converted.**
