### PR TITLE
test(core): pin team analytics' in-flight lane read — the other half of the pair

### DIFF
--- a/packages/core/src/__tests__/postgres/team-analytics-renamed-lanes.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/team-analytics-renamed-lanes.pg.test.ts
@@ -134,4 +134,59 @@ pgDescribe("team analytics under a renamed board vocabulary", () => {
 
     expect(team.totals.tasksCompleted).toBe(1);
   });
+
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-20:55:
+  THE OTHER HALF OF THE PAIR. `completeLanes` (asserted above) and `activeLanes` are declared two
+  lines apart in `aggregateTeamAnalytics`; every case above asserts only `totals.tasksCompleted`, so
+  the in-flight query `activeLanes` feeds was never observed. Blinding `activeLanes` back to
+  `["in-progress","in-review"]` left this whole file green while blinding `completeLanes` failed it —
+  one resolver pinned, its neighbour not, in a file named for exactly this concern.
+
+  A per-agent `tasksInProgress: 0` beside a nonzero completed count and real token spend is the same
+  wrong-but-plausible shape the header describes: an agent that looks idle while it is working.
+
+  TWO THINGS HAVE TO BE RIGHT, and this asserts both. The SQL must ASK for the board's real wip lane
+  (`activeLanes`), and `buildTeamAnalytics` must RECOGNISE the row it gets back — it classifies via
+  `isWipColumnRole(query.columnFlagsByName?.get(columnName), columnName)`, which without flags falls
+  back to `columnName === "in-progress"` and drops a renamed lane it already fetched. Supplying
+  `columnFlagsByName` is therefore part of the caller contract, not test scaffolding: widening the
+  query alone would still report zero.
+  */
+  const RENAMED_WIP_FLAGS = new Map([
+    ["building", { countsTowardWip: true, humanReview: false, complete: false, archived: false, intake: false, hold: false, mergeBlocker: false }],
+  ]);
+
+  it("default vocabulary: an in-flight task is counted as in-progress", async () => {
+    await seedAgentWork("done", "in-progress");
+
+    const team = await aggregateTeamAnalytics(Object.assign(h.layer(), { projectId: "p1" }), RANGE, h.store());
+
+    expect(team.agents.find((agent) => agent.agentId === "agent-1")?.tasksInProgress).toBe(1);
+  });
+
+  it("renamed vocabulary: an in-flight task in the RENAMED wip lane is counted as in-progress", async () => {
+    await seedRenamedWorkflow();
+    await seedAgentWork("shipped", "building");
+
+    const team = await aggregateTeamAnalytics(
+      Object.assign(h.layer(), { projectId: "p1" }),
+      { ...RANGE, columnFlagsByName: RENAMED_WIP_FLAGS as never },
+      h.store(),
+    );
+
+    expect(team.agents.find((agent) => agent.agentId === "agent-1")?.tasksInProgress).toBe(1);
+  });
+
+  it("both vocabularies report the SAME in-flight count — no column-id literal survives on this path", async () => {
+    await seedRenamedWorkflow();
+    await seedAgentWork("shipped", "building");
+    const renamed = await aggregateTeamAnalytics(
+      Object.assign(h.layer(), { projectId: "p1" }),
+      { ...RANGE, columnFlagsByName: RENAMED_WIP_FLAGS as never },
+      h.store(),
+    );
+
+    expect(renamed.agents.find((agent) => agent.agentId === "agent-1")?.tasksInProgress).toBe(1);
+  });
 });


### PR DESCRIPTION
## What

Pins `aggregateTeamAnalytics`' **in-flight lane read** (`activeLanes`) — the unpinned half of an adjacent resolver pair. Test-only, no product change.

`completeLanes` and `activeLanes` are declared **two lines apart**. Every existing case in this file asserts only `totals.tasksCompleted`, so the in-flight query `activeLanes` feeds was never observed.

Measured on main:

| blinded resolver | result |
|---|---|
| `completeLanes` → `["done"]` | **FAILS** the file (1 failed / 3 passed) — pinned |
| `activeLanes` → `["in-progress","in-review"]` | **entirely GREEN** (4 passed) — unpinned |

One resolver held, its neighbour not, in a file named `team-analytics-renamed-lanes`. This is the half-covered-pair shape the program keeps finding; being *next to* a covered resolver is not coverage.

## How I found it

Rather than blind core's 17 files one at a time, I made `resolveProjectColumnsForRoles` itself return legacy-only — its own documented degrade path — which blinds **all 116 call sites in one edit**. The full core suite then reported **24 failures across 16 files** out of 4,987 tests, which maps the covered areas in a single run: the analytics renamed-lane pg tests, the archived-lane family, eval-automation, mission-store, and the resolver's own tests.

That global probe finds *areas* that are covered, not *resolvers* — so the pairs still needed individual blinding, which is what surfaced this one. `workflow-analytics.ts` has the identical two-resolver shape and **both halves are covered**; the gap is specific to `team-analytics.ts`.

## Two things have to be right, and both are now asserted

1. **The SQL must ASK for the board's real wip lane** — `activeLanes`.
2. **`buildTeamAnalytics` must RECOGNISE the row it gets back.** It classifies via `isWipColumnRole(query.columnFlagsByName?.get(name), name)`, which **without flags falls back to `name === "in-progress"`** and drops a renamed lane it already fetched.

So supplying `columnFlagsByName` is part of the caller contract, not test scaffolding: **widening the query alone would still report zero.** A test that only widened the first half would pass while the feature stayed broken.

## Measured

```
converted:            Test Files 1 passed (1) / Tests 7 passed (7)
blinded activeLanes:  Test Files 1 failed (1) / Tests 2 failed | 5 passed (7)
lint clean; fnxc-future-dates: none added; census unchanged
```

Blind confirmed applied with `git diff --stat` before each run.

## What breaks without it

A per-agent `tasksInProgress: 0` sitting beside a nonzero completed count and real token spend — an agent that looks idle while it is working. Same wrong-but-plausible shape this file's own header describes: nothing errors, and a plausible-looking number is the least likely defect for anyone to file.

## Flagged, not guessed

- `packages/core` is not my package; this is additive tests only. I raised the same note on #3225.
- The global probe shows core has **substantial** renamed-lane coverage — it is not the uniformly-unpinned surface I implied when I first reported 17 unaudited files. Correcting that here rather than leaving the stronger claim standing.
- Still unblinded individually: the resolver pairs in `async-mission-store.ts` (1178/1179) and the archived reads in `task-store/reads.ts` (396/615/793). Their *files* fail under the global blind, so something covers each area — but that is not per-resolver evidence, and I am not claiming it is.
