### PR TITLE
test(engine): pin the paused-scope-decay lane filter (plus two probes I threw away)

### DIFF
--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -11629,6 +11629,46 @@ describe("FN-5335 triple-proof no-action unit coverage", () => {
     expect((store as any).recordRunAuditEvent).toHaveBeenCalledWith(expect.objectContaining({ mutationType: "task:auto-rebound-scope-decay-no-action" }));
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-15:40:
+  `scopeDecayWipColumns` was UNCOVERED on the #3115 map. The case above uses `in-progress`, where the
+  literal is correct, so blinding the resolver leaves it green.
+
+  The audit event is the observable: reaching a no-action record proves the holder was SELECTED by
+  the sweep's lane filter. Blinded, a paused holder in a renamed wip lane is not selected at all —
+  the loop never runs, no event is recorded, and its file scope decays with nothing to rebound it.
+  */
+  it("selects a paused holder resting in a RENAMED wip lane", async () => {
+    const store = createMockStore({
+      getSettings: vi.fn().mockResolvedValue({ globalPause: false, enginePaused: false, pausedScopeDecayMs: 1_000 } as any),
+      listTasks: vi.fn().mockResolvedValue([
+        { id: "FN-HOLDER", column: "building", paused: true, pausedReason: "waiting", blockedBy: null, worktree: "/tmp/wt-holder", updatedAt: new Date(Date.now() - 60_000).toISOString(), log: [] },
+        { id: "FN-FOLLOW", column: "drafting", paused: false, blockedBy: "FN-HOLDER" },
+      ]),
+    });
+    (store as unknown as { listWorkflowDefinitions: unknown }).listWorkflowDefinitions = vi.fn(async () => [{
+      ir: {
+        version: "v2",
+        id: "custom:renamed",
+        nodes: [],
+        edges: [],
+        columns: [
+          { id: "drafting", name: "drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+          { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+        ],
+      },
+    }]);
+    const manager = new SelfHealingManager(store, { rootDir: "/tmp/test-project" });
+    mockedClassifyTaskWorktree.mockResolvedValue({ ok: true } as any);
+
+    await manager.autoReboundPausedScopeDecay();
+
+    expect((store as any).recordRunAuditEvent).toHaveBeenCalledWith(expect.objectContaining({
+      target: "FN-HOLDER",
+    }));
+    manager.stop();
+  });
+
   it("emits reclaim-pr-conflict no-action when triple proof fails", async () => {
     const store = createMockStore({
       getSettings: vi.fn().mockResolvedValue({ autoMerge: true, globalPause: false, enginePaused: false, taskStuckTimeoutMs: 1_000 } as any),


### PR DESCRIPTION
Next entry from the verified coverage map on #3115. `scopeDecayWipColumns` was uncovered — the existing case uses `in-progress`, where the literal is correct, so blinding the resolver left all 420 tests green.

## What the literal costs

A paused holder resting in a renamed wip lane is **never selected**. The loop does not run, nothing is recorded, and its file scope decays with nothing to rebound it — so its followers stay blocked behind a card that is not coming back.

## The observable

The audit event. Reaching a no-action record proves the holder was **selected by the lane filter**, which is the only thing this resolver controls. Asserting on the rebound itself would have needed triple-proof to succeed, dragging in state the resolver has nothing to do with.

**Measured:** 420 pass; blinding `scopeDecayWipColumns` fails exactly this case.

## Two attempts thrown away first

Worth recording, because the remaining map entries are not uniform with the ones already closed:

- **`reconcileInReviewBranchRebind`** — a git-free probe (workspace task, rejected before any git runs) returned `{outcomes: [], repaired: 0}`. The loop never ran. I confirmed the `merge` trait does map to `mergeOrchestration`, so the filter should have matched; something else short-circuits and I could not establish what.
- **`recoverAgentsRunningOnInactiveTasks`** — the test passed, then **both** resolvers stayed green when blinded. `agentLinkTerminalColumns` never fires because the live card is caught by the wip∪review set first; `agentParkedColumns` only feeds `evaluateParkedAgentTaskLink`, whose result my fixture already forced true via a fresh run.

Both would have been green, plausible, and worthless. They were reverted rather than adjusted until they passed — which is the failure this whole effort exists to remove, and the one I committed myself in #3078.

## Map status

Closed: 9 resolvers across 7 PRs. **~18 remain.** The easy ones are done; what is left needs real harness work — an `execAsync` git fixture, and understanding how `evaluateParkedAgentTaskLink` weighs run-freshness against lane. Budget for that rather than expecting the pattern that closed the first nine.

## Verification

`self-healing.test.ts` **420 passed** · `pnpm test:gate` 161 + 13 + 487 + 71 · lint — green.
