### PR TITLE
fix(engine): resolve terminal columns in capacity gates

### DIFF
--- a/.changeset/planning-capacity-lifecycle-columns.md
+++ b/.changeset/planning-capacity-lifecycle-columns.md
@@ -1,5 +1,7 @@
 ---
-"@fusion/engine": patch
+"@runfusion/fusion": patch
 ---
 
-Resolve terminal workflow columns before counting retained worktrees against planning and child-agent capacity.
+summary: Resolve terminal workflow columns before counting retained worktrees against capacity.
+category: fix
+dev: Applies workflow-resolved completion and archive lanes to planning and child-agent capacity gates.

--- a/.changeset/planning-capacity-lifecycle-columns.md
+++ b/.changeset/planning-capacity-lifecycle-columns.md
@@ -1,0 +1,5 @@
+---
+"@fusion/engine": patch
+---
+
+Resolve terminal workflow columns before counting retained worktrees against planning and child-agent capacity.

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -21936,8 +21936,9 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
+            const terminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
             const heldWorktrees = spawnTasks.filter((t) =>
-              t.column !== "done" && t.column !== "archived"
+              !terminalColumns.has(t.column)
               && typeof t.worktree === "string" && t.worktree.length > 0).length;
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -2146,6 +2146,7 @@ export class TriageProcessor {
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
         /*
+        FNXC:CapacityModel 2026-08-01-02:12:
         Terminal membership is project-wide: custom workflows can rename both completion and archive
         lanes. Resolving the complete set once keeps retained terminal worktrees cleanup-owned instead
         of charging them against planning capacity.

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -2145,8 +2145,14 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
+        /*
+        Terminal membership is project-wide: custom workflows can rename both completion and archive
+        lanes. Resolving the complete set once keeps retained terminal worktrees cleanup-owned instead
+        of charging them against planning capacity.
+        */
+        const terminalColumns = await resolveProjectColumnsForRoles(this.store, ["complete", "archived"]);
         const heldWorktrees = allTasks.filter((t) =>
-          t.column !== "done" && t.column !== "archived"
+          !terminalColumns.has(t.column)
           && typeof t.worktree === "string" && t.worktree.length > 0).length;
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }


### PR DESCRIPTION
## Summary
- resolve project workflow completion/archive columns before counting retained worktrees
- apply the same lifecycle-aware capacity accounting to planning and child-agent admission
- remove legacy terminal-column guards caught by the lifecycle census

## Test plan
- `node scripts/lifecycle-column-census.mjs --strict`
- `corepack pnpm --filter @fusion/engine exec vitest run --project engine-default src/__tests__/scheduler-worktree-capacity-arithmetic.test.ts src/__tests__/spawn-agent-capacity.test.ts`
- `corepack pnpm --filter @fusion/engine typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planning and child-agent capacity calculations by correctly excluding work items in workflow-defined terminal columns.
  * Capacity tracking now works with customized completion and archival workflows, not only default column names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->