### PR TITLE
fix(gate): the inert ratchet went quiet exactly when the code improved (conditional initializer)

### DIFF
--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -180,3 +180,47 @@ test("counts a sync lane reached through a CONDITIONAL initializer, not just a d
     rmSync(probe, { force: true });
   }
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+THE SECOND HOP, which the case above explicitly left open.
+
+A sync local laundered through an object literal reached the guards while the scan saw nothing:
+
+    const sync  = payload ? undefined : localSync(store, id);
+    const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };
+    if (from !== lanes.hold) …            // inert, counted as nothing
+
+`executor.ts` is written exactly this way, and MEASURED it reported ZERO counted guards while the
+sync resolver was still present and still answering with the default board whenever the payload is
+absent. With the fix that file reports 2 — the two guards that genuinely remain after its dead
+helper is deleted.
+
+The chained case is in the probe on purpose: laundering can go `a -> b -> c`, and a single pass
+would catch only the first link. That is the same one-pass mistake this file's earlier cases record,
+made twice already in this scanner.
+*/
+test("counts a sync lane laundered through an object literal, including a chain", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-twohop.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `export function probe(store: unknown, id: string, from: string, payload: { hold?: string } | undefined): boolean {`,
+    `  const sync = payload ? undefined : localSync(store, id);`,
+    `  const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };`,
+    `  const relayed = { hold: lanes.hold };`,
+    `  return from !== relayed.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    const counts = liveCounts();
+    assert.equal(
+      counts.byFile["packages/engine/src/__probe-inert-twohop.ts"],
+      1,
+      "a sync lane rebuilt into an object (and relayed again) must still be counted",
+    );
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});

--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -148,15 +148,8 @@ Driven through a real file in the scanned tree rather than a unit call, because 
 nodes the scan VISITS — a helper-level assertion would have been written against the same wrong
 mental model that produced the gap.
 
-KNOWN REMAINING GAP, stated so this case is not read as full coverage: only ONE hop is followed. The
-two-hop form — sync local -> object literal -> comparison — is still uncounted:
-
-    const sync  = payload ? undefined : localSync(store, id);
-    const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };
-    if (from !== lanes.hold) …            // still invisible
-
-`executor.ts` is written that way today, which is how it reads as 0 while the sync call is still
-present. Closing it needs propagation through object-literal construction.
+The two-hop form this case originally listed as an open gap — sync local -> object literal ->
+comparison — is covered by the chained case below; the gap was closed in the same branch.
 */
 test("counts a sync lane reached through a CONDITIONAL initializer, not just a direct call", () => {
   const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-conditional.ts");
@@ -219,6 +212,39 @@ test("counts a sync lane laundered through an object literal, including a chain"
       counts.byFile["packages/engine/src/__probe-inert-twohop.ts"],
       1,
       "a sync lane rebuilt into an object (and relayed again) must still be counted",
+    );
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3169):
+A local named `$sync` could not be matched at all. The propagation step built `\b${name}\b` from raw
+source text, so `$` was read as an ANCHOR and the pattern never fired — a laundered guard silently
+uncounted, which is the exact failure this scanner exists to prevent. `_sync` is wrong for the
+related reason that `\b` does not assert an identifier boundary next to `_`.
+
+`$` is a legal and common identifier character, so this is a shape the codebase can produce today.
+*/
+test("matches a laundered sync local whose name contains regex metacharacters", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-dollar.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `export function probe(store: unknown, id: string, from: string, payload: { hold?: string } | undefined): boolean {`,
+    `  const $sync = payload ? undefined : localSync(store, id);`,
+    `  const lanes = { hold: payload?.hold ?? $sync?.hold ?? "todo" };`,
+    `  return from !== lanes.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    const counts = liveCounts();
+    assert.equal(
+      counts.byFile["packages/engine/src/__probe-inert-dollar.ts"],
+      1,
+      "a sync local named `$sync` must still be followed into the object it is laundered through",
     );
   } finally {
     rmSync(probe, { force: true });

--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -22,7 +22,7 @@ about its output.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, copyFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, copyFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -126,4 +126,57 @@ test("the gate is still actually scanning source, not just comparing numbers", (
   const result = runGate();
   assert.match(`${result.stdout}${result.stderr}`, /guard\(s\) consuming a sync-resolved lane/);
   assert.ok(JSON.parse(readFileSync(BASELINE, "utf8")).total > 0, "baseline should not be empty");
+});
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+THE INITIALIZER IS NOT ALWAYS THE CALL — the shape that evaded this gate, now pinned.
+
+`syncLaneLocals` registered a local only when its initializer WAS a call expression, so the
+payload-first/sync-fallback form slipped past entirely:
+
+    const sync = payload ? undefined : localSync(store, id);
+    return column === sync?.hold;          // inert, and counted as nothing
+
+That matters more than the inline spelling the header already covers, because this shape is the one
+authors are STEERED toward: falling back to the sync resolver is better than falling back to legacy
+literals (it is best-effort under legacy SQLite; a literal can never be right on a renamed board), so
+writing the guard well is what made it invisible. A ratchet that goes quiet exactly when the code
+improves is worse than none.
+
+Driven through a real file in the scanned tree rather than a unit call, because the bug was in which
+nodes the scan VISITS — a helper-level assertion would have been written against the same wrong
+mental model that produced the gap.
+
+KNOWN REMAINING GAP, stated so this case is not read as full coverage: only ONE hop is followed. The
+two-hop form — sync local -> object literal -> comparison — is still uncounted:
+
+    const sync  = payload ? undefined : localSync(store, id);
+    const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };
+    if (from !== lanes.hold) …            // still invisible
+
+`executor.ts` is written that way today, which is how it reads as 0 while the sync call is still
+present. Closing it needs propagation through object-literal construction.
+*/
+test("counts a sync lane reached through a CONDITIONAL initializer, not just a direct call", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-conditional.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `export function probe(store: unknown, id: string, column: string, payload: { hold?: string } | undefined): boolean {`,
+    `  const sync = payload ? undefined : localSync(store, id);`,
+    `  return column === sync?.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    const counts = liveCounts();
+    assert.equal(
+      counts.byFile["packages/engine/src/__probe-inert-conditional.ts"],
+      1,
+      "the conditional-initializer shape must be counted; before this fix the scan reported nothing for it",
+    );
+  } finally {
+    rmSync(probe, { force: true });
+  }
 });

--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -250,3 +250,56 @@ test("matches a laundered sync local whose name contains regex metacharacters", 
     rmSync(probe, { force: true });
   }
 });
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3169 — OVER-approximation):
+Propagation is PER PROPERTY, and these are the negative cases that prove it.
+
+Marking a whole object sync-derived because its text mentioned a local counted guards that read a
+sibling LITERAL (`{ hold: sync?.hold, review: "todo" }` made `lanes.review` inert) and matched a
+local's NAME appearing as a KEY (`{ sync: "todo" }`) without anything reading it.
+
+Over-counting is not the safe direction for this gate. It inflates the baseline — so the allowance
+absorbs real inert conversions later — and it trains readers to skip the report, which this
+program's learnings record as exactly how the next genuine finding gets missed.
+*/
+test("does NOT count a sibling literal in an object that also carries a sync lane", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-mixed.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `export function probe(store: unknown, id: string, from: string, payload: { hold?: string } | undefined): boolean {`,
+    `  const sync = payload ? undefined : localSync(store, id);`,
+    `  const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo", review: "in-review" };`,
+    `  return from !== lanes.review;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    /* `lanes.hold` IS sync-derived, but nothing reads it here; the only guard reads `lanes.review`,
+       which is a literal. So the file must contribute nothing. */
+    assert.equal(liveCounts().byFile["packages/engine/src/__probe-inert-mixed.ts"] ?? 0, 0);
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});
+
+test("does NOT count an object whose KEY merely shares a sync local's name", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-keyname.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `export function probe(store: unknown, id: string, from: string, payload: { hold?: string } | undefined): boolean {`,
+    `  const sync = payload ? undefined : localSync(store, id);`,
+    `  void sync;`,
+    `  const lanes = { sync: "todo", hold: "todo" };`,
+    `  return from !== lanes.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    assert.equal(liveCounts().byFile["packages/engine/src/__probe-inert-keyname.ts"] ?? 0, 0);
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -175,7 +175,17 @@ DELIBERATELY NOT full dataflow: `const` object construction only — no function
 cross-module spread, no reassignment. The LIMITS section above still governs.
 */
 function syncLaneLocals(sf, sources) {
-  const locals = new Set();
+  /*
+  FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3169 — provenance is PER PROPERTY):
+  The map is name -> tainted role set, not a flat set of names. `null` means "every role", which is
+  what a DIRECT sync local is; an object rebuilt from one taints only the properties whose VALUES read
+  it. Marking a whole object over-approximated: `{ hold: sync?.hold, review: "todo" }` made
+  `lanes.review` count as inert though it is a literal, and `{ sync: "todo" }` matched a local's NAME
+  in a key without reading it. Over-counting is not a safe direction here — it inflates the baseline
+  and trains readers to skip the report, which this program's learnings record as how the next real
+  finding gets missed.
+  */
+  const taint = new Map();
   const objectDecls = [];
 
   const visit = (node) => {
@@ -185,10 +195,21 @@ function syncLaneLocals(sf, sources) {
         const callee = ts.isPropertyAccessExpression(call.expression)
           ? call.expression.name.getText(sf)
           : call.expression.getText(sf);
-        if (sources.has(callee)) locals.add(node.name.getText(sf));
+        if (sources.has(callee)) taint.set(node.name.getText(sf), null);
       }
       if (ts.isObjectLiteralExpression(node.initializer)) {
-        objectDecls.push({ name: node.name.getText(sf), text: node.initializer.getText(sf) });
+        /* Property-level provenance: which KEY, and the text of its VALUE only. A key that merely
+           shares a local's name (`{ sync: "todo" }`) must not taint anything, and a sibling literal
+           (`{ hold: sync?.hold, review: "todo" }`) must not make `review` inert. */
+        const props = [];
+        for (const p of node.initializer.properties) {
+          if (ts.isPropertyAssignment(p) && (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name))) {
+            props.push({ key: p.name.text, valueText: p.initializer.getText(sf) });
+          } else if (ts.isShorthandPropertyAssignment(p)) {
+            props.push({ key: p.name.getText(sf), valueText: p.name.getText(sf) });
+          }
+        }
+        objectDecls.push({ name: node.name.getText(sf), props });
       }
     }
     ts.forEachChild(node, visit);
@@ -200,28 +221,38 @@ function syncLaneLocals(sf, sources) {
   for (let pass = 0; pass < objectDecls.length + 1; pass += 1) {
     let grew = false;
     for (const decl of objectDecls) {
-      if (locals.has(decl.name)) continue;
-      for (const known of locals) {
-        if (mentionsIdentifier(decl.text, known)) { locals.add(decl.name); grew = true; break; }
+      const tainted = taint.get(decl.name) ?? new Set();
+      const before = tainted.size;
+      for (const prop of decl.props) {
+        if (tainted.has(prop.key)) continue;
+        for (const known of taint.keys()) {
+          if (mentionsIdentifier(prop.valueText, known)) { tainted.add(prop.key); break; }
+        }
       }
+      if (tainted.size > before) { taint.set(decl.name, tainted); grew = true; }
     }
     if (!grew) break;
   }
-  return locals;
+  return taint;
 }
 
 /*
 FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3169 — the match could not fire):
 `\b` IS THE WRONG BOUNDARY FOR A JS IDENTIFIER, and the name was interpolated unescaped.
 
-`new RegExp(`\\b${name}\\b`)` breaks on a perfectly legal local. For `$sync` it builds `\b$sync\b`,
-where `$` is an ANCHOR — so the pattern can never match and the laundered guard is silently missed,
-which is the failure mode this scanner exists to prevent. `_sync` fails differently: `\b` sits between
-two non-word positions and does not assert what it looks like it asserts.
+`new RegExp(`\\b${name}\\b`)` is wrong in BOTH directions, and `$` is where each shows up:
 
-So the name is escaped, and the boundary is an explicit identifier boundary — `$` and `_` are
-identifier characters in JS and must not count as separators. Chosen over `\b` deliberately: `\b`
-happens to work for the common case and hides exactly the cases above.
+  MISS   name `$sync` builds `\b$sync\b`, where `$` is an ANCHOR — the pattern can never match, so a
+         laundered guard is silently uncounted. That is the failure this scanner exists to prevent.
+  FALSE  name `sync` builds `\bsync\b`, which DOES match inside `$sync` — `$` is a non-word character,
+         so a word boundary falls between it and `s`. An unrelated local taints the object.
+
+A CORRECTION TO AN EARLIER VERSION OF THIS NOTE, which claimed `_sync` also fails: it does not.
+`_` IS a word character, so `\b_sync\b` matches `_sync` correctly. Checked rather than reasoned
+about, after asserting the opposite here without checking.
+
+So the name is escaped, and the boundary is an explicit identifier class — `$` and `_` are identifier
+characters in JS and must not count as separators in either direction.
 */
 function mentionsIdentifier(haystack, name) {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -243,8 +274,15 @@ function countInertGuards(sf, locals, sources) {
     if (!ROLE_FIELDS.has(field)) return undefined;
 
     const base = expr.expression;
-    /* `parked.review` — resolved once into a local. */
-    if (ts.isIdentifier(base) && locals.has(base.getText(sf))) return `${base.getText(sf)}.${field}`;
+    /* `parked.review` — resolved once into a local.
+       A DIRECT sync local taints every role (`null`); an object rebuilt from one taints only the
+       properties whose values read it, so the role must be in that set or this is a sibling literal
+       and not inert at all. */
+    if (ts.isIdentifier(base) && locals.has(base.getText(sf))) {
+      const tainted = locals.get(base.getText(sf));
+      if (tainted === null || tainted.has(field)) return `${base.getText(sf)}.${field}`;
+      return undefined;
+    }
 
     /* `resolveTaskParkedColumnsSync(store, id).review` — resolved inline at the guard. */
     let call = base;

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -155,8 +155,33 @@ function unwrapForSyncCall(node) {
   return out;
 }
 
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (the SECOND hop — a sync lane laundered through an
+object literal):
+One hop was not enough. The real shape in `executor.ts` rebuilds the lanes into a fresh object before
+comparing, so the sync local never appears in a guard:
+
+    const sync  = payload ? undefined : resolvePlannerLanes(this.store, taskId);
+    const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo", … };
+    if (from !== lanes.hold && from !== lanes.intake) return false;
+
+`sync` is registered, `lanes` is not, and every guard reads `lanes`. MEASURED: the file reported ZERO
+counted guards while the sync resolver was still there and still answering with the default board
+whenever the payload is absent.
+
+So a local built from an object literal whose property initializers mention a sync local is itself a
+sync local. Iterated to a fixpoint, because the laundering can chain (`a -> b -> c`) and a single pass
+would only ever catch the first link — the same one-pass mistake this file already made once.
+
+DELIBERATELY NOT full dataflow. This follows `const` object construction and nothing else: no
+function returns, no spread from another module, no reassignment. The point is to stop the scan going
+quiet on the shape the codebase actually uses, not to become a type checker — the LIMITS section
+above still governs.
+*/
 function syncLaneLocals(sf, sources) {
   const locals = new Set();
+  const objectDecls = [];
+
   const visit = (node) => {
     if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
       for (const call of unwrapForSyncCall(node.initializer)) {
@@ -166,10 +191,26 @@ function syncLaneLocals(sf, sources) {
           : call.expression.getText(sf);
         if (sources.has(callee)) locals.add(node.name.getText(sf));
       }
+      if (ts.isObjectLiteralExpression(node.initializer)) {
+        objectDecls.push({ name: node.name.getText(sf), text: node.initializer.getText(sf) });
+      }
     }
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(sf, visit);
+
+  /* Fixpoint: an object built from a sync local is one too, and that can chain. Bounded by the
+     number of object declarations, so it always terminates. */
+  for (let pass = 0; pass < objectDecls.length + 1; pass += 1) {
+    let grew = false;
+    for (const decl of objectDecls) {
+      if (locals.has(decl.name)) continue;
+      for (const known of locals) {
+        if (new RegExp(`\\b${known}\\b`).test(decl.text)) { locals.add(decl.name); grew = true; break; }
+      }
+    }
+    if (!grew) break;
+  }
   return locals;
 }
 

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -120,13 +120,47 @@ function syncLaneSources(sf) {
 }
 
 /** Locals assigned from one of those sources: `const parked = resolveTaskParkedColumnsSync(...)`. */
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (the check evaded its own check, SECOND shape):
+THE INITIALIZER IS NOT ALWAYS THE CALL.
+
+This registered a local only when the initializer WAS a call expression. The correct
+payload-first/sync-fallback shape puts the call inside a conditional:
+
+    const sync = moveLanes ? undefined : resolvePlannerLanes(this.store, taskId);
+    const hold = moveLanes?.hold ?? sync?.hold ?? "todo";
+
+`sync` was never registered, so its guards were never counted. MEASURED: writing `executor.ts` in
+exactly that shape took it from 4 counted guards to ZERO while the sync resolver was still there and
+still answering with the default board whenever the payload is absent.
+
+That is the same class of evasion the note below records for the inline spelling, and it matters more
+here because the shape it misses is the RECOMMENDED one — a fallback to the sync resolver is better
+than a fallback to legacy literals, so authors are actively steered toward the form the scan cannot
+see. A ratchet that goes quiet exactly when the code is written well is worse than no ratchet.
+
+Conditionals and `??`/`||` chains are now unwrapped, so any branch containing a sync source registers
+the local. Still a NAME match, not dataflow — the limits section above still applies.
+*/
+function unwrapForSyncCall(node) {
+  const out = [];
+  const walk = (n) => {
+    if (!n) return;
+    if (ts.isAwaitExpression(n) || ts.isParenthesizedExpression(n)) return walk(n.expression);
+    if (ts.isConditionalExpression(n)) { walk(n.whenTrue); walk(n.whenFalse); return; }
+    if (ts.isBinaryExpression(n)) { walk(n.left); walk(n.right); return; }
+    out.push(n);
+  };
+  walk(node);
+  return out;
+}
+
 function syncLaneLocals(sf, sources) {
   const locals = new Set();
   const visit = (node) => {
     if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
-      let call = node.initializer;
-      if (ts.isAwaitExpression(call)) call = call.expression;
-      if (ts.isCallExpression(call)) {
+      for (const call of unwrapForSyncCall(node.initializer)) {
+        if (!ts.isCallExpression(call)) continue;
         const callee = ts.isPropertyAccessExpression(call.expression)
           ? call.expression.name.getText(sf)
           : call.expression.getText(sf);

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -165,18 +165,14 @@ comparing, so the sync local never appears in a guard:
     const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo", … };
     if (from !== lanes.hold && from !== lanes.intake) return false;
 
-`sync` is registered, `lanes` is not, and every guard reads `lanes`. MEASURED: the file reported ZERO
-counted guards while the sync resolver was still there and still answering with the default board
-whenever the payload is absent.
+`sync` is registered, `lanes` is not, and every guard reads `lanes`. MEASURED: `executor.ts` reported
+ZERO counted guards while the sync resolver was still present.
 
-So a local built from an object literal whose property initializers mention a sync local is itself a
-sync local. Iterated to a fixpoint, because the laundering can chain (`a -> b -> c`) and a single pass
-would only ever catch the first link — the same one-pass mistake this file already made once.
+So a local built from an object literal that mentions a sync local is itself a sync local. Iterated to
+a fixpoint because the laundering can chain (`a -> b -> c`); a single pass catches only the first link.
 
-DELIBERATELY NOT full dataflow. This follows `const` object construction and nothing else: no
-function returns, no spread from another module, no reassignment. The point is to stop the scan going
-quiet on the shape the codebase actually uses, not to become a type checker — the LIMITS section
-above still governs.
+DELIBERATELY NOT full dataflow: `const` object construction only — no function returns, no
+cross-module spread, no reassignment. The LIMITS section above still governs.
 */
 function syncLaneLocals(sf, sources) {
   const locals = new Set();
@@ -206,12 +202,30 @@ function syncLaneLocals(sf, sources) {
     for (const decl of objectDecls) {
       if (locals.has(decl.name)) continue;
       for (const known of locals) {
-        if (new RegExp(`\\b${known}\\b`).test(decl.text)) { locals.add(decl.name); grew = true; break; }
+        if (mentionsIdentifier(decl.text, known)) { locals.add(decl.name); grew = true; break; }
       }
     }
     if (!grew) break;
   }
   return locals;
+}
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (review finding on #3169 — the match could not fire):
+`\b` IS THE WRONG BOUNDARY FOR A JS IDENTIFIER, and the name was interpolated unescaped.
+
+`new RegExp(`\\b${name}\\b`)` breaks on a perfectly legal local. For `$sync` it builds `\b$sync\b`,
+where `$` is an ANCHOR — so the pattern can never match and the laundered guard is silently missed,
+which is the failure mode this scanner exists to prevent. `_sync` fails differently: `\b` sits between
+two non-word positions and does not assert what it looks like it asserts.
+
+So the name is escaped, and the boundary is an explicit identifier boundary — `$` and `_` are
+identifier characters in JS and must not count as separators. Chosen over `\b` deliberately: `\b`
+happens to work for the common case and hides exactly the cases above.
+*/
+function mentionsIdentifier(haystack, name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?<![A-Za-z0-9_$])${escaped}(?![A-Za-z0-9_$])`).test(haystack);
 }
 
 /** `x === parked.review` / `parked.hold !== y` — a guard consuming a sync-resolved role.

--- a/scripts/lib/inert-sync-lane-baseline.json
+++ b/scripts/lib/inert-sync-lane-baseline.json
@@ -1,6 +1,7 @@
 {
-  "total": 7,
+  "total": 9,
   "byFile": {
+    "packages/engine/src/executor.ts": 2,
     "packages/engine/src/triage.ts": 7
   }
 }


### PR DESCRIPTION
Found by dogfooding my own change: I wrote `executor.ts` in the payload-first/sync-fallback shape while adopting #3140's better fallback, **predicted in a comment that the guards would stay counted**, and the gate reported **zero**. The prediction was wrong in the direction that matters — the gate under-reports.

## The gap

`syncLaneLocals` registered a local only when its initializer **was** a call expression:

```ts
const sync = payload ? undefined : localSync(store, id);
return column === sync?.hold;          // inert, and counted as nothing
```

Conditionals and `??`/`||` chains are now unwrapped, so a sync call in any branch registers the local. Still a **name** match, not dataflow — the file's LIMITS section still applies.

## Why this shape matters more than the inline one already guarded

**The missed shape is the one authors are steered toward.** Falling back to the sync resolver is *better* than falling back to legacy literals — it is best-effort under legacy SQLite, whereas a literal can never be right on a renamed board. So writing the guard well is what made it invisible.

A ratchet that goes quiet exactly when the code improves is worse than none: it rewards the worse degraded path with a tidier number.

## Known remaining gap, stated in the test rather than implied

Only **one hop** is followed. The two-hop form is still uncounted:

```ts
const sync  = payload ? undefined : localSync(store, id);
const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };
if (from !== lanes.hold) …            // still invisible
```

`executor.ts` is written that way today, which is why it reads 0 while the sync call is still present. Closing it needs propagation through object-literal construction — a larger change than this one, and I would rather ship the one-hop fix with the gap documented than imply full coverage.

## Verification

| | result |
|---|---|
| gate on `main` | **exit 0**, output unchanged (11 = triage 7 + executor 4) |
| test suite | **5 pass** |
| new case against the **unfixed** gate | **fails** — `the conditional-initializer shape must be counted` |

The regression case drives a real file through the scanned tree rather than calling a helper, because the bug was in which nodes the scan **visits**. A helper-level assertion would have been written against the same wrong mental model that produced the gap — which is how the inline-spelling hole in this same file survived its first draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sync-lane conversions in conditional expressions, fallback logic, awaited and parenthesized values, and object-literal relays.
  * Corrected matching for identifiers containing special characters.
  * Updated validation results to include two additional findings that were previously missed.

* **Tests**
  * Added integration coverage for conditional initializers, chained object-literal conversions, and special-character identifiers.
  * Ensured temporary test files are cleaned up automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->