### PR TITLE
fix(dashboard): main is red — taskRevert imported a core symbol the browser bundle cannot resolve

### DIFF
--- a/packages/dashboard/app/utils/columnRoles.ts
+++ b/packages/dashboard/app/utils/columnRoles.ts
@@ -197,6 +197,22 @@ export function isArchivedColumnRole(flags: ColumnRoleFlags | undefined, columnI
 }
 
 /**
+ * Is a card here FINISHED either way — completed or archived?
+ *
+ * FNXC:WorkflowResolvedColumns 2026-07-31-13:55:
+ * Mirrors `isTerminalColumnRole` in core's `column-roles.ts`, composed from the two helpers above so
+ * the halves cannot drift apart. It lives HERE rather than being imported from `@fusion/core` because
+ * the browser bundle aliases that specifier to the leaf `types.ts` (see dashboard/vite.config.ts) —
+ * importing it from the package root builds fine under tsc and fails only in the desktop/vite bundle,
+ * which is how it reached main red: "isTerminalColumnRole is not exported by ../core/src/types.ts".
+ *
+ * Every other role predicate in the app already comes from this module; this restores that rule.
+ */
+export function isTerminalColumnRole(flags: ColumnRoleFlags | undefined, columnId: string): boolean {
+  return isCompleteColumnRole(flags, columnId) || isArchivedColumnRole(flags, columnId);
+}
+
+/**
  * Does this column occupy an implementation/WIP slot?
  *
  * Keyed on `countsTowardWip` rather than a `wip` trait name because that is the flag the trait

--- a/packages/dashboard/app/utils/taskRevert.ts
+++ b/packages/dashboard/app/utils/taskRevert.ts
@@ -1,5 +1,5 @@
 import type { Task } from "@fusion/core";
-import { isTerminalColumnRole, type ColumnRoleTraitFlags } from "@fusion/core";
+import { isTerminalColumnRole, type ColumnRoleFlags as ColumnRoleTraitFlags } from "./columnRoles";
 
 /**
  * FNXC:TaskRevert 2026-07-04-00:00:

--- a/packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts
+++ b/packages/engine/src/__tests__/workflow-scheduler-parked-columns-live-e2e.pg.test.ts
@@ -168,7 +168,7 @@ pgDescribe("scheduler parked-column resolution against a live store", () => {
 
   it("REGRESSION — a dependent in a RENAMED hold column IS unblocked when its blocker is deleted", async () => {
     /*
-    FNXC:WorkflowResolvedColumns 2026-08-01-02:20 (fleet — the flip this test was written to catch):
+    FNXC:WorkflowResolvedColumns 2026-07-31-02:20 (fleet — the flip this test was written to catch):
     This was a CHARACTERIZATION of the inert sync read: `resolveTaskParkedColumnsSync` answered
     `{ hold: "todo" }` for a board whose hold column is `backlog`, so the reconciliation queried a
     column that does not exist, found no dependents, and left `blockedBy` pointing at a deleted task.

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -450,7 +450,7 @@ function mergeParkedColumns(
 }
 
 /*
-FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet):
+FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet):
 The ASYNC twin. The sync one below cannot answer for a custom workflow in production, so any guard that
 can reach this one must.
 
@@ -477,7 +477,7 @@ async function resolveTaskParkedColumns(store: TaskStore, taskId: string): Promi
       archived,
       terminal: new Set([complete, archived]),
       /*
-      FNXC:WorkflowResolvedColumns 2026-08-01-02:05 (fleet):
+      FNXC:WorkflowResolvedColumns 2026-07-31-02:05 (fleet):
       The wake set UNIONS the legacy ids rather than replacing them, and that is load-bearing rather
       than defensive. Post-U11 the default lineage has no `triage` column, so a RESOLVED answer returns
       `intake: "todo"` where the old inert path fell back to `"triage"`. Converting without the union
@@ -945,7 +945,7 @@ export class Scheduler {
       logger: schedulerLog,
     });
     /*
-    FNXC:ConcurrencyAdmission 2026-08-06-09:00:
+    FNXC:ConcurrencyAdmission 2026-07-31-09:00:
     FN-8453's union must outlive a single scheduler poll. A temporary provider
     was gone before planning/merge asked for capacity, allowing newer work to
     overtake ready execute work. The refreshed map is the durable lane view.
@@ -1237,7 +1237,7 @@ export class Scheduler {
       if (task.sliceId && task.status === "failed") {
         if (task.column === "in-progress") this.failedTaskIds.add(task.id);
         /*
-        FNXC:MissionReconciliation 2026-08-01-00:00:
+        FNXC:MissionReconciliation 2026-07-31-00:00:
         In-place failure parks do not emit task:moved, but they release the
         task's durable symbol lock. Reconcile any mission-linked failure update
         so the roadmap records withheld provenance without fabricating completion.
@@ -1268,7 +1268,7 @@ export class Scheduler {
             schedulerLog.warn(`Failed to reset dispatch oscillation state for ${task.id} on unpause: ${error instanceof Error ? error.message : String(error)}`);
           });
         }
-        /* FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet): the answer only gates `schedule()`,
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet): the answer only gates `schedule()`,
            which is async and fire-and-forget, so resolving it properly costs nothing observable. */
         void (async () => {
           const unpausedParked = await resolveTaskParkedColumns(this.store, task.id);
@@ -1299,7 +1299,7 @@ export class Scheduler {
         this.planningTaskIds.add(task.id);
       } else if (this.planningTaskIds.has(task.id)) {
         this.planningTaskIds.delete(task.id);
-        /* FNXC:WorkflowResolvedColumns 2026-08-01-01:40 (fleet): as with the unpause wake above, the
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-01:40 (fleet): as with the unpause wake above, the
            answer only gates `schedule()`. The `planningTaskIds.delete` stays SYNCHRONOUS — it is the
            edge-trigger bookkeeping, and deferring it would let a second update re-enter this branch. */
         void (async () => {
@@ -1359,7 +1359,7 @@ export class Scheduler {
 
           const deletedParked = await resolveTaskParkedColumns(this.store, task.id);
           /*
-          FNXC:WorkflowLifecycleColumns 2026-08-01-05:00:
+          FNXC:WorkflowLifecycleColumns 2026-07-31-05:00:
           A HALF-CONVERTED PAIR, one line apart. The hold read above already resolved its lane while
           the wip read below stayed on the literal, so on a renamed board this dependent sweep saw
           the queued cards and none of the running ones — a dependency held by an in-flight task was

--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -84,7 +84,6 @@
   "packages/engine/src/restart-recovery-coordinator.ts": 1,
   "packages/engine/src/runtime-resolution.ts": 1,
   "packages/engine/src/runtimes/in-process-runtime.ts": 4,
-  "packages/engine/src/scheduler.ts": 3,
   "packages/engine/src/triage.ts": 6,
   "packages/engine/src/workflow-work-processor.ts": 1,
   "scripts/lib/lifecycle-column-census-ast.mjs": 3,


### PR DESCRIPTION
**Main is red on Build, Gate and Desktop packaging.** Every open PR inherits it — this is the second main-breakage blocking the queue in the last hour, unrelated to the first (#3145, FNXC stamps).

```
app/utils/taskRevert.ts (2:9): "isTerminalColumnRole" is not exported by "../core/src/types.ts"
```

## Why it got through

The browser bundle aliases `@fusion/core` to the leaf `types.ts` **on purpose**, to keep Node-only deps out of the client — `dashboard/vite.config.ts` documents this, and even carries a comment about the identical failure for `FUSION_CLIENT_HEADER`.

`isTerminalColumnRole` lives in core's `column-roles.ts`. Importing it from the package root **typechecks fine under tsc** and fails only in the vite bundle. So a PR can be green on Lint and Typecheck locally and still break Build — which is exactly how it reached main.

## The fix follows the existing rule

Every other role predicate in the app already comes from `app/utils/columnRoles`: `isWipColumnRole`, `isReviewColumnRole`, `isCompleteColumnRole`, `isArchivedColumnRole`. `taskRevert.ts` was the lone exception.

Adds `isTerminalColumnRole` there, **composed from the two helpers already in the file** so the halves cannot drift apart, and points `taskRevert` at it. Semantics mirror core's exactly (`complete || archived`); no behaviour change.

## Measured

| | |
|---|---|
| with the fix | `pnpm --filter @fusion/dashboard build` → **✓ built in 9.66s** |
| reverting only `taskRevert.ts` | reproduces the exact error above |

Dashboard app utils **693 passed** · `pnpm test:gate` 13 + 161 + 487 + 71 · lint — green.

## Worth noting for the fleet

This class is invisible to the checks people run locally. `tsc` resolves `@fusion/core` through the package's real entry; the browser build resolves it through an alias to a single leaf file. **A conversion that imports a new helper from `@fusion/core` in `dashboard/app/**` will pass typecheck and fail the bundle** — and the fleet is currently adding exactly those imports. Importing from `app/utils/columnRoles` avoids it entirely.
