### PR TITLE
fix(fnxc): two scheduler stamps to their authoring commits' real times (10 days and 1 day off)

### DIFF
--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -1024,7 +1024,7 @@ export class Scheduler {
       logger: schedulerLog,
     });
     /*
-    FNXC:ConcurrencyAdmission 2026-07-31-09:00:
+    FNXC:ConcurrencyAdmission 2026-07-21-22:30:
     FN-8453's union must outlive a single scheduler poll. A temporary provider
     was gone before planning/merge asked for capacity, allowing newer work to
     overtake ready execute work. The refreshed map is the durable lane view.
@@ -1468,7 +1468,7 @@ export class Scheduler {
 
           const deletedParked = await resolveTaskParkedColumns(this.store, task.id);
           /*
-          FNXC:WorkflowLifecycleColumns 2026-07-31-05:00:
+          FNXC:WorkflowLifecycleColumns 2026-07-30-20:55:
           A HALF-CONVERTED PAIR, one line apart. The hold read above already resolved its lane while
           the wip read below stayed on the literal, so on a renamed board this dependent sweep saw
           the queued cards and none of the running ones — a dependency held by an in-flight task was


### PR DESCRIPTION
Last loose thread from the 2026-07-31 stamp-repointing wave. Two comment lines.

```
line 1027  ConcurrencyAdmission      2026-07-31-09:00  ->  2026-07-21-22:30   (eef5eb751e)
line 1471  WorkflowLifecycleColumns  2026-07-31-05:00  ->  2026-07-30-20:55   (109204c590)
```

## Not a revert — neither value was ever right

| stamp | originally | after #3280 | authoring commit (UTC) |
|---|---|---|---|
| `ConcurrencyAdmission` | `2026-08-06-09:00` (16 days ahead) | `2026-07-31-09:00` (10 days late) | **2026-07-21 22:30** |
| `WorkflowLifecycleColumns` | `2026-08-01-05:00` (~1.5 days ahead) | `2026-07-31-05:00` (~1 day late) | **2026-07-30 20:55** |

Both were written **ahead of their own commits** to begin with. Three lanes then repointed stamps to turn `main` green (#3261, #3269, #3280), moving the **date** back a day while keeping the clock time — which converts an hours-off stamp into a days-off one in the opposite direction. #3282 reverted the batch it owned; these two were outside its scope.

So restoring the originals would be wrong too. The defensible values are the authoring commits' UTC timestamps, per the `date -u` rule #3281 settled.

## Why now

`scheduler.ts` is a hot file. This survived two successive claimants — I flagged it on #3262 and again on #3288 rather than opening a conflicting PR, and said I'd take it once the file was unclaimed. `check-file-claimed` now reports UNCLAIMED, so here it is.

## Scope

The gate is **green either way** — #3277 fixed the comparison, so nothing is blocked by this. It is purely about the FNXC trail recording when the work actually happened, which is the only reason the trail exists. A stamp that satisfies a check while misstating the date by ten days is worse than no stamp.

## Verification

```
check-fnxc-future-dates           green
check-inert-sync-lane-conversions green
check-lane-wiring                 green
check-sql-column-literals         green
census --strict                   green
```

Diff is two comment lines — no executable change. No changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)