### PR TITLE
fix(engine): main is red on two lifecycle gates — mark the terminal fallback, unfuture the stamps

### DIFF
--- a/packages/engine/src/__tests__/workflow-column-boundary-capacity.test.ts
+++ b/packages/engine/src/__tests__/workflow-column-boundary-capacity.test.ts
@@ -57,7 +57,7 @@ function invariantError() {
 
 describe("workflow column boundary — global pause suspends at every node entry", () => {
   /*
-  FNXC:EnginePause 2026-08-01-00:30:
+  FNXC:EnginePause 2026-07-31-23:25-00:30:
   Operator regression: Stop AI Engine (globalPause) did not stop the graph — a live run started a
   fresh Plan Review model session two minutes after pause, because no node boundary ever re-read
   settings. These fail if the `isPaused` probe is removed from onNodeEntry.

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -2309,7 +2309,7 @@ export class InProcessRuntime
   private async drainWorkflowContinuations(): Promise<void> {
     if (this.workflowContinuationDrainActive || this.status !== "active") return;
     /*
-    FNXC:EnginePause 2026-08-01-00:20:
+    FNXC:EnginePause 2026-07-31-23:25-00:20:
     A pause-suspended run persists a runnable continuation (same mechanism as capacity). Without
     this gate the drain would re-dispatch it on the next tick and the graph would bounce
     suspend→dispatch→suspend forever while paused — and worse, dispatch genuinely new work under

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -2230,6 +2230,18 @@ export class Scheduler {
       membership — wip cards without a worktree yet still reserve (they are about to acquire), and
       terminal lanes are excluded because their retained worktrees are cleanup-owned, not capacity.
       */
+      /*
+      DELIBERATE-LITERAL — the unresolvable-workflow default, matching the 148 other marked degraded
+      arms in this tree. `columnFlagsForTask` answers by TRAIT wherever the card's workflow resolves;
+      this line runs only when it does not, and returns exactly what the check did before traits
+      existed. Marked rather than converted because there is nothing left to resolve at this point:
+      the resolver already declined.
+
+      FNXC:LifecycleColumnCensus 2026-07-31-23:20 (why the marker is needed at all):
+      The census counts a trait-first/legacy-fallback pair as backlog unless it carries this marker —
+      `traitFallback` is advisory and never changes `kind`. Without it this reviewed fallback read as
+      two fresh guards and turned the census gate RED on main.
+      */
       const isTerminalColumnTask = (task: Task): boolean => {
         const flags = columnFlagsForTask(task);
         if (flags) return flags.complete === true || flags.archived === true;

--- a/packages/engine/src/workflow-column-boundary-hooks.ts
+++ b/packages/engine/src/workflow-column-boundary-hooks.ts
@@ -61,7 +61,7 @@ export function createExecutorColumnBoundaryHooks(
     // KTD-3 drift-park loop fix (PR #2342): detectDrift clears the stale pin
     // row fields so an ordinary requeue re-resolves the CURRENT IR fresh.
     clearPin: pinPersistence.clearPin,
-    /* FNXC:EnginePause 2026-08-01-00:20: settings re-read per node entry — event-independent. */
+    /* FNXC:EnginePause 2026-07-31-23:25-00:20: settings re-read per node entry — event-independent. */
     isPaused: async () => {
       try {
         const settings = await store.getSettings();

--- a/packages/engine/src/workflow-column-boundary.ts
+++ b/packages/engine/src/workflow-column-boundary.ts
@@ -103,7 +103,7 @@ export interface WorkflowColumnBoundaryDeps {
   /** Persist a durable continuation before control returns to the scheduler. */
   onSuspend?: (suspension: Extract<WorkflowColumnBoundaryEntryResult, { kind: "suspended" }>) => void | Promise<void>;
   /*
-  FNXC:EnginePause 2026-08-01-00:20 (Stop AI Engine did not stop the graph):
+  FNXC:EnginePause 2026-07-31-23:25-00:20 (Stop AI Engine did not stop the graph):
   Operator-observed regression: with `globalPause: true` the graph runner kept crossing node
   boundaries — a live run started a NEW Plan Review step (fresh model session) two minutes after
   Stop AI Engine, and the plan-review→replan loop kept cycling "attempt N/unbounded". The legacy
@@ -290,7 +290,7 @@ export function createWorkflowColumnBoundary(
       const toColumn = node.column;
 
       /*
-      FNXC:EnginePause 2026-08-01-00:20:
+      FNXC:EnginePause 2026-07-31-23:25-00:20:
       Pause gates EVERY node entry — columnless and same-column nodes included, because each node
       can start a real AI session regardless of whether the card moves. Suspend with the same
       durable-continuation mechanism capacity uses, so unpause resumes at exactly this node; the

--- a/packages/engine/src/workflow-graph-task-runner.ts
+++ b/packages/engine/src/workflow-graph-task-runner.ts
@@ -177,7 +177,7 @@ export interface WorkflowColumnBoundaryHooks {
   clearPin?: () => void | Promise<void>;
   onWarn?: (message: string, detail: Record<string, unknown>) => void;
   onSuspend?: WorkflowColumnBoundaryDeps["onSuspend"];
-  /** FNXC:EnginePause 2026-08-01-00:20: polled at every node entry (see boundary deps). */
+  /** FNXC:EnginePause 2026-07-31-23:25-00:20: polled at every node entry (see boundary deps). */
   isPaused?: WorkflowColumnBoundaryDeps["isPaused"];
 }
 

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -4,6 +4,8 @@
   "deliberateByFile": {
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 6,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
+    "packages/engine/src/scheduler.ts\u0000archived": 3,
+    "packages/engine/src/scheduler.ts\u0000done": 3,
     "packages/engine/src/scheduler.ts\u0000in-progress": 3,
     "packages/engine/src/scheduler.ts\u0000in-review": 3,
     "packages/engine/src/self-healing.ts\u0000in-review": 3,
@@ -26,8 +28,6 @@
     "packages/dashboard/src/reliability-metrics.ts\u0000in-review": 2,
     "packages/engine/src/auto-merge-finalization.ts\u0000done": 2,
     "packages/engine/src/cli-agent/state-machine.ts\u0000done": 2,
-    "packages/engine/src/scheduler.ts\u0000archived": 2,
-    "packages/engine/src/scheduler.ts\u0000done": 2,
     "packages/engine/src/self-healing.ts\u0000done": 2,
     "packages/engine/src/triage.ts\u0000triage": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,


### PR DESCRIPTION
## What

**Main is red on two lifecycle gates**, both from `9094d1640e`, and both run in CI's **blocking Lint job**. This turns them green.

## 1. Census: backlog 0 → 2

`isTerminalColumnTask` in `scheduler.ts` is a **correctly written** trait-first check with a legacy fallback:

```ts
const flags = columnFlagsForTask(task);
if (flags) return flags.complete === true || flags.archived === true;
return task.column === "done" || task.column === "archived";
```

There is nothing to convert — `columnFlagsForTask` answers by trait wherever the workflow resolves, and that last line runs *only* when it already declined. It simply lacked the `DELIBERATE-LITERAL` marker that the other **148** degraded arms in this tree carry.

The reason an unmarked fallback reads as fresh debt: `traitFallback` is **advisory and never changes `kind`**, so the census counts a trait-first pair as backlog unless it is marked. Marked at the site with that explanation, and the baseline re-recorded in the same commit as the gate instructs (`done` and `archived` each 2 → 3 deliberate).

## 2. FNXC dates: six stamps dated tomorrow

Six `FNXC:EnginePause 2026-08-01` stamps across five files, while UTC was `2026-07-31`. Re-stamped from `date -u`.

I have broken this exact rule **twice myself** this session — which is how I recognised it on sight. The fix is mechanical, and main should not sit red waiting for the author's next session.

## Measured

```
census --strict          rc=0   (backlog 0, deliberate 148 -> 150)
check-fnxc-future-dates  rc=0
lint                     clean
scheduler suite          15 files / 148 tests passed
workflow-column-boundary-capacity   9 passed
```

## Note on how this was found

The census caught it **because of #3247** — I extended it hours ago to see membership and switch guards, and this is the first new guard the improved detector has stopped. It also caught it *correctly*: it flagged real unmarked literals rather than a false positive, and the `--strict` reclassification message told me exactly what to do (`--update-baseline`, same commit) instead of leaving me to guess whether a rising deliberate count was legitimate.

I also wasted a step here worth naming: I edited the *wrong* site first, because I assumed the commit diff's only visible `done`/`archived` line was the one being counted. It was not — the real site was 500 lines away at `:2247`. Asking the tool for the finding's line number (`findComparisons`) took one command and would have skipped the detour entirely. Same lesson as the rest of this session: **get the location from the instrument, not from the diff you happen to be looking at.**
