### PR TITLE
fix(engine): the maxWorktrees admission ledger reads terminal lanes by role (census 4 → 0)

### DIFF
--- a/packages/engine/src/__tests__/admission-worktree-ledger-lanes.test.ts
+++ b/packages/engine/src/__tests__/admission-worktree-ledger-lanes.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+/*
+FNXC:WorkflowResolvedColumns 2026-08-01-01:53 (fleet):
+
+THE INVARIANT: the three gates that arbitrate the maxWorktrees budget count the SAME holders on a
+renamed board — a finished card's retained worktree is never capacity, whatever its lane is called.
+
+Planning admission (`triage.ts`) and the spawned-child gate (`executor.ts`) each filtered
+`column !== "done" && column !== "archived"`. On a board that renamed its terminal lanes that pair
+matches nothing, so every done card's retained worktree counts as live and `worktreeRoom` collapses:
+admission refuses work while real slots sit free. That failure is QUIETER than the over-admission
+breach the gates were written for — an over-throttled board is indistinguishable from an idle one,
+which is why it is pinned here rather than left to the arithmetic tests.
+
+WHAT THESE CASES COVER AND WHAT THEY DO NOT, stated rather than implied. Both call sites sit inside
+methods (`TriageManager.processTriageTasks`, the `fn_spawn_agent` tool handler) that a unit test has
+no business standing up — the same reasoning `scheduler-terminal-capacity-role.test.ts` and
+`scheduler-load-lane-union.test.ts` record. So these pin the two halves the fix is made of:
+
+  - `heldWorktreeCountOf`, the seam both call sites now share, including that it counts a
+    worktree-less card as no holder and a terminal holder as no holder.
+  - `resolveProjectColumnsForRoles(store, TERMINAL_ROLES)`, the terminal answer both now pass it,
+    over a renamed board and over a degraded store.
+
+The composition of the two is held by the compiler: the predicate is the function's only argument.
+
+REVERTED — either call site restored to the literal pair — the "renamed board" case below fails: it
+resolves `shipped`/`attic` as terminal, and the literal predicate reports 2 holders where the fix
+reports 0. The degraded-store case is what keeps the legacy ids from being dropped in the process,
+and it fails if `resolveProjectColumnsForRoles` is swapped for a trait-only resolver.
+*/
+import { describe, expect, it } from "vitest";
+import { resolveProjectColumnsForRoles, TERMINAL_ROLES } from "@fusion/core";
+import type { WorkflowIr } from "@fusion/core";
+import { heldWorktreeCountOf } from "../scheduler.js";
+
+const RENAMED_IR = {
+  version: "v2", id: "wf-renamed", name: "renamed", nodes: [], edges: [],
+  columns: [
+    { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+    { id: "building", name: "Building", traits: [{ trait: "wip" }] },
+    { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    { id: "attic", name: "Attic", traits: [{ trait: "archived" }] },
+  ],
+} as unknown as WorkflowIr;
+
+/* Only the one method `resolveProjectColumnsForRoles` reads; anything else would be scenery. */
+const storeWith = (definitions: Array<{ ir: unknown }>) =>
+  ({ listWorkflowDefinitions: async () => definitions }) as never;
+
+const task = (id: string, column: string, worktree?: string) =>
+  ({ id, column, worktree }) as never;
+
+describe("the admission-side worktree ledger, on a renamed board", () => {
+  it("does not count a finished card's retained worktree, whatever the lane is called", async () => {
+    const terminal = await resolveProjectColumnsForRoles(storeWith([{ ir: RENAMED_IR }]), TERMINAL_ROLES);
+    const tasks = [
+      task("t1", "shipped", "/wt/shipped"),
+      task("t2", "attic", "/wt/attic"),
+    ];
+
+    /* The subject. Reverted to the literal pair this is 2, and admission throttles on phantom slots. */
+    expect(heldWorktreeCountOf(tasks, (t) => terminal.has(t.column))).toBe(0);
+  });
+
+  it("still counts live cards in renamed working and intake lanes", async () => {
+    const terminal = await resolveProjectColumnsForRoles(storeWith([{ ir: RENAMED_IR }]), TERMINAL_ROLES);
+    const tasks = [
+      task("t1", "building", "/wt/building"),
+      task("t2", "backlog", "/wt/backlog"),
+      task("t3", "shipped", "/wt/shipped"),
+    ];
+
+    /* Under-counting is the dangerous direction — it admits over the cap — so it is pinned too. */
+    expect(heldWorktreeCountOf(tasks, (t) => terminal.has(t.column))).toBe(2);
+  });
+
+  it("counts HOLDING a worktree, not merely being live", () => {
+    const tasks = [
+      task("t1", "building", "/wt/one"),
+      task("t2", "building"),
+      task("t3", "building", ""),
+    ];
+
+    expect(heldWorktreeCountOf(tasks, () => false)).toBe(1);
+  });
+
+  it("keeps the legacy terminal ids when the definition list cannot be read", async () => {
+    const unreadable = ({
+      listWorkflowDefinitions: async () => { throw new Error("db down"); },
+    }) as never;
+    const terminal = await resolveProjectColumnsForRoles(unreadable, TERMINAL_ROLES);
+    const tasks = [
+      task("t1", "done", "/wt/done"),
+      task("t2", "archived", "/wt/archived"),
+      task("t3", "in-progress", "/wt/wip"),
+    ];
+
+    /* A degraded read must be no worse than the literal, never better-looking than it. */
+    expect(heldWorktreeCountOf(tasks, (t) => terminal.has(t.column))).toBe(1);
+  });
+});

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -13,7 +13,7 @@ import { basename, delimiter, isAbsolute, join, relative, resolve as resolvePath
 import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings, WorkflowStep, MissionStore, AsyncMissionStore, Slice, AgentState, AgentCapability, RunMutationContext, AgentHeartbeatConfig, Agent, AgentMemoryInclusionMode, ProjectSettings, MergeResult, WorkflowIrNode, WorkflowIrNodeKind, WorkflowStepResult as CoreWorkflowStepResult, ThinkingLevel } from "@fusion/core";
-import { getUnmetSchedulingDependencies } from "./scheduler.js";
+import { getUnmetSchedulingDependencies, heldWorktreeCountOf } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
 import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
@@ -21936,9 +21936,10 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
-            const heldWorktrees = spawnTasks.filter((t) =>
-              t.column !== "done" && t.column !== "archived"
-              && typeof t.worktree === "string" && t.worktree.length > 0).length;
+            const heldWorktrees = heldWorktreeCountOf(
+              spawnTasks,
+              (t) => t.column === "done" || t.column === "archived",
+            );
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {
               releaseSpawnReservation();

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -16,7 +16,7 @@ import type { TaskStore, Task, TaskDetail, TaskTokenUsage, StepStatus, Settings,
 import { getUnmetSchedulingDependencies, heldWorktreeCountOf } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
-import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
+import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, TERMINAL_ROLES, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, upsertWorkflowStepResult, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, resolveExecutorFallbackModel, resolveValidatorFallbackModel } from "@fusion/core";
 import { finalizeProvenAutoMergeTask } from "./auto-merge-finalization.js";
 import { mergeEffectiveSettings } from "./effective-settings.js";
 import { generateFeatureVideo, type GenerateFeatureVideoOptions } from "./review-artifacts/feature-video.js";
@@ -21936,10 +21936,23 @@ You have access to the file system to review changes.${inlineFixBlock}${verdictB
           const spawnMaxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
           if (typeof spawnMaxWorktrees === "number" && Number.isFinite(spawnMaxWorktrees)) {
             const spawnTasks = await this.store.listTasks({ slim: true, includeArchived: false });
-            const heldWorktrees = heldWorktreeCountOf(
-              spawnTasks,
-              (t) => t.column === "done" || t.column === "archived",
-            );
+            /*
+            FNXC:WorkflowResolvedColumns 2026-08-01-01:53 (fleet — twin of triage.ts's admission ledger):
+            Same predicate, same fix, and it MUST stay the same: this gate and planning admission
+            arbitrate ONE budget, so a renamed board where only one of them recognises its terminal
+            lanes gives two different answers to "how many worktrees are held", and whichever lane
+            asks first wins with its own number.
+
+            Set membership over the whole board (`resolveProjectColumnsForRoles` + `TERMINAL_ROLES`)
+            rather than this task's own terminal role: the filter spans every task, possibly across
+            workflows. The returned set always contains the legacy ids, so an unreadable definition
+            list reproduces the previous behaviour exactly.
+
+            The added await is safe against the TOCTOU rule stated above: the agent-slot reservation
+            is already held at this point, and a worktree refusal unwinds it.
+            */
+            const spawnTerminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
+            const heldWorktrees = heldWorktreeCountOf(spawnTasks, (t) => spawnTerminalColumns.has(t.column));
             // totalSpawnedCount already includes THIS reservation; heldWorktrees covers task lanes.
             if (heldWorktrees + this.totalSpawnedCount > spawnMaxWorktrees) {
               releaseSpawnReservation();

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -924,6 +924,31 @@ export function nonWipWorktreeHolderIdsOf(
     .map((task) => task.id);
 }
 
+/*
+FNXC:WorktreeCapacity 2026-08-01-01:53:
+THE ADMISSION-SIDE HOLDER COUNT, extracted for the same reason as `nonWipWorktreeHolderIdsOf` above.
+
+Two other gates arbitrate the SAME maxWorktrees budget and each carried its own copy of this filter:
+planning admission (`triage.ts`) and the spawned-child gate (`executor.ts`). They differ from the
+scheduler's ledger in having no WIP-set exclusion — every non-terminal holder counts, once — but the
+holder test itself is identical, and three copies of one budget's definition is how the two live
+defects recorded above went unnoticed in the first place.
+
+`isTerminalColumn` is passed in rather than resolved here: the two callers answer it differently
+(project-wide role set vs the scheduler's per-workflow flags map) and this function has no store.
+
+This commit is the MOVE only — the predicate the callers pass is byte-for-byte what they filtered on
+before. The lane-vocabulary fix rides in the next commit so the diff that changes behaviour is the
+one small enough to read.
+*/
+export function heldWorktreeCountOf(
+  tasks: readonly Task[],
+  isTerminalColumn: (task: Task) => boolean,
+): number {
+  return tasks.filter((task) => !isTerminalColumn(task)
+    && typeof task.worktree === "string" && task.worktree.length > 0).length;
+}
+
 /**
  * Slots a candidate must clear to dispatch. A candidate that ALREADY holds a worktree subtracts its
  * own slot: on release the slot TRANSFERS (it executes in the same worktree) rather than adding.

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -37,6 +37,7 @@ import {
   resolveLifecycleColumns,
   resolveWorkflowIrForTaskWithProvenance,
   resolveProjectColumnsForRoles,
+  TERMINAL_ROLES,
   workflowHasColumn,
   getStepParser,
   computePlanApprovalFingerprint,
@@ -2146,10 +2147,26 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
-        const heldWorktrees = heldWorktreeCountOf(
-          allTasks,
-          (t) => t.column === "done" || t.column === "archived",
-        );
+        /*
+        FNXC:WorkflowResolvedColumns 2026-08-01-01:53 (fleet — the ledger's "non-terminal" test):
+        The pair `column === "done" || column === "archived"` is legacy-id-only, so on a renamed board
+        NOTHING is terminal and every finished card's retained worktree counts against live capacity.
+        This fails in the direction that STALLS the board — `worktreeRoom` reaches 0 and planning
+        admission refuses work while real slots sit free — which is the mirror image of the breach the
+        note above was written for, and quieter: a stalled board looks like an idle one.
+
+        `resolveProjectColumnsForRoles(store, TERMINAL_ROLES)` is the resolver this needs rather than
+        the per-task `resolveTerminalColumnsFor`. The filter spans EVERY task on the board, which may
+        span workflows, and the question is set membership ("is this lane one of the finished ones"),
+        not "which lane is this task's complete role" — so it also answers correctly for a board
+        declaring more than one complete-trait column, which a first-match role lookup cannot.
+        One store read for the whole filter.
+
+        Degrades the way every other adopter does: the returned set always contains the legacy ids, so
+        an unreadable definition list gives exactly the behaviour of the literal it replaces.
+        */
+        const terminalColumns = await resolveProjectColumnsForRoles(this.store, TERMINAL_ROLES);
+        const heldWorktrees = heldWorktreeCountOf(allTasks, (t) => terminalColumns.has(t.column));
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }
       const maxToStart = Math.min(projectRoom, worktreeRoom);

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -58,6 +58,7 @@ import {
   parsePlanningPlanMd,
   type NearDuplicateCandidate,
 } from "@fusion/core";
+import { heldWorktreeCountOf } from "./scheduler.js";
 
 
 type TaskListClamp = (lines: string[], opts?: { maxChars?: number }) => string;
@@ -2145,9 +2146,10 @@ export class TriageProcessor {
       const maxWorktrees = (settings as { maxWorktrees?: number | null }).maxWorktrees ?? 4;
       let worktreeRoom = Number.POSITIVE_INFINITY;
       if (typeof maxWorktrees === "number" && Number.isFinite(maxWorktrees)) {
-        const heldWorktrees = allTasks.filter((t) =>
-          t.column !== "done" && t.column !== "archived"
-          && typeof t.worktree === "string" && t.worktree.length > 0).length;
+        const heldWorktrees = heldWorktreeCountOf(
+          allTasks,
+          (t) => t.column === "done" || t.column === "archived",
+        );
         worktreeRoom = Math.max(0, maxWorktrees - heldWorktrees);
       }
       const maxToStart = Math.min(projectRoom, worktreeRoom);


### PR DESCRIPTION
## Census

| | backlog | deliberate |
|---|---|---|
| before (`origin/main`) | **4** | 148 |
| after | **0** | 148 |

Both guards were the same predicate in two copies:

```
packages/engine/src/executor.ts  2   (fn_spawn_agent worktree gate)
packages/engine/src/triage.ts    2   (planning admission)
```

Nothing was reclassified — the count moved because the sites were converted, not marked. `deliberate`
is unchanged, which is the check that distinguishes the two.

## What was wrong

Both gates counted a card as a live worktree holder unless its column was literally `done` or
`archived`. On a board that renamed its terminal lanes neither matched, so every **finished** card's
retained worktree counted against live capacity — `worktreeRoom` collapses toward 0 and planning
admission refuses work while real slots sit free.

This is the quieter of the two failure directions. The commits that added these gates last week were
chasing the opposite one (maxWorktrees=4 with 8 planners and 11 worktrees, `374956ef23`), and an
over-admitting board is loud. An over-throttled board is indistinguishable from an idle one.

Both gates arbitrate **one** budget, so they are converted together: a board where only one of them
recognises its terminal lanes gives two different answers to "how many worktrees are held", and
whichever lane asks first wins with its own number.

## How

`resolveProjectColumnsForRoles(store, TERMINAL_ROLES)` — the same helper self-healing's terminal
sweeps use (7 call sites there).

Set membership rather than the per-task `resolveTerminalColumnsFor` that `parkCompletedBlockedTask`
uses, and that choice is deliberate: this filter spans **every** task on the board, which may span
workflows, and the question is "is this lane one of the finished ones", not "which lane is this
task's complete role". It also answers for a board declaring more than one complete-trait column,
which a first-match role lookup cannot. One store read for the whole filter.

The helper's returned set always contains the legacy ids, so an unreadable definition list gives
exactly the behaviour of the literal it replaces.

## Two commits, deliberately

- `b5a35e2` — **pure move.** `heldWorktreeCountOf` extracted to the seam beside `nonWipWorktreeHolderIdsOf`, with both call sites passing the *same literal predicate they filtered on before*. Behaviour-identical by construction and measured: **the census still reported 4 in the same 2 files after this commit**, because the literals moved rather than changed.
- `272ca56` — the conversion + the test.

## Test, and what it does when reverted

`packages/engine/src/__tests__/admission-worktree-ledger-lanes.test.ts` (4 cases).

Blinding the predicate back to the literal pair — the state before this PR — **2 of the 4 fail**:

```
renamed terminal lanes hold no capacity:   expected 0, received 2
renamed live lanes still counted:          expected 2, received 3
```

The other two pass under the revert **by design**: one pins that the count is about *holding* a
worktree rather than being live, and one pins the degraded-store arm, where the resolved answer must
equal the literal or the legacy ids have been dropped.

**Coverage limit, stated rather than implied:** both call sites live inside methods
(`TriageManager.processTriageTasks`, the `fn_spawn_agent` handler) a unit test has no business
standing up — the same reasoning `scheduler-terminal-capacity-role.test.ts` records for its own
predicate. These cases pin the seam and the resolver; the compiler holds the composition, since the
predicate is the function's only argument. The capacity **arithmetic** downstream remains covered
only by `scheduler-worktree-capacity-arithmetic.test.ts`.

## Flagged, not guessed

`scheduler.ts`'s own ledger (`isTerminalColumnTask`) resolves through a **per-workflow flags map**
built inside `schedule()`, not through the project-wide role set used here. The two therefore differ
on one board shape: a workflow that is defined but has no card in a terminal lane contributes its
lanes to the project set and not to the scheduler's per-task map. I did **not** unify them — that is
a behaviour change to the scheduler's own gate, out of scope for a census conversion, and it needs
someone to decide which of the two definitions the budget is supposed to mean.

## Verification (measured, in the worktree)

- `pnpm test:gate` — **green** (22 files / 499 tests, + 3/13, + CI-shape 71)
- `pnpm --filter @fusion/engine exec tsc --noEmit` — clean
- `pnpm lint` — clean
- `node scripts/check-lane-wiring.mjs` — `12 known unwired call site(s), none added`
- `node scripts/check-fnxc-future-dates.mjs` — `122 known future-dated stamp(s), none added`
- nearest suites: `spawn-agent-capacity`, `triage-plan-admission-throttle-audit`, `scheduler-worktree-capacity-arithmetic`, `scheduler-terminal-capacity-role` — 28/28

One self-inflicted error worth recording: my stamp-repointing script's blanket replace clobbered an
unrelated `FNXC:PumpWatchdog` stamp in `scheduler.ts`. Caught by diffing the FNXC lines and restored;
the diff now touches only my own stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
