### PR TITLE
test(engine): pin the deleted-blocker WIP-lane read, which no test could see

### DIFF
--- a/packages/engine/src/__tests__/scheduler-deleted-blocker-wip-dependent.test.ts
+++ b/packages/engine/src/__tests__/scheduler-deleted-blocker-wip-dependent.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import { Scheduler } from "../scheduler.js";
+import type { Settings, Task, TaskStore, WorkflowIr } from "@fusion/core";
+
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-18:55:
+THE DELETED-BLOCKER SWEEP, on a RENAMED board.
+
+When a task is soft-deleted, a `task:deleted` listener reconciles every dependent that was blocked by
+it: the dependent's `blockedBy` is cleared so it can be scheduled again. It reads two lanes to find
+those dependents — the hold lane and the WIP lane.
+
+WHY THIS FILE EXISTS. The WIP read (`resolveProjectColumnsForRoles(store, ["countsTowardWip"])`) was
+converted to traits, but NO test could observe the conversion. Blinding that resolver back to the
+literal `["in-progress"]` left all 14 existing scheduler test files green (145/145). Two independent
+harness properties made the conversion invisible:
+
+  1. `resolveProjectColumnsForRoles` returns the LEGACY ids and nothing else when the store has no
+     `listWorkflowDefinitions` method (project-lane-vocabulary.ts — an intentional degrade so an
+     unreadable workflow list cannot fail a sweep). The shared scheduler harness does not define it,
+     so the resolved set and the literal set were EQUAL BY CONSTRUCTION in every existing test.
+  2. `listTasks` was mocked as `vi.fn(async () => tasks)`, ignoring its `column` filter entirely. A
+     mock that returns every task regardless of the lane asked for cannot detect a wrong lane.
+
+Either property alone is enough to make a column-set defect unobservable; both were present. So this
+harness supplies `listWorkflowDefinitions` AND filters `listTasks` by column — the two things the
+assertion below actually depends on.
+
+WHAT BREAKS WITHOUT THE CONVERSION. On a board whose WIP lane is `building`, the literal read asks
+for `in-progress`, finds nothing, and the in-flight dependent is never reconciled. It keeps
+`blockedBy` pointing at a task that no longer exists — permanently, because the blocker can never be
+completed or re-deleted to trigger another sweep. Work stops with nothing to rescue it.
+
+DIFFERENTIAL. Both vocabularies run the same workflow SHAPE with identical traits; only the ids
+differ, and no renamed id collides with a legacy literal. The default-vocabulary run is the control:
+it passes with or without the conversion, so a generic break in this path cannot hide here.
+*/
+
+const WF = "custom:deleted-blocker-lanes";
+
+interface Names {
+  hold: string;
+  wip: string;
+  review: string;
+  complete: string;
+}
+
+const DEFAULT_NAMES: Names = { hold: "todo", wip: "in-progress", review: "in-review", complete: "done" };
+const RENAMED_NAMES: Names = { hold: "drafting", wip: "building", review: "checking", complete: "shipped" };
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "FN-001",
+    title: "task",
+    description: "",
+    column: "todo",
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as Task;
+}
+
+function ir(names: Names): WorkflowIr {
+  return {
+    version: "v2",
+    id: WF,
+    nodes: [],
+    edges: [],
+    columns: [
+      { id: names.hold, label: "Hold", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+      { id: names.wip, label: "Wip", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: names.review, label: "Review", traits: [{ trait: "merge" }, { trait: "human-review" }] },
+      { id: names.complete, label: "Complete", traits: [{ trait: "complete" }] },
+    ],
+  } as unknown as WorkflowIr;
+}
+
+type Listener = (task: Task) => void;
+
+function createStore(tasks: Task[], workflowIr: WorkflowIr, settings: Partial<Settings> = {}) {
+  const resolved = { maxConcurrent: 10, maxWorktrees: 10, ...settings };
+  const selection = { workflowId: WF, stepIds: [] };
+  const listeners = new Map<string, Listener>();
+  const updateTask = vi.fn(async (id: string, patch: Partial<Task>) => {
+    const task = tasks.find((candidate) => candidate.id === id);
+    if (task) Object.assign(task, patch);
+    return task as Task;
+  });
+
+  const store = {
+    /*
+    Honours the `column` filter — the whole point of this harness. The shared scheduler harness
+    returns `tasks` unfiltered, which silently satisfies any lane the caller asks for.
+    */
+    listTasks: vi.fn(async (query?: { column?: string }) =>
+      (query?.column ? tasks.filter((task) => task.column === query.column) : tasks)),
+    getSettings: vi.fn(async () => resolved),
+    /*
+    The listener ends with `this.schedule()`, which is not what these cases are about. Stubbed only so
+    its failure cannot fill the run with stderr that a REAL assertion failure would then hide in.
+    */
+    updateSettings: vi.fn(async () => resolved),
+    updateTask,
+    getTask: vi.fn(async (id: string) => tasks.find((task) => task.id === id) ?? null),
+    logEntry: vi.fn(async () => undefined),
+    getRootDir: vi.fn(() => "/tmp/project"),
+    getTasksDir: vi.fn(() => "/tmp/project/.fusion/tasks"),
+    on: vi.fn((event: string, callback: Listener) => {
+      listeners.set(event, callback);
+    }),
+    off: vi.fn(),
+    recordRunAuditEvent: vi.fn(async () => undefined),
+    getCompletionHandoffAcceptedMarker: vi.fn(async () => null),
+    getTaskWorkflowSelection: vi.fn(() => selection),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => selection),
+    getWorkflowDefinition: vi.fn(async () => ({ ir: workflowIr })),
+    /* Without this the resolver hands back legacy ids only, and the conversion is untestable. */
+    listWorkflowDefinitions: vi.fn(async () => [{ ir: workflowIr }]),
+  } as unknown as TaskStore;
+
+  return { store, updateTask, listeners };
+}
+
+/**
+ * A dependent sitting in the board's WIP lane, blocked by a task that has just been soft-deleted.
+ * Reported in role terms so both vocabularies are directly comparable.
+ */
+async function deletedBlockerScenario(names: Names) {
+  const dependent = makeTask({
+    id: "FN-WIP-DEPENDENT",
+    column: names.wip,
+    dependencies: ["FN-GONE"],
+    blockedBy: "FN-GONE",
+  } as Partial<Task>);
+  const { store, updateTask, listeners } = createStore([dependent], ir(names));
+
+  /* Registration happens in the constructor. */
+  const scheduler = new Scheduler(store);
+  (scheduler as unknown as { running: boolean }).running = true;
+
+  const onDeleted = listeners.get("task:deleted");
+  expect(onDeleted, "scheduler must subscribe to task:deleted").toBeDefined();
+  onDeleted?.(makeTask({ id: "FN-GONE", column: names.wip }));
+
+  /* The listener body is a detached async IIFE; let its awaits settle. */
+  await vi.waitFor(() => {
+    expect(updateTask).toHaveBeenCalled();
+  });
+
+  return { updateTask, dependent };
+}
+
+describe("scheduler deleted-blocker reconciliation reaches the WIP lane on a RENAMED board", () => {
+  it("default vocabulary: an in-flight dependent of a deleted blocker is unblocked", async () => {
+    const { updateTask } = await deletedBlockerScenario(DEFAULT_NAMES);
+    expect(updateTask).toHaveBeenCalledWith("FN-WIP-DEPENDENT", expect.objectContaining({ blockedBy: null }));
+  });
+
+  it("renamed vocabulary: an in-flight dependent of a deleted blocker is unblocked", async () => {
+    const { updateTask } = await deletedBlockerScenario(RENAMED_NAMES);
+    expect(updateTask).toHaveBeenCalledWith("FN-WIP-DEPENDENT", expect.objectContaining({ blockedBy: null }));
+  });
+
+  it("both vocabularies reach the SAME outcome — no column-id literal survives on this path", async () => {
+    const defaultRun = await deletedBlockerScenario(DEFAULT_NAMES);
+    const renamedRun = await deletedBlockerScenario(RENAMED_NAMES);
+    expect(renamedRun.dependent.blockedBy).toBe(defaultRun.dependent.blockedBy);
+    expect(renamedRun.dependent.blockedBy).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Pins the deleted-blocker sweep's **WIP-lane read** in `scheduler.ts`. Test-only — no product change.

When a task is soft-deleted, a `task:deleted` listener clears `blockedBy` on every dependent so the work can be scheduled again. It reads two lanes to find them: hold and WIP. The WIP read was already converted to `resolveProjectColumnsForRoles(store, ["countsTowardWip"])`.

**Blinding that resolver back to the literal `["in-progress"]` left all 14 existing scheduler test files green — 145/145.** The conversion was load-bearing and unpinned.

## Why nothing could see it

Two independent harness properties, **either one sufficient** to hide the defect:

1. **`resolveProjectColumnsForRoles` returns legacy ids and nothing else when the store has no `listWorkflowDefinitions`** — an intentional degrade in `project-lane-vocabulary.ts` so an unreadable workflow list cannot fail a sweep. The shared scheduler harness does not define it, so *the resolved set and the literal set were equal by construction* in every existing test.
2. **`listTasks` was mocked as `vi.fn(async () => tasks)`**, ignoring its `column` filter. A mock that returns every task regardless of the lane asked for cannot detect a wrong lane.

This is worth naming because #1 is not a test bug — it is correct production behaviour that happens to erase the difference a test is trying to measure. A harness can satisfy a conversion's *shape* while making its *effect* unobservable.

There is a test file named `scheduler-renamed-dependency-and-review-lanes.test.ts` covering dependency satisfaction, file-scope leases, base-branch stacking, PR hydration and mission completion on a renamed board. It does not reach this sweep, and its harness has both properties above.

## What breaks without the conversion

On a board whose WIP lane is `building`, the literal read asks for `in-progress`, finds nothing, and the in-flight dependent is never reconciled. It keeps `blockedBy` pointing at a task that no longer exists — **permanently**, because the blocker can never be completed or re-deleted to trigger another sweep. Work stops with nothing to rescue it.

## Measured

| | default (control) | renamed | differential |
|---|---|---|---|
| converted | pass | pass | pass |
| blinded to `["in-progress"]` | pass | **FAIL** | **FAIL** |

```
converted: Test Files 1 passed (1) / Tests 3 passed (3)
blinded:   Test Files 1 failed (1) / Tests 2 failed | 1 passed (3)
scheduler suite: 14 files/145 tests -> 15 files/148 tests, all green
lint: clean   fnxc-future-dates: none added
```

The default-vocabulary control passes in **both** columns by design: it is what keeps a generic break in this path from hiding in the renamed assertion.

## Census

Unchanged — **2 / 148 deliberate**. `scheduler.ts` was already at 0. This PR adds coverage, not conversions; the census counts comparisons and would not have moved either way, which is the same blind spot that let #3078 merge green.

## Flagged, not guessed

- The `resolveTaskParkedColumns` **hold** read one line above (`scheduler.ts:1402`) is the other half of this pair. My scenario places its dependent in the WIP lane, so it does not exercise the hold read and I am not claiming it is pinned.
- The FNXC stamp at `scheduler.ts:1404` reads `2026-08-01-05:00`, which is future-dated. It is one of the 181 grandfathered stamps, so the gate is green and I left it alone rather than widen this PR.
