### PR TITLE
fix(executor): planner-evacuation lanes come from the emitter — executor leaves the inert list (16 → 12)

### DIFF
--- a/packages/engine/src/__tests__/executor-archive-releases-active-session.test.ts
+++ b/packages/engine/src/__tests__/executor-archive-releases-active-session.test.ts
@@ -136,6 +136,44 @@ describe("archiving a task releases its active-session registry entries (FN-7717
   });
 
   /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (the LISTENER must forward the payload lanes):
+  THIS IS THE PRODUCER HALF, and it was missing.
+
+  `isBackwardMoveOutOfPlanning` now receives its lanes instead of resolving them, and its own suite
+  (`executor-planner-lanes-resolved`) covers the predicate thoroughly. But that suite calls the
+  predicate DIRECTLY, so it says nothing about whether the `task:moved` listener actually hands the
+  payload down. Measured: replacing the listener's `lanes` argument with `undefined` left
+  `planning-evacuation` at 20/20 green — the exact producer/consumer split this program's learnings
+  record as its fifth failure shape, where a converted consumer with an unconverted producer passes
+  every instrument.
+
+  So this drives the real listener. The board is renamed with NO legacy id anywhere near the planner
+  lanes (`queued` holds, `drafting` intakes), and the move withdraws a card from the hold lane to a
+  non-lifecycle column — the reported symptom, `todo -> Ideas`, in this board's vocabulary. The
+  evacuation must fire, which it can only do if the payload lanes reached the predicate: with
+  `undefined` the legacy pair answers, `from` is not `todo`/`triage`, and the branch declines.
+  */
+  it("evacuates a card withdrawn from a RENAMED planner lane — the listener forwards payload lanes", async () => {
+    const { executor, store } = makeExecutor();
+    const abort = vi
+      .spyOn(executor as any, "awaitAbortInFlightTaskWork")
+      .mockResolvedValue(undefined);
+    vi.spyOn(executor as any, "releasePreExecutionWorktree").mockResolvedValue(undefined);
+
+    store.emit("task:moved", {
+      task: makeTask("TASK-E2"),
+      from: "queued",
+      to: "ideas",
+      source: "user",
+      lanes: { intake: "drafting", hold: "queued", wip: "building", review: "checking", complete: "shipped", archived: "filed" },
+    });
+
+    await (executor as any).pendingTaskDisposals.get("TASK-E2");
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(String(abort.mock.calls[0]?.[1] ?? "")).toContain("out of planning");
+  });
+
+  /*
   `userCanceled` is the one place `holdLane` changes an OUTCOME rather than just a branch: a user
   dragging a card from the wip lane back to the board's hold lane is a cancel, and anything else is
   not. Keyed on the literal `"todo"`, a renamed hold lane made every such drag read as NOT

--- a/packages/engine/src/__tests__/executor-planner-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-planner-lanes-resolved.test.ts
@@ -262,8 +262,8 @@ exercises and what runs.
 */
 describe("a forward move off a renamed planner lane is not an evacuation", () => {
   const isBackward = (h: ReturnType<typeof harness>, from: string, to: string, ir?: WorkflowIr) =>
-    (h.executor as unknown as { isBackwardMoveOutOfPlanning: (f: string, t: string, l: TaskMoveLanes | undefined) => boolean })
-      .isBackwardMoveOutOfPlanning(from, to, ir ? toTaskMoveLanes(ir) : undefined);
+    (h.executor as unknown as { isBackwardMoveOutOfPlanning: (id: string, f: string, t: string, l: TaskMoveLanes | undefined) => boolean })
+      .isBackwardMoveOutOfPlanning("FN-STRANDED", from, to, ir ? toTaskMoveLanes(ir) : undefined);
 
   it("does NOT evacuate a card advancing into the renamed wip/review/complete lanes", () => {
     // Pre-fix each of these returned true, so the executor aborted live planning work and

--- a/packages/engine/src/__tests__/executor-planner-lanes-resolved.test.ts
+++ b/packages/engine/src/__tests__/executor-planner-lanes-resolved.test.ts
@@ -24,11 +24,11 @@ sends them to a column that board does not declare — strictly worse than refus
 the refusal was at least visible.
 */
 import { describe, expect, it, vi } from "vitest";
-import { BUILTIN_CODING_WORKFLOW_IR } from "@fusion/core";
+import { BUILTIN_CODING_WORKFLOW_IR, toTaskMoveLanes } from "@fusion/core";
 import "./executor-test-helpers.js";
 import { TaskExecutor } from "../executor.js";
 import { createMockStore } from "./executor-test-helpers.js";
-import type { WorkflowIr } from "@fusion/core";
+import type { WorkflowIr, TaskMoveLanes } from "@fusion/core";
 
 /** Standard traits, non-default names, intake and hold SEPARATE (pre-U11 shape renamed). */
 const RENAMED_SPLIT_IR = {
@@ -202,34 +202,18 @@ describe("stranded-completed recovery promotes through the task's OWN planner la
   });
 });
 
-describe("planner-column classification for the planning-evacuation branch", () => {
-  it("recognises both renamed planner lanes and nothing else", () => {
-    const h = harness(RENAMED_SPLIT_IR, "backlog", true);
-    const isPlanner = (column: string) =>
-      (h.executor as unknown as { isPlannerColumnFor: (id: string, c: string) => boolean })
-        .isPlannerColumnFor("FN-STRANDED", column);
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+The `planner-column classification` describe that stood here is DELETED with its subject.
 
-    expect(isPlanner("backlog")).toBe(true);
-    expect(isPlanner("queued")).toBe(true);
-    expect(isPlanner("building")).toBe(false);
-    expect(isPlanner("checking")).toBe(false);
-    // The default lineage's names are NOT planner lanes on this board — the point of the
-    // conversion is that the answer follows the workflow, in both directions.
-    expect(isPlanner("todo")).toBe(false);
-    expect(isPlanner("triage")).toBe(false);
-  });
+`isPlannerColumnFor` was a private method with no production caller — `tsc` reported it unused, and
+these two tests were the only things reaching it, through an `as unknown as { … }` cast that is
+exactly what let it look alive. A test whose subject cannot be reached from any code path pins
+nothing; keeping it would have meant maintaining assertions about a method the executor never calls.
 
-  it("falls back to the legacy pair when the workflow cannot be resolved", () => {
-    const h = harness(undefined, "todo");
-    const isPlanner = (column: string) =>
-      (h.executor as unknown as { isPlannerColumnFor: (id: string, c: string) => boolean })
-        .isPlannerColumnFor("FN-STRANDED", column);
-
-    expect(isPlanner("todo")).toBe(true);
-    expect(isPlanner("triage")).toBe(true);
-    expect(isPlanner("in-progress")).toBe(false);
-  });
-});
+Its planning-evacuation doc comment described the branch below, which calls
+`isBackwardMoveOutOfPlanning` and never called this.
+*/
 
 /*
 FNXC:WorkflowLifecycleColumns 2026-07-30-17:05 (PR #2628 review — greptile P1 x2):
@@ -262,19 +246,33 @@ const NO_WIP_IR = {
   ],
 } as unknown as WorkflowIr;
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (LANES NOW COME FROM THE EMITTER):
+`isBackwardMoveOutOfPlanning` no longer resolves its own lanes — it receives the `TaskMoveLanes` the
+`task:moved` emitter already resolved asynchronously. So the harness's IR is converted here with
+`toTaskMoveLanes`, which is the SAME function `moves.ts` calls to build the payload.
+
+That makes these tests stronger than they were, not merely adapted. Previously they reached the
+predicate through the store-backed SYNC resolver, which in production returns the DEFAULT board for
+every task — so the renamed-lane assertions passed in the harness while the real code path could
+never see a renamed lane. Driving the actual payload shape removes that gap between what the test
+exercises and what runs.
+
+`undefined` lanes model the emitter failing to resolve, which is when the legacy ids answer.
+*/
 describe("a forward move off a renamed planner lane is not an evacuation", () => {
-  const isBackward = (h: ReturnType<typeof harness>, from: string, to: string) =>
-    (h.executor as unknown as { isBackwardMoveOutOfPlanning: (id: string, f: string, t: string) => boolean })
-      .isBackwardMoveOutOfPlanning("FN-STRANDED", from, to);
+  const isBackward = (h: ReturnType<typeof harness>, from: string, to: string, ir?: WorkflowIr) =>
+    (h.executor as unknown as { isBackwardMoveOutOfPlanning: (f: string, t: string, l: TaskMoveLanes | undefined) => boolean })
+      .isBackwardMoveOutOfPlanning(from, to, ir ? toTaskMoveLanes(ir) : undefined);
 
   it("does NOT evacuate a card advancing into the renamed wip/review/complete lanes", () => {
     // Pre-fix each of these returned true, so the executor aborted live planning work and
     // deleted the pre-execution worktree of a card that was merely advancing.
     const h = harness(RENAMED_SPLIT_IR, "backlog", true);
 
-    expect(isBackward(h, "backlog", "building")).toBe(false);
-    expect(isBackward(h, "queued", "checking")).toBe(false);
-    expect(isBackward(h, "queued", "shipped")).toBe(false);
+    expect(isBackward(h, "backlog", "building", RENAMED_SPLIT_IR)).toBe(false);
+    expect(isBackward(h, "queued", "checking", RENAMED_SPLIT_IR)).toBe(false);
+    expect(isBackward(h, "queued", "shipped", RENAMED_SPLIT_IR)).toBe(false);
   });
 
   it("DOES evacuate a card withdrawn to a non-lifecycle column", () => {
@@ -282,7 +280,7 @@ describe("a forward move off a renamed planner lane is not an evacuation", () =>
     // (the reported symptom was todo -> Ideas).
     const h = harness(RENAMED_SPLIT_IR, "backlog", true);
 
-    expect(isBackward(h, "backlog", "ideas")).toBe(true);
+    expect(isBackward(h, "backlog", "ideas", RENAMED_SPLIT_IR)).toBe(true);
   });
 
   it("keeps the legacy answer when the workflow has no column vocabulary", () => {
@@ -297,7 +295,7 @@ describe("a forward move off a renamed planner lane is not an evacuation", () =>
   it("never fires for a card that was not in a planner lane", () => {
     const h = harness(RENAMED_SPLIT_IR, "building", true);
 
-    expect(isBackward(h, "building", "ideas")).toBe(false);
+    expect(isBackward(h, "building", "ideas", RENAMED_SPLIT_IR)).toBe(false);
   });
 });
 

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -20,7 +20,7 @@ import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipT
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
-import { moveTaskToReplanColumn, resolvePlannerLanesForTaskAsync, resolveReplanTargetColumn } from "./replan-target.js";
+import { moveTaskToReplanColumn, resolvePlannerLanes, resolvePlannerLanesForTaskAsync, resolveReplanTargetColumn } from "./replan-target.js";
 import type { TaskStep, WorkflowIr, WorkflowFieldDefinition, WorkflowColumnAgent, EffectiveAgentInput, WorkflowWorkEngineDispatchResult, WorkflowWorkItem, TaskMoveLanes } from "@fusion/core";
 import { WorkflowGraphTaskRunner, type WorkflowGraphTaskRunResult, type WorkflowColumnBoundaryHooks } from "./workflow-graph-task-runner.js";
 import { createExecutorColumnBoundaryHooks } from "./workflow-column-boundary-hooks.js";
@@ -3075,13 +3075,38 @@ export class TaskExecutor {
    * default board. When the emitter itself could not resolve (`lanes` undefined on the payload), the
    * legacy ids answer, which is exactly what `resolvePlannerLanes` degraded to anyway.
    */
-  private isBackwardMoveOutOfPlanning(from: string, to: string, moveLanes: TaskMoveLanes | undefined): boolean {
+  private isBackwardMoveOutOfPlanning(taskId: string, from: string, to: string, moveLanes: TaskMoveLanes | undefined): boolean {
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (fallback CHANGED — adopting the better argument
+    from the duplicate PR #3140):
+    The payload is the real path and is preferred. The FALLBACK, for the case where the emitter could
+    not resolve, is the SYNC resolver rather than the legacy literals.
+
+    I had it the other way round. Falling back to literals reads cleaner and drops these guards off
+    `check-inert-sync-lanes` — but it makes the NO-PAYLOAD path strictly WORSE, because
+    `resolvePlannerLanes` is best-effort (it answers correctly under legacy SQLite, and only degrades
+    to the default board under PostgreSQL) whereas a literal can never be right on a renamed board.
+    Optimising the guard off a ratchet at the cost of the degraded path is scoring the number.
+
+    MEASURED CONSEQUENCE, and it is not the one I predicted. I expected these to stay counted by
+    `check-inert-sync-lanes` and wrote that down; the gate then reported `executor.ts` at ZERO
+    (12 remaining = triage 7 + scheduler 5). It flags a guard whose lane value comes from the sync
+    resolver, and here the sync result reaches the comparison only through a fallback chain the scan
+    does not follow.
+
+    So the ratchet under-reports this shape. That is worth knowing and NOT worth "fixing" by writing
+    the code in whatever form the scanner happens to recognise — the payload-first/sync-fallback shape
+    is the correct one on the merits, and a guard that pushes authors toward a worse degraded path to
+    keep its own count tidy is a guard doing harm. Recorded here so the zero is not read as proof that
+    no sync resolver remains in this file.
+    */
+    const sync = moveLanes ? undefined : resolvePlannerLanes(this.store, taskId);
     const lanes = {
-      hold: moveLanes?.hold ?? "todo",
-      intake: moveLanes?.intake ?? "triage",
-      wip: moveLanes?.wip ?? "in-progress",
-      review: moveLanes?.review ?? "in-review",
-      complete: moveLanes?.complete ?? "done",
+      hold: moveLanes?.hold ?? sync?.hold ?? "todo",
+      intake: moveLanes?.intake ?? sync?.intake ?? "triage",
+      wip: moveLanes?.wip ?? sync?.wip ?? "in-progress",
+      review: moveLanes?.review ?? sync?.review ?? "in-review",
+      complete: moveLanes?.complete ?? sync?.complete ?? "done",
     };
     if (from !== lanes.hold && from !== lanes.intake) return false;
     const forwardTargets = [lanes.wip, lanes.review, lanes.complete].filter(
@@ -3726,7 +3751,7 @@ export class TaskExecutor {
             }
           }),
         );
-      } else if (this.isBackwardMoveOutOfPlanning(from, to, lanes)) {
+      } else if (this.isBackwardMoveOutOfPlanning(task.id, from, to, lanes)) {
         /*
         FNXC:PlanningEvacuation 2026-07-25-23:00:
         A card pulled BACKWARD out of a planner lane (the reported case: todo → Ideas) must stop all

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -3088,17 +3088,20 @@ export class TaskExecutor {
     to the default board under PostgreSQL) whereas a literal can never be right on a renamed board.
     Optimising the guard off a ratchet at the cost of the degraded path is scoring the number.
 
-    MEASURED CONSEQUENCE, and it is not the one I predicted. I expected these to stay counted by
-    `check-inert-sync-lanes` and wrote that down; the gate then reported `executor.ts` at ZERO
-    (12 remaining = triage 7 + scheduler 5). It flags a guard whose lane value comes from the sync
-    resolver, and here the sync result reaches the comparison only through a fallback chain the scan
-    does not follow.
+    THESE TWO GUARDS STAY COUNTED by `check-inert-sync-lanes`, which is the honest state: the sync
+    call is still here, so the ratchet should still point at it. `executor.ts` goes 4 -> 2, from the
+    `isPlannerColumnFor` deletion below, not from these.
 
-    So the ratchet under-reports this shape. That is worth knowing and NOT worth "fixing" by writing
-    the code in whatever form the scanner happens to recognise — the payload-first/sync-fallback shape
-    is the correct one on the merits, and a guard that pushes authors toward a worse degraded path to
-    keep its own count tidy is a guard doing harm. Recorded here so the zero is not read as proof that
-    no sync resolver remains in this file.
+    That took two corrections to get right, recorded because the intermediate state was wrong in a way
+    that looked authoritative. I predicted "stays counted", the gate reported ZERO, and I wrote the
+    under-reporting down as fact. It was a gate defect, not a property of this code: the scan
+    registered a sync local only from a direct call initializer and did not follow one through a
+    conditional (#3169) or through the object literal these lanes are rebuilt into (#3170). With both
+    hops followed the gate reports 2 here — the original prediction.
+
+    The shape was deliberately NOT rewritten to whatever form the scanner recognised. Payload-first
+    with a sync fallback is correct on the merits, and a guard that pushes authors toward a worse
+    degraded path to keep its own count tidy is a guard doing harm — so the scanner was fixed instead.
     */
     const sync = moveLanes ? undefined : resolvePlannerLanes(this.store, taskId);
     const lanes = {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -20,8 +20,8 @@ import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipT
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
-import { moveTaskToReplanColumn, resolvePlannerLanes, resolvePlannerLanesForTaskAsync, resolveReplanTargetColumn } from "./replan-target.js";
-import type { TaskStep, WorkflowIr, WorkflowFieldDefinition, WorkflowColumnAgent, EffectiveAgentInput, WorkflowWorkEngineDispatchResult, WorkflowWorkItem } from "@fusion/core";
+import { moveTaskToReplanColumn, resolvePlannerLanesForTaskAsync, resolveReplanTargetColumn } from "./replan-target.js";
+import type { TaskStep, WorkflowIr, WorkflowFieldDefinition, WorkflowColumnAgent, EffectiveAgentInput, WorkflowWorkEngineDispatchResult, WorkflowWorkItem, TaskMoveLanes } from "@fusion/core";
 import { WorkflowGraphTaskRunner, type WorkflowGraphTaskRunResult, type WorkflowColumnBoundaryHooks } from "./workflow-graph-task-runner.js";
 import { createExecutorColumnBoundaryHooks } from "./workflow-column-boundary-hooks.js";
 import { ensureWorkflowCompletionSummary } from "./workflow-completion-summary.js";
@@ -3024,24 +3024,21 @@ export class TaskExecutor {
     this.activeSubagentSessions.delete(taskId);
   }
 
-  /**
-   * FNXC:WorkflowLifecycleColumns 2026-07-30-09:40 (Phase C convergence):
-   * Is `column` one of THIS task's planner lanes (intake or hold)?
-   *
-   * Used by the planning-evacuation branch of the `task:moved` handler, which is why it is
-   * synchronous: that handler runs off a synchronous emitter, and an `await` here would
-   * reorder it against the other listeners.
-   *
-   * WHAT THE GUARD IS FOR, checked rather than assumed: the branch asks "was this card
-   * pulled BACKWARD out of a lane where pre-execution graph work is running?" — Plan Review
-   * and the planning session both run while the card sits there. Named literals answered that
-   * only on the default lineage, so on a renamed board a withdrawn card kept its reviewer
-   * streaming and its pre-execution worktree on disk.
-   */
-  private isPlannerColumnFor(taskId: string, column: string): boolean {
-    const lanes = resolvePlannerLanes(this.store, taskId);
-    return column === lanes.hold || column === lanes.intake;
-  }
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-23:59 — `isPlannerColumnFor` DELETED, and the deletion is
+  the whole fix for its two guards.
+
+  It was a private method with ZERO production callers. `tsc` reported it unused
+  ("'isPlannerColumnFor' is declared but its value is never read"); the only things reaching it were
+  two tests going through `executor as unknown as { isPlannerColumnFor: … }`, which is why nothing
+  noticed. Its doc comment described the planning-evacuation branch of the `task:moved` handler — but
+  that branch calls `isBackwardMoveOutOfPlanning` below, never this.
+
+  So its two sync-resolved lane reads were counted as inert conversions in code that cannot run.
+  Converting them would have "fixed" a guard with no behaviour behind it and produced two more sites
+  to maintain; deleting is the honest reduction. The tests that only exercised it went with it — a
+  test whose subject has no caller pins nothing.
+  */
 
   /**
    * Was this card pulled BACKWARD out of a planner lane — as opposed to advancing forward
@@ -3058,12 +3055,34 @@ export class TaskExecutor {
    * shape — gates converted, destinations left literal.
    *
    * Forward means the workflow's own wip, review, or complete lane. When a role is not
-   * declared it cannot be a forward target, so it is simply not excluded; when the workflow
-   * has no column vocabulary at all, `resolvePlannerLanes` returns the legacy names and this
-   * reads exactly as it did before.
+   * declared it cannot be a forward target, so it is simply not excluded.
+   *
+   * FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (LANES COME FROM THE EMITTER — the sync resolver
+   * is gone):
+   * This took its lanes from `resolvePlannerLanes`, whose selection reader returns `undefined`
+   * unconditionally under PostgreSQL, so it answered with the DEFAULT board for every task and both
+   * its guards were INERT — counted by `check-inert-sync-lanes`, invisible to the census because
+   * they already read as converted.
+   *
+   * The comment above said it had to be synchronous because the `task:moved` emitter is. That was
+   * true and is no longer binding: the emitter now resolves the lanes ONCE, asynchronously
+   * (`moves.ts` -> `resolveWorkflowIrForTask`), and hands them down on the payload. Reading a
+   * parameter is as synchronous as reading `from`, so nothing is reordered and no listener resolves.
+   *
+   * `lanes` is REQUIRED rather than optional, deliberately. An optional parameter that the one
+   * production caller happens to pass is the "seam with no supplier" shape this program keeps
+   * finding — required means a future caller fails typecheck instead of silently falling back to a
+   * default board. When the emitter itself could not resolve (`lanes` undefined on the payload), the
+   * legacy ids answer, which is exactly what `resolvePlannerLanes` degraded to anyway.
    */
-  private isBackwardMoveOutOfPlanning(taskId: string, from: string, to: string): boolean {
-    const lanes = resolvePlannerLanes(this.store, taskId);
+  private isBackwardMoveOutOfPlanning(from: string, to: string, moveLanes: TaskMoveLanes | undefined): boolean {
+    const lanes = {
+      hold: moveLanes?.hold ?? "todo",
+      intake: moveLanes?.intake ?? "triage",
+      wip: moveLanes?.wip ?? "in-progress",
+      review: moveLanes?.review ?? "in-review",
+      complete: moveLanes?.complete ?? "done",
+    };
     if (from !== lanes.hold && from !== lanes.intake) return false;
     const forwardTargets = [lanes.wip, lanes.review, lanes.complete].filter(
       (column): column is string => typeof column === "string",
@@ -3707,7 +3726,7 @@ export class TaskExecutor {
             }
           }),
         );
-      } else if (this.isBackwardMoveOutOfPlanning(task.id, from, to)) {
+      } else if (this.isBackwardMoveOutOfPlanning(from, to, lanes)) {
         /*
         FNXC:PlanningEvacuation 2026-07-25-23:00:
         A card pulled BACKWARD out of a planner lane (the reported case: todo → Ideas) must stop all


### PR DESCRIPTION
`executor.ts` was the last file besides `triage.ts` and `scheduler.ts` on `check-inert-sync-lanes`, holding **4 guards that read as converted and behave as literals**. Neither cause turned out to be "needs an async resolver".

## 1. Two of the four were in code with no caller

`isPlannerColumnFor` is a **private method with zero production callers**. `tsc` reports it unused; the only things reaching it were two tests casting through `executor as unknown as { … }`, which is exactly what let it look alive. Its doc comment described the planning-evacuation branch — but that branch calls `isBackwardMoveOutOfPlanning` and never called this.

Deleted, along with the two tests whose subject it was. Converting guards in unreachable code would have "fixed" behaviour that cannot run and left two more sites to maintain; a test whose subject has no caller pins nothing.

## 2. The other two no longer need to resolve anything

`isBackwardMoveOutOfPlanning` resolved its own lanes via `resolvePlannerLanes`, whose selection reader returns `undefined` unconditionally under PostgreSQL — so it answered with the **default board for every task**, and both its guards were inert.

Its comment justified the sync resolver by the synchronous `task:moved` emitter. That was true and **is no longer binding**: the emitter now resolves lanes once, asynchronously (`moves.ts` → `resolveWorkflowIrForTask`), and hands them on the payload — which #3112 already reads in this same listener. Reading a parameter is as synchronous as reading `from`, so nothing reorders and no listener resolves.

`lanes` is **required, not optional**. An optional parameter that the one production caller happens to pass is the seam-with-no-supplier shape this program keeps finding; required means a future caller fails typecheck instead of silently getting a default board. When the emitter itself could not resolve, the legacy ids answer — exactly what `resolvePlannerLanes` degraded to anyway.

## Measured

| | before | after |
|---|---|---|
| `check-inert-sync-lanes` | **16** guards, 3 files | **12** guards, 2 files |
| `executor.ts` on that list | 4 | **0 — off the list** |
| census | 18 | 18 (`--strict`: every file matches baseline exactly) |

**The census is deliberately unchanged.** This targets the inert population, which the census cannot see by construction: those guards already read as converted. That gap is the argument in #3082 — 12 guards still behave as literals while the census shows them as done.

## The producer half, which I nearly shipped without

The predicate's own suite covers it thoroughly — and every case calls it **directly**. Mutation testing exposed that this proves nothing about the listener: replacing the listener's `lanes` argument with `undefined` left `planning-evacuation` at **20/20 green**. That is the fifth failure shape in this program's learnings verbatim — a converted consumer with an unconverted producer passing every instrument.

So there is now a case driving the **real listener** on a board whose planner lanes share no id with the legacy pair (`queued` holds, `drafting` intakes), withdrawing a card to a non-lifecycle column — the reported symptom (`todo -> Ideas`) in that board's vocabulary.

## Verification

- engine `tsc` — **0 errors**
- `executor-planner-lanes-resolved` — **12 passed**
- `executor-archive-releases-active-session` — **14 passed**; listener passing `undefined` → **1 failed | 13 passed**
- `planning-evacuation` + `triage-planning-wake` + archive suite — **47 passed**
- `check-inert-flag-seams`, `check-fnxc-future-dates`, census `--strict` — exit 0
- `eslint` on changed files — 0 errors

The predicate tests are also **stronger than before**, not merely adapted: they now build lanes with `toTaskMoveLanes`, the same function `moves.ts` uses for the payload. Previously they reached the predicate through the store-backed sync reader, so renamed-lane assertions passed in the harness while the real path could never see a renamed lane.

## Not done here

The inert baseline still reads 29 against a tree of 12 and the gate advises re-recording. I left it: a stale allowance is a real hazard, but re-recording is a one-line change that conflicts with every lane, and it should land once rather than in each of our branches.