### PR TITLE
fix(fnxc): main is red — repoint one future-dated stamp in lifecycle-ops (third instance in an hour)

### DIFF
--- a/packages/core/src/task-store/lifecycle-ops.ts
+++ b/packages/core/src/task-store/lifecycle-ops.ts
@@ -465,7 +465,7 @@ export async function reconcileOrphanedTaskDirsImpl(store: TaskStore, opts: { ig
           if (ageMs > RECONCILE_ORPHAN_TASK_DIR_MAX_AGE_MS) {
             result.skipped.push({ id, reason: "stale-orphan-dir-beyond-recency-window" });
             /*
-            FNXC:Diagnostics 2026-08-01-00:50 (operator report — warn spam):
+            FNXC:Diagnostics 2026-07-31-23:31 (operator report — warn spam):
             This skip is STEADY-STATE: a months-old orphan dir (e.g. a pre-tombstone hard-delete
             leftover) trips it on EVERY maintenance sweep, forever, until someone deletes the dir.
             Per the self-healing logging policy (self-healing.ts header), per-sweep


### PR DESCRIPTION
One-line comment fix. `main` is red on `check-fnxc-future-dates`.

## What

`e52da740a5` (direct to main, ~2 minutes before I picked this up) stamped:

```
FNXC:Diagnostics 2026-08-01-00:50 (operator report — warn spam):
```

Its own commit time was `2026-07-31T16:32:47-07:00` = **23:32 UTC**, so the stamp records the change **78 minutes in the future**.

Repointed to `2026-07-31-23:31` — the real time of the change — rather than deleted. Waiting for UTC midnight would have made the gate pass on its own while leaving a wrong timestamp in the record permanently; the trail's whole value is *when this happened*.

## Third instance in under an hour

- `9094d1640e` — five stamps at `2026-08-01-00:20/00:30`, repointed by #3261 (I had an equivalent fix in #3263; theirs landed first, so I closed mine as superseded rather than rebase a duplicate).
- `e52da740a5` — this one.

All from **direct-to-main commits**, and all invisible to their authors for the same reason AGENTS.md documents: a local clock behind UTC agrees with what was typed, so `pnpm lint` passes locally and the red only appears for everyone else. The standing note already records four such breakages in a single day; this is three more in one hour, which suggests the `date -u` guidance isn't reaching the lanes writing these stamps.

## Verification

```
check-fnxc-future-dates           green
check-inert-sync-lane-conversions green
check-lane-wiring                 green
check-sql-column-literals         green
census --strict                   green
```

Comment only — no executable change.

No changeset: comment/gate fix, no published-package behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)