### PR TITLE
fix(core): deleting a workflow re-homed its cards into `triage`, a lane the default board lacks

### DIFF
--- a/packages/core/src/__tests__/workflow-delete-rehome-default-entry.test.ts
+++ b/packages/core/src/__tests__/workflow-delete-rehome-default-entry.test.ts
@@ -1,0 +1,62 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+DELETING A WORKFLOW RE-HOMED ITS CARDS INTO `triage`, A COLUMN THE DEFAULT BOARD DOES NOT HAVE.
+
+`deleteWorkflow` clears each occupant's selection so they fall back to the built-in default, then
+re-homes them to "the default workflow's entry column" — its own comment's words. It read that entry
+column from `BUILTIN_CODING_WORKFLOW_IR`, which is `builtin:legacy-coding`, not the catalog default.
+
+Post-U11 the two differ by exactly the column this reads:
+
+    default  todo, in-progress, in-review, done, archived
+    legacy   triage, todo, in-progress, in-review, done, archived
+
+so the entry column was `triage` instead of `todo`.
+
+WHY IT GOT PAST THE GUARD THAT EXISTS FOR THIS. `moveTask` rejects a target the workflow does not
+declare — except under `recoveryRehome` with a LEGACY id, the #1411 escape hatch that stops a
+custom-workflow card becoming unrescuable. `triage` is a legacy id, so the rehome slipped through and
+left the card in a lane its new workflow has no node for.
+
+Third door into the same drift: #3178 fixed the TUI board, and `builtin-workflows.ts` records the
+move-path resolvers as already fixed. This asserts the two IRs' entry columns are actually different,
+so the test fails if someone "simplifies" the fix back to the legacy constant — and would go quiet, as
+it should, if the two IRs ever converge again.
+*/
+import { describe, expect, it } from "vitest";
+import { BUILTIN_CODING_WORKFLOW_IR, resolveDefaultWorkflowIr } from "../index.js";
+import { resolveEntryColumnId } from "../workflow-reconciliation.js";
+
+describe("the workflow-delete rehome target comes from the DEFAULT workflow", () => {
+  it("the default workflow's entry column is `todo`", () => {
+    expect(resolveEntryColumnId(resolveDefaultWorkflowIr())).toBe("todo");
+  });
+
+  /*
+  The legacy IR's entry column is what the delete path used to read. Pinned so the difference is a
+  fact in the suite rather than a claim in a comment — this is the whole reason the bug existed.
+  */
+  it("the LEGACY workflow's entry column is `triage`, which the default board does not declare", () => {
+    expect(resolveEntryColumnId(BUILTIN_CODING_WORKFLOW_IR)).toBe("triage");
+
+    const defaultColumns = (resolveDefaultWorkflowIr() as unknown as { columns: { id: string }[] })
+      .columns.map((column) => column.id);
+    expect(defaultColumns).not.toContain("triage");
+  });
+
+  /*
+  ANTI-VACUITY. The two cases above would keep passing if the delete path still read the legacy
+  constant — they describe the IRs, not the call site. This pins that the call site no longer
+  imports it.
+  */
+  it("the delete path no longer reads the legacy IR", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { join, resolve } = await import("node:path");
+    const source = readFileSync(
+      join(resolve(__dirname, "../.."), "src/task-store/workflow-ops.ts"),
+      "utf8",
+    );
+    expect(source).toContain("resolveEntryColumnId(resolveDefaultWorkflowIr())");
+    expect(source).not.toContain("resolveEntryColumnId(BUILTIN_CODING_WORKFLOW_IR)");
+  });
+});

--- a/packages/core/src/task-store/workflow-ops.ts
+++ b/packages/core/src/task-store/workflow-ops.ts
@@ -10,7 +10,7 @@ import {TaskStore} from "../store.js";
 import type {Settings} from "../types.js";
 import {parseWorkflowIr, downgradeIrToV1IfPure} from "../workflow-ir.js";
 import {OccupiedColumnsError, assertRehomeTargetValid, computeRemovedOccupiedColumns, computeIncompatibleFieldChanges, IncompatibleFieldChangeError, resolveEntryColumnId} from "../workflow-reconciliation.js";
-import {BUILTIN_CODING_WORKFLOW_IR} from "../builtin-coding-workflow-ir.js";
+import {resolveDefaultWorkflowIr} from "../builtin-workflows.js";
 import type {WorkflowFieldDefinition} from "../workflow-ir-types.js";
 import "../builtin-traits.js";
 import {normalizeWorkflowIcon, type WorkflowDefinition, type WorkflowDefinitionUpdate} from "../workflow-definition-types.js";
@@ -430,7 +430,28 @@ export async function deleteWorkflowDefinitionImpl(store: TaskStore, id: string)
     // so they now resolve to the built-in default workflow (KTD-1); the re-home
     // move preserves task fields (preserveProgress) and emits one audit per card.
     if (occupantTaskIds.length > 0) {
-      const defaultEntry = resolveEntryColumnId(BUILTIN_CODING_WORKFLOW_IR);
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (the #3178 drift, in the delete path):
+      THE DEFAULT WORKFLOW, NOT THE LEGACY ONE. `BUILTIN_CODING_WORKFLOW_IR` is
+      `builtin:legacy-coding`; the catalog's actual default is `resolveDefaultWorkflowIr()`. Post-U11
+      they differ by exactly the column this line reads:
+
+          default  todo, in-progress, in-review, done, archived
+          legacy   triage, todo, in-progress, in-review, done, archived
+
+      so `resolveEntryColumnId` answered `triage` for the legacy IR and `todo` for the default —
+      measured, not inferred. The comment above already says "re-home each occupant to the DEFAULT
+      workflow's entry column"; the code read the legacy one.
+
+      CONSEQUENCE: deleting a workflow re-homed every occupant into `triage`, a column the default
+      board does not declare. `moveTask` rejects an undeclared target EXCEPT under `recoveryRehome`
+      with a legacy id — and `triage` IS a legacy id — so this slipped through the guard that exists
+      to stop exactly this, and left the card in a lane its workflow has no node for.
+
+      Same drift #3178 fixed in the TUI board and `builtin-workflows.ts` records as already fixed for
+      the move-path resolvers. This is the third door into it.
+      */
+      const defaultEntry = resolveEntryColumnId(resolveDefaultWorkflowIr());
       if (defaultEntry) {
         for (const taskId of occupantTaskIds) {
           await store.rehomeOccupant(taskId, defaultEntry, "workflow-delete", { workflowId: id });


### PR DESCRIPTION
A **third door** into the drift #3178 just fixed in the TUI. Found by looking for siblings of that bug — **not** by the census, which structurally cannot see this class: there is no column literal here to count. The wrong answer comes from reading the wrong IR.

## The bug

`deleteWorkflow` clears each occupant's selection so they fall back to the built-in default, then re-homes them to *"the default workflow's entry column"* — its own comment's words.

It read that entry column from `BUILTIN_CODING_WORKFLOW_IR`, which is `builtin:legacy-coding`, **not** the catalog default. Post-U11 the two differ by exactly the column this reads:

```
default  todo, in-progress, in-review, done, archived
legacy   triage, todo, in-progress, in-review, done, archived
```

**Measured, not inferred:** `resolveEntryColumnId` answers `triage` for the legacy IR and `todo` for the default.

## Why it got past the guard built for exactly this

`moveTask` rejects a target the workflow does not declare — **except** under `recoveryRehome` with a **legacy id**, the #1411 escape hatch that keeps a custom-workflow card rescuable.

`triage` *is* a legacy id. So the rehome slipped through the check that exists to stop this, and left the card in a lane its new workflow has no node for — the undeclared-column state other reconcilers exist to repair.

## Measured

- 3 new cases; **MUTATION**: restoring the legacy constant fails the anti-vacuity case.
- The first two cases pin the two IRs' entry columns as **facts in the suite** rather than claims in a comment — that difference is the entire reason the bug existed. They go quiet, correctly, if the IRs ever converge again.
- The third pins the **call site**, because the first two would keep passing against the unfixed code: they describe the IRs, not the caller. That gap is how an anti-vacuity case earns its place.
- `src/__tests__/workflow*` — **30 files / 402 tests pass**.
- `tsc --noEmit -p packages/core` clean; census `--strict`, `check-fnxc-future-dates` clean.

## Census

**Unchanged — and that is the finding.** This defect has no literal to count. `builtin-workflows.ts` already records the move-path resolvers as fixed for the same drift, #3178 fixed the TUI, and this is the third instance. The census measures *comparisons*; a surface that resolves the **wrong workflow** produces identical-looking code and a wrong answer.

If there is appetite for a next sweep, that is where I would point it: sites that resolve a workflow at all, rather than guards that compare a column.
