### PR TITLE
fix(gate): the SQL-literal check WROTE to the tree it was checking — last of three

### DIFF
--- a/scripts/check-sql-column-literals.mjs
+++ b/scripts/check-sql-column-literals.mjs
@@ -458,14 +458,29 @@ if (process.argv.includes("--update-baseline")) {
   }
 
   if (tightened.length > 0) {
-    writeFileSync(BASELINE, `${JSON.stringify(found, null, 2)}\n`);
-    console.log("\n[check-sql-column-literals] baseline TIGHTENED — fewer literals than it allowed\n");
+    /*
+    FNXC:SqlColumnLiterals 2026-08-01-01:45 (u12 — last of three gates that wrote to the tree they check):
+    This rewrote the baseline during a plain CHECK. The tightening is right — an allowance nobody spends
+    is a hole a literal can be regrown into — but performing it as a side effect handed every worker a
+    byte-identical uncommitted diff they had not authored, which they then reasonably committed.
+
+    Measured cost across the family: nine PRs chased three defects on 2026-07-31/08-01, and two of them
+    (#3283/#3285, five minutes apart, `+0/-1` each) deleted the SAME baseline line — neither author wrote
+    it. As #3289 put it: a check that writes turns every reader into an author. Two of us separately
+    mis-attributed a gate-written baseline to our own work while debugging something else.
+
+    Fixed in #3287 (fnxc) and #3289 (census); this is the third and last. Still computed, still reported
+    loudly, written only under --update-baseline. A plain run stays GREEN rather than failing: counts drop
+    when someone ELSE's merge removes a literal, so failing would redden main on a change the author never
+    made. Report, do not enforce — the rise path above still exits 1 and is untouched.
+    */
+    console.log("\n[check-sql-column-literals] baseline CAN BE TIGHTENED — fewer literals than it allowed\n");
     for (const { file, allowed, count } of tightened.sort((a, b) => a.file.localeCompare(b.file))) {
       console.log(`  ${file}: allowed ${allowed}, now ${count}`);
     }
     console.log(
-      "\nThe baseline has been rewritten downward. COMMIT IT so the allowance cannot be regrown into;\n"
-      + "in CI this write is discarded with the runner, which is why the gate is green and not silent.\n",
+      "\nNot written. Record it deliberately, so the diff has one author:\n"
+      + "\n  node scripts/check-sql-column-literals.mjs --update-baseline\n",
     );
     process.exit(0);
   }


### PR DESCRIPTION
Completes the family. `check-fnxc-future-dates` was #3287, `lifecycle-column-census` is #3289, and this is the third and last gate that rewrote its baseline during a plain check.

## Reproduction

```
inflated one allowance by 6, ran the gate with NO flags
  rc=0
  entry RESET to 1        ← the check modified the tree it was checking
```

## Why it matters

The tightening is right in substance — an allowance nobody spends is a hole a literal can be regrown into. Performing it as a **side effect of checking** handed every worker a byte-identical uncommitted diff they had not authored, which they then reasonably committed.

Measured across the family: nine PRs chased three defects on 2026-07-31/08-01, two of them (#3283/#3285, five minutes apart, `+0/-1` each) deleting the **same line neither author wrote**.

#3289 states the class best — *a check that writes turns every reader into an author*. Two of us separately mis-attributed a gate-written baseline to our own work while debugging something else.

## Measured, all four directions

| scenario | result |
|---|---|
| plain run, stale baseline | `rc=0`, reports `allowed 7, now 1`; **inflation survived** — read-only |
| a new SQL literal added | **`rc=1`**, names `__sql_probe.ts` — regression detection intact |
| `--update-baseline` | `rc=0`, entry written |
| clean tree, plain run | `rc=0`, **zero files dirty** |

Row 2 is the one worth checking: a read-only change to a gate is worthless if it also stops catching the thing it exists for. The rise path is untouched.

`census --strict` 0, `check-fnxc-future-dates` 0, eslint clean.

## Correcting my own delay

I measured this defect family on #3267 and then **declined to fix two of the three**, reasoning that the census *"deliberately fails on a drop"* so the port might be unsafe. That was wrong: it tightened and exited `0`, exactly as its own test asserts — *"TIGHTENS on a drop and exits 0, so somebody else's merge cannot redden the gate."* I had read the `--exact` contract and attributed it to the default path.

The caution cost hours and prevented nothing. #3289 was written by someone else in the meantime; this finishes what I should have finished then.