### PR TITLE
test(engine): assert the evaluator's exact archived-lane set, not toContain

### DIFF
--- a/packages/engine/src/__tests__/evaluator-archived-lanes-renamed.test.ts
+++ b/packages/engine/src/__tests__/evaluator-archived-lanes-renamed.test.ts
@@ -99,12 +99,23 @@ async function archivedLanesHandedToCollector(archivedColumn: string): Promise<s
 }
 
 describe("evaluator resolves the board's own archived lanes", () => {
-  it("default vocabulary: hands the collector the archived lane", async () => {
-    expect(await archivedLanesHandedToCollector("archived")).toContain("archived");
+  /*
+  FNXC:WorkflowResolvedColumns 2026-07-31-22:35 (#3224 review follow-up — the half that was right):
+  EXACT SET, not `toContain`. The review asked for an exact SINGLE-column set (`["vaulted"]`), which
+  fails — see the note below on the legacy floor. But its underlying worry survives that correction:
+  `toContain` also passes when the set grows a lane nobody intended, and an over-broad archived set
+  silently classifies live rows as archived.
+
+  The exact set is assertable, it just is not the one the review proposed. `[...].sort()` in the
+  helper makes the ordering stable, so these pin the resolver's whole answer: the legacy floor plus
+  the board's own lane, and nothing else.
+  */
+  it("default vocabulary: hands the collector exactly the archived lane", async () => {
+    expect(await archivedLanesHandedToCollector("archived")).toEqual(["archived"]);
   });
 
-  it("renamed vocabulary: hands the collector the RENAMED archived lane", async () => {
-    expect(await archivedLanesHandedToCollector("vaulted")).toContain("vaulted");
+  it("renamed vocabulary: hands the collector exactly the legacy floor plus the RENAMED lane", async () => {
+    expect(await archivedLanesHandedToCollector("vaulted")).toEqual(["archived", "vaulted"]);
   });
 
   it("both vocabularies resolve their OWN lane — no column-id literal survives on this path", async () => {


### PR DESCRIPTION
## What

Follow-up to the #3224 review comment *"reject legacy archived identifiers for renamed workflows."* Test-only.

That comment had two halves. **The half it got wrong** is already answered on main: asserting an exact single-column set `["vaulted"]` *fails*, because `resolveProjectColumnsForRoles` unions `LEGACY_COLUMN_IDS_BY_ROLE` in as a documented floor — so a row whose workflow cannot be resolved still classifies. Pinning `["vaulted"]` would encode the opposite of the design.

**The half it got right was never addressed.** `toContain` also passes when the set grows a lane nobody intended, and an over-broad archived set silently classifies *live* rows as archived. So the reviewer's worry was legitimate even though the proposed fix was not.

The exact set is assertable — it just is not the one the review proposed:

| board | resolved set |
|---|---|
| default | `["archived"]` |
| renamed | `["archived", "vaulted"]` — legacy floor + the board's own lane |

`[...].sort()` in the helper makes ordering stable, so these pin the resolver's whole answer rather than a substring of it.

## Proven to catch what `toContain` missed

Giving the fixture a second `archived`-trait column fails both new assertions:

```
AssertionError: expected [ 'archived', 'cold-store' ] to deeply equal [ 'archived' ]
AssertionError: expected [ 'archived', 'cold-store', 'vaulted' ] to deeply equal [ 'archived', 'vaulted' ]
Tests  2 failed | 1 passed (3)
```

The previous `toContain` assertions pass unchanged against that same spurious lane. That is the whole justification for this PR — without the injection test it would be a stylistic preference.

```
clean:            Tests 3 passed (3)
spurious lane:    Tests 2 failed | 1 passed (3)
lint clean
```

## Note

I said in the review thread I would tighten this, so this closes that loop. I also checked before editing whether another worker had already done it — main already carries the FNXC tag and the legacy-floor explanation from the same review round, so this PR adds only the part still missing rather than redoing settled work.
