### PR TITLE
fix(census): the bare command could not say the conversion queue is EMPTY — and a test fix for main

### DIFF
--- a/packages/engine/src/__tests__/lifecycle-column-census.test.ts
+++ b/packages/engine/src/__tests__/lifecycle-column-census.test.ts
@@ -22,6 +22,7 @@ import {
   stripComments,
   summarize,
   mixedVocabularyFiles,
+  hasDeferralNote,
 } from "../../../../scripts/lib/lifecycle-column-census.mjs";
 
 function census(source: string) {
@@ -833,4 +834,68 @@ describe("the ratchet follows the count down", () => {
     expect(run1.code).toBe(1);
     expect(run1.out).toContain("column-guard count ROSE");
   }, 30_000);
+});
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-10:50 (u12 — the rule that decides where the fleet is sent):
+`hasDeferralNote` is what splits the backlog into "debt with a written reason" and "work nobody has
+examined", and the census's default output now states a CONVERSION QUEUE EMPTY verdict from it. A
+rule that only ever answers "deferred" would report the queue empty forever and silently stop the
+fleet; a rule that only ever answers "unexamined" would send workers at sites whose owner wrote down
+why they must not move (the #3108 -> #3114 -> #3126 sequence, three PRs). So it is pinned in BOTH
+directions, and the window boundary is pinned exactly — 40 lines above the guard, not the guard's line.
+*/
+describe("the deferral-note rule the queue-empty verdict is computed from", () => {
+  const guardLine = (noteOffsetAbove: number, note: string): { lines: string[]; line: number } => {
+    const lines = Array.from({ length: 60 }, () => "// filler");
+    const line = 55; // 1-indexed line of the guard
+    lines[line - 1 - noteOffsetAbove] = note;
+    return { lines, line };
+  };
+
+  it("flags a guard whose deferral note sits within the 40-line window", () => {
+    const { lines, line } = guardLine(5, "// DELIBERATE-LITERAL — a sentinel, not a board lane.");
+
+    expect(hasDeferralNote(lines, line)).toBe(true);
+  });
+
+  it("does NOT flag a guard with no note — this is what keeps the queue from reading empty forever", () => {
+    const lines = Array.from({ length: 60 }, () => "// ordinary comment, no deferral language");
+
+    expect(hasDeferralNote(lines, 55)).toBe(false);
+  });
+
+  it("does NOT reach a note further above than the window", () => {
+    // 41 lines above is outside [line-41, line); this pins the boundary rather than the neighbourhood.
+    const { lines, line } = guardLine(41, "// FLAGGED AND LEFT COUNTED");
+
+    expect(hasDeferralNote(lines, line)).toBe(false);
+  });
+
+  it("reaches a note exactly at the window edge", () => {
+    const { lines, line } = guardLine(40, "// FLAGGED AND LEFT COUNTED");
+
+    expect(hasDeferralNote(lines, line)).toBe(true);
+  });
+
+  it("does not count a note BELOW the guard as deferring it", () => {
+    const lines = Array.from({ length: 60 }, () => "// filler");
+    lines[56] = "// DELIBERATE-LITERAL — belongs to the NEXT guard, not this one.";
+
+    expect(hasDeferralNote(lines, 55)).toBe(false);
+  });
+
+  it("recognises the phrasings the real tree actually uses", () => {
+    // Each is verbatim from a site currently counted as deferred; a regex edit that drops one
+    // silently converts that file into fleet work.
+    for (const note of [
+      "FNXC:WorkflowResolvedColumns (fleet phase — FLAGGED AND LEFT COUNTED):",
+      "(fleet — FLAGGED, deliberately NOT converted):",
+      "(audited — DEAD SYNC PATH, do not convert):",
+      "DELIBERATE-LITERAL: a SENTINEL, not a board lane.",
+      "a conversion here would be inert",
+    ]) {
+      expect(hasDeferralNote([note, "const x = 1;"], 2), note).toBe(true);
+    }
+  });
 });

--- a/packages/engine/src/__tests__/lifecycle-column-census.test.ts
+++ b/packages/engine/src/__tests__/lifecycle-column-census.test.ts
@@ -564,8 +564,18 @@ describe("the baseline can always be re-recorded", () => {
       const claimed = out.slice(out.indexOf("CLAIMED by an open PR"), out.indexOf("UNCLAIMED:"));
       expect(claimed).toContain(target);
       expect(claimed).toContain("#9999");
-      /* And it must LEAVE that file out of the start-here list, which is the half that matters. */
-      expect(out.slice(out.indexOf("UNCLAIMED:"))).not.toContain(`  ${target}\n`);
+      /* And it must LEAVE that file out of the start-here list, which is the half that matters.
+
+      FNXC:LifecycleColumnCensus 2026-07-31-10:55 (u12 — this slice was UNBOUNDED and read the wrong section):
+      `slice(indexOf("UNCLAIMED:"))` ran to END OF OUTPUT, so it also covered the SYNC-RESOLVED section
+      printed after the unclaimed block — and that section legitimately lists `scheduler.ts`. The bug was
+      latent while the top remaining file was something else; it became a hard failure the moment the
+      backlog shrank enough for `scheduler.ts` (2 guards) to become `topRemainingFile()`, which is a state
+      every conversion moves toward. Bounded to the unclaimed block's own terminator so it measures the
+      claim/unclaim split it names, not whatever the report prints next. */
+      const unclaimedBlock = out.slice(out.indexOf("UNCLAIMED:"), out.indexOf("A touched file is not proof"));
+      expect(unclaimedBlock).not.toBe("");
+      expect(unclaimedBlock).not.toContain(`  ${target}\n`);
     });
 
     /*

--- a/scripts/lib/lifecycle-column-census.mjs
+++ b/scripts/lib/lifecycle-column-census.mjs
@@ -265,3 +265,23 @@ export function mixedVocabularyFiles(byFile, readFile) {
   }
   return mixed.sort((a, b) => b.count - a.count);
 }
+
+/*
+FNXC:LifecycleColumnCensus 2026-07-31-10:40 (u12 — extraction, no behavior change):
+`FLAG_MARKERS` and the 40-line proximity window moved here VERBATIM from the CLI wrapper so the
+deferral classification is reachable from `packages/engine/src/__tests__/lifecycle-column-census.test.ts`,
+which imports this module. It was previously a private const plus an inline `.slice()` inside the CLI,
+so the only way to exercise it was to run the whole script against the real tree — which is why the
+rule had no test in either direction despite deciding what work the fleet is sent at.
+
+Window is `[line-41, line)`: the 40 lines ABOVE the guard, excluding the guard's own line.
+*/
+export const FLAG_MARKERS = /FLAGGED|LEFT COUNTED|left counted|deliberately NOT converted|Recorded instead|Left as a literal|DELIBERATE-LITERAL|accurate debt|blocked on|NOT CONVERTED|not converted|do not convert|do NOT convert|STAYS INLINE|STILL A LITERAL|archived-column-gate-parity|non-renameable system column|SIZED, NOT|honest literal|honest about being one|would be inert|is inert|the two honest/;
+
+/**
+ * True when a guard at 1-indexed `line` carries a documented deferral note in the 40 lines above it.
+ * `lines` is the file's source split on newlines.
+ */
+export function hasDeferralNote(lines, line) {
+  return FLAG_MARKERS.test(lines.slice(Math.max(0, line - 41), line).join(" "));
+}

--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -47,6 +47,7 @@ import {
   censusFiles as censusFilesText,
   summarize as summarizeText,
   mixedVocabularyFiles,
+  hasDeferralNote,
 } from "./lib/lifecycle-column-census.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -179,7 +180,7 @@ wrote down why it must not move is the #3108 -> #3114 -> #3126 sequence, which c
 Added phrases are specific to declining a conversion ("honest literal", "would be inert"), not generic
 words, because over-matching hides real work instead. Verified in both directions below.
 */
-const FLAG_MARKERS = /FLAGGED|LEFT COUNTED|left counted|deliberately NOT converted|Recorded instead|Left as a literal|DELIBERATE-LITERAL|accurate debt|blocked on|NOT CONVERTED|not converted|do not convert|do NOT convert|STAYS INLINE|STILL A LITERAL|archived-column-gate-parity|non-renameable system column|SIZED, NOT|honest literal|honest about being one|would be inert|is inert|the two honest/;
+/* Moved to ./lib/lifecycle-column-census.mjs so the rule is testable; imported above. */
 
 /** Split the column guards into documented-deferral vs unexamined, by comment proximity. */
 function triageFindings() {
@@ -197,8 +198,7 @@ function triageFindings() {
       lines = readFileSync(join(REPO_ROOT, f.file), "utf8").split("\n");
       sourceCache.set(f.file, lines);
     }
-    const window = lines.slice(Math.max(0, f.line - 41), f.line).join(" ");
-    (FLAG_MARKERS.test(window) ? flagged : open).push(f);
+    (hasDeferralNote(lines, f.line) ? flagged : open).push(f);
   }
   return { flagged, open };
 }

--- a/scripts/lifecycle-column-census.mjs
+++ b/scripts/lifecycle-column-census.mjs
@@ -220,6 +220,31 @@ if (json) {
   while both engine defects (#2670, #2672) were literals in a separate statement instead.
   */
   console.log(`  of the column guards, ${summary.traitFallbackCount ?? 0} are trait-fallback branches (already converted)`);
+  /*
+  FNXC:LifecycleColumnCensus 2026-07-31-10:45 (u12 — the bare command could not say "done"):
+  The availability verdict lived ONLY behind `--claims`, which shells to `gh`. The fleet instruction
+  says to run this script with NO flags, so a worker following it saw per-file counts, read a nonzero
+  backlog as a work queue, and picked a file whose guard was already documented as deferred. Counts
+  alone cannot distinguish "work left" from "debt left" — that is what `--triage` measures, and it was
+  opt-in too.
+
+  Measured cost: the conversion queue reached ZERO unexamined guards while the fleet was still being
+  dispatched to "claim the largest cluster", because nothing in the default output said so. The last
+  three files re-audited this way (merge-queue-ops-2, lifecycle-ops, notification-service) were all
+  already documented; only one was reclassifiable, and by DELETION rather than conversion (#3205).
+
+  Uses LOCAL signals only, so it is honest without network. It reports what it can prove — that no
+  UNEXAMINED guard remains — and explicitly does NOT claim the files are unclaimed, because only
+  `--claims` can see open PRs.
+  */
+  const { open: unexaminedGuards } = triageFindings();
+  if (summary.totals.column > 0 && unexaminedGuards.length === 0) {
+    console.log(`\n  CONVERSION QUEUE EMPTY: all ${summary.totals.column} remaining column guard(s) carry a documented deferral note.`);
+    console.log(`  There is no unexamined guard to claim. A nonzero backlog above is DEBT, not a work queue.`);
+    console.log(`  Re-read the note at a site before converting it; run --claims to also check open-PR ownership.`);
+  } else if (unexaminedGuards.length > 0) {
+    console.log(`\n  ${unexaminedGuards.length} unexamined guard(s) remain (no deferral note) — run --triage to list them by file.`);
+  }
   if (triage) {
     const { flagged, open } = triageFindings();
     console.log(`\n  TRIAGE (heuristic, opt-in; changes no count and no exit code)`);


### PR DESCRIPTION
## Why this exists

The fleet instruction is *"claim the largest unclaimed census file cluster (`node scripts/lifecycle-column-census.mjs`)"*. That command cannot answer it. The availability verdict lived **only** behind `--claims`, which shells to `gh`:

```
line 342:  if (claims && !json) {
```

So a worker following the instruction literally sees per-file counts, reads a nonzero backlog as a work queue, and picks a file whose guard is already documented as deferred. Counts alone cannot separate *work left* from *debt left*.

**Measured cost:** the queue reached **zero unexamined guards** while dispatch continued. I re-audited the last three candidates — `merge-queue-ops-2`, `lifecycle-ops`, `notification-service` — and all three were already documented. Only one was reclassifiable, and by **deletion** rather than conversion (#3205).

## What the bare command prints now

```
  COLUMN guards (the backlog):   11

  CONVERSION QUEUE EMPTY: all 11 remaining column guard(s) carry a documented deferral note.
  There is no unexamined guard to claim. A nonzero backlog above is DEBT, not a work queue.
  Re-read the note at a site before converting it; run --claims to also check open-PR ownership.
```

Or, when work does exist: `N unexamined guard(s) remain (no deferral note) — run --triage to list them by file.`

**Local signals only**, so it is honest offline. It reports what it can prove — no *unexamined* guard remains — and explicitly does **not** claim the files are unclaimed, because only `--claims` sees open PRs. No count, no exit code, `--strict`/`--json` untouched.

## Three commits, deliberately separated

1. **`refactor`** — move `FLAG_MARKERS` + the 40-line window into the lib as `hasDeferralNote()`, verbatim. It was a private const plus an inline `.slice()` in the CLI, so the rule deciding where the fleet is sent had **no test in either direction**. Proven identical on the real tree: `11 documented / 0 unexamined` before and after.
2. **`feat`** — the verdict + 6 tests.
3. **`fix`** — an unrelated pre-existing failure (below).

## The test fix — this one is turning main red

`attributes a remaining file to the open PR that touches it` asserted over `out.slice(out.indexOf("UNCLAIMED:"))`, which runs to **end of output** and so also covers the `SYNC-RESOLVED` section printed afterward. That section legitimately lists `scheduler.ts`.

Latent until `topRemainingFile()` returned `scheduler.ts` — which happened as the backlog shrank, **a state every conversion moves toward**. Confirmed pre-existing: clean `origin/main` runs `42 passed / 1 failed` with the identical message.

## Evidence

| check | result |
|---|---|
| `hasDeferralNote` tests | both directions, boundary exact at 40 above / not below, 5 real phrasings |
| verdict control (by hand) | one tracked undocumented guard → **11 → 12**, verdict flips to `1 unexamined`; removed → restored |
| test-fix anti-vacuity | claim split broken → **FAILS**; restored → passes |
| census file | **49 passed** (was 42 passed / 1 failed) |
| `census --strict` / `check:fnxc-future-dates` | exit 0 / exit 0 |
| `pnpm test:gate` | **exit 0** (732 tests) |

The verdict control was **invalid on the first attempt** — my probe file was untracked and `git ls-files` never scanned it, so the verdict did not flip and nothing was proven. Recording that because a control that silently proves nothing is the exact failure this PR is about.

## Census before / after

No guard converted here; this is tooling. Backlog unchanged at 11, all deferred.