### PR TITLE
chore(engine): mark the scheduler terminal-lane fallback arm DELIBERATE (main was red)

### DIFF
--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -2233,6 +2233,11 @@ export class Scheduler {
       const isTerminalColumnTask = (task: Task): boolean => {
         const flags = columnFlagsForTask(task);
         if (flags) return flags.complete === true || flags.archived === true;
+        /* FNXC:WorkflowResolvedColumns 2026-07-31-23:59: DELIBERATE-LITERAL — the fallback arm.
+           `columnFlagsForTask` returning undefined means this card's board could not be resolved;
+           the legacy ids are then the only answer, and dropping them would make an unresolvable card
+           count as NON-terminal and consume capacity it does not hold. The live arm above is the
+           resolved one. Marked so the census reads this as reviewed rather than as new debt. */
         return task.column === "done" || task.column === "archived";
       };
       const wipTaskIdSet = new Set(wipTaskIds);

--- a/scripts/lib/lifecycle-column-census-baseline.json
+++ b/scripts/lib/lifecycle-column-census-baseline.json
@@ -4,6 +4,8 @@
   "deliberateByFile": {
     "packages/core/src/task-store/async-comments-attachments.ts\u0000archived": 6,
     "packages/dashboard/app/components/TaskContextMenu.tsx\u0000in-review": 3,
+    "packages/engine/src/scheduler.ts\u0000archived": 3,
+    "packages/engine/src/scheduler.ts\u0000done": 3,
     "packages/engine/src/scheduler.ts\u0000in-progress": 3,
     "packages/engine/src/scheduler.ts\u0000in-review": 3,
     "packages/engine/src/self-healing.ts\u0000in-review": 3,
@@ -26,8 +28,6 @@
     "packages/dashboard/src/reliability-metrics.ts\u0000in-review": 2,
     "packages/engine/src/auto-merge-finalization.ts\u0000done": 2,
     "packages/engine/src/cli-agent/state-machine.ts\u0000done": 2,
-    "packages/engine/src/scheduler.ts\u0000archived": 2,
-    "packages/engine/src/scheduler.ts\u0000done": 2,
     "packages/engine/src/self-healing.ts\u0000done": 2,
     "packages/engine/src/triage.ts\u0000triage": 2,
     "packages/engine/src/usage-limit-detector.ts\u0000archived": 2,


### PR DESCRIPTION
**`main` is red on `census --strict`** — the column-guard count rose `0 → 2` when #9094d164 added `isTerminalColumnTask`. This restores it.

## Not new debt — it is the fallback arm

```ts
const isTerminalColumnTask = (task: Task): boolean => {
  const flags = columnFlagsForTask(task);
  if (flags) return flags.complete === true || flags.archived === true;   // live arm, resolved
  return task.column === "done" || task.column === "archived";            // fallback arm
};
```

`columnFlagsForTask` returning `undefined` means this card's board could not be resolved. The legacy ids are then the only answer available, and **dropping them would make an unresolvable card count as NON-terminal** — so it would consume worktree capacity it does not actually hold, which is the bug #9094d164 was written to fix.

Same class as the fallback arms marked in #3056 (`async-mission-store-queries.ts`) and #3107 (`auto-merge-finalization.ts`): the literal *is* the design, so it gets a marker rather than a conversion.

Census **2 → 0**, `--strict` green, baseline re-recorded in the same commit as the ratchet requires.

## The ratchet did its job

Worth noting the sequence: the census had been at 0 for several sweeps, this landed, and the next sweep caught it immediately with the file and the exact delta. That is the behaviour that makes the ratchet worth keeping in CI rather than running by hand.

## Separate, pre-existing: `check-fnxc-future-dates` is ALSO red on main

```
workflow-column-boundary.ts:              2 future-dated stamps, baseline allows 0
workflow-column-boundary-hooks.ts:        1, allows 0
workflow-column-boundary-capacity.test.ts: 1, allows 0
in-process-runtime.ts:                    5, allows 4
```

Verified against clean `origin/main` — it fails there identically, so this branch does not introduce it and does not fix it. Nine future-dated stamps across four files, from the same boundary work. Whoever owns that change should correct the dates; every PR built on main inherits the failure until then.

**Verification:** `scheduler` suites **148 pass**, `tsc --noEmit` 0 errors, `census --strict` exit 0.