### PR TITLE
fix(self-healing): a renamed hold lane re-logged the same overlap blocker on every sweep

### DIFF
--- a/packages/engine/src/__tests__/self-healing-fake-overlap-seam.test.ts
+++ b/packages/engine/src/__tests__/self-healing-fake-overlap-seam.test.ts
@@ -225,6 +225,44 @@ describe("SelfHealingManager stale-blocker cleanup on a RENAMED board", () => {
     manager.stop();
   });
 
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-12:25 (u12 — the log-dedup memo, on a renamed hold lane):
+  `clearStaleBlockedBy` remembers which overlap blocker it already logged per task so a sweep every few
+  seconds does not repeat the same line forever. The memo was retained only while the card sat in a
+  column matching the literal `todo`, so on a renamed board it was dropped on EVERY sweep and the
+  "still blocked by file scope overlap" line was re-logged each time.
+
+  Drives the sweep TWICE, because a single pass cannot observe a dedup memo at all.
+  */
+  it("does not re-log the same overlap blocker on a renamed HOLD lane", async () => {
+    const staleBlocker = makeTask("FN-DONE-BLOCKER", { column: "shipped" });
+    const overlapBlocker = makeTask("FN-ACTIVE-OVERLAP", { column: "building" });
+    const dependent = makeTask("FN-DEPENDENT", {
+      column: "drafting",
+      status: "queued",
+      blockedBy: staleBlocker.id,
+      overlapBlockedBy: overlapBlocker.id,
+      dependencies: [staleBlocker.id],
+    });
+    const { store } = createRenamedBoardStore([staleBlocker, overlapBlocker, dependent]);
+    const manager = new SelfHealingManager(store, {
+      rootDir: "/tmp/test-project",
+      getExecutingTaskIds: () => new Set<string>(),
+    });
+
+    await manager.clearStaleBlockedBy();
+    await manager.clearStaleBlockedBy();
+
+    const overlapLogs = vi.mocked(store.logEntry).mock.calls.filter(
+      ([, message]) => typeof message === "string" && message.includes("still blocked by file scope overlap"),
+    );
+    /* Pre-fix this was 2: `memoTask?.column !== "todo"` was true for `drafting`, so the memo was
+       cleared after the first sweep and the second re-logged the identical line. */
+    expect(overlapLogs).toHaveLength(1);
+
+    manager.stop();
+  });
+
   it("preserves an overlap blocker resting in a RENAMED review column", async () => {
     /* The review half of the predicate, which takes a different branch (worktree + status). */
     const staleBlocker = makeTask("FN-DONE-BLOCKER", { column: "shipped" });

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -6033,33 +6033,6 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       for (const task of blockedTasks) candidates.set(task.id, task);
       for (const task of queuedDependencyTasks) candidates.set(task.id, task);
 
-      for (const [taskId, lastLoggedBlockerId] of this.preservedQueuedOverlapLogged) {
-        const memoTask = taskById.get(taskId);
-        const memoHasActiveOverlapBlocker = memoTask
-          ? await hasActiveFileScopeOverlapBlocker(memoTask, memoTask.overlapBlockedBy)
-          : false;
-        if (
-          !candidates.has(taskId)
-          /*
-          FNXC:WorkflowResolvedColumns 2026-07-30-21:40 (FLAGGED AND LEFT COUNTED):
-          This sits in a log-dedup closure defined BEFORE the per-referenced-task lane prefetch below, so
-          the resolved sets are not in scope here and tsc says so. Hoisting the prefetch above the closure
-          is not available either — it is keyed on `candidates`, which this closure helps build.
-
-          Left as the literal rather than restructured: the closure only decides whether to re-log an
-          already-logged blocker, so the degraded answer costs a duplicate log line on a renamed board, not
-          a wrong lifecycle decision. Restructuring a sweep's control flow to convert a logging guard is
-          the wrong trade.
-          */
-          || memoTask?.column !== "todo"
-          || memoTask.status !== "queued"
-          || memoTask.overlapBlockedBy !== lastLoggedBlockerId
-          || !memoHasActiveOverlapBlocker
-        ) {
-          this.clearPreservedQueuedOverlapMemo(taskId);
-        }
-      }
-
       /*
       FNXC:WorkflowResolvedColumns 2026-07-30-21:40 (batch-engine — every lane question here is about ANOTHER task):
       This method classifies why a BLOCKER or a DEPENDENCY is no longer blocking, and those rows routinely
@@ -6108,6 +6081,51 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         complete: new Set(["done"]), archived: new Set(["archived"]),
         hold: new Set(["todo"]), review: new Set(["in-review"]),
       };
+
+      for (const [taskId, lastLoggedBlockerId] of this.preservedQueuedOverlapLogged) {
+        const memoTask = taskById.get(taskId);
+        const memoHasActiveOverlapBlocker = memoTask
+          ? await hasActiveFileScopeOverlapBlocker(memoTask, memoTask.overlapBlockedBy)
+          : false;
+        if (
+          !candidates.has(taskId)
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-30-21:40 (FLAGGED AND LEFT COUNTED):
+          This sits in a log-dedup closure defined BEFORE the per-referenced-task lane prefetch below, so
+          the resolved sets are not in scope here and tsc says so. Hoisting the prefetch above the closure
+          is not available either — it is keyed on `candidates`, which this closure helps build.
+
+          Left as the literal rather than restructured: the closure only decides whether to re-log an
+          already-logged blocker, so the degraded answer costs a duplicate log line on a renamed board, not
+          a wrong lifecycle decision. Restructuring a sweep's control flow to convert a logging guard is
+          the wrong trade.
+          */
+          /*
+          FNXC:WorkflowResolvedColumns 2026-07-31-12:10 (u12 — CONVERTED; the stated blocker was not real):
+          The prior note said the resolved sets could not be in scope because the lane prefetch is keyed on
+          `candidates`, "which this closure helps build". Measured: this loop does not build `candidates` —
+          it is fully populated two statements above (`blockedTasks` then `queuedDependencyTasks`) and this
+          loop only CLEARS memo entries. So the prefetch was hoistable, and it now sits above.
+
+          Reaching this clause already proves the id is a candidate: `!candidates.has(taskId)` is the first
+          arm of the same `||` chain, so short-circuit means we only ask the lane question for ids the
+          prefetch covered (`referencedIds.add(task.id)` for every candidate). `lanesOf` still falls back to
+          the legacy set, so an unresolvable workflow answers exactly as the literal did.
+
+          `|| !memoTask` is explicit rather than implied: `memoTask?.column !== "todo"` was ALSO the undefined
+          check, and tsc narrowed the clauses after it on that basis. Dropping it silently broke the
+          narrowing (TS18048 on `memoTask.status`), so the undefined arm is now stated on its own line.
+          */
+          || !memoTask
+          || !lanesOf(taskId).hold.has(memoTask.column)
+          || memoTask.status !== "queued"
+          || memoTask.overlapBlockedBy !== lastLoggedBlockerId
+          || !memoHasActiveOverlapBlocker
+        ) {
+          this.clearPreservedQueuedOverlapMemo(taskId);
+        }
+      }
+
 
       for (const task of candidates.values()) {
         const blockerId = task.blockedBy;

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -1,8 +1,7 @@
 {
   "generatedFrom": "node scripts/lifecycle-column-census.mjs --strict --update-baseline",
   "byFile": {
-    "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1,
-    "packages/engine/src/self-healing.ts": 1
+    "packages/dashboard/app/components/ResearchTaskActionModal.tsx": 1
   },
   "deliberateByFile": {
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 6,


### PR DESCRIPTION
## The defect

`clearStaleBlockedBy` keeps a per-task memo of which overlap blocker it already logged, so a sweep running every few seconds doesn't repeat the same line forever. The memo was retained only while the card sat in a column matching the literal `todo` — so on a renamed board it was dropped on **every** sweep and `still blocked by file scope overlap with <id>` was re-logged each time.

## Census before / after

| | before | after |
|---|---|---|
| COLUMN guards (backlog) | 9 | **8** |
| `packages/engine/src/self-healing.ts` | 1 | **0 — converted** |

Baseline re-recorded in the same commit; `--strict` green. (Counts follow #3215, which took 10 → 9.)

## The stated blocker was not real

The note here declined the conversion because the lane prefetch is keyed on `candidates`, *"which this closure helps build"*. Measured — it does not:

```
6033|  for (const task of blockedTasks) candidates.set(task.id, task);
6034|  for (const task of queuedDependencyTasks) candidates.set(task.id, task);
6036|  for (const [taskId, lastLoggedBlockerId] of this.preservedQueuedOverlapLogged) {   <- only CLEARS memos
```

`candidates` is fully populated two statements earlier, and this loop only clears memo entries. So the prefetch was hoistable; it now sits above the loop. That is a pure move of a read-only computation with no conditional between the two positions.

Reaching the lane clause already proves the id is a candidate — `!candidates.has(taskId)` is the first arm of the same `||` chain, so short-circuit means the lane question is only asked for ids the prefetch covered (`referencedIds.add(task.id)` runs for every candidate). `lanesOf` still falls back to the legacy set, so an unresolvable workflow answers exactly as the literal did.

This is the second inherited "too expensive" estimate to fail on inspection this session (see #3215). Both were written in good faith and both were checkable in a few minutes.

## One thing typecheck caught that review would not have

`memoTask?.column !== "todo"` was **also** the undefined check, and tsc narrowed the later clauses on it. Replacing it without that arm compiled clean to the eye but broke narrowing — `TS18048: 'memoTask' is possibly 'undefined'` on the next line. `|| !memoTask` is now explicit rather than implied.

## Evidence

The test drives the sweep **twice**, because a single pass cannot observe a dedup memo at all.

| | pre-fix literal | converted |
|---|---|---|
| `still blocked by file scope overlap` log lines | **2 — FAILS** | **1 — passes** |

Failure message against the pre-fix code: `expected [ [ 'FN-DEPENDENT', …(1) ], …(1) ] to have a length of 1 but got 2`.

Worth correcting the record: the note called the cost *"a duplicate log line, not a wrong lifecycle decision"*. The lifecycle half is right — but it is a duplicate on **every sweep**, so it is recurring log spam, not a one-off. That is a bigger cost than the note implies, though still not a correctness bug.

| check | result |
|---|---|
| `census --strict` / `check-fnxc-future-dates` | exit 0 / exit 0 |
| `eslint` / engine `tsc --noEmit` | clean / exit 0 |
| self-healing + overlap suites | 15 / 21 / 6 passed |
| `pnpm test:gate` | exit 0 (744 tests) |

Reused the existing `RENAMED_BOARD_IR` harness in that file rather than building a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of stale workflow blockers, including renamed workflow lanes.
  - Prevented duplicate overlap warnings during repeated cleanup.
  - More reliably preserves valid queued overlaps while ignoring missing or inactive tasks.

- **Tests**
  - Added regression coverage for repeated stale-blocker cleanup and duplicate warning prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->