### PR TITLE
test(engine): main is red — the census preconditions were MET, repoint two guards that expired on success

### DIFF
--- a/packages/engine/src/__tests__/census-reclassification-message.test.ts
+++ b/packages/engine/src/__tests__/census-reclassification-message.test.ts
@@ -38,7 +38,21 @@ afterEach(() => {
   scratch = undefined;
 });
 
-function runWithBaseline(mutate: (baseline: Record<string, unknown>) => void): { status: number; stderr: string } {
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-23:35 (`extraEnv` — the real tree reached ZERO guards):
+The ROSE case used to manufacture a rise by finding a baseline entry with more than one guard and
+zeroing it. The conversion program drove `byFile` to zero entries, so there was nothing to find, the
+mutation became a no-op, the census correctly passed, and the case failed on main asserting exit 1.
+
+Nothing regressed — the fixture's premise (real debt exists to borrow) expired when the work
+succeeded. `extraEnv` lets a case supply the FUSION_CENSUS_FILE_ROOT/FILE_LIST pair from #3230 and
+build its OWN one-file tree, so a rise is constructed rather than borrowed from whatever debt happens
+to be left. The other cases keep using the real tree, which is what makes them a real integration.
+*/
+function runWithBaseline(
+  mutate: (baseline: Record<string, unknown>) => void,
+  extraEnv: Record<string, string> = {},
+): { status: number; stderr: string } {
   scratch = mkdtempSync(join(tmpdir(), "fusion-census-msg-"));
   const baselinePath = join(scratch, "baseline.json");
   const baseline = JSON.parse(readFileSync(REAL_BASELINE, "utf8")) as Record<string, unknown>;
@@ -47,7 +61,7 @@ function runWithBaseline(mutate: (baseline: Record<string, unknown>) => void): {
   try {
     execFileSync("node", [SCRIPT, "--strict"], {
       cwd: REPO_ROOT,
-      env: { ...process.env, FUSION_CENSUS_BASELINE_PATH: baselinePath },
+      env: { ...process.env, FUSION_CENSUS_BASELINE_PATH: baselinePath, ...extraEnv },
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -89,15 +103,37 @@ describe("the ratchet distinguishes a reclassification from a regression", () =>
   });
 
   it("still says ROSE when guards genuinely grew", () => {
-    // The ratchet's real job must keep its real message — a friendlier failure is not the goal.
-    const { status, stderr } = runWithBaseline((baseline) => {
-      const byFile = baseline.byFile as Record<string, number>;
-      const key = Object.keys(byFile).find((k) => (byFile[k] ?? 0) > 1);
-      if (key) byFile[key] = 0;
-    });
+    /*
+    The ratchet's real job must keep its real message — a friendlier failure is not the goal.
 
-    expect(status).toBe(1);
-    expect(stderr).toContain("column-guard count ROSE");
+    Built on a synthetic one-file tree rather than borrowed from the real baseline: the real
+    `byFile` is now empty, so the old approach found no entry to zero, mutated nothing, and asserted
+    exit 1 against a correct pass. See `extraEnv` above.
+
+    The file carries a REAL unmarked guard, and the baseline records zero for it, so the census sees
+    a genuine rise — the same condition a regression produces, constructed instead of borrowed.
+    */
+    const treeRoot = mkdtempSync(join(tmpdir(), "fusion-census-tree-"));
+    try {
+      const rel = "guard.ts";
+      writeFileSync(
+        join(treeRoot, rel),
+        `export function isReview(task: { column: string }): boolean {\n  return task.column === "in-review";\n}\n`,
+      );
+
+      const { status, stderr } = runWithBaseline(
+        (baseline) => { baseline.byFile = {}; baseline.deliberateByFile = {}; },
+        { FUSION_CENSUS_FILE_ROOT: treeRoot, FUSION_CENSUS_FILE_LIST: rel },
+      );
+
+      expect(status).toBe(1);
+      expect(stderr).toContain("column-guard count ROSE");
+      /* ...and specifically NOT the reclassification wording, which is the distinction this whole
+         file exists to keep: a real rise must not be explained away as a marker move. */
+      expect(stderr).not.toContain("RECLASSIFIED");
+    } finally {
+      rmSync(treeRoot, { recursive: true, force: true });
+    }
   });
 
   it("passes against the unmodified baseline", () => {

--- a/packages/engine/src/__tests__/move-target-declared-census.test.ts
+++ b/packages/engine/src/__tests__/move-target-declared-census.test.ts
@@ -74,15 +74,30 @@ function literalText(node: ts.Node | undefined): string | undefined {
   return undefined;
 }
 
-function collectMoveCalls(): MoveCall[] {
-  const files: string[] = [];
-  collectFiles(ENGINE_SRC, files);
-  // Guards the guard: a broken path would make every assertion below vacuously true.
-  if (files.length < 20) throw new Error(`census scanned only ${files.length} engine files; path resolution is broken`);
+/*
+FNXC:WorkflowLifecycleColumns 2026-07-31-23:20 (the population this file measured reached ZERO):
+`collectMoveCalls` now takes an optional (name, source) list so the collector can be exercised against
+a SYNTHETIC fixture. Reason in the describe block below: the engine's literal move-target population
+is 0, so every assertion that proved this census works by pointing at real debt has nothing left to
+point at. A vacuity guard that depends on real debt existing expires the moment the work succeeds —
+and it expires by FAILING, which reads as a regression in the thing it was guarding.
+*/
+type SourceFileInput = { name: string; source: string };
+
+function collectMoveCalls(inputs?: readonly SourceFileInput[]): MoveCall[] {
+  let entries: SourceFileInput[];
+  if (inputs) {
+    entries = [...inputs];
+  } else {
+    const files: string[] = [];
+    collectFiles(ENGINE_SRC, files);
+    // Guards the guard: a broken path would make every assertion below vacuously true.
+    if (files.length < 20) throw new Error(`census scanned only ${files.length} engine files; path resolution is broken`);
+    entries = files.map((f) => ({ name: f, source: readFileSync(f, "utf-8") }));
+  }
 
   const calls: MoveCall[] = [];
-  for (const file of files) {
-    const source = readFileSync(file, "utf-8");
+  for (const { name: file, source } of entries) {
     const sf = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
     /*
     `createSourceFile` is error-tolerant, so a syntax error yields a PARTIAL tree whose calls are
@@ -105,7 +120,7 @@ function collectMoveCalls(): MoveCall[] {
                   .filter((name): name is string => name !== undefined)
               : [];
           calls.push({
-            file: file.slice(ENGINE_SRC.length + 1),
+            file: file.startsWith(ENGINE_SRC) ? file.slice(ENGINE_SRC.length + 1) : file,
             line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
             target,
             optionKeys,
@@ -132,9 +147,58 @@ function defaultColumnIds(): Set<string> {
 }
 
 describe("engine move targets vs the columns a workflow declares (U12 flip precondition)", () => {
-  it("finds engine moveTask calls with literal targets, so the census is not vacuous", () => {
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-07-31-23:20 (the precondition this file measured is now MET):
+  Every assertion here used to rest on the engine HAVING literal move targets — ">10 exist", "the
+  rescue and plain groups are both non-empty". The conversion program drove that population to 0, so
+  those three assertions began failing on main. Nothing regressed: the census is reporting the
+  success condition for the U12 flip, and the test was written to describe the world before it.
+
+  A guard whose premise is "the debt still exists" expires the moment the work succeeds, and expires
+  by FAILING — which reads as a regression in the very thing it was guarding. Re-pointed rather than
+  deleted, in two halves:
+
+    - VACUITY is now proven against a SYNTHETIC fixture, so the collector is exercised forever
+      regardless of how much real debt remains. This is the assertion that keeps the two below
+      honest: at a real population of 0 they are trivially true, and only the fixture proves they
+      would still fire.
+    - The two real-tree assertions now assert ZERO, so a reintroduced literal move target fails them.
+      That is the same guarantee as before, pointed at the state the tree is actually in.
+
+  `check-move-target-literals` ratchets the same population at 0 from the script side. This file is
+  not redundant with it: it judges targets against the columns the DEFAULT workflow declares, which
+  is the U12 flip question, and the ratchet does not.
+  */
+  const FIXTURE: readonly { name: string; source: string }[] = [{
+    name: "synthetic-fixture.ts",
+    source: [
+      `declare const store: { moveTask: (id: string, to: string, opts?: object) => void };`,
+      `export function a(id: string): void { store.moveTask(id, "in-review"); }`,
+      `export function b(id: string): void { store.moveTask(id, "done", { recoveryRehome: true }); }`,
+      `export function c(id: string): void { store.moveTask(id, "not-a-declared-column"); }`,
+    ].join("\n"),
+  }];
+
+  it("VACUITY — the collector finds literal targets, options and all, in a synthetic fixture", () => {
+    /* Proves the census can still see what it claims to measure, without needing real debt to exist.
+       If the collector breaks, the two zero-assertions below would pass for the wrong reason and this
+       is the only case that notices. */
+    const calls = collectMoveCalls(FIXTURE);
+
+    expect(calls.map((c) => c.target).sort()).toEqual(["done", "in-review", "not-a-declared-column"]);
+    expect(calls.find((c) => c.target === "done")?.optionKeys).toEqual(["recoveryRehome"]);
+    expect(calls.find((c) => c.target === "in-review")?.optionKeys).toEqual([]);
+
+    /* ...and that the declared-column comparison still discriminates, which is the actual U12
+       question. `not-a-declared-column` is not in any lineage; the other two are default ids. */
+    const declared = defaultColumnIds();
+    expect(calls.filter((c) => !declared.has(c.target)).map((c) => c.target)).toEqual(["not-a-declared-column"]);
+  });
+
+  it("the engine has NO literal move targets left — the U12 flip precondition is met", () => {
+    /* Was ">10 exist". The population is 0; asserting the number keeps a reintroduction failing. */
     const calls = collectMoveCalls();
-    expect(calls.length).toBeGreaterThan(10);
+    expect(calls.map((call) => `${call.file}:${call.line} -> "${call.target}"`)).toEqual([]);
   });
 
   it("every literal engine move target IS declared by the DEFAULT workflow", () => {
@@ -174,9 +238,24 @@ describe("engine move targets vs the columns a workflow declares (U12 flip preco
     const rescueMoves = calls.filter((call) => call.optionKeys.includes("recoveryRehome"));
     const plainMoves = calls.filter((call) => !call.optionKeys.includes("recoveryRehome"));
 
-    // Both groups exist; if either were empty the distinction below would be meaningless.
-    expect(rescueMoves.length).toBeGreaterThan(0);
-    expect(plainMoves.length).toBeGreaterThan(0);
+    /*
+    FNXC:WorkflowLifecycleColumns 2026-07-31-23:20 (the exposure is now NIL):
+    Was `rescueMoves > 0 && plainMoves > 0` — "both groups exist, so the distinction is meaningful".
+    Both are now empty because no literal move targets remain, which means NO engine move's safety
+    rests on the #1411 `recoveryRehome` carve-out. That is the answer the flip PR wanted, and it is
+    worth asserting exactly: if a literal move target returns, `plainMoves` becomes non-empty and the
+    inventory below stops being empty, so this fails and a human reads the list again.
+
+    The synthetic-fixture case above is what proves this grouping still works at a real population of
+    0 — without it, a collector that returned nothing would satisfy these two lines forever.
+    */
+    expect(rescueMoves).toEqual([]);
+    expect(plainMoves).toEqual([]);
+
+    const fixtureGrouping = collectMoveCalls(FIXTURE);
+    expect(fixtureGrouping.filter((c) => c.optionKeys.includes("recoveryRehome")).length).toBe(1);
+    expect(fixtureGrouping.filter((c) => !c.optionKeys.includes("recoveryRehome")).length).toBe(2);
+
     const all = new Map<string, number>();
     for (const call of calls) all.set(call.target, (all.get(call.target) ?? 0) + 1);
     console.info(`ALL literal engine move targets: ${[...all.entries()].sort((a,b)=>b[1]-a[1]).map(([t,n])=>`${t}=${n}`).join(", ")} (total ${calls.length})`);


### PR DESCRIPTION
## main is red, and this is the second half of it

Running the full `engine-default` project on `origin/main` — 754 files, 10,538 tests — returns **3 files / 4 tests failing**. One is the parked-seam audit counter, fixed in #3258. The other three are here.

All three assert that lifecycle debt **still exists**. It does not:

| assertion | expected | actual |
| --- | --- | --- |
| `finds >10 literal move targets, so the census is not vacuous` | > 10 | **0** |
| `both recoveryRehome groups are non-empty` | > 0 each | **0 / 0** |
| `still says ROSE when guards genuinely grew` | exit 1 | **exit 0** (mutation was a no-op) |

Nothing regressed. The conversion program drove the engine's literal move-target population to zero and the census baseline to zero entries. **Each guard's premise was "the debt still exists", so each expired the moment the work succeeded — and expired by failing, which reads as a regression in the very thing it was guarding.**

The third is the sharpest: it manufactured a rise by finding a baseline entry with more than one guard and zeroing it. With `byFile` empty there was nothing to find, so it mutated nothing, the census correctly passed, and the test asserted exit 1 against a correct pass.

## Repointed, not deleted

A vacuity guard must not depend on real debt existing. Two halves:

- **Vacuity now runs against a synthetic fixture** — a small in-memory source with three `moveTask` literals (one with `recoveryRehome`, one targeting an undeclared column). The collector is exercised forever regardless of how much real debt remains. This is what keeps the rest honest: at a real population of 0 the zero-assertions are trivially true, and **only the fixture proves they would still fire**.
- **The real-tree assertions now assert zero**, so a reintroduced literal move target fails them. Same guarantee as before, pointed at the state the tree is actually in.

The ROSE case builds its own one-file tree through the `FUSION_CENSUS_FILE_ROOT`/`FILE_LIST` seam from #3230 rather than borrowing a baseline entry that no longer exists — a rise **constructed** instead of borrowed. It also now asserts the failure is *not* the reclassification wording, which is the distinction that file exists to protect.

## Verification

| mutation | expected | result |
| --- | --- | --- |
| reintroduce a literal `moveTask(id, "in-review")` in the engine | fail | exit 1 ✅ |
| blind the collector to return `[]` | fail | exit 1 ✅ |
| remove the `ROSE` wording from the census script | fail | exit 1 ✅ |
| clean tree | pass | exit 0 ✅ |

60 tests green across the three census suites. All eight ratchets exit 0. Test-only; no changeset.

**One honest note on my own method.** My first `ROSE` mutation replaced 1 of the 2 occurrences in the script and the test stayed green — which looks exactly like a dead assertion. It was an ineffective mutation, not a dead test; the manual run still printed `ROSE` from the other occurrence. Re-run against both, it failed. A mutation that does not actually change behaviour proves nothing, and it is worth checking that the mutation landed before concluding the test is dead — the same trap as reading a report-only ratchet's exit 0 as a pass.

## Not in scope

`defaultColumnIds()` has a pre-existing type error (`Property 'columns' does not exist on WorkflowIrV1` — union narrowing). Untouched by this PR and the test executes fine; flagging rather than fixing, since it is unrelated to the red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved census analysis reliability when evaluating guard-count increases and reclassification messages.
  * Improved detection and classification of literal move targets and declared columns.
  * Enhanced file path reporting for inputs outside the primary source directory.

* **Tests**
  * Added isolated test scenarios using temporary census data and fixtures.
  * Strengthened validation of recovery, plain, and declared-column classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->