### PR TITLE
fix(core): the last four archived LANE sites — the ones that already held a store

### DIFF
--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1121,10 +1121,24 @@ export class TaskStore extends EventEmitter<TaskStoreEvents> {
     Scope by asyncLayer.projectId so a revert task from another project cannot match.
     */
     const layer = this.asyncLayer!;
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+    "Is there an OPEN undo task for this source?" is a LANE question — a finished one must not render
+    as an active affordance. Against the literals a renamed board matched neither lane, so a
+    done/archived prior undo attempt kept surfacing as open. Same defect the dashboard-side twin had
+    (`taskRevert.ts`, #3129); this is the store-side query behind it.
+
+    Additive: the resolved sets are legacy-seeded and fall back to the literals, so an unconverted
+    board builds byte-identical SQL and the parity gate's encodings stay in step.
+    */
+    const revertFinishedLanes = await resolveProjectColumnsForRoles(this, ["complete", "archived"])
+      .catch(() => undefined);
+    const revertFinishedExclusions = revertFinishedLanes && revertFinishedLanes.size > 0
+      ? [...revertFinishedLanes].map((lane) => ne(schema.project.tasks.column, lane))
+      : [ne(schema.project.tasks.column, "archived"), ne(schema.project.tasks.column, "done")];
     const conditions = [
       isNull(schema.project.tasks.deletedAt),
-      ne(schema.project.tasks.column, "archived"),
-      ne(schema.project.tasks.column, "done"),
+      ...revertFinishedExclusions,
       sql`${schema.project.tasks.sourceMetadata}->>'revertOf' = ${trimmedId}`,
     ];
     if (layer.projectId) {

--- a/packages/core/src/task-store/branch-and-pr-entities.ts
+++ b/packages/core/src/task-store/branch-and-pr-entities.ts
@@ -31,6 +31,7 @@ import { existsSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { MoveTaskInternalOptions, MoveTaskOptions, storeLog } from "../store.js";
+import { resolveProjectColumnsForRoles } from "../project-lane-vocabulary.js";
 
 export async function getBranchGroupImpl(store: TaskStore, id: string): Promise<BranchGroup | null> {
     // FNXC:RuntimeWorkflowAsync 2026-06-24-16:21:
@@ -434,8 +435,23 @@ export async function findRecentTasksByContentFingerprintImpl(store: TaskStore,
       sql`${schema.project.tasks.sourceMetadata}->>'contentFingerprint' = ${trimmedFingerprint}`,
       sql`${schema.project.tasks.createdAt} >= ${cutoffIso}`,
     ];
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+    LANE. The content-fingerprint duplicate guard runs at CREATE time; against the literal a renamed
+    board left archived cards in the candidate set, so a new task could be refused as a duplicate of
+    one the operator had already filed away. Additive and legacy-seeded.
+    */
     if (!includeArchived) {
-      conditions.push(ne(schema.project.tasks.column, "archived"));
+      const fingerprintArchivedLanes = await resolveProjectColumnsForRoles(store, ["archived"])
+        .catch(() => undefined);
+      /* The fallback stays a literal `ne(..., "archived")` EXPRESSION, not a string in an array: the
+         parity gate counts Drizzle predicates by scanning for exactly that shape, and collapsing it
+         into data drops the SQL encoding's count while the TS and raw encodings hold — which is the
+         divergence that gate exists to catch. It caught this. */
+      const fingerprintExclusions = fingerprintArchivedLanes && fingerprintArchivedLanes.size > 0
+        ? [...fingerprintArchivedLanes].map((lane) => ne(schema.project.tasks.column, lane))
+        : [ne(schema.project.tasks.column, "archived")];
+      conditions.push(...fingerprintExclusions);
     }
     /*
     FNXC:SqliteDualPathCleanup 2026-07-26-15:00:
@@ -463,11 +479,18 @@ export async function findRecentTasksBySourceParentTaskIdImpl(
   const windowMs = Math.max(1, Math.min(dayMs, Math.trunc(options?.windowMs ?? dayMs)));
   const cutoffIso = new Date(Date.now() - windowMs).toISOString();
     const layer = store.asyncLayer!;
+  /* FNXC:WorkflowResolvedColumns 2026-07-31-23:59: LANE — recent LIVE siblings; a finished sibling is
+     not a candidate. Additive and legacy-seeded, so an unconverted board is unchanged. */
+  const siblingFinishedLanes = await resolveProjectColumnsForRoles(store, ["complete", "archived"])
+    .catch(() => undefined);
+  const siblingFinishedExclusions = siblingFinishedLanes && siblingFinishedLanes.size > 0
+    ? [...siblingFinishedLanes].map((lane) => ne(schema.project.tasks.column, lane))
+    : [ne(schema.project.tasks.column, "archived"), ne(schema.project.tasks.column, "done")];
   const rows = await layer.db.select().from(schema.project.tasks).where(and(
     isNull(schema.project.tasks.deletedAt), taskProjectScope(layer),
     eq(schema.project.tasks.sourceParentTaskId, parentId),
     sql`${schema.project.tasks.createdAt} >= ${cutoffIso}`,
-    ne(schema.project.tasks.column, "archived"), ne(schema.project.tasks.column, "done"),
+    ...siblingFinishedExclusions,
   )).orderBy(asc(schema.project.tasks.createdAt));
   return rows.map((row) => store.rowToTask(store.pgRowToTaskRow(row as unknown as Record<string, unknown>)));
 }

--- a/packages/core/src/task-store/branch-group-ops.ts
+++ b/packages/core/src/task-store/branch-group-ops.ts
@@ -20,6 +20,7 @@ import {__setTaskActivityLogLimitsForTesting} from "../task-store/comments.js";
 import {listArtifacts as listArtifactsAsync} from "./async-comments-attachments.js";
 import { and, eq, isNull, ne, sql } from "drizzle-orm";
 import * as schema from "../postgres/schema/index.js";
+import { resolveProjectColumnsForRoles } from "../project-lane-vocabulary.js";
 
 export async function saveWorkflowRunBranchImpl(store: TaskStore, state: { taskId: string; runId: string; branchId: string; currentNodeId: string; status: string; }): Promise<void> {
     /*
@@ -77,10 +78,24 @@ export async function clearNearDuplicateReferencesToImpl(store: TaskStore, canon
      */
     const layer = store.asyncLayer!;
     const table = schema.project.tasks;
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+    LANE. This clears near-duplicate markers pointing at a canonical that is still LIVE; a finished
+    canonical's markers are handled elsewhere. Against the literals a renamed board found no live
+    rows at all, so stale markers survived — and the header above says stale markers alter operator
+    decisions, which is why the PG path mirrors the legacy store here rather than treating it as
+    optional.
+
+    Additive and legacy-seeded: an unconverted board builds the same two `ne`s it built before.
+    */
+    const liveCanonicalLanes = await resolveProjectColumnsForRoles(store, ["complete", "archived"])
+      .catch(() => undefined);
+    const finishedExclusions = liveCanonicalLanes && liveCanonicalLanes.size > 0
+      ? [...liveCanonicalLanes].map((lane) => ne(table.column, lane))
+      : [ne(table.column, "archived"), ne(table.column, "done")];
     const conditions = [
       isNull(table.deletedAt),
-      ne(table.column, "archived"),
-      ne(table.column, "done"),
+      ...finishedExclusions,
       sql`${table.sourceMetadata}->>'nearDuplicateOf' = ${canonicalId}`,
     ];
     if (layer.projectId) conditions.push(eq(table.projectId, layer.projectId));


### PR DESCRIPTION
Completes the six **LANE** sites from the triage (#3154). #3160 and #3162 did the two predicate builders that needed threading; these four already had `store` in scope, so each is a resolve-and-spread at the site.

## What each fixes on a renamed board

| site | defect |
|---|---|
| `store.ts` revert lookup | a done/archived prior undo attempt kept surfacing as an **open** undo task — the store-side twin of the dashboard defect fixed in #3129 |
| `branch-group-ops.ts` | the near-duplicate marker cleanup found **no live rows at all**, so stale markers survived. Its own header says stale markers alter operator decisions |
| `branch-and-pr-entities:438` | the CREATE-time fingerprint duplicate guard kept archived cards in the candidate set — a new task could be refused as a duplicate of one already filed away |
| `branch-and-pr-entities:470` | recent-sibling lookup counted finished siblings as candidates |

## The parity gate caught my first version — and it was right

I collapsed the fingerprint fallback into a **string array** (`["archived"]`) and pushed `ne(col, lane)` in a loop. Behaviourally identical, and it **dropped the Drizzle encoding's literal count**, because the gate scans for the `ne(..., "archived")` *expression shape*. TS and raw held steady, so the encodings diverged — precisely what that gate exists to catch, catching it.

The fix: keep every fallback as a literal `ne(..., "archived")` **expression** rather than data.

That is what makes these conversions **additive** — the resolved path is added, the literal stays, no encoding's count moves, and an unconverted board builds byte-identical SQL. Same property as #3160/#3162, now with a demonstrated failure mode for getting it wrong. Worth knowing for whoever does the remaining TS remainder: *behaviourally identical* is not sufficient; the shape has to survive too.

## Measured

- Parity test **2/2**, inventories unmoved — the point.
- archived / branch / near-duplicate / merge-blocker suites — **6 files / 46 tests pass**.
- `tsc --noEmit -p packages/core` clean; census `--strict`, `check-sql-column-literals`, `check-fnxc-future-dates` clean.

## Census

**Unchanged** — literals remain as fallback arms, by design.

## Where the cluster stands

All **six LANE** Drizzle sites are now converted (#3160, #3162, this). The **two STATE** sites are marked in place and must never be converted (#3157). What remains is the small TS remainder that is neither a fallback arm nor a sentinel, identified in #3156.
