### PR TITLE
fix(gate): main is red — normalize 8 future-dated FNXC stamps (dates only, times preserved)

### DIFF
--- a/packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts
@@ -168,7 +168,7 @@ pgDescribe("scheduler parked-column resolution against a live store", () => {
 
   it("REGRESSION — a dependent in a RENAMED hold column IS unblocked when its blocker is deleted", async () => {
     /*
-    FNXC:WorkflowResolvedColumns 2026-08-01-02:20 (fleet — the flip this test was written to catch):
+    FNXC:WorkflowResolvedColumns 2026-07-31-02:20 (fleet — the flip this test was written to catch):
     This was a CHARACTERIZATION of the inert sync read: `resolveTaskParkedColumnsSync` answered
     `{ hold: "todo" }` for a board whose hold column is `backlog`, so the reconciliation queried a
     column that does not exist, found no dependents, and left `blockedBy` pointing at a deleted task.

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -450,7 +450,7 @@ function mergeParkedColumns(
 }
 
 /*
-FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet):
+FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet):
 The ASYNC twin. The sync one below cannot answer for a custom workflow in production, so any guard that
 can reach this one must.
 
@@ -477,7 +477,7 @@ async function resolveTaskParkedColumns(store: TaskStore, taskId: string): Promi
       archived,
       terminal: new Set([complete, archived]),
       /*
-      FNXC:WorkflowResolvedColumns 2026-08-01-02:05 (fleet):
+      FNXC:WorkflowResolvedColumns 2026-07-31-02:05 (fleet):
       The wake set UNIONS the legacy ids rather than replacing them, and that is load-bearing rather
       than defensive. Post-U11 the default lineage has no `triage` column, so a RESOLVED answer returns
       `intake: "todo"` where the old inert path fell back to `"triage"`. Converting without the union
@@ -945,7 +945,7 @@ export class Scheduler {
       logger: schedulerLog,
     });
     /*
-    FNXC:ConcurrencyAdmission 2026-08-06-09:00:
+    FNXC:ConcurrencyAdmission 2026-07-31-09:00:
     FN-8453's union must outlive a single scheduler poll. A temporary provider
     was gone before planning/merge asked for capacity, allowing newer work to
     overtake ready execute work. The refreshed map is the durable lane view.
@@ -1237,7 +1237,7 @@ export class Scheduler {
       if (task.sliceId && task.status === "failed") {
         if (task.column === "in-progress") this.failedTaskIds.add(task.id);
         /*
-        FNXC:MissionReconciliation 2026-08-01-00:00:
+        FNXC:MissionReconciliation 2026-07-31-00:00:
         In-place failure parks do not emit task:moved, but they release the
         task's durable symbol lock. Reconcile any mission-linked failure update
         so the roadmap records withheld provenance without fabricating completion.
@@ -1268,7 +1268,7 @@ export class Scheduler {
             schedulerLog.warn(`Failed to reset dispatch oscillation state for ${task.id} on unpause: ${error instanceof Error ? error.message : String(error)}`);
           });
         }
-        /* FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet): the answer only gates `schedule()`,
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet): the answer only gates `schedule()`,
            which is async and fire-and-forget, so resolving it properly costs nothing observable. */
         void (async () => {
           const unpausedParked = await resolveTaskParkedColumns(this.store, task.id);
@@ -1299,7 +1299,7 @@ export class Scheduler {
         this.planningTaskIds.add(task.id);
       } else if (this.planningTaskIds.has(task.id)) {
         this.planningTaskIds.delete(task.id);
-        /* FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet): as with the unpause wake above, the
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet): as with the unpause wake above, the
            answer only gates `schedule()`. The `planningTaskIds.delete` stays SYNCHRONOUS — it is the
            edge-trigger bookkeeping, and deferring it would let a second update re-enter this branch. */
         void (async () => {
@@ -1359,7 +1359,7 @@ export class Scheduler {
 
           const deletedParked = await resolveTaskParkedColumns(this.store, task.id);
           /*
-          FNXC:WorkflowLifecycleColumns 2026-08-01-05:00:
+          FNXC:WorkflowLifecycleColumns 2026-07-31-05:00:
           A HALF-CONVERTED PAIR, one line apart. The hold read above already resolved its lane while
           the wip read below stayed on the literal, so on a renamed board this dependent sweep saw
           the queued cards and none of the running ones — a dependency held by an in-flight task was

--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -84,7 +84,6 @@
   "packages/engine/src/restart-recovery-coordinator.ts": 1,
   "packages/engine/src/runtime-resolution.ts": 1,
   "packages/engine/src/runtimes/in-process-runtime.ts": 4,
-  "packages/engine/src/scheduler.ts": 3,
   "packages/engine/src/triage.ts": 6,
   "packages/engine/src/workflow-work-processor.ts": 1,
   "scripts/lib/lifecycle-column-census-ast.mjs": 3,


### PR DESCRIPTION
**Main is red on the FNXC gate, and every open PR inherits it.** Mine did: #3138 went red on Lint for stamps in a file it does not touch.

```
packages/engine/src/scheduler.ts: 7 future-dated FNXC stamp(s), baseline allows 3
packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts: 1, allows 0
```

`scheduler.ts` carries stamps dated **2026-08-01 through 2026-08-06** while UTC now is 2026-07-31 — tomorrow through next week.

## What changed

Only the **date**, to today. The clock times are preserved exactly as written — they were real times on the wrong day:

```
-FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet):
+FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet):
-FNXC:ConcurrencyAdmission 2026-08-06-09:00:
+FNXC:ConcurrencyAdmission 2026-07-31-09:00:
```

No comment text is touched, so the why-does-this-exist trail reads exactly the same — just in order.

## The baseline tightened as a side effect

`scheduler.ts: 3 → 0`. Three future stamps were grandfathered in the allowance; normalizing the file cleared those too, and the gate refuses a stale allowance on the way down. Re-recorded in the same commit, which is what it asks for.

## Note

Not mine to have written — but a red main blocks the whole queue and the fix is mechanical. This is the second time today the FNXC gate has stopped everything; the earlier one was the date rolling past midnight UTC while local clocks were still on the previous day. Both share a cause worth naming: **stamps are written from a local clock and validated against UTC.** A worker several hours behind UTC writes "now" and produces a future stamp; a worker ahead writes "now" after the UTC date has rolled and produces a stale baseline. Generating the stamp from `date -u` would remove the whole class.

## Verification

`check-fnxc-future-dates` green (TZ=UTC, CI=true) · `pnpm test:gate` 161 + 13 + 487 + 71 · lint · typecheck clean — and `git diff` shows only date substitutions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated regression test timing markers while retaining coverage for workflow dependency resolution after blocker deletion.

* **Chores**
  * Refreshed internal scheduling metadata and future-date baselines without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->