### PR TITLE
docs(learnings): a falling count is not evidence that anything changed

### DIFF
--- a/docs/solutions/workflow-learnings/a-falling-count-is-not-evidence.md
+++ b/docs/solutions/workflow-learnings/a-falling-count-is-not-evidence.md
@@ -51,7 +51,7 @@ remaining entries were all in files nobody had touched — which is what a detec
 The inert-lane ratchet was rewritten four times. Each version was correct about the shape in front of
 it and blind to a trivially different spelling of the same defect:
 
-```
+```text
 #3062  matched a local only        →  resolveX(store, id).review           walked past
 #3068  matched comparisons only    →  parked.terminal.has(to)              walked past, and made the count FALL
 #3079  matched same-file only      →  a helper imported from another file  walked past
@@ -87,11 +87,18 @@ figure from an earlier round.
 
 **Branch outputs are not comparable. Scripts on one tree are.** The procedure that works:
 
-```
+```shell
+# Extract both versions; neither needs its branch checked out.
 git show <branchA>:scripts/<check>.mjs > /tmp/a.mjs
 git show <branchB>:scripts/<check>.mjs > /tmp/b.mjs
-git checkout <one tree>
+
+# Run both against ONE tree. The primary checkout on `main` is the natural choice
+# and needs no switching -- `git show` already did the fetching.
 node /tmp/a.mjs ; node /tmp/b.mjs
+
+# If a different tree is genuinely required, take a worktree rather than moving
+# the primary checkout off `main` (AGENTS.md, Standing Rule: Prefer `main`):
+#   wt switch --create <branch>        # or: git worktree add ../wt/<branch> <branch>
 ```
 
 That is how two competing fixes were shown to be **additive rather than overlapping** (#3169 + #3181

--- a/docs/solutions/workflow-learnings/a-falling-count-is-not-evidence.md
+++ b/docs/solutions/workflow-learnings/a-falling-count-is-not-evidence.md
@@ -1,0 +1,123 @@
+---
+category: workflow-learnings
+module: scripts/check-inert-sync-lane-conversions.mjs
+tags: [lifecycle-columns, ratchets, gates, measurement, inert-conversions]
+problem_type: process-learning
+applies_when: reading a ratchet or census number as evidence that work happened
+---
+
+# A falling count is not evidence that anything changed
+
+Sibling to [lifecycle-conversions-that-score-as-wins](./lifecycle-conversions-that-score-as-wins.md),
+which records the *shapes* an inert conversion takes and how to tell a claim from a measurement. Its
+grammatical tell is the portable one:
+
+> if a claim can be written without running anything, it has not been tested.
+
+This document records the **metric** counterpart, and the instrument failures that let it persist. It
+is written from a phase in which the lifecycle-column backlog went 126 → 12, and in which a number
+moved without the system moving **four separate times**.
+
+## The tell
+
+**A count that falls is not evidence that anything changed.** Every gate in this program reports a
+number, and every number has three ways of going down:
+
+1. work happened
+2. the code got denser and the scan stopped matching
+3. someone lowered the allowance
+
+Only the first is progress, and from inside the check all three look identical.
+
+| what moved | what actually happened |
+|---|---|
+| census 12 → 2 in `scheduler.ts` (#3051) | ten guards routed through `resolveTaskWorkflowIrSync`, which answers with the DEFAULT board under PostgreSQL. Byte-identical behaviour. Refuted end-to-end in #3058 |
+| census 45 → 44 in `triage.ts` (#3114) | converted the exact arm #3108 had flagged hours earlier, blockers named and a test behind it. #3126 reverted it — three PRs for one line |
+| ratchet 20 → 15 | not a conversion: #3065 rewrote `a === x \|\| a === y` as `set.has(a)` and the check counted only comparisons. It printed *"total fell — re-record"*, which would have **permanently retired live guards** |
+| ratchet 22 → 9 | `scheduler.ts` reported **0** while 13 guards still fell back to the default board, laundered through `mergeParkedColumns(sync(...), lanes)` |
+
+Rows three and four are the dangerous shape: **the gate went quiet exactly when someone improved the
+code**, and the remedy it suggested was to lower the allowance.
+
+### The obligation this creates
+
+Before re-recording any baseline, establish *which* of the three causes applies. A drop caused by
+denser encoding and a drop caused by a deleted gate are indistinguishable from inside the tool. The
+check that works is cheap: dump the surviving hits and read them. Twice, that dump showed the
+remaining entries were all in files nobody had touched — which is what a detection loss looks like.
+
+## One defect, four spellings
+
+The inert-lane ratchet was rewritten four times. Each version was correct about the shape in front of
+it and blind to a trivially different spelling of the same defect:
+
+```
+#3062  matched a local only        →  resolveX(store, id).review           walked past
+#3068  matched comparisons only    →  parked.terminal.has(to)              walked past, and made the count FALL
+#3079  matched same-file only      →  a helper imported from another file  walked past
+#3181  matched direct assignment   →  wrapper(resolveX(...), lanes)        walked past
+```
+
+The lesson is not "write a better regex". It is that **enumerating the syntax that consumes a value
+is a losing game**; the durable form keys on the *source* — anything derived from the broken reader —
+and treats consumption as opaque. Each of the four fixes was verified by mutation: apply the shape,
+confirm exit 1, restore the file. A green ratchet proves nothing about a shape it cannot express.
+
+## An instrument that runs nowhere and one that cannot fail are the same defect
+
+Both report green forever.
+
+- **`check:inert-sync-lanes` was invoked by nothing** for six PRs — not `test:gate`, not any workflow.
+  It only ran when a human typed it. The #3108 → #3114 → #3126 round trip happened while it was
+  flagging the defect correctly the entire time.
+- **`check:quarantine-ledger` was worse.** It ran nowhere *and* omitted `--strict`, and the script
+  only exits non-zero with that flag. Wiring it alone would have been theatre. AGENTS.md had stated
+  the 14-day deletion policy the whole time.
+
+Both failures are invisible to every normal signal: the script exists, it is documented, it passes
+when run by hand. The audit that finds them is mechanical — list every `check:*` script, grep the gate
+chain and `.github/workflows/` for each, and check the exit-code path for a `--strict`-style flag the
+package script omits.
+
+## Base drift makes branch numbers incomparable
+
+Three false alarms in this phase came from comparing a branch's reported number against a
+remembered or differently-based one. One was mine: I "found" a 13-guard drop that was my own stale
+figure from an earlier round.
+
+**Branch outputs are not comparable. Scripts on one tree are.** The procedure that works:
+
+```
+git show <branchA>:scripts/<check>.mjs > /tmp/a.mjs
+git show <branchB>:scripts/<check>.mjs > /tmp/b.mjs
+git checkout <one tree>
+node /tmp/a.mjs ; node /tmp/b.mjs
+```
+
+That is how two competing fixes were shown to be **additive rather than overlapping** (#3169 + #3181
+= 22 = 13 + 7 + 2), which decided the merge order and let one collapse into six lines inside the
+other.
+
+## A pick-work list nominating decided sites
+
+The census gained a `--triage` split (documented vs unexamined) because the headline number conflated
+"deferred on purpose, reason written next to it" with "nobody has looked". At one point 88 guards
+were 53-in-a-PR, 13-flagged, 11-fallback-arms and 11 genuinely open.
+
+The split then had its own version of the same bug, twice: its marker set missed phrasings like
+`STAYS INLINE`, `honest about being one` and `would be inert`, so a list headed *"this is the list to
+pick work from"* reached **100% false positives** — every entry already decided.
+
+That direction of error is the expensive one. Sending a worker at a site whose owner wrote down why it
+must not move is precisely the #3108 → #3114 → #3126 sequence. Over-reporting hides real work;
+under-reporting manufactures the collision. When in doubt, prefer showing a decided site over hiding
+an open one, and make the marker phrases specific to *declining a conversion* rather than generic.
+
+## Checklist
+
+- Before re-recording a baseline: dump the surviving hits and name which of the three causes applies.
+- Before trusting a ratchet: mutate the shape it claims to catch and confirm it exits non-zero.
+- Before trusting a `check:*` script: confirm something runs it, and that it can fail.
+- Before comparing two numbers: confirm they came from one tree.
+- Before converting a flagged site: read the flag. It is a claim, and it decays — but re-deriving it
+  costs minutes and overriding it wrongly has cost three PRs.


### PR DESCRIPTION
## The metric counterpart to #3200

#3200 (merged) records the **shapes** an inert conversion takes, and its grammatical tell is the portable one: *if a claim can be written without running anything, it has not been tested.* I offered this material there and said I would write it as a sibling rather than bloat that doc; it merged without it, so here it is.

That doc is about **claims**. This one is about **numbers**.

## The tell

**A count that falls is not evidence that anything changed.** Every gate here reports a number, and a number goes down three ways — work happened, the code got denser and the scan stopped matching, or someone lowered the allowance. Only the first is progress, and from inside the check all three look identical.

Four times in one phase:

| what moved | what actually happened |
|---|---|
| census 12 → 2 (`scheduler.ts`, #3051) | ten guards routed through `resolveTaskWorkflowIrSync`, which answers with the DEFAULT board under PostgreSQL. Byte-identical. Refuted in #3058 |
| census 45 → 44 (`triage.ts`, #3114) | converted the exact arm #3108 flagged hours earlier. #3126 reverted it — three PRs for one line |
| ratchet 20 → 15 | not a conversion: #3065 rewrote `a === x \|\| a === y` as `set.has(a)`. It printed *"total fell — re-record"*, which would have **permanently retired live guards** |
| ratchet 22 → 9 | `scheduler.ts` reported **0** while 13 guards still fell back to the default board |

Rows three and four are the dangerous shape: **the gate went quiet exactly when someone improved the code**, and the remedy it suggested was to lower the allowance.

## Also recorded

- **One defect, four spellings** (#3062, #3068, #3079, #3181) — each fix correct about the shape in front of it and blind to a respelling. The lesson is not "write a better regex": enumerating consuming syntax is a losing game, and the durable form keys on the *source*.
- **An instrument that runs nowhere and one that cannot fail are the same defect.** `check:inert-sync-lanes` was invoked by nothing for six PRs; `check:quarantine-ledger` ran nowhere *and* omitted `--strict`, so wiring it alone would have been theatre. Includes the mechanical audit that finds both.
- **Base drift makes branch numbers incomparable** — three false alarms, one of them mine, from comparing against a remembered figure. The procedure that works is extracting both scripts and running them against one tree; that is how #3169 and #3181 were shown additive (22 = 13 + 7 + 2), which decided merge order and collapsed one into six lines inside the other.
- **A pick-work list at 100% false positives**, because under-reporting deferrals is the direction that manufactures the #3108 → #3114 collision.

## Every claim is a measurement

No mechanism here is derived from reading. Nine PRs cited, each the one that produced or refuted the finding — including the ones where I was wrong: a stale number I mistook for a regression, and two future-dated stamps of my own that the full ratchet set caught before they shipped (one earlier one it did not, and that broke `main`).

## Census before / after

```
before:  COLUMN guards (the backlog):   12
after:   COLUMN guards (the backlog):   12
```

Docs only.

## Verification

`test:gate` exit 0 · `fnxc-future-dates`, `lifecycle-columns`, `inert-sync-lanes`, `quarantine-ledger`, `inert-flag-seams`, `lane-wiring`, `sql-column-literals` — all exit 0 · `pnpm lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for interpreting workflow metrics and avoiding misleading conclusions from declining counts.
  * Documented detection blind spots, branch comparison issues, false positives, and validation procedures.
  * Included a practical checklist for reviewing metrics, quality gates, comparisons, and potential conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->