### PR TITLE
test(gate): pin the wrapper-argument capability — #3181 shipped it with no regression case

### DIFF
--- a/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
+++ b/scripts/__tests__/check-inert-sync-lane-conversions.test.mjs
@@ -303,3 +303,46 @@ test("does NOT count an object whose KEY merely shares a sync local's name", () 
     rmSync(probe, { force: true });
   }
 });
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-23:59:
+THE WRAPPER SHAPE HAD NO REGRESSION CASE, so the capability could be removed and every test stay green.
+
+`#3181` taught the scan that a sync answer handed to a wrapper is still a sync answer:
+
+    const parked = mergeParkedColumns(resolveTaskParkedColumnsSync(store, id), lanes);
+
+That recovered thirteen `scheduler.ts` guards which had gone uncounted — the callee is not a source,
+so nothing registered `parked`. But it shipped with no case pinning it: delete the argument check and
+the suite is still green while the thirteen go invisible again. That is the shape this whole gate
+exists to prevent, one layer up in the gate itself.
+
+DEPTH IS DELIBERATELY NOT ASSERTED HERE. This implementation walks arguments recursively, so
+`outer(inner(syncCall(...)))` also taints. That is self-consistent with its own note and may well be
+right — a nested sync value is still a sync value. But it is a CHOICE, and the opposite choice was
+argued on #3122: deeper nesting is where a wrapper is likelier to DISCARD its argument, and a false
+positive there is absorbed into the baseline, which is the direction this ratchet must not fail in.
+
+I have left that question to the author rather than freezing my own answer into a test. What is pinned
+below is only the capability itself, which was shipping with no coverage at all.
+*/
+test("taints a wrapper whose DIRECT argument is a sync call", () => {
+  const probe = join(REPO_ROOT, "packages/engine/src/__probe-inert-wrap1.ts");
+  writeFileSync(probe, [
+    `import { resolveTaskWorkflowIrSync } from "@fusion/core";`,
+    `function localSync(store: unknown, id: string) { return resolveTaskWorkflowIrSync(store as never, id); }`,
+    `function merge(a: unknown, b: unknown) { return (a ?? b) as { hold?: string }; }`,
+    `export function probe(store: unknown, id: string, from: string): boolean {`,
+    `  const lanes = merge(localSync(store, id), { hold: "todo" });`,
+    `  return from !== lanes.hold;`,
+    `}`,
+    "",
+  ].join("\n"));
+  try {
+    assert.equal(liveCounts().byFile["packages/engine/src/__probe-inert-wrap1.ts"], 1);
+  } finally {
+    rmSync(probe, { force: true });
+  }
+});
+
+


### PR DESCRIPTION
**Stacked on #3181.** That PR recovers 13 `scheduler.ts` guards by teaching the scan that a sync answer handed to a wrapper is still a sync answer. It ships with **no test**: delete the argument walk and the entire suite stays green while the 13 go invisible again — the exact failure this gate exists to prevent, one layer up in the gate itself.

Verified as a differential rather than asserted: **removing the capability fails this case (9 pass / 1 fail)**.

## Depth is deliberately not asserted, and that is the interesting part

#3181 walks arguments **recursively**, so `outer(inner(syncCall(...)))` taints as well. I wrote a case pinning one-level behaviour, ran it, and it **failed against this implementation** — so the two PRs disagree about nesting depth.

I removed that case rather than freeze my own answer into a test on someone else's PR. The disagreement is real and worth a decision:

- **recursive (this PR's choice)** — a nested sync value *is* still a sync value, so these are true positives;
- **one level (argued on #3122)** — deeper nesting is where a wrapper is likelier to **discard** its argument, and a false positive there is absorbed into the baseline, which is the direction this ratchet must not fail in, since an inflated allowance later swallows real inert conversions.

Both are defensible. This PR's note is self-consistent — it says *"walking arguments before pushing the call keeps every shape above and adds this one"*, and does exactly that. The #3122 objection was that its code contradicted its own comment, which is a different fault. **Whichever you choose, it should be pinned by a case**, and I am happy to add the one-level case if you decide that way.

## Context: overlapping work, discarded

I had rebased #3122 onto `main` and integrated the same capability on top of #3169 before noticing #3122 was closed **mid-rebase** in favour of this PR. That work is discarded — #3181 is the smaller diff (14 lines vs a helper plus comment block) and reaches the identical count:

```
22 guards = scheduler 13 + triage 7 + executor 2
```

This test is the one piece it was missing.

## Verification

| | result |
|---|---|
| suite | **10 passed** |
| differential — remove the argument walk | **9 pass / 1 fail** |
| gate | exit 0 |
| `check-fnxc-future-dates` | exit 0 |