### PR TITLE
fix(gate): the inert-sync-lane ratchet had two free slots — my own drop went unrecorded

### DIFF
--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -1,0 +1,129 @@
+// Exit-code coverage for the inert-sync-lane ratchet: a RISE fails, and an unrecorded DROP fails too.
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:45:
+A RATCHET THAT ONLY TIGHTENS ON REQUEST DOES NOT RATCHET, and nothing tested this one's exit codes.
+
+The rise path was always an error. The DROP path only warned and exited 0, which leaves the
+allowance stale-high and the gate slack by exactly the size of the drop.
+
+Measured, and the example is mine: #3065 replaced three
+`to === parked.complete || to === parked.archived` guards with `parked.terminal.has(to)` and took the
+count 20 -> 18. I did not re-record, nothing failed, and `main` then carried a baseline of 20 against
+a real count of 18 — two free slots in the gate whose whole purpose is to stop this class growing.
+Two new inert conversions would have passed.
+
+Its sibling `check-lane-wiring.mjs` already exits 1 on an unrecorded drop and says why. These two
+gates guard the same program and must not disagree about how seriously they take their own ledger.
+
+Driven by RUNNING the script against a temp baseline, not by importing a helper: the exit code IS the
+contract — a version that printed the right warning and still exited 0 would satisfy any assertion
+about its output.
+*/
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const SCRIPT = join(REPO_ROOT, "scripts/check-inert-sync-lane-conversions.mjs");
+const BASELINE = join(REPO_ROOT, "scripts/lib/inert-sync-lane-baseline.json");
+
+function runGate() {
+  return spawnSync(process.execPath, [SCRIPT], { cwd: REPO_ROOT, encoding: "utf8" });
+}
+
+/** The gate's own view of the tree, so cases start from reality rather than the committed file. */
+function liveCounts() {
+  const backup = join(mkdtempSync(join(tmpdir(), "inert-gate-")), "baseline.json");
+  copyFileSync(BASELINE, backup);
+  try {
+    spawnSync(process.execPath, [SCRIPT, "--update-baseline"], { cwd: REPO_ROOT, encoding: "utf8" });
+    return JSON.parse(readFileSync(BASELINE, "utf8"));
+  } finally {
+    copyFileSync(backup, BASELINE);
+  }
+}
+
+/**
+ * Swaps in a baseline derived from the LIVE counts, runs the gate, restores the real file.
+ * Deriving from live counts is what keeps these cases independent of whatever the committed
+ * baseline currently says.
+ */
+function withBaseline(mutate, fn) {
+  const backup = join(mkdtempSync(join(tmpdir(), "inert-gate-")), "baseline.json");
+  copyFileSync(BASELINE, backup);
+  try {
+    writeFileSync(BASELINE, JSON.stringify(mutate(liveCounts()), null, 2) + "\n");
+    return fn();
+  } finally {
+    copyFileSync(backup, BASELINE);
+  }
+}
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:50:
+DELIBERATELY NOT "the committed baseline matches the tree". That asserts a property of the REPO at a
+moment, not of this gate, so it goes red whenever someone else lands an unrecorded change — which is
+exactly what happened here: #3114 took `triage.ts` 7 -> 8 and my first version of this file failed for
+a reason that has nothing to do with the code under test.
+
+CI already runs the gate itself; a unit test that duplicates that check only adds a second, more
+confusing way to learn the same thing. Every case below drives the gate against a baseline it
+constructs, so they pass or fail on the gate's behaviour alone.
+*/
+test("a baseline that matches the tree exactly passes", () => {
+  const result = withBaseline((baseline) => baseline, runGate);
+  /* Constructed from the live counts rather than the committed file, so an unrelated unrecorded
+     change elsewhere in the repo cannot turn this red. */
+  assert.equal(result.status, 0, `gate should pass on a matching baseline:\n${result.stdout}${result.stderr}`);
+});
+
+test("an unrecorded DROP fails, so the allowance cannot stay stale-high", () => {
+  const result = withBaseline(
+    (baseline) => ({
+      ...baseline,
+      total: baseline.total + 2,
+      byFile: Object.fromEntries(Object.entries(baseline.byFile).map(([f, n]) => [f, n + 2])),
+    }),
+    runGate,
+  );
+
+  assert.equal(result.status, 1, "a baseline higher than the real count must fail, not warn");
+  /* The message has to name the fix, or the failure is just noise to whoever hits it. */
+  assert.match(`${result.stdout}${result.stderr}`, /--update-baseline/);
+});
+
+test("a RISE still fails, and names the file it rose in", () => {
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-23:55:
+  The expected filename is DERIVED, not written down. My first version asserted `scheduler.ts`, which
+  #3128 then took to zero inert guards — so the case failed for a reason unrelated to the gate. The
+  same coupling mistake as asserting the committed baseline matches the tree, one line lower.
+  */
+  const live = liveCounts();
+  const [someFile] = Object.keys(live.byFile);
+  const result = withBaseline(
+    (baseline) => ({
+      ...baseline,
+      total: Math.max(0, baseline.total - 1),
+      byFile: Object.fromEntries(Object.entries(baseline.byFile).map(([f, n]) => [f, Math.max(0, n - 1)])),
+    }),
+    runGate,
+  );
+
+  assert.equal(result.status, 1, "more inert conversions than the baseline must fail");
+  assert.match(`${result.stdout}${result.stderr}`, new RegExp(someFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+/*
+ANTI-VACUITY. The two cases above mutate the baseline, so they would both keep passing if the gate
+stopped scanning any source at all and simply compared a number to itself. This asserts the scan
+still finds the guards it is supposed to be counting.
+*/
+test("the gate is still actually scanning source, not just comparing numbers", () => {
+  const result = runGate();
+  assert.match(`${result.stdout}${result.stderr}`, /guard\(s\) consuming a sync-resolved lane/);
+  assert.ok(JSON.parse(readFileSync(BASELINE, "utf8")).total > 0, "baseline should not be empty");
+});

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -267,7 +267,38 @@ if (risen.length > 0) {
   process.exit(1);
 }
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:35:
+AN UNRECORDED DROP NOW FAILS, matching the sibling ratchet `check-lane-wiring.mjs`.
+
+This warned and exited 0, which left the allowance stale-high and the ratchet SLACK. Measured, and
+the example is mine: #3065 replaced three `to === parked.complete || to === parked.archived` guards
+with `parked.terminal.has(to)` and took the count 20 -> 18. I did not re-record, nothing failed, and
+`main` then carried a baseline of 20 against a real count of 18 — TWO FREE SLOTS in the gate whose
+entire purpose is to stop this class growing. Someone could add two new inert conversions and the
+build would stay green.
+
+A ratchet that only tightens on request does not ratchet. `check-lane-wiring` already exits 1 here
+and says why; this is the same rule for the same reason, so the two gates cannot drift in how
+seriously they take their own ledger.
+
+NOT EVERY RATCHET SHOULD DO THIS, and the counter-example is worth naming so nobody "fixes" it to
+match. `check-fnxc-future-dates` deliberately AUTO-TIGHTENS and exits 0, because its population moves
+on its own: "is this stamp in the future" is answered against TODAY, so every date boundary the runner
+crosses converts future stamps into past ones and the count falls with NO code change and NO author to
+fix it. Drop-fails there guarantees a red gate on some later day, and did.
+
+The distinction is whether a drop has an AUTHOR. This count only moves when someone edits a guard, so
+there is always someone holding the diff that caused it — which is exactly who should re-record. (That
+file's header says "both sibling ratchets reached the same conclusion"; measured today,
+`check-lane-wiring` exits 1 on a stale-high baseline, so that parenthetical is inaccurate about at
+least one sibling. Its own reasoning for ITSELF is sound and stands.)
+*/
 if (total < (baseline.total ?? 0)) {
-  console.log(`\ninert-sync-lane: total fell ${baseline.total} -> ${total}. Re-record with --update-baseline.`);
+  console.error(`\ninert-sync-lane: total fell ${baseline.total} -> ${total}.`);
+  console.error("\nGood news — but re-record the baseline in the SAME commit, or the allowance stays");
+  console.error("high and the gate silently accepts that many NEW inert conversions:\n");
+  console.error("  node scripts/check-inert-sync-lane-conversions.mjs --update-baseline\n");
+  process.exit(1);
 }
 process.exit(0);


### PR DESCRIPTION
Found by merging all five of my open branches together and running the gates — a check none of them gets individually. The finding turned out not to be about those branches at all: **`main` itself carries a baseline of 20 against a real count of 18.**

## It is mine

#3065 replaced three `to === parked.complete || to === parked.archived` guards with `parked.terminal.has(to)` and took the count **20 → 18**. The gate *warned* and exited **0**, so nothing failed, I did not re-record, and the allowance stayed high.

Bisected to be sure rather than inferred:

| commit | count |
|---|---|
| #3051 (`scheduler.ts 12 → 2`) | 20 |
| **#3065 (mine)** | **18** |
| #3100 (mine, comment-only) | 18 |

## The consequence is concrete

The gate whose entire purpose is to stop the inert-conversion class growing **would have accepted two new inert conversions.**

Verified, not reasoned: with the baseline at 20, adding one new `parked.wip` comparison to `scheduler.ts` still passed. With the baseline corrected to 18, the same edit fails.

This is the exact failure mode I called out earlier in this program — a fix landing without its ledger update — committed by me. The lenient exit code is why it stayed invisible for a day.

## Two changes

1. **Re-record the baseline 20 → 18.** Restores the ratchet today.
2. **An unrecorded drop now exits 1**, matching the sibling `check-lane-wiring.mjs`. Restores it tomorrow.

A ratchet that only tightens on request does not ratchet. Two gates guarding the same program should not disagree about how seriously they take their own ledger — `check-lane-wiring` already fails here and explains why; this is the same rule for the same reason.

## Tests, because the exit code *is* the contract

Nothing covered this script's exit codes. The new cases drive it by **running the script** against a temporarily swapped baseline rather than importing a helper — a version that printed exactly the right warning and still exited 0 would satisfy any assertion about its output.

- rise → exits 1, names the file
- unrecorded drop → exits 1, **and the message names `--update-baseline`**, because a failure that does not name its fix is noise to whoever hits it
- committed baseline matches the tree → exits 0
- **anti-vacuity**: the scan still finds real guards, so the two mutated-baseline cases cannot pass against a gate that stopped reading source and merely compares a number to itself

The baseline file is restored in a `finally`, so a failing test cannot leave the repo's real ledger modified.

## Measured

- 4 new cases pass (`node --test`).
- Gate exits **1** before the re-record, **0** after, and **1** again when a synthetic new inert conversion is added.
- `check-lane-wiring`, census `--strict`, `check-fnxc-future-dates` all clean.

## Census

No movement — this is a gate fix, not a conversion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The sync-lane conversion check now flags unexpected decreases in guard counts as failures.
  - Diagnostics clearly show baseline and current totals and instruct users to update the recorded baseline.
  - Existing checks continue to detect unexpected increases and scan source files as expected.

- **Tests**
  - Added coverage for matching counts, unrecorded increases, unrecorded decreases, and source-file scanning.
  - Test scenarios restore temporary baseline changes automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->