### PR TITLE
docs(triage): its inert lane guards depend on the sync resolver FAILING — measured, not converted

### DIFF
--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -878,6 +878,33 @@ export class TriageProcessor {
   */
   private async sweepStalePlanningStatuses(allTasks: Task[], now: number): Promise<void> {
     try {
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (FLAGGED — same blocker as `recoverApprovedTask`;
+      the async twin is NOT a drop-in):
+
+      This lane test is inert (`resolvePlannerLanes` -> `resolveTaskWorkflowIrSync` -> DEFAULT board
+      under PostgreSQL) and the enclosing sweep is `async`, so converting looks free. MEASURED: it is
+      not. Swapping in `resolvePlannerLanesForTaskAsync` (with the `filter` rewritten as an awaited
+      loop, which is itself fine) fails `clears a stale planning status so triage can re-pick the card`
+      — and correctly.
+
+      A stored pre-U11 row sits in `triage`. The sync reader fails to `LEGACY_PLANNER_LANES`, whose
+      `intake` IS `"triage"`, so the row matches. The async reader succeeds and returns the workflow's
+      real lanes, where post-U11 intake and hold are one merged column — so `"triage"` matches nothing
+      and the sweep stops clearing the strand it was written for (FN-8596).
+
+      So this guard's current correctness DEPENDS ON THE SYNC RESOLVER'S FAILURE MODE. Converting it
+      needs the legacy `triage` acceptance made explicit, not a different resolver.
+
+      THE PATTERN ALREADY EXISTS IN THIS FILE and is the right one:
+      `recoverApprovedTask` scopes its legacy acceptance to an ORPHANED `triage` row — one whose
+      workflow does not declare a `triage` column — using `resolveWorkflowIrForTaskWithProvenance`,
+      precisely because a custom workflow may legitimately name a non-intake lane `triage`. Applying
+      that here is a real change with its own surfaces (every row in the sweep, plus the R11
+      compatibility contract), which is why it is sized here rather than smuggled into a conversion.
+
+      Left inert and COUNTED, deliberately NOT marked deliberate: the gate should keep pointing here.
+      */
       const stale = allTasks.filter((t) => {
         if (t.status !== "planning") return false;
         const lanes = resolvePlannerLanes(this.store, t.id);
@@ -1271,6 +1298,30 @@ export class TriageProcessor {
     a fix. `triage` stays a legal column id for stored rows (R11), so accepting both
     is compatibility, not a second source of truth — once a row is re-homed the
     resolved lane is what matches.
+    */
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (FLAGGED — the async twin is NOT a drop-in here, and
+    swapping it is a BEHAVIOR CHANGE that 13 tests catch):
+
+    This guard is inert for the usual reason — `resolvePlannerLanes` reads `resolveTaskWorkflowIrSync`,
+    which answers with the DEFAULT board under PostgreSQL — and `recoverApprovedTask` is `async`, so
+    the mechanical fix looks free. It is not. MEASURED: swapping in
+    `resolvePlannerLanesForTaskAsync` fails 13 cases in `triage.test.ts`, and they are right to fail.
+
+    WHY THE TWO RESOLVERS DISAGREE HERE. The sync reader cannot resolve, so it returns
+    `LEGACY_PLANNER_LANES` — `intake: "triage"`. The async reader SUCCEEDS and returns the workflow's
+    real lanes, where post-U11 intake and hold are one merged column (`intake: "todo"`). So a stored
+    pre-U11 row sitting in `triage` matches today and stops matching after the swap: the recovery this
+    function exists to perform silently stops happening for exactly the migration case the note below
+    describes.
+
+    In other words this site's CURRENT correctness depends on the sync resolver's failure mode. That is
+    a genuinely bad place to be, and it is not fixable by changing which resolver is called — the
+    legacy `triage` acceptance has to become explicit rather than a side effect of the fallback, which
+    is a compatibility decision with its own surfaces (R11 keeps `triage` a legal stored column id).
+
+    Left inert and COUNTED rather than converted, and NOT marked deliberate: the gate should keep
+    pointing here. Tracked with the emitter/async-threading work in #3082.
     */
     const lanes = resolvePlannerLanes(this.store, task.id);
     /*


### PR DESCRIPTION
I tried the conversion that took `executor.ts` off `check-inert-sync-lanes` in #3137, on the file holding the largest remaining inert cluster. **It does not transfer, and the tests are what proved it — not my reading of the code.** Comments only; no behaviour change.

## What looked free

`triage.ts`'s 7 guards are inert for the usual reason (`resolvePlannerLanes` → `resolveTaskWorkflowIrSync` → default board under PostgreSQL), the file **already imports** `resolvePlannerLanesForTaskAsync`, and the two most promising sites sit inside `async` functions. Mechanical swap, apparently.

| site | result of swapping in the async twin |
|---|---|
| `recoverApprovedTask` | **13 failures** in `triage.test.ts` |
| `sweepStalePlanningStatuses` | fails *"clears a stale planning status so triage can re-pick the card"* |

## One cause, and it inverts the usual argument

A stored pre-U11 row sits in `triage`.

- The **sync** reader cannot resolve under PostgreSQL, so it falls back to `LEGACY_PLANNER_LANES` — whose `intake` **is** `"triage"`. The row matches.
- The **async** reader *succeeds* and returns the workflow's real lanes, where post-U11 intake and hold are **one merged column**. So `"triage"` matches nothing, and both the approved-plan recovery and the FN-8596 strand-clearing silently stop happening — for precisely the migration case they exist to serve.

**These guards' current correctness depends on the sync resolver's failure mode.** Everywhere else in this program the sync resolver is the bug; here it is load-bearing, and "convert to the async twin" would be a regression that the census would score as progress.

## Why this is not a resolver choice

The legacy `triage` acceptance has to become **explicit** before either site can resolve properly. The pattern already exists in this file: `recoverApprovedTask` scopes its legacy acceptance to an **orphaned** `triage` row — one whose workflow does not declare a `triage` column — using `resolveWorkflowIrForTaskWithProvenance`, precisely because a custom workflow may legitimately name a non-intake lane `triage`.

Applying that to these sites is a compatibility change with its own surface list (every row in the sweep, plus the R11 contract that keeps `triage` a legal stored column id). That is a real piece of work, not a fleet conversion, so it is **sized here rather than smuggled in**.

## Disposition

Both sites stay inert and **counted**, and deliberately **not** marked `DELIBERATE-LITERAL` — the gate should keep pointing here. What lands is the measurement and the named solution, so the next person does not repeat the swap and discover the same 14 failures.

## Verification

- `triage.test.ts` + `recover-approved-intake-post-u11` — **237 passed**
- engine `tsc` — **0 errors**
- `check-inert-sync-lanes` — exit 0 (unchanged at 7 for this file, by design)
- census `--strict` — exit 0, unchanged

## Separately: `main` is red on `check-fnxc-future-dates`

Not from this branch — measured on a clean detached `origin/main`:

```
packages/engine/src/scheduler.ts: 7 future-dated FNXC stamp(s), baseline allows 3
packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts: 1, baseline allows 0
  FNXC:ConcurrencyAdmission 2026-08-06  (dated after today)
```

One stamp is **six days** in the future. I have not touched them: correcting another author's stamps is exactly what caused collateral damage in my #3124 cycle, and these belong to whoever has that work open. Flagging for them.