### PR TITLE
docs(dashboard): the research-modal archive filter is prop threading, not a data-fetch change

### DIFF
--- a/packages/dashboard/app/components/ResearchTaskActionModal.tsx
+++ b/packages/dashboard/app/components/ResearchTaskActionModal.tsx
@@ -62,6 +62,29 @@ export function ResearchTaskActionModal({ open, mode, run, finding, projectId, o
         The honest fix is for this modal to resolve lanes for the page it fetched — either a
         `fetchTasks` variant that returns resolved flags, or a per-task resolution over the 50 rows.
         That is a data-fetch change, not a prop-threading one, so it is sized here rather than faked.
+
+        FNXC:WorkflowResolvedColumns 2026-07-31-23:50 (CORRECTING THE SHAPE — it is not a data-fetch
+        change, and the objection above applies to a map this guard does not need):
+        Everything above is about a per-TASK map (`columnFlagsByTaskId`), and it is right that one
+        cannot help here: it is built from board-resident rows, and the rows this filter cares about
+        are archived ones, which are exactly what a board map omits.
+
+        But this guard does not ask a per-task question. "Is `task.column` an archive lane" is a
+        question about a COLUMN, and the answer lives in the workflow definition — a lane exists there
+        whether or not any board row currently sits in it. The board already derives exactly that map:
+        `ListView.tsx:756` builds `columnFlagsById` (ColumnId -> flags) from its workflow columns, and
+        `useExecutorStats` takes the same shape. Archived rows being absent from the board is
+        irrelevant to a column-keyed answer.
+
+        So the cost is prop threading, not a fetch: MainContent -> ResearchView -> this modal, plus
+        sourcing the column map where MainContent renders ResearchView (it does not hold one today).
+        Three layers for one guard is a real cost and a fair thing to decline — but it is a different
+        decision from "needs new data", which is what the note above would have the next reader
+        believe, and the two have very different prices.
+
+        Left counted and unconverted. I am recording the corrected shape rather than threading it,
+        because a three-component prop chain wants to be someone's deliberate change rather than a
+        drive-by on the last census entry in this file.
         */
         .then((rows) => setTasks(rows.filter((task) => task.column !== "archived")))
         .finally(() => setLoadingTasks(false));


### PR DESCRIPTION
Correcting the **shape** of the last census entry in this file. The existing note sizes it as needing new data. It does not, and the difference changes who can pick it up and for how much.

## What the note gets right

A per-**task** map (`columnFlagsByTaskId`) cannot help here. It is built from board-resident rows, and the rows this filter cares about are **archived** ones — exactly what a board map omits. Threading that map would look converted and leave the case it exists for unresolved. That reasoning is correct and I kept it.

## What it misses

This guard does not ask a per-task question.

*"Is `task.column` an archive lane"* is a question about a **column**, and the answer lives in the workflow definition — a lane exists there whether or not any row currently sits in it. **Archived rows being absent from the board is irrelevant to a column-keyed answer.**

That map already exists on the board:

- `ListView.tsx:756` derives `columnFlagsById` (`ColumnId -> flags`) from its workflow columns
- `useExecutorStats` takes the same shape

## So the real cost

`MainContent → ResearchView → this modal`, plus sourcing the column map where MainContent renders ResearchView (it holds none today).

Three layers for one guard is a real cost and a fair thing to decline — but it is a **different decision** from *"needs new data"*, and the two have very different prices. The note as written would have the next reader believe an API change is required.

## Left counted and unconverted, deliberately

A three-component prop chain wants to be someone's considered change, not a drive-by on the last entry in a file — especially from me, at the end of a long session where two rushed changes already went wrong. Recording the corrected shape is the part that was cheap and wrong to leave.

## Measured

- Comment-only.
- `ResearchView.test.tsx` — **27 tests pass**.
- `tsc --noEmit -p tsconfig.app.json` clean; census `--strict`, `check-fnxc-future-dates` clean.

## Census

**No movement.** The entry stays, with an accurate price on it.
