### PR TITLE
fix: the last 4 literal move targets — Retry threw on renamed boards; allow-list now empty (#3150 closed)

### DIFF
--- a/packages/cli/src/extension.ts
+++ b/packages/cli/src/extension.ts
@@ -2453,7 +2453,7 @@ export default function kbExtension(pi: ExtensionAPI) {
       
       // Move to todo column
       // FNXC:ToolPermissionGates 2026-07-26-13:55: user-facing retry move carries the user/hard-cancel source (Move-Task contract).
-      await store.moveTask(params.id, 'todo', { moveSource: "user" });
+      await store.moveTask(params.id, await fusionCore.resolveReboundTargetForTask(store, params.id), { moveSource: "user" });
       
       // Log the retry action
       await store.logEntry(params.id, "Retry requested via Fusion extension", "Task reset to todo for retry");

--- a/packages/core/src/task-store/branch-and-pr-entities.ts
+++ b/packages/core/src/task-store/branch-and-pr-entities.ts
@@ -627,7 +627,7 @@ export async function updateTaskImpl(store: TaskStore,
           throw new Error(validation.message);
         }
         if (validation.requiresFinalize) {
-          await store.moveTask(id, "done", {
+          await store.moveTask(id, (await resolveTaskLifecycleColumns(store, id))?.complete ?? "done", {
             moveSource: "engine",
             recoveryRehome: true,
             preserveProgress: true,

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -20,7 +20,7 @@ import type {
   AgentLogEntry,
   RunAuditEvent,
 } from "@fusion/core";
-import { AgentStore, ChatStore, queryRunAuditEvents, resolveGlobalDir, resolveProjectColumnsForRoles, REVIEW_ROLES, setRunningAgentCountSource } from "@fusion/core";
+import { AgentStore, ChatStore, queryRunAuditEvents, resolveGlobalDir, resolveProjectColumnsForRoles, resolveReboundTargetForTask, REVIEW_ROLES, setRunningAgentCountSource } from "@fusion/core";
 import type { AuthStorageLike, ModelRegistryLike } from "./routes.js";
 import { createApiRoutes } from "./routes.js";
 import { createSSE, disconnectSSEClient, markSSEClientAlive } from "./sse.js";
@@ -761,10 +761,19 @@ type CliRelaunchSessionStore = ServerOptions["cliSessionTransport"] extends infe
     : never
   : never;
 
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+`column` WIDENED from the literal `"todo"` to `string`, because the target is now resolved.
+
+The narrow literal type was not a constraint anyone chose — it was inferred from the single call
+below, which passed `"todo"`. It then made the type system ENFORCE the bug: a resolved rebound target
+is a `string`, so the correct value could not be passed without this edit. A type that only admits the
+legacy id is a lint against fixing it.
+*/
 interface CliRelaunchTaskStoreLike {
   getTask(taskId: string): Promise<Task | null>;
   updateTask(taskId: string, patch: Record<string, unknown>): Promise<unknown>;
-  moveTask(taskId: string, column: "todo", options?: Record<string, unknown>): Promise<unknown>;
+  moveTask(taskId: string, column: string, options?: Record<string, unknown>): Promise<unknown>;
   logEntry(taskId: string, message: string, details?: string): Promise<unknown>;
 }
 
@@ -804,7 +813,7 @@ export function wireCliRelaunchListener(options: {
         `CLI session relaunch requested from ${info.sessionId} — clearing resume linkage and re-enqueueing for a fresh executor run`,
       );
       await taskStore.updateTask(info.taskId, { paused: false, status: null, error: null });
-      await taskStore.moveTask(info.taskId, "todo", {
+      await taskStore.moveTask(info.taskId, await resolveReboundTargetForTask(taskStore as never, info.taskId), {
         preserveProgress: true,
         moveSource: "engine",
         recoveryRehome: true,

--- a/packages/engine/src/__tests__/no-legacy-move-targets.test.ts
+++ b/packages/engine/src/__tests__/no-legacy-move-targets.test.ts
@@ -40,18 +40,20 @@ const LEGACY = "(?:todo|triage|in-progress|in-review|done|archived)";
 const MOVE_TARGET = new RegExp(`moveTask\\s*\\(\\s*[^,()]+,\\s*["']${LEGACY}["']`, "g");
 
 /*
-Files that still hold literal targets, with the count each is allowed. `self-healing.ts` is absent
-because it is now zero — the whole point of the change this guards.
+Files that still hold literal targets, with the count each is allowed.
+
+EMPTY, and that is the end state rather than a starting one: every `moveTask` call in the tree now
+resolves its target. It was populated when this guard was written — `cli/src/extension.ts`,
+`core/task-store/branch-and-pr-entities.ts`, `dashboard/src/server.ts` and `engine/agent-tools.ts`
+each held one — and the stale-allowance case below is what forced this map to be emptied when those
+four were converted in the same change. Leaving the entries behind would have left four slots open
+for the class to regrow through while the guard stayed green.
+
+A NOTE FOR WHOEVER ADDS ONE. If a call genuinely cannot resolve its target, record it here with a
+comment saying why, rather than widening the matcher. The failure this guards is not "a literal
+appears" — it is `TransitionRejectionError: unknown-column` thrown at runtime on a renamed board.
 */
-const ALLOWED: Record<string, number> = {
-  "packages/cli/src/extension.ts": 1,
-  "packages/core/src/task-store/branch-and-pr-entities.ts": 1,
-  /* One CALL. An earlier raw scan counted 2 here by matching the interface DECLARATION
-     (`moveTask(taskId: string, column: "todo", …)`) as a call site — the stale-allowance case below
-     caught that, which is what it is for. */
-  "packages/dashboard/src/server.ts": 1,
-  "packages/engine/src/agent-tools.ts": 1,
-};
+const ALLOWED: Record<string, number> = {};
 
 function sourceFiles(): string[] {
   return execFileSync(
@@ -87,13 +89,28 @@ function countByFile(): Record<string, number> {
 
 describe("moveTask targets resolve the board's own lane", () => {
   /*
-  ANTI-VACUITY. A scan that silently matched nothing would pass forever, including after `moveTask`
-  is renamed or this glob stops resolving. Prove the corpus is real and the matcher still finds the
-  sites the allow-list documents.
+  ANTI-VACUITY, and its first version was self-defeating: it asserted the scan finds at least one
+  offender, which can only hold while the defect exists. Converting the last four sites turned it red
+  — the guard failing precisely because the tree became correct.
+
+  A clean tree is the expected end state, so the proof has to be that the scan REACHES the right code
+  rather than that it finds something wrong in it. Two independent legs, both of which break if the
+  glob stops resolving or `moveTask` is renamed: the corpus is a real file list, and files that
+  genuinely call `moveTask` are inside it. The matcher itself is covered by the case table below.
   */
-  it("scans a real corpus and still finds the allow-listed sites", () => {
-    expect(sourceFiles().length).toBeGreaterThan(200);
-    expect(Object.keys(countByFile()).length).toBeGreaterThan(0);
+  it("scans a real corpus that still reaches the moveTask call sites", () => {
+    const files = sourceFiles();
+    expect(files.length).toBeGreaterThan(200);
+
+    const callers = files.filter((file) => {
+      try {
+        return /moveTask\s*\(/.test(stripComments(readFileSync(resolve(REPO_ROOT, file), "utf8")));
+      } catch {
+        return false;
+      }
+    });
+    expect(callers.length).toBeGreaterThan(5);
+    expect(callers).toContain("packages/engine/src/self-healing.ts");
   });
 
   /* The matcher is covered, because the scan is only as good as it: each case is a real shape. */

--- a/packages/engine/src/agent-tools.ts
+++ b/packages/engine/src/agent-tools.ts
@@ -3206,7 +3206,7 @@ export function createTaskRetryTool(store: TaskStore): ToolDefinition {
           return { content: [{ type: "text" as const, text: `Task ${params.id} is not in a retryable state (status: ${task.status || "none"})` }], details: { taskId: params.id, currentStatus: task.status }, isError: true };
         }
         await store.updateTask(params.id, { status: null, error: null });
-        await store.moveTask(params.id, "todo");
+        await store.moveTask(params.id, await fusionCore.resolveReboundTargetForTask(store, params.id));
         await store.logEntry(params.id, "Retry requested via chat tool", "Task reset to todo for retry");
         return { content: [{ type: "text" as const, text: `Retried ${params.id} → todo` }], details: { taskId: params.id, newColumn: "todo" } };
       } catch (err: unknown) {


### PR DESCRIPTION
**Stacked on #3152** (which now also carries #3155). Final slice of #3150 — every `moveTask` call in the tree resolves its target.

## Two of these are user-facing Retry

| site | what broke on a renamed board |
|---|---|
| `cli/src/extension.ts` | `fn task retry` moved to the literal `"todo"` |
| `engine/agent-tools.ts` | the chat `task_retry` tool, same |

`moveTaskInternal` **rejects** a target the workflow does not declare, so Retry did not degrade to a no-op — **it failed**. `extension.ts` already calls `resolveReboundTargetForTask` twice a few lines above; this site was simply missed. That is the argument for a ratchet rather than for more care.

The other two: CLI session relaunch re-enqueue (`dashboard/src/server.ts`) and the node-override finalize to the complete lane (`core/task-store/branch-and-pr-entities.ts`).

## A type that enforced the bug

```ts
-  moveTask(taskId: string, column: "todo", options?: …): Promise<unknown>;
+  moveTask(taskId: string, column: string, options?: …): Promise<unknown>;
```

That literal was never a constraint anyone chose — it was inferred from the single call site passing `"todo"`, and it then made the **type system enforce the defect**: a resolved target is a `string` and could not be passed without this edit. Worth flagging as a shape to look for; a type narrowed to a legacy id is a lint against fixing it.

## The allow-list is empty, and the guard forced that

Converting these four turned the ratchet's **stale-allowance** case red — four recorded slots the class could regrow through while the guard stayed green — so the map is emptied in the same commit.

That case has now caught **two of my own errors**: a miscounted allowance (an interface *declaration* read as a call site), and this one.

## The anti-vacuity check was self-defeating

Its first version asserted the scan finds at least one offender — which can only hold **while the defect exists**. Converting the last sites made the guard fail *because the tree became correct*.

It now proves the scan **reaches** the `moveTask` call sites rather than that it finds something wrong in them; the matcher is covered by the case table. A guard whose vacuity check depends on the bug surviving is not a guard.

## Verification

| | result |
|---|---|
| `tsc` — engine, core, dashboard, cli | **0 errors** each |
| 55 engine suites | **977 passed** |
| ratchet at zero | **12 passed** |
| ratchet differential | reintroduce one literal → **1 failed / 12** |

## #3150 closes with this stack

`self-healing.ts` 25 → 0 (#3152, #3155), the remaining 4 → 0 here, and the class is guarded so it cannot return invisibly. The census is untouched throughout — this population was never in it, which was the finding.