### PR TITLE
fix(events): every live task:moved emitter carries the resolved lanes (1 of 7 → 5 of 5 live)

### DIFF
--- a/packages/core/src/task-store/archive-lifecycle-2.ts
+++ b/packages/core/src/task-store/archive-lifecycle-2.ts
@@ -7,7 +7,7 @@
  * instance as its first parameter and performs byte-identical work.
  */
 import {TaskStore, storeLog} from "../store.js";
-import { columnsWithFlag, declaresAnyLifecycleTrait } from "../workflow-lifecycle-traits.js";
+import { columnsWithFlag, declaresAnyLifecycleTrait, toTaskMoveLanes } from "../workflow-lifecycle-traits.js";
 import { resolveWorkflowIrForTask } from "../workflow-ir-resolver.js";
 import {getFeatureByTaskId as getMissionFeatureByTaskId, unlinkFeatureFromTaskId as unlinkMissionFeatureFromTaskId, recordGeneratedFixOperatorStop} from "../async-mission-store-queries.js";
 import {TaskHasLineageChildrenError, TaskNotFoundError, TaskSelfDeleteError} from "./errors.js";
@@ -370,7 +370,14 @@ export async function archiveTaskBackendImpl(store: TaskStore, id: string, optio
     task.updatedAt = archivedAt;
     task.deletedAt = archivedAt;
 
-    store.emit("task:moved", { task, from: fromColumn, to: "archived" as Column, source: "engine" });
+    /* FNXC:WorkflowEvents 2026-08-01-01:30 (fleet — every emitter carries the lanes):
+         #3109 attached lanes at `moves.ts` only, so six of seven emitters still sent `lanes:
+         undefined` and every listener fell back to `resolveTaskParkedColumnsSync` — the DEFAULT board
+         under PostgreSQL. Two of those six emit a RESOLVED lane id (`completeColumn` here,
+         `task.column` in update-task-deps), so the emitter had already resolved the board and threw
+         the answer away, leaving the listener comparing a renamed id against a legacy literal. */
+    const lanes = toTaskMoveLanes(await resolveWorkflowIrForTask(store, task.id).catch(() => undefined));
+    store.emit("task:moved", { task, from: fromColumn, to: "archived" as Column, source: "engine", lanes });
 
     // Best-effort near-duplicate cleanup.
     await store.clearNearDuplicateReferencesToFailSoft(id, {

--- a/packages/core/src/task-store/lifecycle-ops.ts
+++ b/packages/core/src/task-store/lifecycle-ops.ts
@@ -663,6 +663,14 @@ export async function checkForChangesImpl(store: TaskStore): Promise<void> {
               Recorded rather than converted, for the same reason as `mission-store.ts` and
               `project-store-ops.ts`: an unconverted literal in dead code is not debt a fleet pass
               should spend a signature change on, but it must not read as missed either.
+
+              FNXC:WorkflowEvents 2026-08-01-01:45 (fleet — the two emitters here stay lane-less):
+              The `task:moved` emitters in this function are the only two of seven that do NOT carry
+              `lanes` after the emitter sweep. Deliberate, and for the reason above: both sit on this
+              SQLite-only polling-replica path, which cannot execute under PostgreSQL, so resolving a
+              workflow here would add an await to dead code. If this path is ever revived, they must
+              be attached — a listener that reads `lanes` treats absence as "unknown" and falls back
+              to the DEFAULT board, which is wrong rather than merely stale.
               */
               if (cached.column !== "archived") {
                 store.emit("task:moved", { task: cached, from: cached.column, to: "archived" as Column, source: "engine" });

--- a/packages/core/src/task-store/task-artifacts-ops.ts
+++ b/packages/core/src/task-store/task-artifacts-ops.ts
@@ -10,9 +10,10 @@
  */
 
 import { TaskStore } from "../store.js";
+import {toTaskMoveLanes} from "../workflow-lifecycle-traits.js";
+import {resolveWorkflowIrForTask} from "../workflow-ir-resolver.js";
 import { resolveProjectColumnsForRoles } from "../project-lane-vocabulary.js";
 import {declaresAnyLifecycleTrait, resolveReviewColumns, resolveTaskLifecycleColumns} from "../workflow-lifecycle-traits.js";
-import {resolveWorkflowIrForTask} from "../workflow-ir-resolver.js";
 import { countAgentLogEntries, readAgentLogEntries } from "../agent-log-file-store.js";
 import { toJsonNullable } from "../db.js";
 import { DbTransaction, recordRunAuditEventWithinTransaction } from "../postgres/data-layer.js";
@@ -563,7 +564,14 @@ export async function moveToDoneImpl(store: TaskStore, task: Task, dir: string):
     // Update cache if watcher is active
     if (store.isWatching) store.taskCache.set(task.id, { ...task });
 
-    store.emit("task:moved", { task, from: fromColumn, to: completeColumn as Column, source: "engine" });
+    /* FNXC:WorkflowEvents 2026-08-01-01:30 (fleet — every emitter carries the lanes):
+         #3109 attached lanes at `moves.ts` only, so six of seven emitters still sent `lanes:
+         undefined` and every listener fell back to `resolveTaskParkedColumnsSync` — the DEFAULT board
+         under PostgreSQL. Two of those six emit a RESOLVED lane id (`completeColumn` here,
+         `task.column` in update-task-deps), so the emitter had already resolved the board and threw
+         the answer away, leaving the listener comparing a renamed id against a legacy literal. */
+    const lanes = toTaskMoveLanes(await resolveWorkflowIrForTask(store, task.id).catch(() => undefined));
+    store.emit("task:moved", { task, from: fromColumn, to: completeColumn as Column, source: "engine", lanes });
 }
 
 export function clearDoneTransientFieldsImpl(store: TaskStore, task: Task): boolean {

--- a/packages/core/src/task-store/task-update.ts
+++ b/packages/core/src/task-store/task-update.ts
@@ -7,6 +7,8 @@
  * instance as its first parameter and performs byte-identical work.
  */
 import {type TaskStore, storeLog} from "../store.js";
+import {toTaskMoveLanes} from "../workflow-lifecycle-traits.js";
+import {resolveWorkflowIrForTask} from "../workflow-ir-resolver.js";
 import {resolveTaskLifecycleColumns} from "../workflow-lifecycle-traits.js";
 import {InvalidFileScopeError} from "./errors.js";
 import {mkdir, readFile, writeFile} from "node:fs/promises";
@@ -959,7 +961,14 @@ export async function updateTaskUnlockedImpl(store: TaskStore, id: string, updat
       }
 
       if (movedToTriage) {
-        store.emit("task:moved", { task, from: "todo" as Column, to: "triage" as Column, source: "engine" });
+        /* FNXC:WorkflowEvents 2026-08-01-01:30 (fleet — every emitter carries the lanes):
+         #3109 attached lanes at `moves.ts` only, so six of seven emitters still sent `lanes:
+         undefined` and every listener fell back to `resolveTaskParkedColumnsSync` — the DEFAULT board
+         under PostgreSQL. Two of those six emit a RESOLVED lane id (`completeColumn` here,
+         `task.column` in update-task-deps), so the emitter had already resolved the board and threw
+         the answer away, leaving the listener comparing a renamed id against a legacy literal. */
+        const lanes = toTaskMoveLanes(await resolveWorkflowIrForTask(store, task.id).catch(() => undefined));
+        store.emit("task:moved", { task, from: "todo" as Column, to: "triage" as Column, source: "engine", lanes });
       }
       store.emitTaskLifecycleEventSafely("task:updated", [task]);
       return task;

--- a/packages/core/src/task-store/update-task-deps.ts
+++ b/packages/core/src/task-store/update-task-deps.ts
@@ -7,6 +7,8 @@
  * instance as its first parameter and performs byte-identical work.
  */
 import {TaskStore, storeLog, type TaskDependencyMutation} from "../store.js";
+import {toTaskMoveLanes} from "../workflow-lifecycle-traits.js";
+import {resolveWorkflowIrForTask} from "../workflow-ir-resolver.js";
 import {buildRefinementSeedPrompt} from "../mesh-task-replication.js";
 import {SelfDefeatingDependencyError, detectSelfDefeatingDependency} from "./errors.js";
 import {resolveTaskLifecycleColumns} from "../workflow-lifecycle-traits.js";
@@ -499,11 +501,13 @@ export async function updateTaskDependenciesImpl(store: TaskStore, id: string, m
       column the card is already in is what re-runs reset-on-entry effects downstream.
       */
       if (movedToTriage && respecifyFromColumn !== task.column) {
+        /* FNXC:WorkflowEvents 2026-08-01-01:30 (fleet — every emitter carries the lanes): see the note in archive-lifecycle-2.ts. */
         store.emit("task:moved", {
           task,
           from: respecifyFromColumn as Column,
           to: task.column as Column,
           source: "engine",
+          lanes: toTaskMoveLanes(await resolveWorkflowIrForTask(store, task.id).catch(() => undefined)),
         });
       }
       store.emitTaskLifecycleEventSafely("task:updated", [task]);


### PR DESCRIPTION
## #3109 landed the mechanism at one of seven emitters

Follow-up to the review I left on #3109/#3112, now measured against `main` after #3109 merged:

```
LANES    moves.ts:1450
MISSING  archive-lifecycle-2.ts:373
MISSING  task-update.ts:962
MISSING  update-task-deps.ts:502
MISSING  task-artifacts-ops.ts:549
MISSING  lifecycle-ops.ts:668
MISSING  lifecycle-ops.ts:715
```

The listener contract is "absent `lanes` means unknown, keep your fallback" — and the fallback is `resolveTaskParkedColumnsSync`, which returns the **default board** for every task under PostgreSQL. So absence does not degrade to cautious, it degrades to *confidently wrong on exactly the renamed boards this work exists to fix*, while the listener code now reads as resolved at every site. That is harder to spot than the defect #3109 fixed.

## The two that mattered most

Two of the six had **already resolved the board and threw the answer away**:

| emitter | sends | attaches lanes |
|---|---|---|
| `task-artifacts-ops.ts:549` | `to: completeColumn` — a resolved lane | no |
| `update-task-deps.ts:502` | `to: task.column` — the row's actual lane | no |

On a renamed board these emit `"shipped"` while the listener compares against `"done"`. Never matches, nothing errors, the branch silently stops firing. That is the inverse of a stale-literal bug: the two sides disagree about vocabulary in *opposite directions*, and the field that would reconcile them was the optional one.

## What changed

Lanes attached at all **five live** emitters, using the exact pattern #3109 established (`toTaskMoveLanes(await resolveWorkflowIrForTask(...).catch(() => undefined))`). No new helper, no signature changes, no listener changes.

## Flagged — the two I did NOT convert

`lifecycle-ops.ts:668` and `:715` stay lane-less **on purpose**. Both sit on the polling-replica path that the file already documents as legacy-SQLite-only — it reaches `store.db`, which throws under PostgreSQL — and that same note argues against spending a signature change on dead code. I agreed rather than overrode it, and left a note recording that if the path is ever revived these must be attached, because absence resolves to the default board rather than to nothing.

Those two are why this is 5-of-7 rather than 7-of-7, and the distinction is deliberate: **every emitter that can execute under the shipped backend now carries lanes.**

## Census before / after

```
before:  COLUMN guards (the backlog):   45
after:   COLUMN guards (the backlog):   45
```

Unchanged — this converts no guards. It makes the resolved answer *reach* the guards #3109 already converted, which is the half that was missing.

Worth noting for the ledger: `check:inert-sync-lanes` reports 5 on `main` (down from 20) because #3109 moved `scheduler.ts` onto payload lanes. Those 5 are the fallback paths — the ones this PR feeds.

## Verification

Full `@fusion/core` suite **461 files / 4901 passed, 0 failed** · `test:gate` exit 0 · typecheck exit 0 · `check:inert-sync-lanes` exit 0 · lifecycle-column census exit 0 · `pnpm lint` clean.
