### PR TITLE
chore(core): mark the mission-store dead-sync-path literal DELIBERATE (census 13→12)

### DIFF
--- a/packages/core/src/mission-store.ts
+++ b/packages/core/src/mission-store.ts
@@ -2331,6 +2331,12 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
       ).get(feature.taskId) as { id: string; column: string } | undefined;
       /*
       FNXC:WorkflowResolvedColumns 2026-07-31-20:15 (audited — DEAD SYNC PATH, do not convert):
+      DELIBERATE-LITERAL — marked, not merely described. The verdict below is right; it was recorded in
+      prose the census cannot read, so the site stayed in `byFile` as apparent debt and each fleet pass
+      re-derived it. Verified before marking rather than deferred to: `async-mission-store.ts:168`
+      independently states `getMissionStoreImpl` returns the async implementation in PG backend mode,
+      so the sync class here really is unreachable in the shipped backend. Same treatment as
+      `dequeueMergeQueueOnColumnExitImpl` (#3060).
       On a renamed board this literal would call an archived card LIVE and refuse the unforced delete,
       except that this class does not run in production. `getMissionStoreImpl` returns the
       AsyncDataLayer-backed `AsyncMissionStore` in PostgreSQL backend mode; the sync `MissionStore`

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -2,7 +2,6 @@
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
     "packages/engine/src/scheduler.ts": 2,
-    "packages/core/src/mission-store.ts": 1,
     "packages/core/src/task-store/audit-ops.ts": 1,
     "packages/core/src/task-store/lifecycle-ops.ts": 1,
     "packages/core/src/task-store/merge-queue-ops-2.ts": 1,
@@ -54,6 +53,7 @@
     "packages/core/src/eval-signal-collector.ts\u0000archived": 1,
     "packages/core/src/live-agent-count.ts\u0000archived": 1,
     "packages/core/src/live-agent-count.ts\u0000done": 1,
+    "packages/core/src/mission-store.ts\u0000archived": 1,
     "packages/core/src/plugin-store.ts\u0000done": 1,
     "packages/core/src/store.ts\u0000archived": 1,
     "packages/core/src/store.ts\u0000done": 1,


### PR DESCRIPTION
Comment-only. `tsc` 0 errors, `census --strict` and `check-fnxc-future-dates` exit 0.

## Claimed with the new tool

First use of `scripts/check-file-claimed.mjs` (#3175) to pick work instead of guessing:

```
CLAIMED    packages/engine/src/scheduler.ts        #3177, #3142
CLAIMED    packages/core/src/task-store/audit-ops.ts   #3165
UNCLAIMED  packages/core/src/mission-store.ts
UNCLAIMED  packages/core/src/task-store/task-id-integrity.ts
```

Two of the four files I would have reached for were already taken — by PRs whose branch names give no hint they touch those paths. That is the collision this phase paid for five times, answered in one command. I took `mission-store.ts`; `task-id-integrity.ts` is still free.

## Census 13 → 12

Reclassification, not conversion — the line is unchanged.

## Verified the blocker rather than deferring to it

The site carries an audited note: the sync `MissionStore` reaches `this.db.prepare`, and `getMissionStoreImpl` returns the `AsyncDataLayer`-backed `AsyncMissionStore` under PostgreSQL, so the class is unreachable in the shipped backend.

I checked that independently instead of accepting it — `async-mission-store.ts:168` states the same routing from the other side. **That check exists because of #3129**, where a note I had accepted as settled ("blocked on a per-neighbour flag map that does not exist") turned out to name the wrong variable, and the file was convertible all along. I had publicly argued it should stay counted.

So the rule I am applying: a documented blocker gets marked only after its named obstacle is confirmed from a second source. Here it held; on `taskRevert.ts` it did not.

## Related, and still open

`merge-queue-ops-2.ts` carries a note of the same shape that does **not** survive this check — it names two ways to convert (make the path async, push the trait read down) and misses the one that worked twice this phase: thread the resolved lanes in from a caller that already awaited them, as #3112 and #3118 did for `executor.ts`. Its sibling `taskStillInReview(projectId, reviewColumns)` already takes lanes from its caller. Worth a real look rather than a marker.