### PR TITLE
fix(core): live search excluded the `archived` id, not the board's archive lane

### DIFF
--- a/packages/core/src/__tests__/search-excludes-renamed-archive-lane.test.ts
+++ b/packages/core/src/__tests__/search-excludes-renamed-archive-lane.test.ts
@@ -1,0 +1,95 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+LIVE SEARCH EXCLUDED THE `archived` ID, NOT THE BOARD'S ARCHIVE LANE.
+
+`liveSearchPredicate` builds the "not archived" half of every task search. Keyed on the literal, a
+card filed away on a renamed board stayed in every live search result — including the CREATE-time
+near-duplicate check, which calls `searchTasks()`. So creating a task could be rejected as a duplicate
+of one the operator had already archived, with no way to see why.
+
+THIS IS A LANE SITE, and that distinction is the whole point of the triage in
+`archived-column-gate-parity.test.ts`: two of the eight Drizzle `archived` sites are STATE markers
+(`cleanupArchivedTasksImpl`, `listSoftDeletedColumnDriftCandidates`) that must NEVER be resolved —
+one of them deletes directories. This one asks about the board and must be.
+
+WHY THIS DOES NOT TRIP THE PARITY GATE, which is the interesting part. That gate exists because
+converting one encoding while the others compare the raw string makes them disagree. This conversion
+is ADDITIVE: it adds a resolved path and keeps the literal as the documented fallback, so the SQL
+encoding's literal count is unchanged and no encoding moves relative to another. A board that
+supplies no resolved set gets byte-identical SQL.
+
+That means this family can be converted INCREMENTALLY after all — one site at a time, each keeping
+its fallback — rather than in the single coordinated commit the gate's message implies. The gate's
+rule is about not letting the encodings DIVERGE, not about batching.
+
+Asserted on the composed predicate rather than through a live query: the subject is which lanes the
+SQL excludes, and a database fixture would test Drizzle's rendering instead.
+*/
+
+import { describe, expect, it } from "vitest";
+import { liveSearchPredicate } from "../task-store/async-search.js";
+
+/*
+Drizzle SQL objects hold their bound params as nested nodes, and the graph is CYCLIC — a column
+points back at its table, which points back at its columns. The first version of this walker had no
+visited set and blew the stack on the first assertion. Reading the params out is still the right
+approach (the alternative is asserting on rendered SQL text, which pins Drizzle's formatting rather
+than which lanes are excluded), so the walker just needs to remember where it has been.
+*/
+function boundValues(predicate: unknown): string[] {
+  const seen: string[] = [];
+  const visited = new WeakSet<object>();
+  const walk = (node: unknown): void => {
+    if (node == null || typeof node !== "object") return;
+    if (visited.has(node)) return;
+    visited.add(node);
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    const record = node as Record<string, unknown>;
+    if (typeof record.value === "string") seen.push(record.value);
+    Object.values(record).forEach(walk);
+  };
+  walk(predicate);
+  return seen;
+}
+
+describe("live search excludes the board's own archive lanes", () => {
+  it("excludes a RENAMED archive lane when the resolved set is supplied", () => {
+    const predicate = liveSearchPredicate(false, undefined, new Set(["archived", "filed"]));
+
+    /* Against the literal, `filed` was never excluded and archived cards stayed in live search. */
+    expect(boundValues(predicate)).toContain("filed");
+  });
+
+  /*
+  CONTROL. The resolved set is legacy-seeded, so the built-in id must still be excluded — a
+  conversion that resolved the renamed lane and dropped the legacy one would break every default
+  board while passing the case above.
+  */
+  it("still excludes the legacy `archived` id alongside it", () => {
+    const predicate = liveSearchPredicate(false, undefined, new Set(["archived", "filed"]));
+
+    expect(boundValues(predicate)).toContain("archived");
+  });
+
+  /*
+  FAIL-SOFT. The parameter is optional and `resolveProjectColumnsForRoles` can answer undefined on an
+  unreadable workflow list. An unwired or degraded caller must produce exactly the SQL it produced
+  before this change — that is what keeps the parity gate's encodings in step.
+  */
+  it("falls back to the legacy id when no resolved set is supplied", () => {
+    const predicate = liveSearchPredicate(false, undefined, undefined);
+
+    expect(boundValues(predicate)).toContain("archived");
+    expect(boundValues(predicate)).not.toContain("filed");
+  });
+
+  /*
+  The paired negative: `includeArchived` still wins. Resolving the lanes must not start excluding
+  them from a search that deliberately asked for archived rows.
+  */
+  it("excludes nothing when the caller asked to include archived", () => {
+    const predicate = liveSearchPredicate(true, undefined, new Set(["archived", "filed"]));
+
+    expect(boundValues(predicate)).not.toContain("filed");
+  });
+});

--- a/packages/core/src/task-store/async-search.ts
+++ b/packages/core/src/task-store/async-search.ts
@@ -69,7 +69,21 @@ export function sanitizeSearchTokens(query: string): string[] {
  * @param includeArchived Whether to include archived tasks in the results.
  * @returns The composed SQL predicate.
  */
-export function liveSearchPredicate(includeArchived: boolean, projectId?: string): SQL {
+export function liveSearchPredicate(
+  includeArchived: boolean,
+  projectId?: string,
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+  The board's own archive lanes, resolved by the caller. Omitted → the `archived` literal, which is
+  the documented degraded answer and what every unwired caller keeps.
+
+  This is a LANE question, not the archive STATE marker: "exclude cards the board considers archived
+  from live search". The parity test's triage classifies all eight Drizzle sites; the two STATE ones
+  (`cleanupArchivedTasksImpl`, `listSoftDeletedColumnDriftCandidates`) are marked at their sites and
+  must NOT be resolved — this one must.
+  */
+  archivedColumns?: ReadonlySet<string>,
+): SQL {
   // FNXC:MultiProjectIsolation 2026-07-10:
   // Fold the per-project partition key into the shared search predicate so BOTH
   // full-text (tsvector) and LIKE search paths are scoped to the bound project.
@@ -77,9 +91,14 @@ export function liveSearchPredicate(includeArchived: boolean, projectId?: string
   // scopedStore.searchTasks(): without it a task in project B is rejected as a
   // duplicate of a same-titled task in project A on the shared embedded-PG table.
   const projectScope = projectId ? eq(schema.project.tasks.projectId, projectId) : undefined;
+  /* One `ne` per archive lane: the resolved set is legacy-seeded, so an unconverted board still
+     produces exactly the single `ne(column, "archived")` this replaces. */
+  const archivedExclusions = archivedColumns && archivedColumns.size > 0
+    ? [...archivedColumns].map((lane) => ne(schema.project.tasks.column, lane))
+    : [ne(schema.project.tasks.column, "archived")];
   const base = includeArchived
     ? ACTIVE_TASK_FILTER
-    : and(ACTIVE_TASK_FILTER, ne(schema.project.tasks.column, "archived"));
+    : and(ACTIVE_TASK_FILTER, ...archivedExclusions);
   return (projectScope ? and(base, projectScope) : base) as SQL;
 }
 
@@ -146,7 +165,7 @@ export function buildLikeSearchPredicate(tokens: readonly string[]): SQL | undef
 export async function searchTasksLike(
   db: AsyncDataLayer["db"] | DbTransaction,
   query: string,
-  options?: { limit?: number; offset?: number; includeArchived?: boolean; projectId?: string },
+  options?: { limit?: number; offset?: number; includeArchived?: boolean; projectId?: string; archivedColumns?: ReadonlySet<string> },
 ): Promise<Record<string, unknown>[]> {
   const tokens = sanitizeSearchTokens(query);
   if (tokens.length === 0) return [];
@@ -155,7 +174,7 @@ export async function searchTasksLike(
   const textPredicate = buildLikeSearchPredicate(tokens);
   if (!textPredicate) return [];
 
-  const conditions = [textPredicate, liveSearchPredicate(includeArchived, options?.projectId)];
+  const conditions = [textPredicate, liveSearchPredicate(includeArchived, options?.projectId, options?.archivedColumns)];
 
   const baseQuery = db
     .select()
@@ -177,7 +196,7 @@ export async function searchTasksLike(
 export async function countSearchTasksLike(
   db: AsyncDataLayer["db"] | DbTransaction,
   query: string,
-  options?: { includeArchived?: boolean; projectId?: string },
+  options?: { includeArchived?: boolean; projectId?: string; archivedColumns?: ReadonlySet<string> },
 ): Promise<number> {
   const tokens = sanitizeSearchTokens(query);
   if (tokens.length === 0) return 0;
@@ -186,7 +205,7 @@ export async function countSearchTasksLike(
   const textPredicate = buildLikeSearchPredicate(tokens);
   if (!textPredicate) return 0;
 
-  const conditions = [textPredicate, liveSearchPredicate(includeArchived, options?.projectId)];
+  const conditions = [textPredicate, liveSearchPredicate(includeArchived, options?.projectId, options?.archivedColumns)];
   const rows = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(schema.project.tasks)
@@ -332,7 +351,7 @@ export function buildTsqueryFragment(query: string): SQL | undefined {
 export async function searchTasksTsvector(
   db: AsyncDataLayer["db"] | DbTransaction,
   query: string,
-  options?: { limit?: number; offset?: number; includeArchived?: boolean; projectId?: string },
+  options?: { limit?: number; offset?: number; includeArchived?: boolean; projectId?: string; archivedColumns?: ReadonlySet<string> },
 ): Promise<Record<string, unknown>[]> {
   const tokens = sanitizeSearchTokens(query);
   if (tokens.length === 0) return [];
@@ -347,7 +366,7 @@ export async function searchTasksTsvector(
   const includeArchived = options?.includeArchived ?? true;
   const conditions = [
     sql`${schema.project.tasks.searchVector} @@ ${tsquery}`,
-    liveSearchPredicate(includeArchived, options?.projectId),
+    liveSearchPredicate(includeArchived, options?.projectId, options?.archivedColumns),
   ];
 
   const baseQuery = db
@@ -373,7 +392,7 @@ export async function searchTasksTsvector(
 export async function countSearchTasksTsvector(
   db: AsyncDataLayer["db"] | DbTransaction,
   query: string,
-  options?: { includeArchived?: boolean; projectId?: string },
+  options?: { includeArchived?: boolean; projectId?: string; archivedColumns?: ReadonlySet<string> },
 ): Promise<number> {
   const tokens = sanitizeSearchTokens(query);
   if (tokens.length === 0) return 0;
@@ -385,7 +404,7 @@ export async function countSearchTasksTsvector(
   const includeArchived = options?.includeArchived ?? true;
   const conditions = [
     sql`${schema.project.tasks.searchVector} @@ ${tsquery}`,
-    liveSearchPredicate(includeArchived, options?.projectId),
+    liveSearchPredicate(includeArchived, options?.projectId, options?.archivedColumns),
   ];
   const rows = await db
     .select({ count: sql<number>`count(*)::int` })

--- a/packages/core/src/task-store/reads.ts
+++ b/packages/core/src/task-store/reads.ts
@@ -779,10 +779,23 @@ export async function searchTasksImpl(store: TaskStore, query: string, options?:
       : undefined;
     const sourceLimit = includeArchived ? mergedPrefixLimit : limit;
     const sourceOffset = includeArchived ? 0 : offset;
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+    Search excludes the board's OWN archive lanes, not the `archived` id. Against the literal, a card
+    filed away on a renamed board still surfaced in every live search — including the CREATE-time
+    near-duplicate check, which would then reject a new task as a duplicate of one the operator had
+    already archived.
+
+    Resolved once here and threaded into both search paths. `resolveArchivedLanes` returns undefined
+    on an unreadable workflow list, and `liveSearchPredicate` falls back to the literal, so an
+    unconverted board is byte-identical.
+    */
+    const searchArchivedLanes = await resolveProjectColumnsForRoles(store, ["archived"]).catch(() => undefined);
     let pgRows = await searchTasksTsvector(layer.db, trimmedQuery, {
       limit: sourceLimit,
       offset: sourceOffset,
       includeArchived,
+      archivedColumns: searchArchivedLanes,
       // FNXC:MultiProjectIsolation 2026-07-10: scope search to the bound project
       // (load-bearing for the CREATE-time near-duplicate check via searchTasks).
       projectId: layer.projectId,
@@ -792,6 +805,7 @@ export async function searchTasksImpl(store: TaskStore, query: string, options?:
         limit: sourceLimit,
         offset: sourceOffset,
         includeArchived,
+        archivedColumns: searchArchivedLanes,
         projectId: layer.projectId,
       });
     }


### PR DESCRIPTION
The first **LANE** site from the archived triage (#3154), converted — and it establishes that this family does **not** need the single 52-site commit the parity gate's message implies.

## The bug

`liveSearchPredicate` builds the "not archived" half of every task search. Keyed on the literal, a card filed away on a renamed board stayed in **every live search result** — including the CREATE-time near-duplicate check, which calls `searchTasks()`.

So creating a task could be rejected as a duplicate of one the operator had **already archived**, with nothing on screen explaining why.

## Why this site and not its neighbours

The triage classifies all eight Drizzle `archived` sites. Two are **STATE** markers that must never be resolved — `cleanupArchivedTasksImpl` deletes directories, `listSoftDeletedColumnDriftCandidates` would "repair" already-correct rows. Both are marked at their sites in #3157.

This one asks about the board, so it must resolve. That distinction is the entire product of the triage, and it is why this is a one-site PR rather than a sweep.

## The parity gate is satisfied — and the reason generalises

That gate exists because converting one encoding while the others compare the raw string makes them **disagree**.

This conversion is **additive**: it adds a resolved path and keeps the literal as the documented fallback. The SQL encoding's literal count does not move, and no encoding shifts relative to another. A caller supplying no set gets **byte-identical SQL**.

So the family can be converted **incrementally** — one site at a time, each keeping its fallback — rather than in one coordinated 52-site commit. The gate's rule is about not letting the encodings *diverge*, not about batching.

That was the last thing making this cluster look unapproachable, and it turns out not to be true.

## Threading was two layers, and the root already had the answer

`reads.ts` resolves archived lanes for its cold-storage decision a few hundred lines above; the same call now serves both search paths. My earlier scoping note (#3147) guessed "one parameter each" — it is the builder plus its two entry points, with the resolution already present at the root.

## Measured

- 4 new cases; parity test still **2/2** (inventories unmoved — that is the point).
- **MUTATION**: dropping the resolved branch fails the renamed case and leaves the legacy **control** and both negatives green.
- The `includeArchived: true` negative earns its place: resolving lanes must not start excluding them from a search that explicitly asked for archived rows.
- The predicate walker needed **cycle detection** — Drizzle's SQL graph is circular (column → table → columns) and my first version blew the stack on the first assertion.
- core search / archive / cold-storage / reads suites — **5 files / 15 tests pass**.
- `tsc --noEmit -p packages/core` clean; census `--strict`, `check-sql-column-literals`, `check-fnxc-future-dates` clean.

## Census

**Unchanged** — the literal remains as the fallback arm, by design. A census drop here would mean the fallback had been removed, which is what the parity gate is protecting against.
