### PR TITLE
fix(self-healing): the last 7 terminal move targets, plus a ratchet so the class cannot regrow (#3150, slice 2)

### DIFF
--- a/packages/engine/src/__tests__/no-legacy-move-targets.test.ts
+++ b/packages/engine/src/__tests__/no-legacy-move-targets.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+A MOVE TARGET IS AN ARGUMENT, SO NO EXISTING GATE COUNTS IT.
+
+The lifecycle-column census counts COMPARISONS against legacy ids. `moveTask(task.id, "todo")` contains
+no comparison, so the census reported zero while 25 such targets sat in `self-healing.ts` alone and 31
+across the tree.
+
+The failure mode is worse than a stale guard's. `moveTaskInternal` REJECTS a target the workflow does
+not declare — `TransitionRejectionError: unknown-column` — which `task-store/moves.ts` documents after
+a completion handoff was found THROWING on every renamed board. A guard that fails to match degrades to
+"no rescue"; a target that throws is "no rescue, plus an exception in the sweep", and every one of these
+sites is a recovery path.
+
+So this ratchet exists because the population was invisible, not because it was large. Fixing it once
+without a guard means it is invisible again the moment someone adds the next one.
+
+WHAT IS AND IS NOT A TARGET. Only the SECOND argument of a `moveTask(...)` call counts. A legacy id as
+a FALLBACK (`resolveReboundTargetForTask` returning `"todo"`, or `lifecycle?.complete ?? "done"`) is
+the degraded answer every resolver in this program is required to have, and is not flagged — the
+resolver is what makes the call correct, and its fallback is what keeps default boards working.
+
+BASELINE, NOT ZERO. Files outside the converted set keep their current counts so this can land without
+blocking other lanes; the ratchet fails on any INCREASE, and on a decrease that was not re-recorded —
+a stale allowance is a hole the same guards can regrow through.
+*/
+
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../../../../..");
+
+/** Legacy lifecycle column ids, as move TARGETS. */
+const LEGACY = "(?:todo|triage|in-progress|in-review|done|archived)";
+const MOVE_TARGET = new RegExp(`moveTask\\s*\\(\\s*[^,()]+,\\s*["']${LEGACY}["']`, "g");
+
+/*
+Files that still hold literal targets, with the count each is allowed. `self-healing.ts` is absent
+because it is now zero — the whole point of the change this guards.
+*/
+const ALLOWED: Record<string, number> = {
+  "packages/cli/src/extension.ts": 1,
+  "packages/core/src/task-store/branch-and-pr-entities.ts": 1,
+  /* One CALL. An earlier raw scan counted 2 here by matching the interface DECLARATION
+     (`moveTask(taskId: string, column: "todo", …)`) as a call site — the stale-allowance case below
+     caught that, which is what it is for. */
+  "packages/dashboard/src/server.ts": 1,
+  "packages/engine/src/agent-tools.ts": 1,
+};
+
+function sourceFiles(): string[] {
+  return execFileSync(
+    "git",
+    ["ls-files", "packages/*/src/**/*.ts", "packages/*/src/*.ts", "packages/*/app/**/*.ts", "packages/*/app/**/*.tsx"],
+    { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  )
+    .split("\n")
+    .filter((f) => f && !f.includes("__tests__") && !/\.(test|spec)\.tsx?$/.test(f));
+}
+
+/** Blank comments in place so prose describing a past call is not counted as one. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, "");
+}
+
+function countByFile(): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const file of sourceFiles()) {
+    let source: string;
+    try {
+      source = readFileSync(resolve(REPO_ROOT, file), "utf8");
+    } catch {
+      continue;
+    }
+    const hits = stripComments(source).match(MOVE_TARGET);
+    if (hits && hits.length > 0) counts[file] = hits.length;
+  }
+  return counts;
+}
+
+describe("moveTask targets resolve the board's own lane", () => {
+  /*
+  ANTI-VACUITY. A scan that silently matched nothing would pass forever, including after `moveTask`
+  is renamed or this glob stops resolving. Prove the corpus is real and the matcher still finds the
+  sites the allow-list documents.
+  */
+  it("scans a real corpus and still finds the allow-listed sites", () => {
+    expect(sourceFiles().length).toBeGreaterThan(200);
+    expect(Object.keys(countByFile()).length).toBeGreaterThan(0);
+  });
+
+  /* The matcher is covered, because the scan is only as good as it: each case is a real shape. */
+  it.each<[source: string, shouldFlag: boolean, why: string]>([
+    ['await store.moveTask(task.id, "todo");', true, "the plain form"],
+    ['await this.store.moveTask(taskId, "archived", { moveSource: "engine" });', true, "with options"],
+    ["await store.moveTask(id, 'done');", true, "single quotes"],
+    ['await store.moveTask(task.id, await resolveReboundTargetForTask(store, task.id));', false, "resolved"],
+    ['await store.moveTask(task.id, completeLane);', false, "resolved via a local"],
+    ['const target = lifecycle?.complete ?? "done";', false, "a FALLBACK is not a target"],
+    ['return resolveReboundTarget(ir) ?? "todo";', false, "a resolver's own degraded answer"],
+    ['if (task.column === "todo") return;', false, "a comparison — the census owns that class"],
+  ])("matcher: %s -> %s (%s)", (source, shouldFlag) => {
+    expect(new RegExp(MOVE_TARGET.source).test(source)).toBe(shouldFlag);
+  });
+
+  it("self-healing.ts has NO literal move targets", () => {
+    /* The file this ratchet was written for: 25 sites, now zero. Asserted by name because a
+       regression here is a recovery path that throws on a renamed board. */
+    expect(countByFile()["packages/engine/src/self-healing.ts"] ?? 0).toBe(0);
+  });
+
+  it("no file exceeds its recorded allowance", () => {
+    const counts = countByFile();
+    const violations: string[] = [];
+    for (const [file, count] of Object.entries(counts)) {
+      const allowed = ALLOWED[file] ?? 0;
+      if (count > allowed) violations.push(`${file}: ${count} literal move target(s), allowed ${allowed}`);
+    }
+    expect(
+      violations,
+      "A moveTask target the workflow does not declare is REJECTED (TransitionRejectionError: "
+      + "unknown-column), so this throws on a renamed board rather than degrading.\n"
+      + "Resolve the target (resolveReboundTargetForTask / resolveArchiveTargetForTask /\n"
+      + "resolveTaskLifecycleColumns) — a legacy id is fine as the resolver's FALLBACK, not as the "
+      + "argument:\n" + violations.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("no allowance is stale", () => {
+    /* A recorded allowance that exceeds the tree is a hole the same targets can regrow through —
+       the same reason the census baseline fails on an unrecorded DROP. */
+    const counts = countByFile();
+    const stale = Object.entries(ALLOWED)
+      .filter(([file, allowed]) => (counts[file] ?? 0) < allowed)
+      .map(([file, allowed]) => `${file}: allows ${allowed}, tree has ${counts[file] ?? 0}`);
+    expect(stale, `Lower the allowance to match the tree:\n${stale.join("\n")}`).toEqual([]);
+  });
+});

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -30,7 +30,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { type TaskMoveLanes, resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, resolveReboundTargetForTask, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+import { type TaskMoveLanes, resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, resolveReboundTargetForTask, resolveArchiveTargetForTask, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
   LEGACY_COLUMN_IDS_BY_ROLE,
   TERMINAL_ROLES,
   resolveProjectColumnsForRoles,
@@ -251,7 +251,7 @@ export async function archiveAsGhostBug(
   });
   // #1411: recovery/terminal move — recoveryRehome skips order-derived adjacency
   // so a custom-workflow card can always reach the terminal column.
-  await store.moveTask(taskId, "archived", { moveSource: "engine", recoveryRehome: true });
+  await store.moveTask(taskId, await resolveArchiveTargetForTask(store, taskId), { moveSource: "engine", recoveryRehome: true });
 }
 
 async function classifyOwnedLandedEvidenceForSelfHealing(rootDir: string, task: Task, mergeTargetBranch: string): Promise<OwnedLandedClassification> {
@@ -7876,7 +7876,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.logEntry(task.id, `Auto-finalized no-op (proven): start point on ${classification.baseRef}; modifiedFiles cleared`);
         }
 
-        const movedTask = await this.store.moveTask(task.id, "done");
+        const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
+const movedTask = await this.store.moveTask(task.id, completeLane);
         this.emitTaskMerged(movedTask, { mergeConfirmed: true });
         recovered++;
       }
@@ -9517,7 +9518,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               mergeDetails,
             });
             await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-interrupted-merging");
-            const movedTask = await this.store.moveTask(task.id, "done");
+            const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
+const movedTask = await this.store.moveTask(task.id, completeLane);
             this.emitTaskMerged(movedTask, { mergeConfirmed: true });
             await this.cleanupInterruptedMergeArtifacts(task);
             await this.store.logEntry(
@@ -10722,7 +10724,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               mergeDetails,
             });
             await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-stuck-merge-deadlocks");
-            const movedTask = await this.store.moveTask(task.id, "done");
+            const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
+const movedTask = await this.store.moveTask(task.id, completeLane);
             this.emitTaskMerged(movedTask, { mergeConfirmed: true });
             await this.cleanupInterruptedMergeArtifacts(task);
 
@@ -10962,7 +10965,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             mergeDetails,
           });
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-orphan-only-scope-violations");
-          const movedTask = await this.store.moveTask(task.id, "done");
+          const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
+const movedTask = await this.store.moveTask(task.id, completeLane);
           this.emitTaskMerged(movedTask, { mergeConfirmed: true });
           await this.store.logEntry(
             task.id,
@@ -11226,7 +11230,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           });
           const worktreeHint = task.worktree;
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-already-merged-review");
-          const movedTask = await this.store.moveTask(task.id, "done");
+          const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
+const movedTask = await this.store.moveTask(task.id, completeLane);
           this.emitTaskMerged(movedTask, { mergeConfirmed: true });
           await this.store.logEntry(
             task.id,
@@ -11876,7 +11881,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           // merger.ts completeTask() and project-engine.ts auto-merge already-confirmed path.
           await this.store.updateTask(task.id, { status: null, error: null, paused: false });
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-branch-misbound-in-review");
-          const movedTask = await this.store.moveTask(task.id, "done");
+          const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
+const movedTask = await this.store.moveTask(task.id, completeLane);
           this.emitTaskMerged(movedTask, { mergeConfirmed: true });
           await this.store.logEntry(
             task.id,


### PR DESCRIPTION
**Stacked on #3152** (base is that branch, not `main`). Second and final slice for `self-healing.ts`: the 6 `done` finalizations and the 1 `archived` target. **The file now holds zero literal move targets.**

## The ratchet is the point, more than the seven sites

A move target is an **argument**, so the lifecycle census — which counts **comparisons** — reported zero the entire time 25 of these existed in one file. Converting the population once without a guard means it is invisible again the moment someone adds the next one. That is the actual lesson of #3150, and it is why this slice carries `no-legacy-move-targets.test.ts`.

It is **baselined, not zero-everywhere**, so it lands without blocking other lanes: 4 files keep their current counts, `self-healing.ts` is asserted at 0 by name, and it fails on an **increase** or on a **drop that was not re-recorded** — a stale allowance being the hole the same targets regrow through.

**It caught an error in my own allow-list on the first run.** I recorded 2 for `dashboard/src/server.ts`; one of those was the interface **declaration** (`moveTask(taskId: string, column: "todo", …)`), not a call site. The stale-allowance case exists for exactly that.

## Audit correction

`self-healing.ts` has **25** literal targets, not the 26 I reported in #3150. One site my earlier scan counted was **comment prose** — `* could call moveTask("in-review")` — the same comment-inflation the census itself had to fix once. The ratchet strips comments before matching.

## Coverage limit, stated rather than implied

The 18 `todo` rebounds in #3152 have a renamed-board **behaviour** test driving a public sweep. **These 7 do not.**

Their sweeps require git-level fixtures — `isBranchAheadOfBase`, landed-evidence classification, integration-branch resolution — and a test that mocked all of that would be testing the mock, not the fix. So they are covered by:

- the 43 self-healing suites, for default-board behaviour,
- `tsc`,
- the ratchet, for regrowth.

The renamed-board assertion for the terminal targets is **genuinely absent**. I would rather say that than let "855 passed" imply otherwise. If a reviewer wants it before merge, the honest way is an integration-level fixture, not more mocking.

## Verification

| | result |
|---|---|
| engine `tsc` | **0 errors** |
| 44 suites (43 self-healing + ratchet) | **855 passed** |
| ratchet differential | reintroducing one literal target → **2 failed / 12** |
| census `--strict` | unchanged — invisible to it |

`check-fnxc-future-dates` fails on `main` itself (`scheduler.ts`, fixed by #3139); none of its output names files from this branch.