### PR TITLE
fleet: triage's planning-evacuation check uses the resolved wip lane (census 45 → 44)

### DIFF
--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -748,7 +748,21 @@ export class TriageProcessor {
       session is aborted mid-run.
       */
       const disposeLanes = resolvePlannerLanes(this.store, task.id);
-      if (task.column === disposeLanes.hold || task.column === disposeLanes.intake || task.column === "in-progress") return;
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-21:30 (fleet — the third lane on this line):
+      `disposeLanes.wip`, not the literal — the same resolver already answers the other two.
+
+      This line asked two role questions and one id question. `resolvePlannerLanes` is already called
+      immediately above and its result carries `wip`, so no new resolution and no new await are
+      introduced: the literal simply stops being the odd one out. On a board whose execution lane is
+      renamed, the previous form treated a card advancing into execution as an EVACUATION and killed
+      a healthy planning session — the one case the note above says must not abort.
+
+      `wip` is optional by design (PR #2628: a missing role stays undefined so callers refuse rather
+      than invent a column). Undefined here means the board declares no execution lane, so there is
+      no advance-into-execution to exclude and the comparison is correctly false.
+      */
+      if (task.column === disposeLanes.hold || task.column === disposeLanes.intake || task.column === disposeLanes.wip) return;
       if (this.activeSubagentSessions.has(task.id)) {
         this.disposeSubagentsForTask(task.id, `task moved to ${task.column}`);
       }

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -17,8 +17,7 @@
     "packages/core/src/task-store/task-id-integrity.ts": 1,
     "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1,
     "packages/dashboard/app/components/TaskCard.tsx": 1,
-    "packages/engine/src/notification/notification-service.ts": 1,
-    "packages/engine/src/triage.ts": 1
+    "packages/engine/src/notification/notification-service.ts": 1
   },
   "deliberateByFile": {
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 5,


### PR DESCRIPTION
## Census

| | column guards |
|---|---|
| before | **45** |
| after | **44** |

## What changed

```ts
if (task.column === disposeLanes.hold || task.column === disposeLanes.intake
    || task.column === "in-progress") return;
```

Two role questions and one id question on the same line. `resolvePlannerLanes` is **already called immediately above**, and its result carries `wip` — so this needs no new resolution and no new await. The literal just stops being the odd one out among its neighbours.

## What it cost on a renamed board

This handler aborts a planning session when a card leaves the planner lanes. `in-progress` is excluded because *a card advancing into execution is not an evacuation* — that's stated in the note directly above it.

Against the literal, that exclusion **never matched** on a board whose execution lane is renamed. So a legitimate advance into execution read as an evacuation and **killed a healthy planning session** — precisely the case the comment says must not abort.

`wip` is optional by design (PR #2628: a missing role stays `undefined` so callers refuse rather than invent a column). Undefined here means the board declares no execution lane, so there's no advance-into-execution to exclude and the comparison is correctly false.

## Not addressed, and pre-existing

This line resolves through `resolvePlannerLanes` — the **sync** twin, which returns the default workflow's lanes under PostgreSQL. That affects all three lanes on the line equally and predates this change: the handler is `(task: Task) => {}` with no await available, so fixing it needs the same emitter-side change as #3082.

Making the third lane consistent with the other two doesn't deepen that, and it leaves **one** shape to fix there rather than two.

## Measured

| check | result |
|---|---|
| triage / evacuation / planner-lane suites | **453 tests green** |
| four gates + strict census | green |
| engine `tsc` | clean |