### PR TITLE
chore(fnxc): retire the stale scheduler allowance left by the rollover re-record

### DIFF
--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -59,7 +59,6 @@
   "packages/engine/src/restart-recovery-coordinator.ts": 1,
   "packages/engine/src/runtime-resolution.ts": 1,
   "packages/engine/src/runtimes/in-process-runtime.ts": 4,
-  "packages/engine/src/scheduler.ts": 1,
   "packages/engine/src/triage.ts": 5,
   "docs/dashboard-guide.md": 2,
   "docs/workflow-steps.md": 1


### PR DESCRIPTION
**The date gate passes on `main` — but not because this was fixed.**

## What actually happened

UTC rolled over to `2026-08-01`. The gate compares against the later of local and UTC, so two `2026-08-01` stamps in `scheduler.ts` became valid on their own. That is the ratchet's normal drop path and is fine.

`#3278` then re-recorded the baseline "after the UTC rollover", which set `scheduler.ts` to **allow 1** — exactly enough to absorb the one stamp that did *not* age out:

```
FNXC:ConcurrencyAdmission 2026-08-06-09:00     ← six days out, wrong on any calendar
```

So the gate reports `123 known future-dated stamp(s), none added` and exits 0, with a stamp inside it that will not be valid until next week.

## Why this is the failure the gate exists to catch

A blanket re-record cannot distinguish **aged out** from **still wrong**, so it launders the second past the first. The sibling ratchet states the rule outright:

> Do NOT re-record the baseline to clear this — that is the same false green one layer up.

This is that, one layer up again: not a guard cleared by a baseline, but a *baseline refresh* clearing a guard as a side effect.

## The fix

- stamp repointed to `2026-08-01` — today in UTC, which is the calendar the gate actually compares against
- **allowance removed**, not left at 1, so the entry cannot be regrown into

**Mutation-verified**: with the allowance gone, restoring `2026-08-06` exits **1**. Before this change the same stamp exited **0**. That is the whole point — the ratchet can now see it.

## One thing worth carrying forward

A six-days-out stamp is not a timezone slip. Neither the old `date -u` guidance nor the current local-date guidance in AGENTS.md would have prevented it, and CI-only checking cannot catch it before merge. This is the concrete case for running the date check at author time, which I have flagged but not landed since it changes the gate's contract.

## Verification

- `check-fnxc-future-dates` — exit 0, allowance removed
- `scheduler` suites — **148 pass**
- `tsc --noEmit` (engine) — 0 errors