### PR TITLE
fix(fnxc): the one stamp still keeping main red after #3269

### DIFF
--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -2255,7 +2255,7 @@ export class Scheduler {
           && typeof task.worktree === "string" && task.worktree.length > 0)
         .map((task) => task.id);
       /*
-      FNXC:WorkflowScheduling 2026-08-01-01:05 (self-deadlock in the widened ledger, observed live):
+      FNXC:WorkflowScheduling 2026-07-31-23:39 (self-deadlock in the widened ledger, observed live):
       A planned Ready card RETAINS its planning worktree for execution reuse, so counting it as a
       holder must not block ITS OWN release — on release the slot TRANSFERS (the card executes in
       the same worktree), it does not add. Without this exclusion the first unpause released only


### PR DESCRIPTION
One comment line. `main` is still red on `check-fnxc-future-dates`.

#3269 ("the last future-dated stamp keeping main red") repointed the `lifecycle-ops.ts` stamp but left its sibling, so the gate did not go green:

```
packages/engine/src/scheduler.ts: 3 future-dated FNXC stamp(s), baseline allows 2
  FNXC:WorkflowScheduling 2026-08-01  (dated after today)
```

`3f95c6d53e` committed at **23:39 UTC** and stamped `2026-08-01-01:05` — 86 minutes ahead.

Repointed to the real time of the change rather than deleted. **UTC midnight is minutes away**: after the rollover this gate goes green on its own while the stamp still misrecords when the work happened, and there is no signal left to catch it. A gate that passes because the calendar moved is not the defect being fixed.

## Deliberately untouched

The file's two other future stamps — `FNXC:ConcurrencyAdmission 2026-08-06-09:00` (10 days old) and `FNXC:WorkflowLifecycleColumns 2026-08-01-05:00` (27 hours old) — are **grandfathered in the baseline** (`allows 2`). Accepted debt, not this red; repointing them means a baseline change unrelated to the failure at hand. The `2026-08-06` one is six days out, which is an invented date rather than clock skew, and is worth someone's separate pass.

## Fifth stamp incident in ~two hours

`9094d1640e` ×5 (fixed by #3261), `e52da740a5` (fixed by #3269), and this one — all direct-to-main. AGENTS.md attributes four fleet breakages in one day to this mechanism; the rate today suggests the `date -u` rule isn't reaching the lanes writing the stamps.

## Verification

`check-fnxc-future-dates` green. Diff is one comment line — no executable change.

No changeset: comment/gate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated an internal scheduling comment with revised timestamp information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->