### PR TITLE
fix: main is red on check-fnxc-future-dates — one stamp dated tomorrow (blocks every open PR)

### DIFF
--- a/packages/core/src/task-store/task-update.ts
+++ b/packages/core/src/task-store/task-update.ts
@@ -961,7 +961,7 @@ export async function updateTaskUnlockedImpl(store: TaskStore, id: string, updat
       }
 
       if (movedToTriage) {
-        /* FNXC:WorkflowEvents 2026-08-01-05:10 (fleet — the last two emitters):
+        /* FNXC:WorkflowEvents 2026-07-31-23:10 (fleet — the last two emitters):
            #3109 attached lanes at moves.ts and #3120 at the archive/completion emits. This one and
            `update-task-deps.ts` were still sending `lanes: undefined`, and a listener reads absence as
            "unknown" and falls back to `resolveTaskParkedColumnsSync` — the DEFAULT board under


### PR DESCRIPTION
`check-fnxc-future-dates` runs in `pr-checks.yml`, so while `main` is red **every open PR fails this check** regardless of what it touches. Measured on a clean detached `origin/main`:

```
[check-fnxc-future-dates] FNXC stamp population changed:
  packages/core/src/task-store/task-update.ts: 2 future-dated FNXC stamp(s), baseline allows 1
    FNXC:StateMachine   2026-08-01  (dated after today)
    FNXC:WorkflowEvents 2026-08-01  (dated after today)
```

## One line, scoped by blame

Two stamps in the file are future-dated; only one is **new**:

| line | stamp | commit | action |
|---|---|---|---|
| 86 | `FNXC:StateMachine 2026-08-01-10:20` | `e5c9ea38709` (07-30) | **baselined — left alone** |
| 964 | `FNXC:WorkflowEvents 2026-08-01-05:10` | `71f459c2a5d` (07-31) | corrected → `2026-07-31-23:10` |

The baselined one is not what turned main red, and rewriting it would register as a **drop** — which is exactly how I did collateral damage in the #3124 cycle by rewriting two stamps I had not authored. Exact-match replacement on the distinct new string; the older stamp is verified still present afterwards.

## What is not changed

**The baseline file is untouched.** The fix is the stamp, not the allowance — re-recording would clear the red while leaving tomorrow's date in the tree, which is the false green this gate exists to prevent.

## Process note

I checked for an existing fix PR **before** writing this one. My #3143 was a duplicate of #3139 because I skipped that step on the last red, and a red `main` is the single most likely thing for two lanes to notice simultaneously.

## Verification

- `check-fnxc-future-dates` — **exit 1 on `origin/main`, exit 0 here**
- diff is one line; baseline file confirmed unmodified