### PR TITLE
fix(gate): catch cast move-targets, keep `??` fallbacks unflagged, and pin all of it

### DIFF
--- a/scripts/__tests__/check-move-target-literals.test.mjs
+++ b/scripts/__tests__/check-move-target-literals.test.mjs
@@ -1,0 +1,99 @@
+/*
+FNXC:MoveTargetRatchet 2026-07-31-19:35 (u12 — five spellings, three rounds, zero regressions kept):
+
+This gate has missed FIVE destination spellings across three rounds — direct/backtick (#3246),
+ternary (#3250), and cast (here) — and every probe was run by hand against a throwaway file and then
+thrown away, because the scanner executed on import and there was nowhere to put a test.
+
+The root cause of the repeat is one sentence: the destination is a POSITION, and every fix so far has
+enumerated NODE KINDS. A kind list is something the language extends faster than anyone guesses, so
+the only durable defence is that each shape someone finds stays found. That is this file.
+
+It pins BOTH directions deliberately. Widening a matcher is where false positives arrive: adding
+`??`/`||` unwrapping flagged the fail-soft idiom
+`moveTask(id, (await resolveTaskLifecycleColumns(...))?.complete ?? "done")` — the correct pattern the
+whole conversion programme rests on — so the negative cases below are load-bearing, not padding.
+*/
+import test from "node:test";
+import assert from "node:assert/strict";
+import ts from "typescript";
+
+import { destinationLiterals } from "../check-move-target-literals.mjs";
+
+/** Parse `expr` as the second argument of a moveTask call and return the literals the gate sees. */
+function literalsOf(expr) {
+  const source = `declare const s: any; declare const id: string; s.moveTask(id, ${expr});`;
+  const sf = ts.createSourceFile("probe.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  let found = null;
+  const walk = (node) => {
+    if (ts.isCallExpression(node) && node.arguments.length >= 2 && found === null) {
+      found = destinationLiterals(node.arguments[1]);
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(sf);
+  assert.notEqual(found, null, `probe did not parse: ${expr}`);
+  return found;
+}
+
+test("catches a direct string destination", () => {
+  assert.deepEqual(literalsOf('"in-review"'), ["in-review"]);
+});
+
+test("catches a no-substitution template destination", () => {
+  assert.deepEqual(literalsOf("`archived`"), ["archived"]);
+});
+
+test("catches BOTH arms of a ternary destination", () => {
+  assert.deepEqual(literalsOf('ok ? "done" : "in-review"'), ["done", "in-review"]);
+});
+
+test("catches a nested ternary", () => {
+  assert.deepEqual(literalsOf('a ? (b ? "archived" : "todo") : "done"'), ["archived", "todo", "done"]);
+});
+
+test("catches through parentheses", () => {
+  assert.deepEqual(literalsOf('("todo")'), ["todo"]);
+});
+
+test("catches an `as` cast — the idiomatic spelling where the parameter is typed ColumnId", () => {
+  assert.deepEqual(literalsOf('"done" as ColumnId'), ["done"]);
+});
+
+test("catches a cast wrapping a ternary", () => {
+  assert.deepEqual(literalsOf('(ok ? "done" : "todo") as ColumnId'), ["done", "todo"]);
+});
+
+/*
+The negative half. Each of these was either a real false positive that shipped and was fixed, or one
+that arrived while widening the matcher and had to be backed out.
+*/
+test("does NOT report a resolved destination", () => {
+  assert.deepEqual(literalsOf("lanes.complete"), []);
+});
+
+test("does NOT report a `??` fallback — that is the fail-soft idiom, not a defect", () => {
+  // Adding `??` unwrapping flagged branch-and-pr-entities.ts:653, which resolves first and falls back
+  // to the legacy id exactly as the role helpers degrade. Flagging it would demand a marker on every
+  // safe fallback, and a marker applied by habit is how the next real literal walks through.
+  assert.deepEqual(literalsOf('resolved?.complete ?? "done"'), []);
+});
+
+test("does NOT report a `||` fallback", () => {
+  assert.deepEqual(literalsOf('resolved || "todo"'), []);
+});
+
+test("does NOT report a template with substitution", () => {
+  assert.deepEqual(literalsOf("`${prefix}-done`"), []);
+});
+
+test("extracts a renamed lane too — legacy filtering is the CALLER's job, not this function's", () => {
+  /*
+  Written expecting `[]` and corrected after it returned `["drafting"]`. `destinationLiterals` answers
+  "what literal strings could this destination be", and the call site then asks
+  `LEGACY_COLUMN_IDS.has(...)`. Keeping the split matters: a future change that filters here would
+  make the extractor silently vocabulary-aware, and the next shape added would need the legacy list
+  threaded into it to work at all.
+  */
+  assert.deepEqual(literalsOf('"drafting"'), ["drafting"]);
+});

--- a/scripts/check-move-target-literals.mjs
+++ b/scripts/check-move-target-literals.mjs
@@ -45,44 +45,7 @@ const strict = process.argv.includes("--strict");
 const updateBaseline = process.argv.includes("--update-baseline");
 const json = process.argv.includes("--json");
 
-let files;
-try {
-  files = execSync(
-    "git ls-files 'packages/*/src/**/*.ts' 'packages/*/src/*.ts' 'packages/*/src/**/*.tsx' 'packages/*/app/**/*.ts' 'packages/*/app/**/*.tsx'",
-    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
-  ).split("\n").map((f) => f.trim()).filter(Boolean)
-    .filter((f) => !f.includes("__tests__") && !/\.(test|spec)\.tsx?$/.test(f));
-} catch (err) {
-  /* FAIL CLOSED: an unreadable file list means nothing was checked, which must not read as clean. */
-  console.error(`check-move-target-literals: could not list files — ${err?.message ?? err}`);
-  process.exit(1);
-}
-if (files.length === 0) {
-  console.error("check-move-target-literals: file list is EMPTY — refusing to report on zero files.");
-  process.exit(1);
-}
-
-/** True when the statement enclosing `node` carries a DELIBERATE-LITERAL in its LEADING comments. */
-/*
-FNXC:MoveTargetRatchet 2026-07-31-21:55 (probe of this gate's own claim):
-TERNARY DESTINATIONS. The gate prints "POPULATION EMPTY ... keep it empty", and a staged probe showed
-that claim held for two spellings and not a third: `moveTask(id, ok ? "done" : "in-review")` was
-invisible, because the check required arguments[1] to BE a literal. A ternary over two lanes is a
-natural way to write exactly the destination this gate exists to prevent.
-
-ONE hit per call site, not per branch — a two-branch ternary is one move, and counting both would
-inflate a population the ratchet holds at zero.
-
-DELIBERATELY NOT DESCENDING into `??` or `||`. `moveTask(id, lanes.complete ?? "done")` is the
-documented degraded arm this program writes on purpose — a resolved value with a legacy fallback,
-which the lifecycle census classifies as `traitFallback` rather than backlog. Counting those would
-report correct code as debt. Probed and left alone rather than assumed: both forms measure 0.
-
-STILL NOT DETECTED, stated so nobody assumes coverage: a destination bound to a local first
-(`const t = "archived"; moveTask(id, t)`). Resolving that needs symbol/dataflow analysis rather than a
-shape test, which is a different tool than this file is.
-*/
-function destinationLiterals(expr) {
+export function destinationLiterals(expr) {
   if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) return [expr.text];
   if (ts.isConditionalExpression(expr)) {
     return [...destinationLiterals(expr.whenTrue), ...destinationLiterals(expr.whenFalse)];
@@ -102,88 +65,141 @@ function hasDeliberateMarker(node, source) {
   return false;
 }
 
-const byFile = {};
-for (const file of files) {
-  let source;
+/*
+FNXC:MoveTargetRatchet 2026-07-31-19:05 (u12 — the scan ran on IMPORT, so the shape list could not be tested):
+Everything below executed at module load and ended in `process.exit`, so importing this file to unit-test
+`destinationLiterals` would have run the whole scan and killed the test process. That list has missed FOUR
+spellings across three rounds, each found by hand against a throwaway probe file and then discarded,
+because there was nowhere to put a regression.
+
+Behaviour-preserving: the CLI body is unchanged, only wrapped so it runs when this file is the entry point
+and not when imported. The two pure helpers are hoisted above it and `destinationLiterals` is exported.
+*/
+const isEntryPoint = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isEntryPoint) {
+  let files;
   try {
-    source = readFileSync(join(REPO, file), "utf8");
-  } catch (error) {
-    /* FNXC:MoveTargetRatchet 2026-07-31-23:55 (#3246 review): an unreadable tracked file made the
-       count silently short, and this count is a claim about the whole tree. Fail closed. */
-    console.error(`check-move-target-literals: cannot read tracked file ${file}: ${error?.message ?? error}`);
-    console.error("check-move-target-literals: refusing to report a count that may be short.");
-    process.exit(2);
+    files = execSync(
+      "git ls-files 'packages/*/src/**/*.ts' 'packages/*/src/*.ts' 'packages/*/src/**/*.tsx' 'packages/*/app/**/*.ts' 'packages/*/app/**/*.tsx'",
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    ).split("\n").map((f) => f.trim()).filter(Boolean)
+      .filter((f) => !f.includes("__tests__") && !/\.(test|spec)\.tsx?$/.test(f));
+  } catch (err) {
+    /* FAIL CLOSED: an unreadable file list means nothing was checked, which must not read as clean. */
+    console.error(`check-move-target-literals: could not list files — ${err?.message ?? err}`);
+    process.exit(1);
   }
-  if (!source.includes("moveTask")) continue;
-  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
-  let count = 0;
-  const walk = (node) => {
-    if (ts.isCallExpression(node)) {
-      const callee = ts.isPropertyAccessExpression(node.expression)
-        ? node.expression.name.text
-        : ts.isIdentifier(node.expression) ? node.expression.text : "";
-      if (MOVE_FNS.has(callee)) {
-        /* FNXC:MoveTargetRatchet 2026-07-31-23:55 (#3246 review): DESTINATION ARGUMENT ONLY.
-           moveTask(id, toColumn, options?) and moveTaskInternal(id, toColumn, options, internal,
-           currentTask?) both put the destination at index 1. Scanning every argument counted
-           `{ reason: "done" }` in an options bag as a move target — work that does not exist and
-           that no real fix could clear. Backtick form included. */
-        const destination = node.arguments[1];
-        const hit = destination && destinationLiterals(destination).find((text) => LEGACY_COLUMN_IDS.has(text));
-        if (hit && !hasDeliberateMarker(node, source)) {
-          count += 1;
+  if (files.length === 0) {
+    console.error("check-move-target-literals: file list is EMPTY — refusing to report on zero files.");
+    process.exit(1);
+  }
+
+  /** True when the statement enclosing `node` carries a DELIBERATE-LITERAL in its LEADING comments. */
+  /*
+  FNXC:MoveTargetRatchet 2026-07-31-21:55 (probe of this gate's own claim):
+  TERNARY DESTINATIONS. The gate prints "POPULATION EMPTY ... keep it empty", and a staged probe showed
+  that claim held for two spellings and not a third: `moveTask(id, ok ? "done" : "in-review")` was
+  invisible, because the check required arguments[1] to BE a literal. A ternary over two lanes is a
+  natural way to write exactly the destination this gate exists to prevent.
+
+  ONE hit per call site, not per branch — a two-branch ternary is one move, and counting both would
+  inflate a population the ratchet holds at zero.
+
+  DELIBERATELY NOT DESCENDING into `??` or `||`. `moveTask(id, lanes.complete ?? "done")` is the
+  documented degraded arm this program writes on purpose — a resolved value with a legacy fallback,
+  which the lifecycle census classifies as `traitFallback` rather than backlog. Counting those would
+  report correct code as debt. Probed and left alone rather than assumed: both forms measure 0.
+
+  STILL NOT DETECTED, stated so nobody assumes coverage: a destination bound to a local first
+  (`const t = "archived"; moveTask(id, t)`). Resolving that needs symbol/dataflow analysis rather than a
+  shape test, which is a different tool than this file is.
+  */
+
+
+  const byFile = {};
+  for (const file of files) {
+    let source;
+    try {
+      source = readFileSync(join(REPO, file), "utf8");
+    } catch (error) {
+      /* FNXC:MoveTargetRatchet 2026-07-31-23:55 (#3246 review): an unreadable tracked file made the
+         count silently short, and this count is a claim about the whole tree. Fail closed. */
+      console.error(`check-move-target-literals: cannot read tracked file ${file}: ${error?.message ?? error}`);
+      console.error("check-move-target-literals: refusing to report a count that may be short.");
+      process.exit(2);
+    }
+    if (!source.includes("moveTask")) continue;
+    const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+    let count = 0;
+    const walk = (node) => {
+      if (ts.isCallExpression(node)) {
+        const callee = ts.isPropertyAccessExpression(node.expression)
+          ? node.expression.name.text
+          : ts.isIdentifier(node.expression) ? node.expression.text : "";
+        if (MOVE_FNS.has(callee)) {
+          /* FNXC:MoveTargetRatchet 2026-07-31-23:55 (#3246 review): DESTINATION ARGUMENT ONLY.
+             moveTask(id, toColumn, options?) and moveTaskInternal(id, toColumn, options, internal,
+             currentTask?) both put the destination at index 1. Scanning every argument counted
+             `{ reason: "done" }` in an options bag as a move target — work that does not exist and
+             that no real fix could clear. Backtick form included. */
+          const destination = node.arguments[1];
+          const hit = destination && destinationLiterals(destination).find((text) => LEGACY_COLUMN_IDS.has(text));
+          if (hit && !hasDeliberateMarker(node, source)) {
+            count += 1;
+          }
         }
       }
-    }
-    ts.forEachChild(node, walk);
-  };
-  walk(sf);
-  if (count > 0) byFile[file] = count;
-}
+      ts.forEachChild(node, walk);
+    };
+    walk(sf);
+    if (count > 0) byFile[file] = count;
+  }
 
-const total = Object.values(byFile).reduce((a, b) => a + b, 0);
-if (json) {
-  console.log(JSON.stringify({ total, byFile }, null, 2));
+  const total = Object.values(byFile).reduce((a, b) => a + b, 0);
+  if (json) {
+    console.log(JSON.stringify({ total, byFile }, null, 2));
+    process.exit(0);
+  }
+
+  console.log(`check-move-target-literals: scanned ${files.length} source files`);
+  console.log(`  moveTask targets that are legacy column literals: ${total}`);
+  for (const [file, n] of Object.entries(byFile).sort((a, b) => b[1] - a[1])) {
+    console.log(`    ${String(n).padStart(4)}  ${file}`);
+  }
+  if (total === 0) {
+    console.log("  POPULATION EMPTY — #3150 measured 31 here; a wrong target THROWS rather than no-ops,");
+    console.log("  so keep it empty. Use resolveTaskLifecycleColumns / the role helpers for destinations.");
+  }
+
+  const baseline = existsSync(BASELINE_PATH) ? JSON.parse(readFileSync(BASELINE_PATH, "utf8")) : { byFile: {} };
+  if (updateBaseline) {
+    writeFileSync(BASELINE_PATH, `${JSON.stringify({ byFile }, null, 2)}\n`);
+    console.log("check-move-target-literals: baseline re-recorded.");
+    process.exit(0);
+  }
+  if (!strict) process.exit(0);
+
+  const allowed = baseline.byFile ?? {};
+  const problems = [];
+  for (const [file, n] of Object.entries(byFile)) {
+    const cap = allowed[file] ?? 0;
+    if (n > cap) problems.push(`  ${file}: ${n} legacy move target(s), baseline allows ${cap}`);
+  }
+  for (const [file, cap] of Object.entries(allowed)) {
+    const n = byFile[file] ?? 0;
+    if (n < cap) problems.push(`  ${file}: ${n} legacy move target(s), baseline allows ${cap} — DROP, re-record it`);
+  }
+  if (problems.length > 0) {
+    console.error("\ncheck-move-target-literals --strict: move-target population DIVERGES from baseline:\n");
+    console.error(problems.join("\n"));
+    console.error("\nA legacy move TARGET is rejected on a renamed board (TransitionRejectionError: unknown-column),");
+    console.error("so this is a runtime throw rather than a silent no-op. Resolve the destination through the role");
+    console.error("helpers, or add a leading DELIBERATE-LITERAL comment if the legacy id is genuinely the point");
+    console.error("(the #1411 recoveryRehome safe-landing path). If a count went DOWN, re-record with");
+    console.error("--strict --update-baseline in the same commit.\n");
+    process.exit(1);
+  }
+  console.log("check-move-target-literals --strict: every file matches its baseline exactly.");
   process.exit(0);
-}
 
-console.log(`check-move-target-literals: scanned ${files.length} source files`);
-console.log(`  moveTask targets that are legacy column literals: ${total}`);
-for (const [file, n] of Object.entries(byFile).sort((a, b) => b[1] - a[1])) {
-  console.log(`    ${String(n).padStart(4)}  ${file}`);
 }
-if (total === 0) {
-  console.log("  POPULATION EMPTY — #3150 measured 31 here; a wrong target THROWS rather than no-ops,");
-  console.log("  so keep it empty. Use resolveTaskLifecycleColumns / the role helpers for destinations.");
-}
-
-const baseline = existsSync(BASELINE_PATH) ? JSON.parse(readFileSync(BASELINE_PATH, "utf8")) : { byFile: {} };
-if (updateBaseline) {
-  writeFileSync(BASELINE_PATH, `${JSON.stringify({ byFile }, null, 2)}\n`);
-  console.log("check-move-target-literals: baseline re-recorded.");
-  process.exit(0);
-}
-if (!strict) process.exit(0);
-
-const allowed = baseline.byFile ?? {};
-const problems = [];
-for (const [file, n] of Object.entries(byFile)) {
-  const cap = allowed[file] ?? 0;
-  if (n > cap) problems.push(`  ${file}: ${n} legacy move target(s), baseline allows ${cap}`);
-}
-for (const [file, cap] of Object.entries(allowed)) {
-  const n = byFile[file] ?? 0;
-  if (n < cap) problems.push(`  ${file}: ${n} legacy move target(s), baseline allows ${cap} — DROP, re-record it`);
-}
-if (problems.length > 0) {
-  console.error("\ncheck-move-target-literals --strict: move-target population DIVERGES from baseline:\n");
-  console.error(problems.join("\n"));
-  console.error("\nA legacy move TARGET is rejected on a renamed board (TransitionRejectionError: unknown-column),");
-  console.error("so this is a runtime throw rather than a silent no-op. Resolve the destination through the role");
-  console.error("helpers, or add a leading DELIBERATE-LITERAL comment if the legacy id is genuinely the point");
-  console.error("(the #1411 recoveryRehome safe-landing path). If a count went DOWN, re-record with");
-  console.error("--strict --update-baseline in the same commit.\n");
-  process.exit(1);
-}
-console.log("check-move-target-literals --strict: every file matches its baseline exactly.");
-process.exit(0);

--- a/scripts/check-move-target-literals.mjs
+++ b/scripts/check-move-target-literals.mjs
@@ -51,6 +51,29 @@ export function destinationLiterals(expr) {
     return [...destinationLiterals(expr.whenTrue), ...destinationLiterals(expr.whenFalse)];
   }
   if (ts.isParenthesizedExpression(expr)) return destinationLiterals(expr.expression);
+  /*
+  FNXC:MoveTargetRatchet 2026-07-31-19:25 (u12 — CAST yes, FALLBACK deliberately no):
+  Columns are typed `ColumnId`, so `moveTask(id, "done" as ColumnId)` is the NATURAL spelling wherever
+  the parameter is nominally typed. It was invisible until now, which left the gate weakest exactly
+  where this codebase is most likely to write a literal.
+
+  `??` / `||` / `&&` are NOT unwrapped, and that is a decision rather than an omission. I added them,
+  ran the tree, and they flagged this:
+
+      moveTask(id, (await resolveTaskLifecycleColumns(store, id))?.complete ?? "done", ...)
+
+  which is the fail-soft idiom the whole conversion programme is built on — resolve, and fall back to
+  the legacy id when the workflow is unreadable, exactly as the role helpers degrade. A gate that
+  demands a DELIBERATE-LITERAL marker on every safe fallback teaches people to sprinkle markers, and a
+  marker applied by habit is how the next real literal walks through.
+
+  So the legacy id AFTER `??` is the SAFE shape and stays unflagged; a legacy id as the WHOLE
+  destination is the unsafe one and is caught. If a fallback ever needs auditing it wants its own
+  report, not this ratchet's exit code.
+  */
+  if (ts.isAsExpression(expr) || ts.isSatisfiesExpression?.(expr) || ts.isTypeAssertionExpression?.(expr)) {
+    return destinationLiterals(expr.expression);
+  }
   return [];
 }
 


### PR DESCRIPTION
Follow-up to #3250. Two changes, and **one of them is a decision not to widen** — which is the part I would review first.

## Caught now: the cast form

```ts
moveTask(id, "done" as ColumnId)   // was invisible
```

Columns are typed `ColumnId`, so a cast is the **natural** spelling wherever the parameter is nominally typed. The gate was weakest exactly where this codebase is most likely to write a literal. Cast-wrapping-a-ternary is caught too.

## Deliberately NOT caught: `??` / `||` / `&&`

I recommended these arms on #3250. **I was wrong, and the tree proved it.** Adding them flagged:

```ts
moveTask(id, (await resolveTaskLifecycleColumns(store, id))?.complete ?? "done", ...)
```

That is the fail-soft idiom this entire programme rests on — resolve, fall back to the legacy id when the workflow is unreadable, exactly as the role helpers degrade. It is the **correct** pattern.

A gate that demands a `DELIBERATE-LITERAL` marker on every safe fallback teaches people to add markers by habit, and a habitual marker is how the next real literal walks straight through. So: a legacy id **after** `??` is the safe shape and stays unflagged; a legacy id as the **whole** destination is caught. Backed out, with the reasoning at the site so nobody re-adds it.

If you disagree, the counter-argument is that a fallback could mask a lane that should have resolved — but that wants its own report, not this ratchet's exit code.

## Pinned — the gate had no tests at all

Fifth spelling missed across three rounds, and every earlier probe was run by hand and thrown away, because the scanner executed on import. Commit 1 makes it importable (behaviour-preserving, `--strict` identical); commit 2 adds **12 tests in both directions**:

| catches | does not catch |
|---|---|
| direct, backtick, ternary, nested ternary, parenthesised, cast, cast-over-ternary | `??` fallback, `\|\|` fallback, resolved destination, substituted template |

The negatives are load-bearing, not padding — four of them encode false positives that either shipped or arrived while widening.

## The root cause, recorded in the test header

**The destination is a POSITION; every fix so far has enumerated NODE KINDS.** A kind list is something the language extends faster than we guess — I started that pattern myself in #3246 by requiring `arguments[1]` to *be* a literal. The durable defence is that each shape someone finds stays found.

## Measured

| check | result |
|---|---|
| real tree | **0** targets, `--strict` exit 0 (the `??` false positive is gone) |
| gate tests | **12 pass / 0 fail** |
| anti-vacuity | removing the cast arm **fails** the suite; restoring passes |
| eslint / `check-fnxc-future-dates` | clean / 0 |

One test corrected itself during writing: I asserted `"drafting"` extracts to `[]`, and it returns `["drafting"]` — legacy filtering is the caller's job. Kept as a test of that split, since folding the vocabulary into the extractor would force every future shape to thread the legacy list.