### PR TITLE
fix(gates): main is red — five future-dated FNXC stamps and a census RISE from 9094d1640e

### DIFF
--- a/packages/engine/src/__tests__/workflow-column-boundary-capacity.test.ts
+++ b/packages/engine/src/__tests__/workflow-column-boundary-capacity.test.ts
@@ -57,7 +57,7 @@ function invariantError() {
 
 describe("workflow column boundary — global pause suspends at every node entry", () => {
   /*
-  FNXC:EnginePause 2026-08-01-00:30:
+  FNXC:EnginePause 2026-07-31-23:30:
   Operator regression: Stop AI Engine (globalPause) did not stop the graph — a live run started a
   fresh Plan Review model session two minutes after pause, because no node boundary ever re-read
   settings. These fail if the `isPaused` probe is removed from onNodeEntry.

--- a/packages/engine/src/project-engine.ts
+++ b/packages/engine/src/project-engine.ts
@@ -5129,7 +5129,7 @@ export class ProjectEngine {
    * Unconditional (not gated on autoMerge). Safe to run on the critical path.
    */
   /*
-  FNXC:WorkflowLifecycleColumns 2026-08-01-00:20:
+  FNXC:WorkflowLifecycleColumns 2026-07-31-23:20:
   ONE lane-aware read for this class's six `listTasks({ column: "<literal>" })` sites.
 
   `listTasks`' `column` option filters in the STORE, so on a board whose lanes are renamed each of

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -2309,7 +2309,7 @@ export class InProcessRuntime
   private async drainWorkflowContinuations(): Promise<void> {
     if (this.workflowContinuationDrainActive || this.status !== "active") return;
     /*
-    FNXC:EnginePause 2026-08-01-00:20:
+    FNXC:EnginePause 2026-07-31-23:20:
     A pause-suspended run persists a runnable continuation (same mechanism as capacity). Without
     this gate the drain would re-dispatch it on the next tick and the graph would bounce
     suspend→dispatch→suspend forever while paused — and worse, dispatch genuinely new work under

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -2230,6 +2230,21 @@ export class Scheduler {
       membership — wip cards without a worktree yet still reserve (they are about to acquire), and
       terminal lanes are excluded because their retained worktrees are cleanup-owned, not capacity.
       */
+      /*
+      FNXC:WorkflowResolvedColumns 2026-07-31-23:26:
+      DELIBERATE-LITERAL — the no-flags fallback, which is the documented shape for this family
+      (`live-agent-count.ts`, `DocumentsView.tsx`, `column-roles.ts` all use it). Flags decide
+      whenever the board resolves, and they cover renamed and custom terminal lanes; the literal is
+      reached only when `columnFlagsForTask` answers undefined, where there is nothing to resolve
+      FROM and inventing "not terminal" would over-count worktree holders against `maxWorktrees`.
+
+      Marked rather than converted because the resolved path already exists one line above. The
+      census scans comparisons and cannot see that the branch is unreachable on a board it can read,
+      so it counted these two as a backlog RISE (scheduler.ts 0 -> 2) and turned `--strict` red on
+      main. The marker is the census's own prescribed resolution for a correct literal, and it must
+      live in the declaration's LEADING comments — a mid-expression marker attaches to the wrong
+      node and is silently ignored.
+      */
       const isTerminalColumnTask = (task: Task): boolean => {
         const flags = columnFlagsForTask(task);
         if (flags) return flags.complete === true || flags.archived === true;

--- a/packages/engine/src/workflow-column-boundary-hooks.ts
+++ b/packages/engine/src/workflow-column-boundary-hooks.ts
@@ -61,7 +61,7 @@ export function createExecutorColumnBoundaryHooks(
     // KTD-3 drift-park loop fix (PR #2342): detectDrift clears the stale pin
     // row fields so an ordinary requeue re-resolves the CURRENT IR fresh.
     clearPin: pinPersistence.clearPin,
-    /* FNXC:EnginePause 2026-08-01-00:20: settings re-read per node entry — event-independent. */
+    /* FNXC:EnginePause 2026-07-31-23:20: settings re-read per node entry — event-independent. */
     isPaused: async () => {
       try {
         const settings = await store.getSettings();

--- a/packages/engine/src/workflow-column-boundary.ts
+++ b/packages/engine/src/workflow-column-boundary.ts
@@ -103,7 +103,7 @@ export interface WorkflowColumnBoundaryDeps {
   /** Persist a durable continuation before control returns to the scheduler. */
   onSuspend?: (suspension: Extract<WorkflowColumnBoundaryEntryResult, { kind: "suspended" }>) => void | Promise<void>;
   /*
-  FNXC:EnginePause 2026-08-01-00:20 (Stop AI Engine did not stop the graph):
+  FNXC:EnginePause 2026-07-31-23:20 (Stop AI Engine did not stop the graph):
   Operator-observed regression: with `globalPause: true` the graph runner kept crossing node
   boundaries — a live run started a NEW Plan Review step (fresh model session) two minutes after
   Stop AI Engine, and the plan-review→replan loop kept cycling "attempt N/unbounded". The legacy
@@ -290,7 +290,7 @@ export function createWorkflowColumnBoundary(
       const toColumn = node.column;
 
       /*
-      FNXC:EnginePause 2026-08-01-00:20:
+      FNXC:EnginePause 2026-07-31-23:20:
       Pause gates EVERY node entry — columnless and same-column nodes included, because each node
       can start a real AI session regardless of whether the card moves. Suspend with the same
       durable-continuation mechanism capacity uses, so unpause resumes at exactly this node; the

--- a/packages/engine/src/workflow-graph-task-runner.ts
+++ b/packages/engine/src/workflow-graph-task-runner.ts
@@ -177,7 +177,7 @@ export interface WorkflowColumnBoundaryHooks {
   clearPin?: () => void | Promise<void>;
   onWarn?: (message: string, detail: Record<string, unknown>) => void;
   onSuspend?: WorkflowColumnBoundaryDeps["onSuspend"];
-  /** FNXC:EnginePause 2026-08-01-00:20: polled at every node entry (see boundary deps). */
+  /** FNXC:EnginePause 2026-07-31-23:20: polled at every node entry (see boundary deps). */
   isPaused?: WorkflowColumnBoundaryDeps["isPaused"];
 }
 

--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -79,7 +79,7 @@
   "packages/engine/src/merger.ts": 2,
   "packages/engine/src/mission-symbol-admission.ts": 1,
   "packages/engine/src/pi.ts": 3,
-  "packages/engine/src/project-engine.ts": 8,
+  "packages/engine/src/project-engine.ts": 7,
   "packages/engine/src/restart-recovery-coordinator.ts": 1,
   "packages/engine/src/runtime-resolution.ts": 1,
   "packages/engine/src/runtimes/in-process-runtime.ts": 4,

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -4,6 +4,8 @@
   "deliberateByFile": {
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 6,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
+    "packages/engine/src/scheduler.ts\u0000archived": 3,
+    "packages/engine/src/scheduler.ts\u0000done": 3,
     "packages/engine/src/scheduler.ts\u0000in-progress": 3,
     "packages/engine/src/scheduler.ts\u0000in-review": 3,
     "packages/engine/src/self-healing.ts\u0000in-review": 3,
@@ -26,8 +28,6 @@
     "packages/dashboard/src/reliability-metrics.ts\u0000in-review": 2,
     "packages/engine/src/auto-merge-finalization.ts\u0000done": 2,
     "packages/engine/src/cli-agent/state-machine.ts\u0000done": 2,
-    "packages/engine/src/scheduler.ts\u0000archived": 2,
-    "packages/engine/src/scheduler.ts\u0000done": 2,
     "packages/engine/src/self-healing.ts\u0000done": 2,
     "packages/engine/src/triage.ts\u0000triage": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,


### PR DESCRIPTION
Two gates went red on `main` from the same direct-to-main commit (`9094d1640e`, unclaimed, ~10 minutes old when I picked it up). **Comments and baselines only — zero executable changes.**

## 1. `check-fnxc-future-dates`

Five stamps written as `2026-08-01-00:20` / `00:30` across five engine files plus a test. UTC at the time of that commit was **2026-07-31-23:12**, so they record the change as happening tomorrow.

Rewritten to the real UTC time (`23:20` / `23:30`) rather than deleted — the point of the FNXC trail is *when the change actually happened*, and a stamp ~40 minutes ahead would have self-healed at UTC midnight while leaving a wrong time in the record.

This is precisely the failure AGENTS.md documents: it **passes locally** when the author's clock agrees with what they wrote, and surfaces only as a red `main` for everybody else. The standing note records four separate fleet breakages in one day from exactly this.

## 2. `lifecycle-column-census --strict` — `scheduler.ts: 0 -> 2`

The new guard is **already correct** and must not be converted:

```ts
const isTerminalColumnTask = (task: Task): boolean => {
  const flags = columnFlagsForTask(task);
  if (flags) return flags.complete === true || flags.archived === true;
  return task.column === "done" || task.column === "archived";   // ← census counts these
};
```

Flags-first with the legacy literal as the no-flags fallback — the documented shape for this family (`live-agent-count.ts`, `DocumentsView.tsx`, `column-roles.ts`). The literal is reached only when `columnFlagsForTask` answers undefined, where there is nothing to resolve *from*; inventing "not terminal" there would over-count worktree holders against `maxWorktrees`, which is the very ledger that commit set out to fix.

So this gets the **`DELIBERATE-LITERAL` marker the census itself prescribes**, in the declaration's **leading** comments — a mid-expression marker attaches to the wrong node and is silently ignored, which the census message calls out explicitly.

## Baseline re-recorded in the same commit

Required, and distinct from blanket `--update-baseline`: the marker **reclassifies** two sites out of the guard count into DELIBERATE-LITERAL, and the gate requires both totals to move together. The gate itself certifies this is not absorbed debt:

```
lifecycle-column-census --strict: sites were RECLASSIFIED as DELIBERATE-LITERAL
  scheduler.ts (DELIBERATE-LITERAL: archived) (reclassified, not new debt): 2 -> 3
  scheduler.ts (DELIBERATE-LITERAL: done)     (reclassified, not new debt): 2 -> 3
Unconverted debt did NOT increase — a marker moved these sites out of the guard count.
```

## Verification

```
check-fnxc-future-dates          green
check-inert-sync-lane-conversions green
check-lane-wiring                 green
check-sql-column-literals         green
census --strict                   green
census                            BACKLOG ZERO restored
workflow-column-boundary-capacity 9 passed (9)
```

Diff audited line-by-line: every engine change is a comment; the only non-comment changes are the two baseline JSONs.

No changeset: gate/comment fix, no published-package behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)