### PR TITLE
chore(gate): re-record the inert-sync-lane baseline (11 → 7) — main is red

### DIFF
--- a/scripts/lib/inert-sync-lane-baseline.json
+++ b/scripts/lib/inert-sync-lane-baseline.json
@@ -1,7 +1,6 @@
 {
-  "total": 11,
+  "total": 7,
   "byFile": {
-    "packages/engine/src/executor.ts": 4,
     "packages/engine/src/triage.ts": 7
   }
 }


### PR DESCRIPTION
The merge gate fails on main: the inert-sync-lane count fell **11 → 7** and the allowance was not re-recorded, so the ratchet refuses to pass. Every open PR inherits it; mine did, on a docs-only change.

Mechanical — run the updater the failure message itself names. No source touched, one line of JSON.

**The check is right to fail.** A stale allowance is room for four NEW inert conversions to land unnoticed, which is precisely what this gate exists to stop. Inert conversions are the defect the fleet has been producing all day: #3058 refuted one against live PG, #3062 added this gate, and it rejected four PRs this morning for exactly that.

Whoever converted those four sites did the work — only the re-record was missed. That is the same shape as the FNXC baseline drift I fixed earlier: **a ratchet moving in the good direction still fails until someone records it**, which is correct behaviour and keeps surprising people.

**Verification:** `check-inert-sync-lane-conversions` green · `pnpm test:gate` full pass · diff is one JSON line.