### PR TITLE
test(dashboard): pin the typed-title regression MY archived-lane fix caused

### DIFF
--- a/packages/dashboard/app/__tests__/research-modal-archive-lane-resolved.test.tsx
+++ b/packages/dashboard/app/__tests__/research-modal-archive-lane-resolved.test.tsx
@@ -10,7 +10,8 @@ in the cross-workflow union. A repro-only test here would pass on the legacy boa
 about the case the guard exists for.
 */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { Task } from "@fusion/core";
 
 import { ResearchTaskActionModal } from "../components/ResearchTaskActionModal";
@@ -105,5 +106,70 @@ describe("the research picker hides archived tasks on ANY board, not just the le
     ]) as never);
 
     expect(await renderPickerTaskIds()).toEqual(["FN-1"]);
+  });
+});
+
+/*
+FNXC:ResearchTaskModal 2026-08-01-01:20 (u12 — the regression MY archived-lane fix caused, now pinned):
+#3215 (mine) added `isArchivedColumn` to the effect's dependency list to keep the task fetch honest.
+That effect ALSO owned four setState calls, and `isArchivedColumn` is a useMemo over `useBoardWorkflows()`
+— which revalidates asynchronously. Each revalidation re-ran the reset over whatever the operator had
+typed, so a title entered before the workflows settled silently reverted to `Research: <heading>` and
+the task was created with a title nobody wrote. Fixed in #3286 by splitting reset from fetch.
+
+The four cases above could not see it: every one asserts the FILTERED TASK LIST and none types into the
+form. I tested what I added and not what I touched, which is why this file gets the regression rather
+than a new one.
+
+Types with per-character `userEvent`, not `fireEvent.change`: the documented failure here is state being
+overwritten between renders, and a single synthetic change event can land after the reset and mask it.
+*/
+describe("operator input survives board-workflow revalidation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("keeps a typed title when useBoardWorkflows resolves afterwards", async () => {
+    vi.mocked(fetchTasks).mockResolvedValue([task("FN-1", "building")] as never);
+    // First render: workflows unresolved, exactly as when the operator opens the modal and types.
+    vi.mocked(useBoardWorkflows).mockReturnValue({ boardWorkflows: null } as never);
+
+    const { rerender } = render(
+      <ResearchTaskActionModal
+        open mode="create"
+        run={{ title: "run" } as never}
+        finding={{ id: "f1", heading: "h", content: "c" }}
+        projectId="p1"
+        onClose={() => {}}
+        onConfirm={async () => {}}
+      />,
+    );
+
+    const title = screen.getAllByRole("textbox")[0] as HTMLInputElement;
+    await userEvent.clear(title);
+    await userEvent.type(title, "Operator wrote this");
+    expect(title.value).toBe("Operator wrote this");
+
+    /* The revalidation. A NEW object identity is the whole point — a memo over it changes, and the
+       pre-#3286 effect re-ran its setters on that change. */
+    vi.mocked(useBoardWorkflows).mockReturnValue(workflows([[
+      { id: "building", flags: { archived: false } },
+      { id: "cold", flags: { archived: true } },
+    ]]) as never);
+    rerender(
+      <ResearchTaskActionModal
+        open mode="create"
+        run={{ title: "run" } as never}
+        finding={{ id: "f1", heading: "h", content: "c" }}
+        projectId="p1"
+        onClose={() => {}}
+        onConfirm={async () => {}}
+      />,
+    );
+
+    /* No fetch to await here: `fetchTasks` runs only in enrich mode, while the title field exists only
+       in create mode — so the reset effect, not the fetch, is the thing under test. Settle the effects
+       React ran for the rerender, then read the field back. */
+    await waitFor(() => expect(vi.mocked(useBoardWorkflows)).toHaveBeenCalled());
+    // Pre-#3286 this read "Research: h" — the derived default, over the operator's text.
+    expect((screen.getAllByRole("textbox")[0] as HTMLInputElement).value).toBe("Operator wrote this");
   });
 });


### PR DESCRIPTION
#3286 fixed a real user-facing regression and **shipped no test**, so nothing stops it returning. The regression was mine.

## The bug

#3215 (mine) added `isArchivedColumn` to an effect's dependency list to keep the task fetch honest. That effect **also owned four `setState` calls**, and `isArchivedColumn` is a `useMemo` over `useBoardWorkflows()` — which revalidates asynchronously.

Every revalidation re-ran the reset over whatever the operator had typed. A title entered before the workflows settled silently reverted to `Research: <heading>`, and the task was created with a title nobody wrote.

## Why my own four tests could not see it

Every existing case in this file asserts the **filtered task list** — render, await `fetchTasks`, read the datalist. **None types into the form.**

I tested what I added and not what I touched. That is why the regression belongs in this file rather than a new one: the gap is this file's.

## The case

Renders with `boardWorkflows: null` — the state when an operator opens the modal and starts typing — types a title with per-character `userEvent`, then rerenders with a resolved workflow set (a **new object identity**, which is the entire mechanism) and asserts the typed text survived.

Two details that each cost a cycle, recorded at the site:

- **`fetchTasks` is not awaited.** It runs only in enrich mode, while the title field exists only in create mode — so the reset effect, not the fetch, is under test. My first version waited on it and failed for the wrong reason.
- **`userEvent.type`, not `fireEvent.change`.** The documented failure is state overwritten between renders; a single synthetic change event can land after the reset and mask it.

## Measured both directions, on main `6834ba35bd`

| state | result |
|---|---|
| fixed main | **5 passed** |
| dependency re-added to the reset effect (my bug) | **1 failed / 4 passed** — and only that case |

The second row is the point: it fails on precisely the mutation that recreates the defect, and leaves the four archived-lane cases green — so it pins the regression without duplicating what is already covered.

`eslint` clean, `check-fnxc-future-dates` 0. Test-only.

## Note on provenance

Getting this measurement took three attempts: a `git checkout` of the PR branch silently failed (stderr suppressed), so I twice ran against the wrong tree and nearly concluded the fix did not work. HEAD and dirty-count are printed beside every number above for that reason.