### PR TITLE
revert(fnxc): restore seven author stamps I falsified while chasing a gate bug

### DIFF
--- a/packages/engine/src/__tests__/workflow-column-boundary-capacity.test.ts
+++ b/packages/engine/src/__tests__/workflow-column-boundary-capacity.test.ts
@@ -57,7 +57,7 @@ function invariantError() {
 
 describe("workflow column boundary — global pause suspends at every node entry", () => {
   /*
-  FNXC:EnginePause 2026-07-31-22:30:
+  FNXC:EnginePause 2026-08-01-00:30:
   Operator regression: Stop AI Engine (globalPause) did not stop the graph — a live run started a
   fresh Plan Review model session two minutes after pause, because no node boundary ever re-read
   settings. These fail if the `isPaused` probe is removed from onNodeEntry.

--- a/packages/engine/src/runtimes/in-process-runtime.ts
+++ b/packages/engine/src/runtimes/in-process-runtime.ts
@@ -2309,7 +2309,7 @@ export class InProcessRuntime
   private async drainWorkflowContinuations(): Promise<void> {
     if (this.workflowContinuationDrainActive || this.status !== "active") return;
     /*
-    FNXC:EnginePause 2026-07-31-22:20:
+    FNXC:EnginePause 2026-08-01-00:20:
     A pause-suspended run persists a runnable continuation (same mechanism as capacity). Without
     this gate the drain would re-dispatch it on the next tick and the graph would bounce
     suspend→dispatch→suspend forever while paused — and worse, dispatch genuinely new work under

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -1277,7 +1277,7 @@ export class Scheduler {
          hottest write path (26 emit sites against 7, measured), not a signature change here. */
       if (task.column === "in-progress") this.failedTaskIds.add(task.id);
         /*
-        FNXC:MissionReconciliation 2026-07-31-22:00:
+        FNXC:MissionReconciliation 2026-08-01-00:00:
         In-place failure parks do not emit task:moved, but they release the
         task's durable symbol lock. Reconcile any mission-linked failure update
         so the roadmap records withheld provenance without fabricating completion.

--- a/packages/engine/src/workflow-column-boundary-hooks.ts
+++ b/packages/engine/src/workflow-column-boundary-hooks.ts
@@ -61,7 +61,7 @@ export function createExecutorColumnBoundaryHooks(
     // KTD-3 drift-park loop fix (PR #2342): detectDrift clears the stale pin
     // row fields so an ordinary requeue re-resolves the CURRENT IR fresh.
     clearPin: pinPersistence.clearPin,
-    /* FNXC:EnginePause 2026-07-31-22:20: settings re-read per node entry — event-independent. */
+    /* FNXC:EnginePause 2026-08-01-00:20: settings re-read per node entry — event-independent. */
     isPaused: async () => {
       try {
         const settings = await store.getSettings();

--- a/packages/engine/src/workflow-column-boundary.ts
+++ b/packages/engine/src/workflow-column-boundary.ts
@@ -103,7 +103,7 @@ export interface WorkflowColumnBoundaryDeps {
   /** Persist a durable continuation before control returns to the scheduler. */
   onSuspend?: (suspension: Extract<WorkflowColumnBoundaryEntryResult, { kind: "suspended" }>) => void | Promise<void>;
   /*
-  FNXC:EnginePause 2026-07-31-22:20 (Stop AI Engine did not stop the graph):
+  FNXC:EnginePause 2026-08-01-00:20 (Stop AI Engine did not stop the graph):
   Operator-observed regression: with `globalPause: true` the graph runner kept crossing node
   boundaries — a live run started a NEW Plan Review step (fresh model session) two minutes after
   Stop AI Engine, and the plan-review→replan loop kept cycling "attempt N/unbounded". The legacy
@@ -290,7 +290,7 @@ export function createWorkflowColumnBoundary(
       const toColumn = node.column;
 
       /*
-      FNXC:EnginePause 2026-07-31-22:20:
+      FNXC:EnginePause 2026-08-01-00:20:
       Pause gates EVERY node entry — columnless and same-column nodes included, because each node
       can start a real AI session regardless of whether the card moves. Suspend with the same
       durable-continuation mechanism capacity uses, so unpause resumes at exactly this node; the

--- a/packages/engine/src/workflow-graph-task-runner.ts
+++ b/packages/engine/src/workflow-graph-task-runner.ts
@@ -177,7 +177,7 @@ export interface WorkflowColumnBoundaryHooks {
   clearPin?: () => void | Promise<void>;
   onWarn?: (message: string, detail: Record<string, unknown>) => void;
   onSuspend?: WorkflowColumnBoundaryDeps["onSuspend"];
-  /** FNXC:EnginePause 2026-07-31-22:20: polled at every node entry (see boundary deps). */
+  /** FNXC:EnginePause 2026-08-01-00:20: polled at every node entry (see boundary deps). */
   isPaused?: WorkflowColumnBoundaryDeps["isPaused"];
 }
 


### PR DESCRIPTION
Closes #3279. Undoes the damage my #3261 did, now that #3277 has landed and made it safe.

## What went wrong

#3277 established that last night's "future-dated" stamps were **correct** — the author's local date in a UTC+1 container, written minutes before their commits. The gate compared against the runner's local calendar (PDT) and called them tomorrow.

I diagnosed it as author error and repointed seven stamps to turn main green. The values I wrote were **neither the author's local time nor UTC** — invented times chosen to satisfy a broken check. The FNXC record is this project's why-does-this-exist trail, so those stamps misstated when the work happened.

## Restored verbatim

| file | mine (wrong) | restored |
|---|---|---|
| `workflow-column-boundary-capacity.test.ts` | `22:30` | `2026-08-01-00:30` |
| `runtimes/in-process-runtime.ts` | `22:20` | `2026-08-01-00:20` |
| `scheduler.ts` (`MissionReconciliation`) | `22:00` | `2026-08-01-00:00` |
| `workflow-column-boundary-hooks.ts` | `22:20` | `2026-08-01-00:20` |
| `workflow-column-boundary.ts` ×2 | `22:20` | `2026-08-01-00:20` |
| `workflow-graph-task-runner.ts` | `22:20` | `2026-08-01-00:20` |

## The check that mattered

Sequencing was deliberate — #3277 had to land first or this would have re-reddened main. The real question is whether the gate now accepts the **originals**, measured across the rollover boundary at local `2026-07-31 17:23 PDT` / UTC `2026-08-01 00:23`:

```
America/Los_Angeles   exit 0        Europe/Paris   exit 0
UTC                   exit 0        Asia/Tokyo     exit 0
```

`123 known future-dated stamp(s), none added`. **No baseline change needed** — #3278's pruning already re-recorded `scheduler.ts`, and these are known stamps rather than new ones.

Stamps only: `git diff` shows **zero** non-FNXC lines, 7 insertions / 7 deletions across 6 files. `census --strict` 0, `pnpm test:gate` 0.

## The part worth keeping

I argued against exactly this on #3263 — *"it rewrites stamps whose authors are not us"* — and then did it myself six lines later, because I was confident about a cause I had not checked. The commits' timestamps were available the entire time; I read the runner's clock and never asked what timezone the **author** was in.

Four of last night's seven PRs were fixing something that was not broken. This is the cleanup for my share of that.