### PR TITLE
census: --triage's pick-work list was 100% false positives

### DIFF
--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -165,7 +165,21 @@ anywhere in a 40-line window and quietly reclassify live guards as reviewed, whi
 in the opposite direction. These are the literal phrasings present in the tree, added as evidence
 rather than as a net.
 */
-const FLAG_MARKERS = /FLAGGED|LEFT COUNTED|left counted|deliberately NOT converted|Recorded instead|Left as a literal|DELIBERATE-LITERAL|accurate debt|blocked on|NOT CONVERTED|not converted|do not convert|do NOT convert|STAYS INLINE|STILL A LITERAL|archived-column-gate-parity|non-renameable system column|SIZED, NOT/;
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-16:24 (the pick-list was 100% false positives):
+Measured on `main`: `--triage` listed 2 sites as unexamined and BOTH carry a full deferral note —
+`triage.ts:793` ("the arm goes back to the literal, which is honest about being one", restored by
+#3126 after #3114 converted it inertly) and `scheduler.ts:1323` ("the second of the two honest
+literals ... converting it here would be inert"). Neither phrasing was in the set.
+
+Every entry on a list headed "this is the list to pick work from" was already decided. That is the
+harmful direction for this tool and it is not hypothetical: sending a worker at a site whose owner
+wrote down why it must not move is the #3108 -> #3114 -> #3126 sequence, which cost three PRs.
+
+Added phrases are specific to declining a conversion ("honest literal", "would be inert"), not generic
+words, because over-matching hides real work instead. Verified in both directions below.
+*/
+const FLAG_MARKERS = /FLAGGED|LEFT COUNTED|left counted|deliberately NOT converted|Recorded instead|Left as a literal|DELIBERATE-LITERAL|accurate debt|blocked on|NOT CONVERTED|not converted|do not convert|do NOT convert|STAYS INLINE|STILL A LITERAL|archived-column-gate-parity|non-renameable system column|SIZED, NOT|honest literal|honest about being one|would be inert|is inert|the two honest/;
 
 /** Split the column guards into documented-deferral vs unexamined, by comment proximity. */
 function triageFindings() {


### PR DESCRIPTION
## Every entry on the pick-work list was already decided

`--triage` prints a list headed *"unexamined, by file — this is the list to pick work from"*. On `main` it held 2 sites. **Both carry a full deferral note:**

| site | what its note says |
|---|---|
| `triage.ts:793` | *"the arm goes back to the literal, which is **honest about being one**"* — restored by #3126 after #3114 converted it inertly |
| `scheduler.ts:1323` | *"the second of the two **honest literals** … converting it here **would be inert**"* |

Neither phrasing was in the marker set. So the pick-list was **100% false positives**.

## Why this direction of error is the expensive one

Under-reporting a deferral sends a worker at a site whose owner already wrote down why it must not move. That is not a hypothetical failure — it is the sequence that cost three PRs: **#3108** flagged a site with both blockers named and a test behind it, **#3114** converted it anyway hours later, **#3126** reverted it. A pick-list that nominates decided sites reproduces exactly that.

Over-reporting has the opposite failure — it hides real work — so the added phrases are specific to *declining a conversion* (`honest literal`, `would be inert`), not generic words that appear in ordinary notes.

## Verified in both directions

Not asserted. I resolved **each of the 12** remaining guards to its individual marker:

```
 1. scheduler.ts:1238            FLAGGED
 2. scheduler.ts:1323            honest literal
 3. audit-ops.ts:231             Not converted
 4. lifecycle-ops.ts:667         do not convert
 5. merge-queue-ops-2.ts:53      FLAGGED
 6. moves.ts:346                 STAYS INLINE
 7. task-id-integrity.ts:445     Left counted
 8. ResearchTaskActionModal:66   SIZED, NOT
 9. TaskCard.tsx:406             FLAGGED
10. notification-service:1245    FLAGGED
11. self-healing.ts:6054         FLAGGED
12. triage.ts:793                honest about being one
```

**Unexamined is 0.** That is a meaningful state, not just a small number: the conversion backlog is fully *triaged*, every remaining literal has a recorded reason, and the next person to touch one is reading an argument rather than guessing.

## Census before / after

```
before:  COLUMN guards (the backlog):   12
after:   COLUMN guards (the backlog):   12
```

Unchanged, as required — `--triage` is opt-in and moves no count and no exit code. `--json` and `--strict` verified unaffected.

## Verification

`test:gate` exit 0 · `--strict` exit 0 · `--json` exit 0 · plus `fnxc-future-dates`, `lifecycle-columns`, `inert-sync-lanes`, `quarantine-ledger`, `inert-flag-seams`, `lane-wiring`, `sql-column-literals` — all exit 0. One script; no production file touched.

*Process note: my first draft of this PR carried a future-dated FNXC stamp — the third time I have done that. I have switched to taking the stamp from `date -u` per #3174 rather than typing it, and my pre-push run of the full `pr-checks` ratchet set (not `test:gate` alone) caught it before it left the branch, which is what that habit is for.*
