### PR TITLE
test(engine): pin the stalled-card watchdog's terminal skip on a renamed board (13th resolver)

### DIFF
--- a/packages/engine/src/__tests__/self-healing-stalled-card-watchdog.test.ts
+++ b/packages/engine/src/__tests__/self-healing-stalled-card-watchdog.test.ts
@@ -118,6 +118,38 @@ describe("stalled-card watchdog", () => {
     expect(await manager(store).detectStalledCards()).toBe(0);
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-17:45:
+  `sweepTerminalColumns` was UNCOVERED on the #3115 map. The case directly above asserts the terminal
+  skip using `done` and `archived` — the ids — so blinding the resolver leaves it green.
+
+  On a renamed board the skip matched nothing, so FINISHED cards were scanned as live and a card
+  parked in a renamed completion lane could be reported stalled. A watchdog that cries about
+  completed work is worse than a quiet one: it trains operators to ignore the alert, which is the
+  failure mode this sweep's dedup logic exists to avoid.
+  */
+  it("stays silent for a card resting in a RENAMED terminal lane", async () => {
+    const store = storeFor([
+      task("FN-SHIPPED", { column: "shipped", status: "planning" }),
+      task("FN-VAULT", { column: "vault", status: "planning" }),
+    ]);
+    (store as unknown as { listWorkflowDefinitions: unknown }).listWorkflowDefinitions = vi.fn(async () => [{
+      ir: {
+        version: "v2",
+        id: "custom:renamed",
+        nodes: [],
+        edges: [],
+        columns: [
+          { id: "building", name: "building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+          { id: "shipped", name: "shipped", traits: [{ trait: "complete" }] },
+          { id: "vault", name: "vault", traits: [{ trait: "archived" }] },
+        ],
+      },
+    }]);
+
+    expect(await manager(store).detectStalledCards()).toBe(0);
+  });
+
   it("does not re-emit for an unchanged card, but re-alerts once its shape changes", async () => {
     const stalled = task("FN-DEDUP", { column: "triage", status: "planning" });
     const store = storeFor([stalled]);


### PR DESCRIPTION
Thirteenth resolver from the verified coverage map on #3115.

`sweepTerminalColumns` was uncovered: the case directly above it asserts the terminal skip using `done` and `archived` — **the ids** — so blinding the resolver left the file green.

## What the literal costs

The skip matched nothing on a renamed board, so **finished cards were scanned as live**, and a card parked in a renamed completion lane could be reported stalled.

A watchdog that cries about completed work is worse than a quiet one: it trains operators to ignore the alert. That is the exact failure this sweep's own dedup logic was built to avoid, reintroduced through the lane vocabulary.

## The case

The renamed twin of the existing terminal-skip test — same assertion, same shape, different vocabulary. That is the whole point: the original passes either way, so it cannot see the conversion.

**Measured:** 10 pass; blinding `sweepTerminalColumns` fails exactly this case.

## Map status

**13 of 26 pinned** across 12 merged PRs, plus `starvedWaitingColumns` now covered by another worker independently. Re-measure before picking the next one — the map drifts green as the fleet adds coverage, and I have already caught it stale once today.

## Verification

`self-healing-stalled-card-watchdog` **10 passed** · `pnpm test:gate` full pass · lint — green.