### PR TITLE
fix(fnxc): main is red — repoint two future-dated stamps (third and fourth instance in ninety minutes)

### DIFF
--- a/packages/core/src/task-store/lifecycle-ops.ts
+++ b/packages/core/src/task-store/lifecycle-ops.ts
@@ -465,7 +465,7 @@ export async function reconcileOrphanedTaskDirsImpl(store: TaskStore, opts: { ig
           if (ageMs > RECONCILE_ORPHAN_TASK_DIR_MAX_AGE_MS) {
             result.skipped.push({ id, reason: "stale-orphan-dir-beyond-recency-window" });
             /*
-            FNXC:Diagnostics 2026-08-01-00:50 (operator report — warn spam):
+            FNXC:Diagnostics 2026-07-31-23:31 (operator report — warn spam):
             This skip is STEADY-STATE: a months-old orphan dir (e.g. a pre-tombstone hard-delete
             leftover) trips it on EVERY maintenance sweep, forever, until someone deletes the dir.
             Per the self-healing logging policy (self-healing.ts header), per-sweep

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -2255,7 +2255,7 @@ export class Scheduler {
           && typeof task.worktree === "string" && task.worktree.length > 0)
         .map((task) => task.id);
       /*
-      FNXC:WorkflowScheduling 2026-08-01-01:05 (self-deadlock in the widened ledger, observed live):
+      FNXC:WorkflowScheduling 2026-07-31-23:39 (self-deadlock in the widened ledger, observed live):
       A planned Ready card RETAINS its planning worktree for execution reuse, so counting it as a
       holder must not block ITS OWN release — on release the slot TRANSFERS (the card executes in
       the same worktree), it does not add. Without this exclusion the first unpause released only


### PR DESCRIPTION
`main` is red on `check-fnxc-future-dates`. Comment-only fix; no executable change.

Replaces #3268, which was based on a now-superseded `main` and covered only the first of these two.

## Two offenders, ten minutes apart, both direct-to-main

| commit | stamp | committed (UTC) | ahead by |
|---|---|---|---|
| `e52da740a5` | `FNXC:Diagnostics 2026-08-01-00:50` | 23:32 | 78 min |
| `3f95c6d53e` | `FNXC:WorkflowScheduling 2026-08-01-01:05` | 23:39 | 86 min |

Repointed to the real time of each change rather than deleted. **UTC midnight is minutes away**, at which point this gate goes green on its own while both stamps still record the change as happening after it happened — a gate passing because the calendar moved is not the defect being fixed, and after the rollover there is no signal left to catch it.

## Deliberately left alone

Two other future stamps in `scheduler.ts` — `FNXC:ConcurrencyAdmission 2026-08-06-09:00` (from 10 days ago) and `FNXC:WorkflowLifecycleColumns 2026-08-01-05:00` (27 hours ago) — are **grandfathered in the baseline** (`allows 2`). They are accepted debt, not this red. The `2026-08-06` one is six days out, which is an invented date rather than clock skew, but repointing it means a baseline change unrelated to the failure at hand.

## Fourth instance in ninety minutes

`9094d1640e`'s five (repointed by #3261, which superseded my equivalent #3263), plus these two. All from direct-to-main commits. AGENTS.md already attributes four fleet breakages in a single day to this exact mechanism: a local clock behind UTC agrees with what was typed, so `pnpm lint` passes locally and the red lands on everyone else. The recurrence rate suggests the `date -u` guidance isn't reaching the lanes writing these stamps.

## Note on how this branch was made

Rebasing #3268 was blocked by an unrelated **11-hour-old stale `rebase-merge` directory** from a different branch (`fleet/executor-lanes-from-payload`, abandoned 05:24). Rather than delete another branch's in-flight rebase state, I branched fresh from current `main` and cherry-picked. Worth flagging for whoever owns that branch — the stale state will block their rebases too.

## Verification

```
check-fnxc-future-dates           green
check-inert-sync-lane-conversions green
check-lane-wiring                 green
check-sql-column-literals         green
census --strict                   green
```

Diff is two comment lines. No changeset: comment/gate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)