### PR TITLE
fix: main is red on check-fnxc-future-dates — every open PR fails this check until it lands

### DIFF
--- a/packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts
@@ -168,7 +168,7 @@ pgDescribe("scheduler parked-column resolution against a live store", () => {
 
   it("REGRESSION — a dependent in a RENAMED hold column IS unblocked when its blocker is deleted", async () => {
     /*
-    FNXC:WorkflowResolvedColumns 2026-08-01-02:20 (fleet — the flip this test was written to catch):
+    FNXC:WorkflowResolvedColumns 2026-07-31-22:20 (fleet — the flip this test was written to catch):
     This was a CHARACTERIZATION of the inert sync read: `resolveTaskParkedColumnsSync` answered
     `{ hold: "todo" }` for a board whose hold column is `backlog`, so the reconciliation queried a
     column that does not exist, found no dependents, and left `blockedBy` pointing at a deleted task.

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -450,7 +450,7 @@ function mergeParkedColumns(
 }
 
 /*
-FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet):
+FNXC:WorkflowResolvedColumns 2026-07-31-21:40 (fleet):
 The ASYNC twin. The sync one below cannot answer for a custom workflow in production, so any guard that
 can reach this one must.
 
@@ -477,7 +477,7 @@ async function resolveTaskParkedColumns(store: TaskStore, taskId: string): Promi
       archived,
       terminal: new Set([complete, archived]),
       /*
-      FNXC:WorkflowResolvedColumns 2026-08-01-02:05 (fleet):
+      FNXC:WorkflowResolvedColumns 2026-07-31-22:05 (fleet):
       The wake set UNIONS the legacy ids rather than replacing them, and that is load-bearing rather
       than defensive. Post-U11 the default lineage has no `triage` column, so a RESOLVED answer returns
       `intake: "todo"` where the old inert path fell back to `"triage"`. Converting without the union
@@ -1268,7 +1268,7 @@ export class Scheduler {
             schedulerLog.warn(`Failed to reset dispatch oscillation state for ${task.id} on unpause: ${error instanceof Error ? error.message : String(error)}`);
           });
         }
-        /* FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet): the answer only gates `schedule()`,
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-21:40 (fleet): the answer only gates `schedule()`,
            which is async and fire-and-forget, so resolving it properly costs nothing observable. */
         void (async () => {
           const unpausedParked = await resolveTaskParkedColumns(this.store, task.id);
@@ -1299,7 +1299,7 @@ export class Scheduler {
         this.planningTaskIds.add(task.id);
       } else if (this.planningTaskIds.has(task.id)) {
         this.planningTaskIds.delete(task.id);
-        /* FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet): as with the unpause wake above, the
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-21:40 (fleet): as with the unpause wake above, the
            answer only gates `schedule()`. The `planningTaskIds.delete` stays SYNCHRONOUS — it is the
            edge-trigger bookkeeping, and deferring it would let a second update re-enter this branch. */
         void (async () => {


### PR DESCRIPTION
`check-fnxc-future-dates` runs in `pr-checks.yml`, so while `main` is red **every open PR in the fleet fails this check**, regardless of what it touches. Measured on a clean detached `origin/main`:

```
[check-fnxc-future-dates] FNXC stamp population changed:
  packages/engine/src/scheduler.ts: 7 future-dated FNXC stamp(s), baseline allows 3
  packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts: 1, baseline allows 0
```

## Scoped by blame, not by pattern

`git blame` attributes exactly **five** of these to one commit landed today (`6483f9ce2b5`), all stamped `2026-08-01` while today is `2026-07-31`: the four pushing `scheduler.ts` from 3 → 7, plus the one in the pg test. Those five are corrected to today's date.

**Three other future stamps are deliberately left alone** — `2026-08-06-09:00`, `2026-08-01-00:00`, `2026-08-01-05:00`, from 2026-07-19 / 07-21 / 07-30. They sit inside the recorded baseline, so they are not what turned main red, and rewriting them would register as a **drop**. That is precisely how I did collateral damage in my #3124 cycle: a loose regex rewrote two stamps I had not authored, and the tell was the baseline dropping rather than holding level.

One of the three is dated **six days out** and looks like a typo, but that is its author's call to make, not a drive-by in a red-main fix.

## What is not changed

- **No baseline edit.** The fix is the stamps, not the allowance — re-recording would clear the red while leaving the wrong dates in the tree, which is the false green this gate exists to prevent.
- No code, no tests, no behaviour. Five comment lines.

## Verification

- `check-fnxc-future-dates` — **exit 1 on `origin/main`, exit 0 here**
- `git diff` is five lines, all FNXC stamps; the three baselined stamps verified still present
- baseline file confirmed unmodified

I would normally leave another author's stamps to them, and I have done exactly that this week. The difference is that this one is blocking the whole fleet's CI, and the correction is mechanical and reversible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow scheduling comments and a regression test timestamp marker.
* **Tests**
  * Refreshed test documentation without changing test behavior or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->