### PR TITLE
refactor(scheduler): the capacity gate's terminal check uses the shared isTerminalColumnRole

### DIFF
--- a/packages/engine/src/__tests__/scheduler-terminal-capacity-role.test.ts
+++ b/packages/engine/src/__tests__/scheduler-terminal-capacity-role.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+/*
+FNXC:WorkflowResolvedColumns 2026-08-01-09:20 (fleet):
+
+THE INVARIANT: the worktree-capacity read excludes terminal lanes by ROLE, on any board.
+
+The capacity gate counts every non-terminal task holding a worktree. Terminal cards are excluded
+because their retained worktrees are cleanup-owned, not capacity. That exclusion arrived hand-rolled,
+with `flags.complete === true || flags.archived === true` and a `"done" | "archived"` literal fallback
+— the same shape the FNXC on `isWipColumnTask` records as already removed once from this file.
+
+Getting it wrong is not symmetric. Under-counting admits work over the cap: the commit that added the
+gate reports maxWorktrees=4 with four planning sessions and a fifth worktree admitted. Over-counting
+merely starves dispatch. So the risk of a renamed board silently failing the exclusion is the
+dangerous direction.
+
+WHY THIS TESTS THE PREDICATE AND NOT THE DISPATCH PATH: same reason as
+`scheduler-load-lane-union.test.ts` — the call site sits inside `schedule()`, which a unit test has no
+business standing up. The predicate is the whole of the decision.
+
+NOTE ON COVERAGE, recorded rather than implied: blinding this predicate to `false` leaves all 22
+scheduler suites green (365 tests). The capacity logic it feeds has no behavioural coverage at all.
+This pins the lane vocabulary; it does NOT pin the capacity arithmetic, which is still unguarded.
+*/
+import { describe, expect, it } from "vitest";
+import { isTerminalColumnRole, resolveColumnFlags } from "@fusion/core";
+import type { WorkflowIr } from "@fusion/core";
+
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "hold" }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    { id: "attic", name: "Attic", traits: [{ trait: "archived" }] },
+  ],
+} as unknown as WorkflowIr;
+
+const flagsFor = (columnId: string) => resolveColumnFlags(
+  RENAMED_IR.columns.find((c) => c.id === columnId) as never,
+);
+
+describe("worktree capacity excludes terminal lanes by role", () => {
+  it("excludes BOTH renamed terminal lanes, not just the complete one", () => {
+    expect(isTerminalColumnRole(flagsFor("shipped"), "shipped")).toBe(true);
+    expect(isTerminalColumnRole(flagsFor("attic"), "attic")).toBe(true);
+  });
+
+  it("counts renamed working and hold lanes toward capacity", () => {
+    expect(isTerminalColumnRole(flagsFor("building"), "building")).toBe(false);
+    expect(isTerminalColumnRole(flagsFor("backlog"), "backlog")).toBe(false);
+  });
+
+  /*
+  The degraded arm is why the shared helper is used rather than the hand-rolled version: an
+  unresolvable column must keep answering for the legacy ids, or a board mid-migration starts counting
+  its own done cards against the worktree cap.
+  */
+  it("still recognises the legacy terminal ids when flags cannot be resolved", () => {
+    expect(isTerminalColumnRole(undefined, "done")).toBe(true);
+    expect(isTerminalColumnRole(undefined, "archived")).toBe(true);
+    expect(isTerminalColumnRole(undefined, "in-progress")).toBe(false);
+  });
+});

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -41,7 +41,7 @@ import { BacklogPressureReporter } from "./backlog-pressure-reporter.js";
 import { UnlinkedMissionsAdvisoryReporter } from "./unlinked-missions-advisory-reporter.js";
 import { createRunAuditor, generateSyntheticRunId } from "./run-audit.js";
 import type { TaskMoveLanes } from "@fusion/core";
-import { resolveProjectColumnsForRoles, resolveWorkflowIrForTask, resolveWorkflowIrById, resolveColumnFlags, resolveWorktreeCapacityLimit, resolveLifecycleColumns, isWipColumnRole, isReviewColumnRole, isCompleteColumnRole, columnsWithFlag } from "@fusion/core";
+import { resolveProjectColumnsForRoles, resolveWorkflowIrForTask, resolveWorkflowIrById, resolveColumnFlags, resolveWorktreeCapacityLimit, resolveLifecycleColumns, isWipColumnRole, isReviewColumnRole, isCompleteColumnRole, isTerminalColumnRole, columnsWithFlag } from "@fusion/core";
 import type { ColumnRoleTraitFlags } from "@fusion/core";
 import type { WorkflowIr, WorkflowIrV2 } from "@fusion/core";
 import { runHoldReleaseSweep, isUnplannedForExecution, type SlotReservation } from "./hold-release.js";
@@ -2243,11 +2243,26 @@ export class Scheduler {
       Marker sits in the DECLARATION's leading comments, not inline: markers are read from a node's
       leading comments, so a mid-expression one attaches to the wrong node and is silently ignored.
       */
-      const isTerminalColumnTask = (task: Task): boolean => {
-        const flags = columnFlagsForTask(task);
-        if (flags) return flags.complete === true || flags.archived === true;
-        return task.column === "done" || task.column === "archived";
-      };
+      /*
+      FNXC:WorkflowResolvedColumns 2026-08-01-10:05 (fleet — correcting "nothing to convert TO"):
+      There is: `isTerminalColumnRole` in core is this predicate, term for term. With flags it reads
+      `flags.complete === true || flags.archived === true`; without them it falls back to the legacy
+      complete/archived ids — the same two arms written out below, verified against `column-roles.ts`.
+
+      Its own doc-comment names this exact case: it exists "because the pattern
+      `column !== \"done\" && column !== \"archived\"` is the single most repeated shape in the backlog"
+      and "keeps callers from re-deriving it and from accidentally dropping one half."
+
+      The DELIBERATE reasoning above is otherwise correct and kept: the undefined-flags arm is a live
+      path and treating an unreadable workflow as non-terminal would count a finished card's retained
+      worktree against live capacity. That argument is about the FALLBACK's existence, not about where
+      the predicate lives — and the shared helper carries the identical fallback.
+
+      Second time in this file: `isWipColumnTask` two lines up records that it was itself once "a
+      hand-rolled copy of `isWipColumnRole`".
+      */
+      const isTerminalColumnTask = (task: Task): boolean =>
+        isTerminalColumnRole(columnFlagsForTask(task), task.column);
       const wipTaskIdSet = new Set(wipTaskIds);
       const nonWipWorktreeHolderIds = tasks
         .filter((task) => !wipTaskIdSet.has(task.id)


### PR DESCRIPTION
**Rebased. The census claim in my original title was overtaken — this is now a correction, not a conversion.**

## Census: 0 before, 0 after

#3261 got there first, by **recording** the fallback rather than converting it. Its `DELIBERATE` reasoning is correct and I kept it verbatim.

## What this corrects

That note says:

> Recorded rather than converted because **there is nothing to convert TO**.

There is. **`isTerminalColumnRole` in core is this predicate, term for term** — verified against `column-roles.ts` rather than assumed:

| | hand-rolled | `isTerminalColumnRole` |
|---|---|---|
| flags present | `flags.complete === true \|\| flags.archived === true` | same, via the two role helpers |
| flags undefined | `columnId === "done" \|\| columnId === "archived"` | same, via `LEGACY_COMPLETE/ARCHIVED_COLUMN_ID` |

And the helper's own doc names this exact case — it exists *"because the pattern `column !== \"done\" && column !== \"archived\"` is the single most repeated shape in the backlog"* and *"keeps callers from re-deriving it and from accidentally dropping one half."*

**The rest of #3261's argument stands and is preserved.** The undefined-flags arm is a **live** path, and treating an unreadable workflow as non-terminal would count a finished card's retained worktree against live capacity. That reasoning is about the *fallback's existence*, not about *where the predicate lives* — and the shared helper carries the identical fallback.

Second time in this file: `isWipColumnTask` two lines up records that it was itself once *"a hand-rolled copy of `isWipColumnRole`"*. That's an argument for the helper being easy to miss, not for anyone being careless.

## Coverage, stated rather than implied

**Blinding this predicate to `false` leaves all 22 scheduler suites green (365 tests)** — the capacity logic it feeds has no behavioural coverage at all.

The added test pins the **lane vocabulary** (both renamed terminal lanes, the non-terminal lanes, the legacy fallback). It does **not** pin the capacity arithmetic, which stays unguarded and belongs to that gate's owner. Under-counting is the dangerous direction: the commit adding the gate reports `maxWorktrees=4` with **a fifth worktree admitted**.

## Verification

- 23 scheduler suites — **368 green**; `tsc` clean
- Census 0 → 0; DELIBERATE count unchanged at 148; inert ratchet green

🤖 Generated with [Claude Code](https://claude.com/claude-code)