### PR TITLE
docs(agents): take FNXC timestamps from date -u, not the local clock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,6 +357,7 @@ Note: the embedded main-content views Workflows (`_WorkflowEditorView`), Import 
 
 ## FNXC_LOG comments:
    - Please whenever you're working on a codebase. I want you to add comments describing the date of the change (must be in this format yyyy-MM-dd-hh:mm) and describing the requirements or the change in requirements that made you implement certain functionality.
+   - **Take the timestamp from `date -u`, not your local clock.** `check-fnxc-future-dates` validates against UTC, so a stamp written from a clock behind UTC is a FUTURE stamp the moment UTC rolls over — and `pnpm lint` passes locally, because the local date agrees with what you wrote. It surfaces only as a red `main` for everybody else. This cost the fleet four separate breakages in one day (`scheduler.ts`, a scheduler PG test, and `task-update.ts` twice, by different authors); every one was a real time on the wrong day. The gate also rejects an impossible clock time, so an hour above 23 or a minute above 59 fails for a different reason.
    - I want you to write FNXC:Area-of-product in front of all your comments so they can be grepped.
    - Most of this should be written as jsdocs but you can add short comments around for the important variables and more complex parts of the codebase.
    - The idea is to encode the requiements of the system (especially software behavior, UX, and important technical decisions) into the code so it's clearer later why a certain piece of code was written.


### PR DESCRIPTION
I have patched this same breakage **three times today**, and it is not a per-file defect — the convention is under-specified.

`check-fnxc-future-dates` validates against **UTC**. A stamp written from a clock **behind** UTC is a future stamp the moment UTC rolls over, and `pnpm lint` passes locally because the local date agrees with what was written. Nothing in the authoring loop can catch it. It surfaces only as a **red main for everybody else**.

## The evidence

Four separate breakages in one day, four files, at least two authors:

| file | stamps |
|---|---|
| `packages/engine/src/scheduler.ts` | 7 dated 2026-08-01 → 08-06 |
| the scheduler PG test | 1 |
| `packages/core/src/task-store/task-update.ts` | 2, fixed by two different people |

Every one was a **real time on the wrong day** — nobody was careless, they read their own clock.

## What changed

`AGENTS.md` already specifies the *format* (`yyyy-MM-dd-hh:mm`) and says nothing about the *clock*, so every worker reasonably used their own. This adds the one missing sentence, plus the impossible-hour rule the gate also enforces — which produced its own main-red earlier today (#3006 normalized four hour-26 stamps).

Docs only; no changeset, per the AGENTS.md rule for internal docs.

## Note

This PR will show red on Gate until **#3173** merges — main's inert-sync-lane allowance is stale (11 → 7, never re-recorded), unrelated to this change and inherited by every open PR.