### PR TITLE
census: --triage under-reported documented deferrals by 44%

### DIFF
--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -116,7 +116,20 @@ guard whose text marks a deliberate deferral. It cannot tell a good reason from 
 far above its guard reads as unflagged. It is a triage aid for choosing work, never a gate — which is
 why it is opt-in and why nothing downstream consumes it.
 */
-const FLAG_MARKERS = /FLAGGED|LEFT COUNTED|left counted|deliberately NOT converted|Recorded instead|Left as a literal|DELIBERATE-LITERAL|accurate debt|blocked on/;
+/*
+FNXC:LifecycleColumnCensus 2026-08-01-04:20 (the marker set under-reported, which is the harmful direction):
+Measured after shipping: of nine sites `--triage` listed as unexamined, FOUR carried a full deferral
+note my markers simply did not match — `moves.ts` ("THIS ARM STAYS INLINE, deliberately"),
+`ResearchTaskActionModal.tsx` ("sized here rather than faked"), `audit-ops.ts` ("Not converted
+here because ..."), `mission-store.ts` ("do not convert"). A 44% false-positive rate on a list
+headed "this is the list to pick work from".
+
+Under-reporting is worse than over-reporting for this tool: it sends a worker at a site whose owner
+already wrote down why it must not move, which is exactly the sequence that produced #3114 (converting
+an arm #3108 had flagged hours earlier). Over-reporting would hide real work, so the added phrases are
+specific to declining a conversion rather than generic words like "deliberately" on its own.
+*/
+const FLAG_MARKERS = /FLAGGED|LEFT COUNTED|left counted|deliberately NOT converted|Recorded instead|Recorded rather than|Left as a literal|DELIBERATE-LITERAL|accurate debt|blocked on|STAYS INLINE|[Nn]ot converted|do NOT convert|do not convert|sized here|in dead code/;
 
 /** Split the column guards into documented-deferral vs unexamined, by comment proximity. */
 function triageFindings() {


### PR DESCRIPTION
## The triage list was pointing workers at already-decided sites

Follow-up to #3097 (merged), measured on `main` rather than assumed. Of the **nine** guards `--triage` listed as unexamined, **four carried a full deferral note** that the marker set did not match:

| site | what its note actually says |
|---|---|
| `moves.ts:346` | *"THIS ARM STAYS INLINE, deliberately"* — naming it moves the tally `archived-column-gate-parity.test.ts` pins, and that guard exists to stop exactly this split brain |
| `ResearchTaskActionModal.tsx:66` | *"sized here rather than faked"* — the honest fix is a data-fetch change, not prop threading |
| `audit-ops.ts:231` | *"Not converted here because ..."* — must land with `getLiveTaskColumn` or the pair disagrees |
| `mission-store.ts:2343` | *"do not convert"* |

A **44% false-positive rate** on a list headed *"this is the list to pick work from"*.

## Why this direction of error is the dangerous one

Under-reporting sends a worker at a site whose owner already wrote down why it must not move. That is not hypothetical — it is precisely the sequence behind **#3114**, which converted the arm **#3108** had flagged hours earlier, with both blockers named and a test behind them. The tool I shipped to prevent workers burning effort on decided sites was quietly nominating four of them.

Over-reporting has the opposite failure: it hides real work. So the added phrases are specific to *declining a conversion* — `STAYS INLINE`, `not converted`, `do not convert`, `Recorded rather than`, `sized here`, `in dead code` — rather than generic words like `deliberately` on its own, which appears in plenty of notes that are not deferrals.

## Verified in both directions

- **Newly counted (4):** each independently read and confirmed to carry a real deferral note.
- **Still listed (4):** `eval-signal-collector.ts`, `async-comments-attachments.ts`, `auto-merge-finalization.ts`, `scheduler.ts` — the first three are fallback arms of already-converted seams (`x ? resolved : literal`), the fourth is the known synchronous-listener site. None is hidden convertible debt.
- `lifecycle-ops.ts` moved to documented, correctly — its note explains the polling-replica path is legacy-SQLite-only dead code.

```
before:  documented 8  / unexamined 9
after:   documented 13 / unexamined 4
```

## Census before / after

```
before:  COLUMN guards (the backlog):   17
after:   COLUMN guards (the backlog):   17
```

Unchanged, as required — `--triage` is opt-in and touches no count and no exit code. `--json` and `--strict` verified unaffected.

## Verification

`test:gate` exit 0 · `lifecycle-column-census --strict` exit 0 · `--json` exit 0 · headline output unchanged · `pnpm lint` clean. One script; no production file touched.

## Still open, and the reason the ratchet matters

`main` is **red on `check:inert-sync-lanes`** right now (#3114's inert conversion) and nothing in CI runs it. **#3127** fixes both halves — restores the flagged literal and wires the ratchet into `test:gate`. **#3122** restores 13 guards laundered through `mergeParkedColumns`; **#3119** attaches lanes at all five live emitters so the fallback path stops being taken.
