### PR TITLE
docs(solutions): the audit table had one axis — add the one that missed three defects

### DIFF
--- a/docs/solutions/workflow-learnings/a-falling-count-is-not-evidence.md
+++ b/docs/solutions/workflow-learnings/a-falling-count-is-not-evidence.md
@@ -133,6 +133,42 @@ Run against all five lifecycle gates on one tree, staging a probe file per form.
 | `check-inert-sync-lane-conversions` | lane reads via the `resolvePlannerLanes` helper | a DIRECT `store.resolveTaskWorkflowIrSync(...)` read feeding `resolveLifecycleColumns` — inert by the same mechanism, untracked |
 | `check-fnxc-future-dates` | future stamps | nothing found — it caught the author of this table, twice |
 
+### The axis this table did not have
+
+Everything above is **detection**: what each tool can and cannot see. I probed that thoroughly and
+then wrote "sound" for two gates on the strength of it.
+
+Within a day, three of these tools turned out to share a different defect entirely — **they wrote to
+the tree they were checking**, auto-tightening their own baseline during a plain check run:
+
+| gate | wrote during a check | fixed by |
+|---|---|---|
+| `check-fnxc-future-dates` | yes | #3287 |
+| `lifecycle-column-census` | yes, under `--strict` | #3289 |
+| `check-sql-column-literals` | yes | #3292 |
+
+No number of detection probes could have surfaced that. The table asserted one property carefully and
+**said nothing about the other while reading as comprehensive** — which is the same failure it
+documents in the tools it audits.
+
+What it cost: every worker who ran a gate received a byte-identical uncommitted diff they had not
+authored, and reasonably committed it. #3283 and #3285 are the same `+0/-1` five minutes apart, by
+two authors, neither of whom wrote that line.
+
+**So audit a tool on at least three axes, not one:**
+
+1. **What can it see?** — probe each spelling of the thing it claims to catch.
+2. **Can it fail at all?** — invoke it as `package.json` does; a report-only run exits 0 forever.
+3. **Does it write?** — `git status --porcelain` before and after, on a clean tree.
+
+A trap for the third: these gates write only when a tightening is *available*, so a clean tree after
+a run proves the trigger is absent, not that the tool is read-only. Inflate a baseline entry first,
+then run it.
+
+Three tools converged on the same write-during-check design independently, which says the pattern is
+attractive rather than that anyone was careless: the tightening is correct, the write saves a step,
+and the message even tells you to commit it.
+
 Two lessons the table encodes beyond its rows.
 
 **A ratchet's blind spot is invisible in exactly the way its subject is.** Both fixed gaps sat next to


### PR DESCRIPTION
## What

My blind-spot table in #3251 audited **one axis**. Adds the one that missed three defects. Docs only.

That table records what each of the five lifecycle ratchets can and cannot **see**. I probed that carefully — several spellings per tool — and then wrote *"nothing found; sound"* for two of them.

Within a day, three of those same tools turned out to share a completely different defect: **they wrote to the tree they were checking**, auto-tightening their own baseline during a plain check run.

| gate | wrote during a check | fixed by |
|---|---|---|
| `check-fnxc-future-dates` | yes | #3287 |
| `lifecycle-column-census` | yes, under `--strict` | #3289 |
| `check-sql-column-literals` | yes | #3292 |

**No number of detection probes could have surfaced that.** The table asserted one property carefully and said nothing about the other *while reading as comprehensive* — which is precisely the failure it documents in the tools it audits.

## The rule it adds

1. **What can it see?** — probe each spelling of the thing it claims to catch.
2. **Can it fail at all?** — invoke it as `package.json` does; a report-only run exits 0 forever (#3255).
3. **Does it write?** — `git status --porcelain` before and after, on a clean tree.

With the trap on the third spelled out: these gates write only when a tightening is **available**, so a clean tree after a run proves the *trigger* is absent, not that the tool is read-only. Inflate a baseline entry first, then run it. I hit exactly this while reviewing #3292 — ran all three gates on main, saw a clean tree, and had to stop myself concluding the SQL gate was fine.

## Why the pattern, not the people

Three tools converged on write-during-check independently. That argues the design is **attractive**, not that three authors were careless: the tightening is correct, the write saves a step, and the message even tells you to commit it. It only becomes a defect at the moment a second person runs the same gate — which is invisible from inside any one of them.

What it cost, measured: #3283 and #3285 are the same `+0/-1`, five minutes apart, by two authors, **neither of whom wrote that line**.

```
lint clean; fnxc-future-dates clean
```
