### PR TITLE
fix(events): carry lanes on the last two live task:moved emits

### DIFF
--- a/.changeset/remaining-emitters-lanes.md
+++ b/.changeset/remaining-emitters-lanes.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Replan and respecify transitions now report the board's own lanes to engine listeners.
+category: fix
+dev: `updateTaskUnlockedImpl` and the respecify path in `update-task-deps.ts` attach `lanes` to their `task:moved` emits.


### PR DESCRIPTION
Completes the emitter sweep: **#3109** (main move path) → **#3120** (archive/completion) → this (replan/respecify). Independent of my other branches.

## I flagged these two as blocked in #3120, and I was wrong

I recorded them as *"fires from a watcher callback"* and *"sync path"*. Both are `async` — `updateTaskUnlockedImpl` and the respecify path in `update-task-deps.ts`. I had inferred the context from surrounding code instead of reading upward to the enclosing signature.

That's the **fourth** time in this program I've mis-flagged a site as blocked, always in the same direction: assuming unreachable rather than checking. Worth stating plainly, because a wrong "blocked" flag costs more than an unconverted literal — it tells every later worker not to look.

## What changes

| Emit path | Before | Now |
|---|---|---|
| `task-update.ts:962` (`updateTaskUnlockedImpl`) | lane-less | carries lanes |
| `update-task-deps.ts:502` (respecify) | lane-less | carries lanes |

A lane-less emit does not leave a listener **without** an answer — it leaves it with the **legacy** one, which on a renamed board is wrong rather than absent. Both fail soft to `undefined`, matching every other emitter.

## Deliberately untouched

The two remaining lane-less emits in `lifecycle-ops.ts` (668, 715) stay counted. They sit in the **legacy SQLite polling replica path**, which throws under the PostgreSQL backend, and another worker has already recorded that reasoning in place. Converting dead code to satisfy a count is the inverse of the mistake above.

With this, **every live `task:moved` emitter carries lanes.**

## Verification

- Full `@fusion/core` suite — **462 files, 4905 tests green**
- **`pnpm test:gate` green**; `tsc` clean
- Changeset added; `check:changesets` passes

## Census

**No change** — this converts emit payloads, not comparison literals. The effect is that guards converted in #3109/#3112 now get a correct answer on these paths instead of a legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)