### PR TITLE
fix(engine): the two new capacity gates compare lane names — main is RED on the census

### DIFF
--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -16,7 +16,7 @@ import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings,
 import { getUnmetSchedulingDependencies } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
-import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
+import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, TERMINAL_ROLES, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
@@ -21936,8 +21936,16 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
+            /*
+            FNXC:WorktreeCapacity 2026-08-01-01:55:
+            TERMINAL BY ROLE — same ledger as the scheduler's and triage's, same reason. Comparing
+            the two literals here made a renamed board count every finished card as a live holder, so
+            the spawn gate refused work against a cap it could never reach. Project-wide rather than
+            per-task: this filters every task and the answer is project-level.
+            */
+            const spawnTerminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
             const heldWorktrees = spawnTasks.filter((t) =>
-              t.column !== "done" && t.column !== "archived"
+              !spawnTerminalColumns.has(t.column)
               && typeof t.worktree === "string" && t.worktree.length > 0).length;
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -13,7 +13,7 @@ import { basename, delimiter, isAbsolute, join, relative, resolve as resolvePath
 import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings, WorkflowStep, MissionStore, AsyncMissionStore, Slice, AgentState, AgentCapability, RunMutationContext, AgentHeartbeatConfig, Agent, AgentMemoryInclusionMode, ProjectSettings, MergeResult, WorkflowIrNode, WorkflowIrNodeKind, WorkflowStepResult as CoreWorkflowStepResult, ThinkingLevel } from "@fusion/core";
-import { getUnmetSchedulingDependencies } from "./scheduler.js";
+import { getUnmetSchedulingDependencies, nonWipWorktreeHolderIdsOf } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
 import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, TERMINAL_ROLES, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
@@ -21944,9 +21944,12 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
             per-task: this filters every task and the answer is project-level.
             */
             const spawnTerminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
-            const heldWorktrees = spawnTasks.filter((t) =>
-              !spawnTerminalColumns.has(t.column)
-              && typeof t.worktree === "string" && t.worktree.length > 0).length;
+            /* ONE implementation of the holder rule, shared with the scheduler's ledger and triage's
+               — see the note on `nonWipWorktreeHolderIdsOf`. No wip exclusions here: this gate counts
+               every live holder, and the spawn reservation is tracked separately. */
+            const heldWorktrees = nonWipWorktreeHolderIdsOf(
+              spawnTasks, [], (t) => spawnTerminalColumns.has(t.column),
+            ).length;
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {
               releaseSpawnReservation();

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -121,6 +121,7 @@ import type {
   ToolDefinition,
   AgentSession,
 } from "@earendil-works/pi-coding-agent";
+import { nonWipWorktreeHolderIdsOf } from "./scheduler.js";
 import { ModelFallbackExhaustedError, describeModel, formatModelMarkerDetails, promptWithFallback } from "./pi.js";
 import { hasAdvancedPastPlanning, isTaskStillInPlanningStage, resolvePlannerLanes, resolvePlannerLanesForTaskAsync } from "./replan-target.js";
 import {
@@ -2157,9 +2158,11 @@ export class TriageProcessor {
         workflow reads for a question with one project-level answer.
         */
         const terminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
-        const heldWorktrees = allTasks.filter((t) =>
-          !terminalColumns.has(t.column)
-          && typeof t.worktree === "string" && t.worktree.length > 0).length;
+        /* ONE implementation of the holder rule, shared with the scheduler's ledger and the spawn
+           gate's — see the note on `nonWipWorktreeHolderIdsOf`. */
+        const heldWorktrees = nonWipWorktreeHolderIdsOf(
+          allTasks, [], (t) => terminalColumns.has(t.column),
+        ).length;
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }
       const maxToStart = Math.min(projectRoom, worktreeRoom);

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -37,6 +37,7 @@ import {
   resolveLifecycleColumns,
   resolveWorkflowIrForTaskWithProvenance,
   resolveProjectColumnsForRoles,
+  TERMINAL_ROLES,
   workflowHasColumn,
   getStepParser,
   computePlanApprovalFingerprint,
@@ -2145,8 +2146,19 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
+        /*
+        FNXC:WorktreeCapacity 2026-08-01-01:55:
+        TERMINAL BY ROLE. This ledger mirrors the scheduler's, and the scheduler's resolves — so
+        comparing `"done"`/`"archived"` here meant the same capacity question got different answers
+        depending on which lane asked it. On a renamed board every finished card counted as a live
+        worktree holder, and planning admission starved against a cap it could never reach.
+
+        PROJECT-WIDE, not per-task: this filters every task, so a per-task flags read would be N+1
+        workflow reads for a question with one project-level answer.
+        */
+        const terminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
         const heldWorktrees = allTasks.filter((t) =>
-          t.column !== "done" && t.column !== "archived"
+          !terminalColumns.has(t.column)
           && typeof t.worktree === "string" && t.worktree.length > 0).length;
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }


### PR DESCRIPTION
## Main is RED on the census gate

```
lifecycle-column-census --strict
  packages/engine/src/executor.ts: 0 -> 2
  packages/engine/src/triage.ts:   0 -> 2
```

That gate runs in CI's blocking **Lint** job, so every open PR inherits the failure.

## What landed

Both are the **same predicate** #3262 converted in `scheduler.ts`, hand-rolled again in the capacity gates added by `374956ef23` (planning admission) and `6c7467a78d` (spawned children):

```ts
t.column !== "done" && t.column !== "archived" && typeof t.worktree === "string" && t.worktree.length > 0
```

Third and fourth appearance of this shape. The FNXC note #3262 left says *"second time in this file"* — it has since escaped the file.

## The real defect is the inconsistency, not the count

The scheduler's ledger **resolves** lanes. These two compare literals. So on a renamed board the same capacity question gets **different answers depending on which lane asks it**: every finished card counts as a live worktree holder, and both new gates then refuse work against a cap they can never reach — planning admission starves, spawns refuse. That is the under-count's mirror image, and it is silent.

## Why project-wide rather than per-task

Both sites filter over **every task**. A per-task flags read would be N+1 workflow reads for a question with one project-level answer, so this uses `resolveProjectColumnsForRoles(store, TERMINAL_ROLES)` — one await, board-aware, the pattern already used throughout `self-healing.ts`.

## Measured

```
census --strict            rc=0   — BACKLOG ZERO restored
triage + executor suites   110 files / 1238 tests passed
typecheck, lint, fnxc      clean
```

## Not pinned by a test — stated, not implied

Both predicates sit inline in async admission/spawn paths, and reaching them needs exactly the mock-the-world harness those suites deliberately avoid. **This restores the invariant and unblocks the gate; it does not pin it.** A renamed-board pin for these two gates is follow-up work I am happy to take — the same seam-extraction shape as #3288, which is what made the scheduler's ledger testable.

I claimed this on #3288 before starting, since `executor.ts` and `triage.ts` are both actively being edited tonight.
