### PR TITLE
fix(engine): the new worktree-capacity gates counted finished cards on a renamed board

### DIFF
--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -16,7 +16,7 @@ import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings,
 import { getUnmetSchedulingDependencies } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
-import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
+import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, TERMINAL_ROLES, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
@@ -21936,8 +21936,19 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
+            /*
+            FNXC:WorkflowResolvedColumns 2026-08-01-02:10 (u12 — the census caught this on the merge):
+            The terminal exclusion was `!== "done" && !== "archived"`. On a board that renames either
+            lane those match NOTHING, so every finished card holding a retained worktree counts against
+            capacity — the over-count that starves dispatch, which `scheduler-worktree-capacity-arithmetic`
+            pins from the other direction. Resolved per project because capacity is a project-wide sum.
+
+            Degrades to the legacy pair when no workflow is readable, so an unconverted board is
+            byte-identical.
+            */
+            const spawnTerminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
             const heldWorktrees = spawnTasks.filter((t) =>
-              t.column !== "done" && t.column !== "archived"
+              !spawnTerminalColumns.has(t.column)
               && typeof t.worktree === "string" && t.worktree.length > 0).length;
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -37,6 +37,7 @@ import {
   resolveLifecycleColumns,
   resolveWorkflowIrForTaskWithProvenance,
   resolveProjectColumnsForRoles,
+  TERMINAL_ROLES,
   workflowHasColumn,
   getStepParser,
   computePlanApprovalFingerprint,
@@ -2145,8 +2146,15 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
+        /*
+        FNXC:WorkflowResolvedColumns 2026-08-01-02:10 (u12 — same shape as the executor's spawn gate):
+        `!== "done" && !== "archived"` matches nothing on a renamed board, so finished cards holding a
+        retained worktree are counted as capacity holders and planning admission starves. Project-scoped
+        because the cap is a project-wide sum; degrades to the legacy pair when unreadable.
+        */
+        const terminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
         const heldWorktrees = allTasks.filter((t) =>
-          t.column !== "done" && t.column !== "archived"
+          !terminalColumns.has(t.column)
           && typeof t.worktree === "string" && t.worktree.length > 0).length;
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }


### PR DESCRIPTION
**The census caught a regression on main: 0 → 4.** Two merges landed the same shape in two files.

## Census before / after

| file | before | after |
|---|---|---|
| `packages/engine/src/executor.ts` | 2 | **0** |
| `packages/engine/src/triage.ts` | 2 | **0** |
| **total** | **4** | **0** — `--strict` exit 0 |

## The defect

```ts
t.column !== "done" && t.column !== "archived" && typeof t.worktree === "string" && ...
```

- `374956ef23` — triage: planning admission respects `maxWorktrees`
- `6c7467a78d` — executor: spawned children gate on `maxWorktrees` too

Both count *"tasks holding a worktree that are not finished."* On a board that renames either terminal lane, those literals match **nothing** — so every finished card still holding a retained worktree counts against capacity.

That is the **over-count** direction: planning admission and child spawning starve while the operator sees free slots. #3288 pins exactly this failure from the other side — a Ready card retaining its planning worktree deadlocking its own release. The two merges reintroduced it in the two gates that suite does not reach.

## The conversion

`resolveProjectColumnsForRoles(store, TERMINAL_ROLES)` — the helper both files already import. Project-scoped, because the cap is a project-wide sum, and it degrades to the legacy pair when no workflow is readable, so an unconverted board is byte-identical.

## Measured

| check | result |
|---|---|
| census | 4 → **0**, `--strict` 0 |
| `scheduler-worktree-capacity-arithmetic` | 13 passed |
| `workflow-column-boundary-capacity` | 9 passed |
| `triage` | 232 passed |
| engine `tsc` / eslint / `fnxc` / `test:gate` | 0 / clean / 0 / 0 |

## Not pinned — stated plainly

Neither site has a regression test, and I am not implying otherwise. Both are inline inside large async methods, and **neither harness supplies `listWorkflowDefinitions`** — so `resolveProjectColumnsForRoles` degrades to the legacy pair in tests and a renamed-board case cannot tell the conversion from the literal. A test of the helper would pass either way, which is precisely the shape I have spent this session arguing is not coverage.

Pinning wants the caller-side seam #3288 used: extract the count, take the store, resolve inside. That is its own commit and I would rather land the fix now — the gates are live on main and starving admission today — than hold it behind a refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow capacity tracking to recognize project-specific terminal statuses, not just standard “Done” or “Archived” statuses.
  * Prevented completed work from being incorrectly counted as held or active when projects use customized workflow columns.
  * Retained compatibility with existing workflows when project-specific status information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->