### PR TITLE
docs(scheduler): narrow the reason on the two flagged literals — the verdict is right, the reason is too broad

### DIFF
--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -1227,11 +1227,27 @@ export class Scheduler {
 
       They stay literal and COUNTED, which is the honest state: an unconverted literal is at least
       visible to the census, while an inert conversion leaves the backlog and takes the evidence with
-      it. Both live in a synchronous `task:updated` listener, so the async resolver is unavailable
-      without reordering this handler against every other subscriber.
+      it. That decision is unchanged.
 
-      Unblocking needs a sync-capable workflow-selection reader — one change that un-inerts every
-      sync-path conversion in this file at once.
+      FNXC:WorkflowResolvedColumns 2026-08-01-06:40 (fleet — narrowing the REASON, not the verdict):
+      "Both live in a synchronous `task:updated` listener, so the async resolver is unavailable" is
+      broader than what actually blocks them, and left standing it tells the next worker this whole
+      listener is off-limits. It is not: two guards in THIS listener were converted asynchronously
+      (the unpause wake and the planning-finished wake), because their answers only gate
+      `schedule()`, which is itself async, fire-and-forget and re-entrance-guarded.
+
+      THE CRITERION IS WHETHER THE ANSWER IS CONSUMED SYNCHRONOUSLY, not whether the enclosing
+      listener is declared sync. These two meet it for their own reasons, and those are what to check
+      before trying again:
+
+        - the `in-progress` guard feeds `failedTaskIds`, edge-trigger bookkeeping READ LATER IN THE
+          SAME TICK by the mission-failure reconcile below. Deferring the add lets that read miss it
+          — the same hazard that keeps `planningTaskIds.delete` synchronous a few lines down.
+        - the `in-review` guard is an early `return` gating the whole PR-monitoring tail. Deferring it
+          means restructuring that tail, which is a control-flow change, not a lane resolution.
+
+      A sync-capable workflow-selection reader would still un-inert every sync-path conversion in this
+      file at once, and remains the cleanest unblock for both.
       */
       // Track mission failure signals before moveTask clears failure metadata.
       if (task.sliceId && task.status === "failed") {


### PR DESCRIPTION
Comment-only. **Census unchanged at 13**; both literals stay counted, which was the correct call.

`scheduler.ts` was the only unclaimed census file — verified with #3175's claim check, one command instead of 25.

## What's wrong with the note

> Both live in a synchronous `task:updated` listener, so the async resolver is unavailable without reordering this handler against every other subscriber.

Left standing, that tells the next worker **the whole listener is off-limits**. It isn't — two guards in *that same listener* were converted asynchronously (the unpause wake and the planning-finished wake), because their answers only gate `schedule()`, which is itself async, fire-and-forget and re-entrance-guarded.

**The criterion is whether the ANSWER is consumed synchronously, not whether the enclosing listener is declared sync.**

## Why these two still qualify

Their verdict is right; the reasons are specific and worth recording so the next attempt checks the correct thing:

- **`in-progress`** feeds `failedTaskIds` — edge-trigger bookkeeping **read later in the same tick** by the mission-failure reconcile below. Deferring the add lets that read miss it: the same hazard that keeps `planningTaskIds.delete` synchronous a few lines down.
- **`in-review`** is an early `return` gating the whole PR-monitoring tail. Deferring it restructures that tail — a control-flow change, not a lane resolution.

## Why this is worth a PR

**A wrong or overbroad BLOCKED flag costs more than an unconverted literal, because it tells every later worker not to look.** I made that mistake four times in this program:

- a phantom `listTasks({column})` blocker whose line numbers were *comments*
- a "watcher callback" that was `async`
- a "sync path" that was `async`
- a listener I called unconvertible before converting three of its guards

Each cost a cycle or more. This note is a teammate's and their verdict stands — only the reason needed narrowing.

## Verification

21 scheduler suites, **361 green**; `tsc` clean; census unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)