### PR TITLE
chore(fnxc): tighten the future-dates baseline — merge-queue-ops-2 4 -> 3

### DIFF
--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -29,7 +29,7 @@
   "packages/core/src/store.ts": 2,
   "packages/core/src/task-store/archive-lifecycle-2.ts": 2,
   "packages/core/src/task-store/branch-group-ops.ts": 1,
-  "packages/core/src/task-store/merge-queue-ops-2.ts": 4,
+  "packages/core/src/task-store/merge-queue-ops-2.ts": 3,
   "packages/core/src/task-store/task-artifacts-ops.ts": 6,
   "packages/core/src/task-store/task-store-helpers.ts": 2,
   "packages/core/src/task-store/update-task-deps.ts": 5,


### PR DESCRIPTION
One-line baseline tightening, produced by the gate's own auto-tighten path.

`check-fnxc-future-dates` deliberately auto-tightens rather than failing on a drop, because its population moves with the calendar and a drop has **no author** — the counterpart asymmetry to `check-inert-sync-lane-conversions`, where a drop *does* have an author and must fail. Any gate run regenerates this; `main`'s committed baseline had simply not caught up.

**Why this isn't churn:** left loose, the baseline permits 4 future stamps in a file that now has 3. That slack silently absorbs one genuine future-dated stamp — precisely the failure this gate exists to catch, and one the fleet hit four times in a single day (`scheduler.ts`, a scheduler PG test, `task-update.ts` twice by different authors), each a real time on the wrong day that passed locally and reddened `main` for everyone else.

Verified: both `check-fnxc-future-dates` and `check-inert-sync-lane-conversions` green on the tightened baseline.

No changeset: tooling baseline, no published-package surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)