### PR TITLE
fleet(engine): the worktree capacity ledger counted by legacy lane ids — census 4 → 0, main is red

### DIFF
--- a/packages/engine/src/__tests__/spawn-agent-capacity.test.ts
+++ b/packages/engine/src/__tests__/spawn-agent-capacity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { RENAMED_VOCAB, lifecycleIr } from "./_workflow-vocabulary-fixture.js";
 import { TaskExecutor } from "../executor.js";
 
 /*
@@ -48,6 +49,55 @@ async function trySpawn(executor: TaskExecutor, taskId: string, maxConcurrent: n
   }).createSpawnAgentTool(taskId, "/tmp/wt", { maxConcurrent });
   return tool.execute("call-1", { name: "child", role: "engineer", task: "do a thing" });
 }
+
+describe("fn_spawn_agent worktree ledger on a RENAMED board", () => {
+  /*
+  FNXC:CapacityModel 2026-08-01-02:20 (coverage for the spawn-gate half of #3297):
+  The spawn gate counted a task as holding a worktree unless its column was literally `done` or
+  `archived`. On a renamed board neither id exists, so FINISHED work still consumed the worktree
+  budget and the gate refused spawns while capacity was free — silently, and only ever in the
+  refusing direction.
+
+  This is the executor half of the ledger; `triage-plan-admission-throttle-audit.test.ts` covers the
+  planning-admission half. Both were uncovered: blinding either guard left engine-core green at 499.
+
+  The store exposes `listWorkflowDefinitions` on purpose. Without it `resolveProjectColumnsForRoles`
+  fails soft to the legacy ids by design — the degraded contract every unconverted caller keeps — and
+  a store that cannot resolve would make this case pass pre-fix for the wrong reason.
+  */
+  function executorWithHeldWorktree(): TaskExecutor {
+    const executor = Object.create(TaskExecutor.prototype) as TaskExecutor;
+    const priv = executor as unknown as Record<string, unknown>;
+    priv.store = {
+      /* One FINISHED card on a renamed board, still carrying a worktree path. */
+      listTasks: vi.fn(async () => [{ id: "FN-SHIPPED", column: RENAMED_VOCAB.complete, worktree: "/tmp/wt/shipped" }]),
+      getTask: vi.fn(async (id: string) => ({ id, column: RENAMED_VOCAB.complete })),
+      getTaskWorkflowSelectionAsync: vi.fn(async () => undefined),
+      getWorkflowDefinition: vi.fn(async () => undefined),
+      listWorkflowDefinitions: vi.fn(async () => [{ ir: lifecycleIr(RENAMED_VOCAB, "custom:spawn-ledger") }]),
+    };
+    priv.options = { agentStore: { createAgent: vi.fn() } };
+    priv.spawnedAgents = new Map<string, Set<string>>();
+    priv.totalSpawnedCount = 0;
+    return executor;
+  }
+
+  it("does not count a FINISHED renamed-lane card against the worktree budget", async () => {
+    const executor = executorWithHeldWorktree();
+    const tool = (executor as unknown as {
+      createSpawnAgentTool(taskId: string, worktreePath: string, settings: unknown): {
+        execute(id: string, params: unknown): Promise<{ content: Array<{ text: string }>; details: { state: string } }>;
+      };
+    }).createSpawnAgentTool("FN-PARENT", "/tmp/wt", { maxConcurrent: 5, maxWorktrees: 1 });
+
+    const result = await tool.execute("call-1", { name: "child", role: "engineer", task: "do a thing" });
+
+    /* Pre-fix `shipped` is neither `done` nor `archived`, so the finished card consumes the only
+       worktree slot and this refuses with "Worktree capacity reached". */
+    const text = result.content.map((c) => c.text).join(" ");
+    expect(text).not.toContain("Worktree capacity reached");
+  });
+});
 
 describe("fn_spawn_agent capacity", () => {
   /*

--- a/packages/engine/src/__tests__/triage-plan-admission-throttle-audit.test.ts
+++ b/packages/engine/src/__tests__/triage-plan-admission-throttle-audit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RENAMED_VOCAB, lifecycleIr } from "./_workflow-vocabulary-fixture.js";
 import type { Settings, Task, TaskStore } from "@fusion/core";
 import { TriageProcessor } from "../triage.js";
 
@@ -263,6 +264,55 @@ describe("plan admission throttle run-audit (FN-8600)", () => {
     await (processor as unknown as { poll: () => Promise<void> }).poll();
     await new Promise((resolve) => setImmediate(resolve));
 
+    expect(recorded.filter((event) => event.type === "task:plan-admission-throttled")).toHaveLength(0);
+  });
+
+  it("REGRESSION — the worktree ledger honours a RENAMED board's terminal lanes", async () => {
+    /*
+    FNXC:CapacityModel 2026-08-01-02:05 (coverage for the ledger converted in #3297):
+    The ledger counted a task as holding a worktree unless its column was literally `done` or
+    `archived`. On a renamed board neither id exists, so FINISHED work still counted against
+    `maxWorktrees` and admission throttled itself on a board with free capacity — silently, and only
+    ever in the refusing direction.
+
+    Blinding the converted guard leaves `engine-core` green at 499 passed, so nothing reached this
+    ledger before. This case does: a renamed board whose completed lane is `shipped`, one finished
+    card still carrying a worktree path, and `maxWorktrees: 1`.
+
+    Pre-fix that card consumes the only worktree slot (`shipped` is neither `done` nor `archived`),
+    worktreeRoom is 0, and the eligible card is throttled with `blockedBy` recorded. Post-fix
+    `resolveProjectColumnsForRoles(store, ["complete","archived"])` resolves `shipped`, the finished
+    card is excluded, and admission proceeds.
+
+    The store exposes `listWorkflowDefinitions` deliberately: without it the resolver fails soft to the
+    legacy ids by design, which is the degraded contract every unconverted caller keeps — and a store
+    that cannot resolve would make this case vacuous rather than failing.
+    */
+    const finishedCardHoldingATree = {
+      ...runningTask("FN-SHIPPED"),
+      column: RENAMED_VOCAB.complete,
+      worktree: "/tmp/does-not-need-to-exist/shipped",
+    } as Task;
+
+    const store = createStore([eligibleTodoTask("FN-RENAMED-ROOM"), finishedCardHoldingATree], recorded, {
+      maxConcurrent: 3,
+      maxWorktrees: 1,
+    });
+    /* The shared fixture, not a hand-rolled object: `parseWorkflowIr` VALIDATES (it rejects a graph
+       without exactly one start and one end), and the resolver isolates a bad definition per-row and
+       falls back to the legacy ids. A malformed fixture therefore produces a GREEN pre-fix run rather
+       than an error — measured: my first draft hand-built the IR, the resolver silently discarded it,
+       and the case failed for the wrong reason. */
+    (store as unknown as { listWorkflowDefinitions: () => Promise<unknown[]> }).listWorkflowDefinitions =
+      async () => [{ ir: lifecycleIr(RENAMED_VOCAB, "custom:worktree-ledger") }];
+
+    const processor = new TriageProcessor(store, "/tmp/fn-worktree-ledger-root", {});
+    vi.spyOn(processor, "specifyTask").mockResolvedValue(undefined);
+    (processor as unknown as { running: boolean }).running = true;
+    await (processor as unknown as { poll: () => Promise<void> }).poll();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    /* The finished card does not hold a slot, so the eligible card is admitted and nothing throttles. */
     expect(recorded.filter((event) => event.type === "task:plan-admission-throttled")).toHaveLength(0);
   });
 

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -21936,8 +21936,23 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
+            /*
+            FNXC:CapacityModel 2026-08-01-01:48 (the worktree ledger counted by legacy lane ids):
+            `!== "done" && !== "archived"` asked "is this task still live" by naming two columns of the
+            default board. On a renamed board neither id exists, so EVERY task passed the filter —
+            including finished and archived ones that no longer hold a tree — and the ledger
+            over-counted held worktrees, refusing spawns while capacity was actually free. The failure
+            is silent and one-directional: it never over-grants, it just wedges a board shut.
+
+            `resolveProjectColumnsForRoles(..., ["complete", "archived"])` is the project-wide union of
+            the columns carrying those traits, which is the right scope for a project-wide capacity
+            ledger (the same reasoning team-analytics records: analytics and capacity both aggregate a
+            whole project, so a per-task resolution is not needed). Awaited, so it reads the real
+            selection rather than the sync resolver's default-board answer.
+            */
+            const spawnTerminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
             const heldWorktrees = spawnTasks.filter((t) =>
-              t.column !== "done" && t.column !== "archived"
+              !spawnTerminalColumns.has(t.column)
               && typeof t.worktree === "string" && t.worktree.length > 0).length;
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -2145,8 +2145,16 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
+        /*
+        FNXC:CapacityModel 2026-08-01-01:48 (the same legacy-id ledger as the executor's spawn gate):
+        See `executor.ts`'s note — on a renamed board neither `done` nor `archived` exists, so every
+        task counted as holding a worktree and planning admission throttled itself to zero on a board
+        with free capacity. Resolved as the project-wide union of the complete/archived traits, which
+        matches this ledger's project-wide scope.
+        */
+        const terminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
         const heldWorktrees = allTasks.filter((t) =>
-          t.column !== "done" && t.column !== "archived"
+          !terminalColumns.has(t.column)
           && typeof t.worktree === "string" && t.worktree.length > 0).length;
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }


### PR DESCRIPTION
## main is red

```
$ node scripts/lifecycle-column-census.mjs --strict
lifecycle-column-census --strict: column-guard count ROSE
exit 1
```

Seven commits landed a worktree-capacity ledger in two places, and both filter live tasks by naming two default-board columns.

## Census before / after

| | column | role | status | deliberate |
| --- | --- | --- | --- | --- |
| before (`6c7467a78d`) | **4** | 12 | 185 | 148 |
| after | **0** | 12 | 185 | 148 |

Both new guards, by file: `executor.ts` 2, `triage.ts` 2. `--triage` classed all four as *unexamined* (no deferral note), which is what makes them a claim rather than a documented deferral.

## The defect

```ts
t.column !== "done" && t.column !== "archived" && typeof t.worktree === "string" && t.worktree.length > 0
```

- `executor.ts:21940` — the spawn-time worktree gate
- `triage.ts:2149` — planning admission's worktree room

On a renamed board neither id exists, so **every** task passes the filter — including finished and archived rows that no longer hold a tree. The ledger over-counts held worktrees and refuses work while capacity is free.

The failure is silent and one-directional: it never over-grants, it **wedges the board shut**. And it defeats the ledger's own purpose — `triage.ts`'s note records the incident it was written for (8 concurrent planning sessions and 11 worktrees on a 4-slot board within one restart). On a renamed board that fix simply does not apply.

## The conversion

```ts
const terminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
… !terminalColumns.has(t.column) && typeof t.worktree === "string" && …
```

Existing helper only, already imported and used elsewhere in both files. **Awaited**, so it reads the task's real selection rather than `resolveTaskWorkflowIrSync`'s default-board answer — the inert-conversion trap this program exists to catch. The project-wide union is the correct scope here: a capacity ledger aggregates a whole project, the same reasoning `team-analytics` records for its aggregates.

## Verification

- Census **4 → 0**; `check:lifecycle-columns --strict` exit 0 (was exit 1 on main).
- Typecheck clean; `inert-sync-lanes`, `move-target-literals`, `lane-wiring`, `inert-flag-seams` exit 0.
- `pnpm test:gate` exit 0.
- 29 tests pass across `triage-release-renamed-hold`, `executor-execution-policy-renamed-columns`, `scheduler-load-lane-union`, `workflow-column-boundary-capacity`.

## Coverage gap — stated, not implied

**Blinding both new guards** (replacing the membership test with `false`, so `heldWorktrees` is always 0) leaves `engine-core` **fully green at 499 passed**. The gate reaches neither ledger.

So these conversions are correct by construction and by review, **not by test**. I am not claiming coverage I do not have. Writing a test for either would mean driving a real spawn-time capacity refusal and a real planning-admission throttle on a renamed board — worth doing, but it is a harness rather than a one-line assertion, and bundling it here would delay a fix for a red `main`.

Flagged rather than guessed: nothing else in either file's ledger was touched, and the `deliberate` count is unchanged at 148, so no site was reclassified to make the number move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed worktree capacity calculations for projects with renamed completion or archive columns.
  - Completed tasks in any configured terminal workflow column no longer consume available worktree capacity.
  - Improved planning and agent spawning so valid capacity is recognized instead of incorrectly triggering capacity limits.
- **Tests**
  - Added regression coverage for renamed workflow columns and completed tasks with worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->