### PR TITLE
fix(cli): the TUI board fell back to the LEGACY workflow — it rendered a `triage` lane the default no longer has

### DIFF
--- a/packages/cli/src/__tests__/dashboard-default-workflow-fallback.test.ts
+++ b/packages/cli/src/__tests__/dashboard-default-workflow-fallback.test.ts
@@ -1,0 +1,77 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+THE TUI'S NO-SELECTION FALLBACK WAS THE LEGACY WORKFLOW, so it rendered a lane the board does not have.
+
+`packages/cli/src/commands/dashboard.ts` resolved a task's columns as `def?.ir ?? BUILTIN_CODING_WORKFLOW_IR`
+and its card-chip fields the same way. That constant is the LEGACY monolithic IR
+(`builtin:legacy-coding`); the catalog's actual default is `resolveDefaultWorkflowIr()`. Post-U11 they
+differ, and the difference is a whole column:
+
+    default  todo, in-progress, in-review, done, archived          (planning merged into todo)
+    legacy   triage, todo, in-progress, in-review, done, archived
+
+So a task with no workflow selection row was rendered against a six-column board including `triage`,
+which the real default no longer declares.
+
+This is the same drift `builtin-workflows.ts` records as ALREADY FIXED for the move-path resolvers —
+`prepareWorkflowMovePolicyPreflightImpl` went through the catalog while `resolveTaskWorkflowIrForMove`
+used the raw constant, and a no-selection task produced two different workflow signatures ("workflow
+move policy preflight is stale"). Both were routed through the shared helper so the default could not
+drift again. This surface was missed.
+
+WHAT THIS TEST CAN AND CANNOT DO, stated because the honest scope is narrow. Driving the TUI board
+end-to-end needs a rendered terminal and a live store; that harness does not exist here and building
+one to assert a fallback would be testing the harness. So this pins the two facts that make the bug
+possible and the fix meaningful:
+
+  1. the two IRs genuinely disagree, and disagree about `triage` specifically — if a future change
+     re-merges them this test says so, and the fix becomes unnecessary rather than silently wrong;
+  2. the TUI source no longer reaches for the legacy constant as a fallback.
+
+(2) is a source assertion, which is weaker than driving the code. It is used here for the same reason
+the FloatingWindow aria-label scan uses one: the defect is a VALUE at a call site, there is no single
+render that reaches it, and a per-site render test would pin the one site someone bothered to write.
+*/
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { BUILTIN_CODING_WORKFLOW_IR, resolveDefaultWorkflowIr } from "@fusion/core";
+
+const DASHBOARD_SRC = resolve(fileURLToPath(import.meta.url), "../../commands/dashboard.ts");
+
+function columnIds(ir: unknown): string[] {
+  const v2 = ir as { version?: string; columns?: Array<{ id: string }> };
+  return v2.version === "v2" ? (v2.columns ?? []).map((c) => c.id) : [];
+}
+
+/** Comment-stripped, so prose naming the constant is not read as a call site. */
+function dashboardCode(): string {
+  return readFileSync(DASHBOARD_SRC, "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, "");
+}
+
+describe("the TUI's no-selection workflow fallback", () => {
+  it("the catalog default and the legacy constant genuinely disagree", () => {
+    const def = columnIds(resolveDefaultWorkflowIr());
+    const legacy = columnIds(BUILTIN_CODING_WORKFLOW_IR);
+
+    /* Anti-vacuity: both must actually resolve to v2 column sets, or the comparison below is
+       comparing two empty arrays and passes for the wrong reason. */
+    expect(def.length).toBeGreaterThan(0);
+    expect(legacy.length).toBeGreaterThan(0);
+
+    expect(legacy).toContain("triage");
+    expect(def).not.toContain("triage");
+  });
+
+  it("dashboard.ts does not fall back to the legacy constant", () => {
+    /* The bug was `def?.ir ?? BUILTIN_CODING_WORKFLOW_IR` in two places — board columns and card
+       chip fields. Asserting absence rather than a specific call shape, because the next spelling of
+       the same mistake will not look like the last one. */
+    expect(dashboardCode()).not.toContain("BUILTIN_CODING_WORKFLOW_IR");
+    expect(dashboardCode()).toContain("resolveDefaultWorkflowIr");
+  });
+});

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_AGENT_HEARTBEAT_INTERVAL_MS,
   isWorkspaceTask,
   resolveColumnFlags,
-  BUILTIN_CODING_WORKFLOW_IR,
+  resolveDefaultWorkflowIr,
   mergeBuiltInGrokProviderModels,
   mergeBuiltInZaiProviderModels,
   parseWorkflowIr,
@@ -1127,7 +1127,26 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
         const def = workflowId
           ? await projectStore.getWorkflowDefinition(workflowId)
           : undefined;
-        const ir = def?.ir ?? BUILTIN_CODING_WORKFLOW_IR;
+        /*
+        FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+        THE NO-SELECTION FALLBACK IS THE CURRENT DEFAULT, NOT THE LEGACY CONSTANT.
+
+        `BUILTIN_CODING_WORKFLOW_IR` is the legacy monolithic IR (`builtin:legacy-coding`);
+        `resolveDefaultWorkflowIr()` is the catalog's actual default. Post-U11 they DIFFER:
+
+            default  todo, in-progress, in-review, done, archived        (planning merged into todo)
+            legacy   triage, todo, in-progress, in-review, done, archived
+
+        So a task with no selection row rendered a `triage` column the real default no longer
+        declares — the TUI board showed a lane the board does not have.
+
+        This is the same drift `builtin-workflows.ts` records as already fixed for the move-path
+        resolvers: `prepareWorkflowMovePolicyPreflightImpl` resolved through the catalog while
+        `resolveTaskWorkflowIrForMove` used the raw constant, and a no-selection task produced two
+        different workflow signatures ("workflow move policy preflight is stale"). Both were routed
+        through the shared helper so the default could not drift again; this surface was missed.
+        */
+        const ir = def?.ir ?? resolveDefaultWorkflowIr();
         columns = ir.version === "v2" ? ir.columns : [];
         workflowIrCache.set(workflowId, columns);
       }
@@ -3306,9 +3325,12 @@ export async function runDashboard(port: number, opts: { paused?: boolean; dev?:
                     const def = selection?.workflowId
                       ? await projectStore.getWorkflowDefinition(selection.workflowId)
                       : undefined;
+                    /* Same no-selection fallback as the column resolution above: the catalog default,
+                       not the legacy constant. Here it decides which `fields` render as card chips,
+                       so the legacy IR showed a different chip set for unselected tasks. */
                     const ir = def
                       ? (typeof def.ir === "string" ? parseWorkflowIr(def.ir) : def.ir)
-                      : BUILTIN_CODING_WORKFLOW_IR;
+                      : resolveDefaultWorkflowIr();
                     const fields = ir.version === "v2" ? (ir.fields ?? []) : [];
                     const chips: Array<{ label: string; value: string }> = [];
                     for (const field of fields) {


### PR DESCRIPTION
Found by following an unexplained number rather than by a sweep: while re-verifying #3141 the resolver reported `intake: "todo"` where `BUILTIN_CODING_WORKFLOW_IR` resolves `intake: "triage"`. That divergence is correct and intentional inside core — and wrong here.

## The defect

`dashboard.ts` resolved a task's columns as `def?.ir ?? BUILTIN_CODING_WORKFLOW_IR`, and its card-chip fields the same way. That constant is the **legacy** monolithic IR (`builtin:legacy-coding`); the catalog's actual default is `resolveDefaultWorkflowIr()`. Post-U11 they differ **by a whole column**:

```
default  todo, in-progress, in-review, done, archived          (planning merged into todo)
legacy   triage, todo, in-progress, in-review, done, archived
```

So a task with **no workflow selection row** was rendered against a six-column board including `triage` — a lane the real default no longer declares.

## The same drift is already documented as fixed elsewhere

`builtin-workflows.ts` records it:

> `prepareWorkflowMovePolicyPreflightImpl` resolved the default through the catalog while `resolveTaskWorkflowIrForMove` used the raw constant, so a task with NO selection row produced two different workflow signatures and every flag-ON move threw *"workflow move policy preflight is stale"*. Both sides (and the sync resolver) now call this helper so the default cannot drift again.

This surface was missed, and it is the **last non-test consumer of the legacy constant outside core**.

## Test scope, stated because it is narrow

Driving the TUI end-to-end needs a rendered terminal and a live store. That harness does not exist here, and building one to assert a fallback would be testing the harness. So the test pins the two facts that make the bug possible and the fix meaningful:

1. **the two IRs genuinely disagree, about `triage` specifically** — if a future change re-merges them, this reports it rather than leaving the fix silently pointless;
2. **the source no longer reaches for the legacy constant.**

(2) is a source assertion, weaker than driving the code. It is used for the same reason as the `FloatingWindow` aria-label scan: the defect is a **value at a call site**, there is no single render that reaches both sites, and a per-site render test would pin the one someone bothered to write. Both assertions are anti-vacuity guarded — the IR comparison fails if either side stops resolving to a v2 column set.

## Verification

| | result |
|---|---|
| cli `tsc` | **0 errors** |
| new test | **2 passed** |
| mutation — restore `?? BUILTIN_CODING_WORKFLOW_IR` | **1 failed / 2** |
| census `--strict`, `check-fnxc-future-dates` | exit 0 (this class is invisible to the census — an argument, not a comparison) |