### PR TITLE
fix(triage): the plan-release move target hit a column renamed boards don't have — and its test was passing for the wrong reason

### DIFF
--- a/packages/engine/src/__tests__/triage-release-renamed-hold.test.ts
+++ b/packages/engine/src/__tests__/triage-release-renamed-hold.test.ts
@@ -144,10 +144,19 @@ function createStore(task: Task, ir: WorkflowIr | null): { store: TaskStore; mov
     getTaskWorkflowSelection: vi.fn(() => selection),
     getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
     getWorkflowDefinition: vi.fn(async () => (ir ? { ir } : null)),
-    resolveTaskWorkflowIrSync: vi.fn(() => {
-      if (!ir) throw new Error("unresolvable");
-      return ir;
-    }),
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59:
+    THE SYNC READER STUB IS GONE, and its absence is the point.
+
+    This harness fed `resolveTaskWorkflowIrSync` the test's own IR — the shape this repo's learnings
+    call out as feeding the broken reader the right answer. In production that reader answers with the
+    DEFAULT board for every task, so the suite proved the release LOGIC while being structurally
+    unable to notice that the real call site resolved nothing.
+
+    The release target now resolves through the async path (`getTaskWorkflowSelectionAsync` +
+    `getWorkflowDefinition`, both mocked below), which is what production actually takes. Removing the
+    stub is what makes these cases evidence about production rather than about the fixture.
+    */
   };
   return { store: store as unknown as TaskStore, moveTaskIf };
 }

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -4443,7 +4443,19 @@ export class TriageProcessor {
       if (!await this.updatePlanningStateIfStillCurrent(task, { title: promptDeclaredTitle })) return;
     }
 
-    const releaseTarget = resolvePlannerLanes(this.store, task.id).hold;
+    /*
+    FNXC:WorkflowResolvedColumns 2026-07-31-23:59 (SYNC -> ASYNC — this one is a MOVE TARGET):
+    `resolvePlannerLanes` answers with the DEFAULT board under PostgreSQL, so on a renamed board this
+    released a finalized plan to the legacy `todo` — a column that board does not declare. The move
+    below is the handoff, and `moveTaskInternal` REJECTS an undeclared target, so the card stayed in
+    the planner lane with a finished spec. The note directly under this line says that failure must
+    never be silent; it was not silent, it was just always failing off the default lineage.
+
+    `finalizeApprovedTaskBody` is `async` and this is a plain statement in its body — the line above
+    already awaits — so there is no ordering constraint here, unlike the two sync `task:*` handlers
+    earlier in this file which stay literal for reasons written at those sites.
+    */
+    const releaseTarget = (await resolvePlannerLanesForTaskAsync(this.store, task.id)).hold;
     if (task.column !== releaseTarget) {
       const moveTaskIf = (this.store as unknown as { moveTaskIf?: TaskStore["moveTaskIf"] }).moveTaskIf;
       if (typeof moveTaskIf !== "function") {


### PR DESCRIPTION
**Stacked on #3191** (which now also carries #3193). Third `triage.ts` site unblocked by the same mechanism.

## The defect

`finalizeApprovedTaskBody` computed its release target through `resolvePlannerLanes`, which answers with the **default board** under PostgreSQL. So on a renamed board the planning handoff targeted the legacy `todo`, `moveTaskInternal` **rejects** an undeclared target, and a card holding a **finished spec** stayed in the planner lane.

The note directly under that line says the failure must never be silent. It was not silent — it was always failing off the default lineage.

Safe to await: the method is `async` and the line above already awaits, unlike the two sync `task:*` handlers earlier in this file which stay literal for reasons written at their sites.

## The more useful half: the existing test was passing for the wrong reason

`triage-release-renamed-hold.test.ts` opens with:

> Written against the literal implementation and observed FAILING first.

But its harness stubbed `resolveTaskWorkflowIrSync` to return the test's own IR — the exact shape this repo's learnings name: **feeding the broken reader the right answer**. In production that reader answers with the default board for every task, so the suite proved the release *logic* while being structurally unable to notice the real call site resolved nothing.

The stub is deleted. The target now resolves through the async path the mock already provides:

| | result |
|---|---|
| with conversion, no stub | **5 passed** |
| sync resolver, no stub | **1 failed \| 4 passed** — the test now discriminates |

That second row is the differential the file claimed to have and did not.

## Measured

- broad suite (triage / finalize / planning / self-healing): **84 files, 1356 tests passed**
- post-rebase, directly affected suites: **237 passed**
- `census --strict`, `check-inert-sync-lanes`, `check-fnxc-future-dates`: exit 0

**The inert count is unchanged at 4 for `triage.ts`** — this guard compares against a *local*, so the ratchet never saw it. Not a ratchet reduction; a real fix the ratchet cannot count, same class as #3191. Stating it so the numbers are not read as more than they are.

## What remains in this file

Two sites stay literal: the `task:moved` wake handler and the evacuation handler — both **synchronous arrow callbacks** whose answers are consumed in-tick. That is the genuine sync-emitter constraint documented at each site, and it needs the emitter-side work in #3082, not a resolver swap.