### PR TITLE
fix(engine): the new worktree ledgers count terminal lanes by NAME — renamed boards stall

### DIFF
--- a/packages/engine/src/__tests__/spawn-agent-capacity.test.ts
+++ b/packages/engine/src/__tests__/spawn-agent-capacity.test.ts
@@ -163,3 +163,88 @@ describe("fn_spawn_agent capacity", () => {
     expect((executor as unknown as { totalSpawnedCount: number }).totalSpawnedCount).toBe(0);
   });
 });
+
+/*
+FNXC:WorkflowResolvedColumns 2026-08-01-03:20:
+THE SPAWN WORKTREE LEDGER EXCLUDES TERMINAL LANES BY ROLE, NOT BY NAME.
+
+`6c7467a78d` added the maxWorktrees dimension to this gate with `t.column !== "done" && t.column
+!== "archived"`. On a RENAMED board neither literal matches, so every finished card still counts as
+a live worktree holder, `heldWorktrees` only grows, and eventually EVERY spawn is refused on a board
+with free slots. That is worse than the over-spawn the gate exists to prevent, because a permanent
+refusal is silent — the operator sees children that never start and no capacity breach to explain it.
+
+Measured before this case existed: blinding the resolver back to the two literals left all 19 tests
+in the capacity suites green, so nothing in the tree could tell the conversion from what it replaced.
+
+The fixture is built so the two answers DISAGREE, which is the whole point: one card sits in a
+renamed COMPLETE lane holding a worktree, with `maxWorktrees: 1`. Resolved, it is terminal and
+consumes nothing, so the spawn proceeds. Against the literals it is counted, `heldWorktrees` is 1,
+and 1 + the reserved child exceeds the budget.
+*/
+describe("fn_spawn_agent worktree ledger on a renamed board", () => {
+  /** Complete lane is `shipped`; the board declares no column called `done`. */
+  const RENAMED_IR = {
+    version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+    columns: [
+      { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+      { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+      { id: "filed", name: "Filed", traits: [{ trait: "archived" }] },
+    ],
+  };
+
+  function executorOnRenamedBoard(tasks: unknown[]) {
+    const executor = Object.create(TaskExecutor.prototype) as TaskExecutor;
+    const priv = executor as unknown as Record<string, unknown>;
+    priv.store = {
+      listTasks: vi.fn(async () => tasks),
+      getTask: vi.fn(async (id: string) => ({ id, column: "building" })),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => undefined),
+      getWorkflowDefinition: vi.fn(async () => undefined),
+      /* The only store read `resolveProjectColumnsForRoles` makes. */
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
+    };
+    priv.options = { agentStore: { createAgent: vi.fn() } };
+    priv.spawnedAgents = new Map<string, Set<string>>();
+    priv.totalSpawnedCount = 0;
+    return executor;
+  }
+
+  async function spawnWith(executor: TaskExecutor, settings: unknown) {
+    const tool = (executor as unknown as {
+      createSpawnAgentTool(taskId: string, worktreePath: string, settings: unknown): {
+        execute(id: string, params: unknown): Promise<{ content: Array<{ text: string }>; details: { state: string } }>;
+      };
+    }).createSpawnAgentTool("FN-1", "/tmp/wt", settings);
+    return tool.execute("call-1", { name: "child", role: "engineer", task: "do a thing" });
+  }
+
+  it("does not count a card in a RENAMED complete lane against the worktree budget", async () => {
+    const executor = executorOnRenamedBoard([
+      { id: "FN-1", column: "building" },
+      /* Finished work whose worktree is cleanup-owned, not capacity. */
+      { id: "FN-SHIPPED", column: "shipped", worktree: "/tmp/wt-shipped" },
+    ]);
+
+    const result = await spawnWith(executor, { maxConcurrent: 10, maxWorktrees: 1 });
+
+    /* Against the literals `shipped` is counted, heldWorktrees is 1, and the spawn is refused. */
+    expect(result.content[0]?.text ?? "").not.toContain("Worktree capacity reached");
+  });
+
+  /*
+  THE PAIRED POSITIVE. The case above is a "does not refuse" assertion, which a gate that never
+  refused would also satisfy — including one broken into ignoring maxWorktrees entirely. This pins
+  that the SAME renamed board still refuses when a live card genuinely holds the last worktree.
+  */
+  it("still refuses when a card in a live RENAMED lane holds the last worktree", async () => {
+    const executor = executorOnRenamedBoard([
+      { id: "FN-1", column: "building" },
+      { id: "FN-LIVE", column: "building", worktree: "/tmp/wt-live" },
+    ]);
+
+    const result = await spawnWith(executor, { maxConcurrent: 10, maxWorktrees: 1 });
+
+    expect(result.content[0]?.text ?? "").toContain("Worktree capacity reached");
+  });
+});

--- a/packages/engine/src/__tests__/triage-admission-worktree-ledger-renamed-lanes.test.ts
+++ b/packages/engine/src/__tests__/triage-admission-worktree-ledger-renamed-lanes.test.ts
@@ -1,0 +1,168 @@
+/*
+FNXC:WorkflowResolvedColumns 2026-08-01-03:35:
+PLANNING ADMISSION'S WORKTREE LEDGER EXCLUDES TERMINAL LANES BY ROLE, NOT BY NAME.
+
+`374956ef23` gave planning admission a maxWorktrees dimension — correctly, a live board was running
+8 planners against a 4-slot budget — and counted holders with
+`t.column !== "done" && t.column !== "archived"`.
+
+On a RENAMED board neither literal matches, so every FINISHED card whose worktree has not been
+reaped yet still counts as a live holder. `heldWorktrees` only grows, `worktreeRoom` reaches zero,
+and planning admission is withheld forever on a board with free slots. That is the mirror of the
+breach the commit set out to fix and strictly worse: the breach is visible as 8 planners, the stall
+is silent — cards sit "Queued to plan" and the recorded reason names the worktree budget, which the
+operator then checks and finds has room.
+
+WHY THIS FILE RATHER THAN A CASE IN `triage-plan-admission-throttle-audit.test.ts`: that suite's
+fixture deliberately exhausts `maxConcurrent` (1 slot, consumed by a running card) so the AGENT gate
+binds. The agent gate is checked with the worktree gate via `Math.min`, so an exhausted agent count
+masks the worktree answer entirely — the conversion under test would never decide anything. This
+fixture leaves agent headroom so the worktree ledger is the only gate that can bind.
+
+MEASURED FIRST, per the blinding procedure: before this file existed, reverting the resolver to the
+two literals left all 19 tests in the capacity suites green. Nothing in the tree could tell the
+conversion from what it replaced.
+
+The assertion is the run-audit event, not a return value: `task:plan-admission-throttled` is what
+the withhold path DOES, and it names the binding gate. A boolean "did anything start" would also be
+satisfied by an unrelated early return.
+*/
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Settings, Task, TaskStore } from "@fusion/core";
+import { TriageProcessor } from "../triage.js";
+
+vi.mock("@fusion/core", async (importOriginal) => {
+  const { createEngineCoreMock } = await import("../test/mockCore.js");
+  const original = await importOriginal<typeof import("@fusion/core")>();
+  return createEngineCoreMock(() => Promise.resolve(original));
+});
+
+/** Hold lane `drafting`, wip `building`, complete `shipped`, archive `filed`. No legacy ids. */
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "drafting", name: "Drafting", traits: [{ trait: "hold", config: { release: "capacity" } }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip", config: { limitSetting: "maxConcurrent" } }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    { id: "filed", name: "Filed", traits: [{ trait: "archived" }] },
+  ],
+};
+
+interface RecordedEvent { type: string; target: string; metadata?: Record<string, unknown> }
+
+function task(id: string, column: string, extra: Partial<Task> = {}): Task {
+  return {
+    id,
+    description: "Add ability to favorite projects on mobile",
+    column,
+    dependencies: [],
+    steps: [],
+    currentStep: 0,
+    log: [],
+    createdAt: "2026-07-26T15:37:52.786Z",
+    updatedAt: "2026-07-26T15:37:52.786Z",
+    ...extra,
+  } as Task;
+}
+
+/**
+ * `maxConcurrent` is generous on purpose — admission takes `min(projectRoom, worktreeRoom)`, so an
+ * exhausted agent count would mask the ledger this file is about.
+ */
+function createStore(tasks: Task[], recorded: RecordedEvent[], maxWorktrees: number): TaskStore {
+  return {
+    getTask: vi.fn(async (id: string) => {
+      const found = tasks.find((candidate) => candidate.id === id);
+      return found ? { ...found, prompt: "", attachments: [], comments: [] } : null;
+    }),
+    listTasks: vi.fn().mockResolvedValue(tasks),
+    getSettings: vi.fn().mockResolvedValue({
+      maxConcurrent: 20,
+      maxWorktrees,
+      pollIntervalMs: 600_000,
+      groupOverlappingFiles: false,
+      autoMerge: true,
+    } as Settings),
+    /* The only store read `resolveProjectColumnsForRoles` makes. */
+    listWorkflowDefinitions: vi.fn(async () => [{ ir: RENAMED_IR }]),
+    recordRunAuditEvent: vi.fn(async (event: { mutationType: string; target: string; metadata?: Record<string, unknown> }) => {
+      recorded.push({ type: event.mutationType, target: event.target, metadata: event.metadata });
+    }),
+    updateTask: vi.fn().mockResolvedValue(undefined),
+    logEntry: vi.fn().mockResolvedValue(undefined),
+    appendAgentLog: vi.fn().mockResolvedValue(undefined),
+    moveTask: vi.fn(),
+    createTask: vi.fn(),
+    deleteTask: vi.fn(),
+    mergeTask: vi.fn(),
+    updateSettings: vi.fn(),
+    getAgentLogs: vi.fn().mockResolvedValue([]),
+    addSteeringComment: vi.fn(),
+    parseDependenciesFromPrompt: vi.fn().mockResolvedValue([]),
+    parseStepsFromPrompt: vi.fn().mockResolvedValue([]),
+    parseFileScopeFromPrompt: vi.fn().mockResolvedValue([]),
+    /*
+    The candidate scan resolves each task's OWN workflow (`resolveWorkflowIrForTask`), which reads
+    the SELECTION — not `listWorkflowDefinitions`. Omitting these makes every card fall back to the
+    DEFAULT board, where `drafting` is not a hold lane, so nothing is eligible, nothing throttles,
+    and the absence assertion below passes for the wrong reason. Caught by the paired positive.
+    */
+    getTaskWorkflowSelection: vi.fn(() => ({ workflowId: "wf-renamed", stepIds: [] })),
+    getTaskWorkflowSelectionAsync: vi.fn(async () => ({ workflowId: "wf-renamed", stepIds: [] })),
+    getWorkflowDefinition: vi.fn(async () => ({ ir: RENAMED_IR })),
+    on: vi.fn(),
+    emit: vi.fn(),
+  } as unknown as TaskStore;
+}
+
+async function pollOnce(store: TaskStore): Promise<void> {
+  const processor = new TriageProcessor(store, "/tmp/fn-admission-renamed-root", {});
+  /* poll() no-ops unless running; driving one pass directly keeps this time-independent. */
+  (processor as unknown as { running: boolean }).running = true;
+  await (processor as unknown as { poll: () => Promise<void> }).poll();
+  /* The audit write is fire-and-forget. */
+  await new Promise((resolve) => setImmediate(resolve));
+  processor.stop();
+}
+
+describe("planning admission's worktree ledger on a renamed board", () => {
+  let recorded: RecordedEvent[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recorded = [];
+  });
+
+  it("does not count a card in a RENAMED complete lane against the worktree budget", async () => {
+    const store = createStore([
+      task("FN-WAITING", "drafting"),
+      /* Finished work whose worktree is cleanup-owned, not capacity. */
+      task("FN-SHIPPED", "shipped", { worktree: "/tmp/wt-shipped" }),
+    ], recorded, 1);
+
+    await pollOnce(store);
+
+    /* Against the literals `shipped` is counted, worktreeRoom is 0, and admission is withheld. */
+    const throttle = recorded.filter((event) => event.type === "task:plan-admission-throttled");
+    expect(throttle, "a finished card must not consume a worktree slot").toHaveLength(0);
+  });
+
+  /*
+  THE PAIRED POSITIVE. The case above asserts an ABSENCE, which a processor that never throttled at
+  all would also satisfy — including one broken into ignoring `maxWorktrees` entirely. This pins that
+  the SAME renamed board still withholds when a live card genuinely holds the last worktree, so the
+  first case is measuring the lane role rather than a dead gate.
+  */
+  it("still withholds when a card in a live RENAMED lane holds the last worktree", async () => {
+    const store = createStore([
+      task("FN-WAITING", "drafting"),
+      task("FN-LIVE", "building", { worktree: "/tmp/wt-live" }),
+    ], recorded, 1);
+
+    await pollOnce(store);
+
+    const throttle = recorded.filter((event) => event.type === "task:plan-admission-throttled");
+    expect(throttle.length, "a live worktree holder must still consume its slot").toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -21936,8 +21936,21 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
+            /*
+            FNXC:WorkflowResolvedColumns 2026-08-01-03:05:
+            TERMINAL IS A ROLE, NOT A NAME — same conversion as the planning-admission ledger this
+            gate was copied from. Against the literals a RENAMED board matches neither `done` nor
+            `archived`, so finished cards keep counting as live worktree holders, `heldWorktrees`
+            only ever grows, and every spawn is refused on a board with free slots. A permanent
+            refusal is worse than the over-spawn this gate exists to prevent, because it is silent.
+
+            PROJECT-level (`resolveProjectColumnsForRoles`) because the ledger spans the whole
+            board with no single task to resolve against; it is legacy-seeded, so a default board
+            still excludes exactly `done` and `archived` and this is byte-identical there.
+            */
+            const spawnTerminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
             const heldWorktrees = spawnTasks.filter((t) =>
-              t.column !== "done" && t.column !== "archived"
+              !spawnTerminalColumns.has(t.column)
               && typeof t.worktree === "string" && t.worktree.length > 0).length;
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -2145,8 +2145,23 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
+        /*
+        FNXC:WorkflowResolvedColumns 2026-08-01-03:05:
+        TERMINAL IS A ROLE HERE, NOT A NAME. The ledger above excludes terminal lanes because their
+        retained worktrees are cleanup-owned rather than capacity; against the literals `done` and
+        `archived` a RENAMED board matched neither, so every finished card still counted as a live
+        worktree holder. The gate then reads worktreeRoom=0 on a board with free slots and planning
+        admission stalls permanently — the mirror of the breach this commit set out to fix, and
+        strictly worse, because a stall is silent where a breach is at least visible as 8 planners.
+
+        PROJECT-level, matching this file's existing use at `sweepStalePlanningStatuses`: the ledger
+        spans every card on the board, so there is no single task to resolve against.
+        `resolveProjectColumnsForRoles` is legacy-seeded, so a default board still excludes exactly
+        `done` and `archived` and this conversion is byte-identical there.
+        */
+        const terminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
         const heldWorktrees = allTasks.filter((t) =>
-          t.column !== "done" && t.column !== "archived"
+          !terminalColumns.has(t.column)
           && typeof t.worktree === "string" && t.worktree.length > 0).length;
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }


### PR DESCRIPTION
## Census

**Before: `COLUMN guards (the backlog): 2`, `--strict` RED. After: `BACKLOG ZERO`, all five gates green.**

Two commits from last night's `maxWorktrees` rollout copied the same holder ledger, both with literals:

| commit | file | gate |
|---|---|---|
| `374956ef23` | `triage.ts` | planning admission |
| `6c7467a78d` | `executor.ts` | `fn_spawn_agent` |

```ts
t.column !== "done" && t.column !== "archived"
```

## What it costs

Both exclude terminal lanes because a finished card's worktree is **cleanup-owned, not capacity**. On a renamed board neither literal matches, so every finished card keeps counting as a live holder. The count only grows, the gate reaches zero room on a board with free slots, and planning admission is withheld forever / every spawn is refused.

That is the **mirror** of the breach these commits fixed, and strictly worse: 8 planners on a 4-slot board is visible; a permanent stall is silent. The recorded reason even names the worktree budget, which the operator then checks and finds has room.

## The conversion

`resolveProjectColumnsForRoles(store, ["complete", "archived"])` — project-level, because the ledger spans the whole board with no single task to resolve against. Matches triage's existing use in `sweepStalePlanningStatuses` and executor's at the wip gates. Legacy-seeded, so a default board still excludes exactly `done` and `archived` — byte-identical there.

## Both conversions were UNCOVERED when written

Measured with #3214's blinding procedure **before** writing tests: reverting either to the literals left **all 19 tests in the capacity suites green**. Nothing in the tree could tell the conversion from what it replaced — which is how the literals got there in the first place.

Each now has a renamed-board case that fails when blinded:

```
triage    converted 2 passed  |  BLINDED 1 failed | 1 passed  |  restored 2 passed
executor  converted 8 passed  |  BLINDED 1 failed | 7 passed  |  restored 8 passed
```

## The pairing earned itself immediately

Both new cases assert an **absence** (no throttle / no refusal), so each is paired with a positive proving the gate still fires on the same renamed board when a card genuinely holds the last worktree.

That caught a real defect in my own fixture: the candidate scan resolves each task's **own workflow selection**, not `listWorkflowDefinitions`, so my first version fell back to the default board where `drafting` isn't a hold lane. No card was eligible, nothing throttled, and the absence assertion **passed for the wrong reason**. The positive failed and exposed it. Recorded at the fixture so the next reader doesn't reintroduce it.

## Verification

```
42 tests across 6 capacity suites             pass
check-fnxc-future-dates                       green
check-inert-sync-lane-conversions             green
check-lane-wiring                             green
check-sql-column-literals                     green
census --strict                               green   (BACKLOG ZERO restored)
```

No changeset: internal engine fix, no published-package surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)