### PR TITLE
fix(gate): follow the SECOND hop — a sync lane laundered through an object literal

### DIFF
--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -180,3 +180,47 @@ test("counts a sync lane reached through a CONDITIONAL initializer, not just a d
     rmSync(probe, { force: true });
   }
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+THE SECOND HOP, which the case above explicitly left open.
+
+A sync local laundered through an object literal reached the guards while the scan saw nothing:
+
+    const sync  = payload ? undefined : localSync(store, id);
+    const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };
+    if (from !== lanes.hold) …            // inert, counted as nothing
+
+`executor.ts` is written exactly this way, and MEASURED it reported ZERO counted guards while the
+sync resolver was still present and still answering with the default board whenever the payload is
+absent. With the fix that file reports 2 — the two guards that genuinely remain after its dead
+helper is deleted.
+
+The chained case is in the probe on purpose: laundering can go `a -> b -> c`, and a single pass
+would catch only the first link. That is the same one-pass mistake this file's earlier cases record,
+made twice already in this scanner.
+*/
+test("counts a sync lane laundered through an object literal, including a chain", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-twohop.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `export function probe(store: unknown, id: string, from: string, payload: { hold?: string } | undefined): boolean {`,
+    `  const sync = payload ? undefined : localSync(store, id);`,
+    `  const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo" };`,
+    `  const relayed = { hold: lanes.hold };`,
+    `  return from !== relayed.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    const counts = liveCounts();
+    assert.equal(
+      counts.byFile["packages/engine/src/__probe-inert-twohop.ts"],
+      1,
+      "a sync lane rebuilt into an object (and relayed again) must still be counted",
+    );
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});

--- a/scripts/check-inert-sync-lane-conversions.mjs
+++ b/scripts/check-inert-sync-lane-conversions.mjs
@@ -155,8 +155,33 @@ function unwrapForSyncCall(node) {
   return out;
 }
 
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59 (the SECOND hop — a sync lane laundered through an
+object literal):
+One hop was not enough. The real shape in `executor.ts` rebuilds the lanes into a fresh object before
+comparing, so the sync local never appears in a guard:
+
+    const sync  = payload ? undefined : resolvePlannerLanes(this.store, taskId);
+    const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo", … };
+    if (from !== lanes.hold && from !== lanes.intake) return false;
+
+`sync` is registered, `lanes` is not, and every guard reads `lanes`. MEASURED: the file reported ZERO
+counted guards while the sync resolver was still there and still answering with the default board
+whenever the payload is absent.
+
+So a local built from an object literal whose property initializers mention a sync local is itself a
+sync local. Iterated to a fixpoint, because the laundering can chain (`a -> b -> c`) and a single pass
+would only ever catch the first link — the same one-pass mistake this file already made once.
+
+DELIBERATELY NOT full dataflow. This follows `const` object construction and nothing else: no
+function returns, no spread from another module, no reassignment. The point is to stop the scan going
+quiet on the shape the codebase actually uses, not to become a type checker — the LIMITS section
+above still governs.
+*/
 function syncLaneLocals(sf, sources) {
   const locals = new Set();
+  const objectDecls = [];
+
   const visit = (node) => {
     if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
       for (const call of unwrapForSyncCall(node.initializer)) {
@@ -166,10 +191,26 @@ function syncLaneLocals(sf, sources) {
           : call.expression.getText(sf);
         if (sources.has(callee)) locals.add(node.name.getText(sf));
       }
+      if (ts.isObjectLiteralExpression(node.initializer)) {
+        objectDecls.push({ name: node.name.getText(sf), text: node.initializer.getText(sf) });
+      }
     }
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(sf, visit);
+
+  /* Fixpoint: an object built from a sync local is one too, and that can chain. Bounded by the
+     number of object declarations, so it always terminates. */
+  for (let pass = 0; pass < objectDecls.length + 1; pass += 1) {
+    let grew = false;
+    for (const decl of objectDecls) {
+      if (locals.has(decl.name)) continue;
+      for (const known of locals) {
+        if (new RegExp(`\\b${known}\\b`).test(decl.text)) { locals.add(decl.name); grew = true; break; }
+      }
+    }
+    if (!grew) break;
+  }
   return locals;
 }
 


### PR DESCRIPTION
**Stacked on #3169**, which documented this gap as known-open. Closing it instead of leaving it.

## The shape

```ts
const sync  = payload ? undefined : resolvePlannerLanes(this.store, taskId);
const lanes = { hold: payload?.hold ?? sync?.hold ?? "todo", … };
if (from !== lanes.hold && from !== lanes.intake) return false;
```

`sync` was registered as a sync local; `lanes` was not; every guard reads `lanes`. So the file reported **zero** counted guards while the sync resolver was still present and still answering with the default board whenever the payload is absent.

## This corrects a correction

In #3137 I wrote `executor.ts` in exactly this shape, **predicted the guards would stay counted**, saw zero, and recorded in the file that the gate under-reports. With both hops followed:

| | before | after |
|---|---|---|
| `main` tree | 11 (triage 7 + executor 4) | **11 — unchanged**, no false positives |
| `executor.ts`, #3137 shape | **0** | **2** |

Two is the right answer: #3137 deletes the dead `isPlannerColumnFor` (2 guards) and converts the other predicate to payload-first with a sync fallback — so two genuinely remain. **My original prediction was correct and the gate simply could not see them.** I will update that file's comment once this lands, since it currently records the under-reporting as the final state.

## Design notes

**Iterated to a fixpoint**, because laundering chains (`a → b → c`) and a single pass catches only the first link — the same one-pass mistake this scanner has now made twice (the inline spelling, then the conditional initializer). The probe includes a relayed hop for that reason. Bounded by the object-declaration count, so it terminates.

**Deliberately not full dataflow.** This follows `const` object construction and nothing else: no function returns, no cross-module spread, no reassignment. The goal is to stop the scan going quiet on the shape the codebase actually uses, not to become a type checker. The file's LIMITS section still governs.

## Verification

- **6 tests pass**; the new case **fails against the one-hop gate**
- gate **exit 0** on `main`, output unchanged
- measured against the real `executor.ts` shape, not only the probe