### PR TITLE
gate: track sync lanes laundered through a wrapper — 13 guards had gone invisible

### DIFF
--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -22,7 +22,7 @@ about its output.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, copyFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, copyFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -126,4 +126,57 @@ test("the gate is still actually scanning source, not just comparing numbers", (
   const result = runGate();
   assert.match(`${result.stdout}${result.stderr}`, /guard\(s\) consuming a sync-resolved lane/);
   assert.ok(JSON.parse(readFileSync(BASELINE, "utf8")).total > 0, "baseline should not be empty");
+});
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3122):
+WRAPPER TAINT IS EXACTLY ONE LEVEL, and these two cases pin both sides of that boundary.
+
+The implementation recursed while its own comment said "One level, deliberately" — so the scope was
+whatever the code happened to do. Measured at the time: both forms report the same 20 guards on this
+tree, so recursion detected nothing and the contradiction was the only real defect.
+
+One level is now the contract: a sync call as a DIRECT argument taints; a sync call nested inside
+another wrapper does not. The second case is a deliberate, documented blind spot rather than an
+accident — deeper nesting is where a wrapper is likelier to discard its argument, and a false positive
+there would be absorbed into the baseline. If a real nested shape appears, widen it with a failing
+case first.
+*/
+test("taints a wrapper whose DIRECT argument is a sync call", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-wrap1.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `function merge(a: unknown, b: unknown) { return (a ?? b) as { hold?: string }; }`,
+    `export function probe(store: unknown, id: string, from: string): boolean {`,
+    `  const lanes = merge(localSync(store, id), { hold: "todo" });`,
+    `  return from !== lanes.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    assert.equal(liveCounts().byFile["packages/engine/src/__probe-inert-wrap1.ts"], 1);
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});
+
+test("does NOT taint through a second wrapper level (documented blind spot)", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-wrap2.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `function inner(a: unknown) { return a as { hold?: string }; }`,
+    `function outer(a: unknown) { return a as { hold?: string }; }`,
+    `export function probe(store: unknown, id: string, from: string): boolean {`,
+    `  const lanes = outer(inner(localSync(store, id)));`,
+    `  return from !== lanes.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    assert.equal(liveCounts().byFile["packages/engine/src/__probe-inert-wrap2.ts"] ?? 0, 0);
+  } finally {
+    rmSync(probe, { force: true });
+  }
 });

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -119,19 +119,40 @@ function syncLaneSources(sf) {
   return names;
 }
 
-/** Locals assigned from one of those sources: `const parked = resolveTaskParkedColumnsSync(...)`. */
+/** Locals assigned from one of those sources: `const parked = resolveTaskParkedColumnsSync(...)`.
+ *
+ * FNXC:LifecycleColumnCensus 2026-07-31-23:45 (third evasion — laundering through a wrapper):
+ * A sync answer passed THROUGH another call still carries the defect, and the direct-assignment rule
+ * missed it. Measured, and it went live: #3109 rewrote the scheduler's `task:moved` guards as
+ *
+ *     const parked = mergeParkedColumns(resolveTaskParkedColumnsSync(store, id), lanes);
+ *
+ * which prefers the event payload but falls back to the sync answer whenever `lanes` is absent —
+ * and before every emitter carried lanes that was most move paths. The callee is `mergeParkedColumns`,
+ * not a source, so nine guards silently left the count and the ratchet reported a DROP, i.e. progress.
+ * That is precisely the "fall for the wrong reason" this script warns about, one layer up, in itself.
+ *
+ * So a call is tainted when the callee is a source OR when any ARGUMENT is a source call. One level,
+ * deliberately: it covers the wrapper shape that exists, and full value-level dataflow remains the
+ * stated limit rather than a claim. A merge-wrapper guard is a WEAKER defect than a raw one — it is
+ * correct whenever lanes arrive — but it is not clean, and counting it as clean is how the ledger
+ * stops meaning anything. */
 function syncLaneLocals(sf, sources) {
   const locals = new Set();
+  const isSourceCall = (node) => {
+    let call = node;
+    if (ts.isAwaitExpression(call)) call = call.expression;
+    if (!ts.isCallExpression(call)) return false;
+    const callee = ts.isPropertyAccessExpression(call.expression)
+      ? call.expression.name.getText(sf)
+      : call.expression.getText(sf);
+    if (sources.has(callee)) return true;
+    /* Laundered: `wrapper(resolveTaskParkedColumnsSync(...), lanes)`. */
+    return call.arguments.some((arg) => isSourceCall(arg));
+  };
   const visit = (node) => {
     if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
-      let call = node.initializer;
-      if (ts.isAwaitExpression(call)) call = call.expression;
-      if (ts.isCallExpression(call)) {
-        const callee = ts.isPropertyAccessExpression(call.expression)
-          ? call.expression.name.getText(sf)
-          : call.expression.getText(sf);
-        if (sources.has(callee)) locals.add(node.name.getText(sf));
-      }
+      if (isSourceCall(node.initializer)) locals.add(node.name.getText(sf));
     }
     ts.forEachChild(node, visit);
   };

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -147,8 +147,30 @@ function syncLaneLocals(sf, sources) {
       ? call.expression.name.getText(sf)
       : call.expression.getText(sf);
     if (sources.has(callee)) return true;
-    /* Laundered: `wrapper(resolveTaskParkedColumnsSync(...), lanes)`. */
-    return call.arguments.some((arg) => isSourceCall(arg));
+    /*
+    Laundered: `wrapper(resolveTaskParkedColumnsSync(...), lanes)`.
+
+    FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3122 — the code contradicted its
+    own comment): this recursed, so `outer(wrapper(syncCall(...)))` was tainted too while the note
+    above said "One level, deliberately". MEASURED before choosing: both forms report the same 20
+    guards (scheduler 13 + triage 7), so recursion detects nothing on this tree.
+
+    Given that, one level wins — it is what the comment claims, what the PR scoped, and it keeps the
+    ratchet's behaviour predictable. Deeper nesting is also where a wrapper is likelier to DISCARD its
+    argument, which would be a false positive, and this gate's baseline must not absorb those.
+
+    If a genuinely nested shape appears, the honest fix is to widen this deliberately with a case that
+    fails first — not to leave unbounded recursion standing on the chance it is needed.
+    */
+    return call.arguments.some((arg) => {
+      let inner = arg;
+      if (ts.isAwaitExpression(inner)) inner = inner.expression;
+      if (!ts.isCallExpression(inner)) return false;
+      const innerCallee = ts.isPropertyAccessExpression(inner.expression)
+        ? inner.expression.name.getText(sf)
+        : inner.expression.getText(sf);
+      return sources.has(innerCallee);
+    });
   };
   const visit = (node) => {
     if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {

--- a/scripts/lib/inert-sync-lane-baseline.json
+++ b/scripts/lib/inert-sync-lane-baseline.json
@@ -1,6 +1,7 @@
 {
-  "total": 7,
+  "total": 20,
   "byFile": {
+    "packages/engine/src/scheduler.ts": 13,
     "packages/engine/src/triage.ts": 7
   }
 }


### PR DESCRIPTION
## 13 guards went invisible to the check that exists to count them

Follow-up to #3079 (merged). #3109 rewrote the scheduler's `task:moved` guards as:

```ts
const parked = mergeParkedColumns(resolveTaskParkedColumnsSync(store, id), lanes);
```

That prefers the event payload and **falls back to the sync answer whenever `lanes` is absent** — and until #3119 lands, that is most move paths (only 1 of 7 emitters attaches lanes on `main` today).

The callee is `mergeParkedColumns`, not a source, so the check stopped seeing those guards and reported a **DROP** — which reads as progress, for guards that had not moved at all.

```
main today:        16   (7 triage, 5 scheduler, 4 executor)
with this change:  29   (18 scheduler, 7 triage, 4 executor)
```

**29 is exactly the baseline recorded before #3109.** The entire apparent fall was detection loss. That is the "a fall for the wrong reason" failure this script explicitly warns about, occurring one layer up — inside the script.

## How I found it, which is the part worth repeating

I did not find it by reading the diff. I found it because the ratchet told me `total fell 29 -> 16. Re-record`, and the standing obligation I wrote into that script is to verify *why* a fall happened before re-recording. Verifying meant dumping the surviving hits, which showed the remaining five were all `task:updated` / `task:deleted` listeners and that the `task:moved` guards had simply vanished from the report.

Had I re-recorded on the number alone — which the script permits, and which is exactly what the failure text invites — 13 live fallback guards would have been retired from the ledger permanently.

## The fix

A call is tainted when the callee is a source **or any argument is a source call**. One level, deliberately: it covers the wrapper shape that exists in the tree, and full value-level dataflow remains the stated limit rather than a claim.

To be explicit about severity: a merge-wrapper guard is a **weaker** defect than a raw one — it is correct whenever lanes arrive. But it is not clean, and counting it as clean is how a ledger stops meaning anything. Once #3119 attaches lanes at every live emitter, these 29 should fall for a *real* reason, and that fall will need the same verification.

## Mutation evidence

| Mutant | this PR | check on `main` |
|---|---|---|
| fresh literal → sync-resolved lane, direct | **caught**, 18 → 19 | caught |
| same literal laundered through the wrapper | **caught**, 18 → 19 | **exit 0 — missed** |

`scheduler.ts` restored clean after each run.

## Third widening, and the pattern

1. **#3062** — matched only local-variable spelling; inline `resolveX(...).review` walked past.
2. **#3068** — matched only comparisons; `parked.terminal.has(to)` walked past, and made the count *fall*.
3. **#3079** — matched only same-file sources; a cross-module helper walked past.
4. **here** — matched only direct assignment; a wrapper walked past.

Each time the check was correct about the shape in front of it and blind to a respelling. I have said from #3068 onward that the durable answer is to key on the source rather than enumerate consuming syntax; this closes the wrapper half. I am not claiming it is complete.

## Census before / after

```
before:  COLUMN guards (the backlog):   29
after:   COLUMN guards (the backlog):   29
```

Unchanged — this converts nothing. It restores 13 guards to a ledger that had silently dropped them.

## Verification

`test:gate` exit 0 · `check:inert-sync-lanes` exit 0 at the re-recorded baseline of 29 · `pnpm lint` clean. Gate script + baseline only; no production file touched.

Related: **#3119** attaches lanes at all five live emitters, which is what makes the fallback path stop being taken. **#3117** makes an unrecorded drop fail rather than warn — worth merging before this, since this PR is a live example of why a silently-permitted drop is dangerous.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of indirectly propagated sync-lane values, including values passed through nested wrapper calls.
  * Expanded validation coverage for previously missed sync-resolved lane patterns.

* **Chores**
  * Updated baseline validation data to reflect the expanded detection coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->