### PR TITLE
fix(i18n): restore reverted-task locale parity

### DIFF
--- a/.changeset/reverted-task-secondary-locale-parity.md
+++ b/.changeset/reverted-task-secondary-locale-parity.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep translated dashboard catalogs aligned with reverted-task resolution actions.
+category: fix
+dev: Adds the revertedTasks, revertedResolutionActions, and revise keys to every secondary app catalog so locale parity remains valid after the reverted-task dashboard UI landed.

--- a/packages/engine/src/execution-block-classifier.ts
+++ b/packages/engine/src/execution-block-classifier.ts
@@ -34,8 +34,11 @@ export type BlockedExitClassification = {
 };
 
 const TASK_ID_RE = /^[A-Z][A-Z0-9]*-\d+$/i;
-/** Bare PR refs: pr:2398, pr#2398, pr-2398, #2398, PR-2398 (not FN-#### task ids). */
-const PR_REF_RE = /^(?:pr[:#\-]|#|PR-)(\d+)$/i;
+/**
+ * FNXC:ExecutionBlockClassification 2026-08-01-18:45:
+ * Bare PR blockers accept pr:2398, pr#2398, pr-2398, #2398, and PR-2398 while excluding FN-#### task IDs. Keep the hyphen last in the character class so ESLint does not require an unnecessary escape.
+ */
+const PR_REF_RE = /^(?:pr[:#-]|#|PR-)(\d+)$/i;
 const PR_IN_TEXT_RE = /\bPR\s*#?\s*(\d+)\b/gi;
 const CLAIM_REASON_RE =
   /check-file-claimed|actively claimed|file[- ]claim|claimed by (?:open )?pr|open pr\s*#?\s*\d+|collision policy|claimed paths?|file claims?/i;

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -8548,7 +8548,10 @@
     "awaitingApprovalTitle": "",
     "statusReplan": "Replanificar",
     "refinesOf": "",
-    "refinesOfTitle": ""
+    "refinesOfTitle": "",
+    "revertedTasks": "",
+    "revertedResolutionActions": "",
+    "revise": ""
   },
   "terminal": {
     "arrowKeysLabel": "",

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -8548,7 +8548,10 @@
     "awaitingApprovalTitle": "",
     "statusReplan": "Replanifier",
     "refinesOf": "",
-    "refinesOfTitle": ""
+    "refinesOfTitle": "",
+    "revertedTasks": "",
+    "revertedResolutionActions": "",
+    "revise": ""
   },
   "terminal": {
     "arrowKeysLabel": "",

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -8548,7 +8548,10 @@
     "awaitingApprovalTitle": "",
     "statusReplan": "재계획",
     "refinesOf": "",
-    "refinesOfTitle": ""
+    "refinesOfTitle": "",
+    "revertedTasks": "",
+    "revertedResolutionActions": "",
+    "revise": ""
   },
   "terminal": {
     "arrowKeysLabel": "",

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -8548,7 +8548,10 @@
     "awaitingApprovalTitle": "",
     "statusReplan": "重新规划",
     "refinesOf": "",
-    "refinesOfTitle": ""
+    "refinesOfTitle": "",
+    "revertedTasks": "",
+    "revertedResolutionActions": "",
+    "revise": ""
   },
   "terminal": {
     "arrowKeysLabel": "",

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -8548,7 +8548,10 @@
     "awaitingApprovalTitle": "",
     "statusReplan": "重新規劃",
     "refinesOf": "",
-    "refinesOfTitle": ""
+    "refinesOfTitle": "",
+    "revertedTasks": "",
+    "revertedResolutionActions": "",
+    "revise": ""
   },
   "terminal": {
     "arrowKeysLabel": "",


### PR DESCRIPTION
## Summary
- add reverted-task resolution keys to every secondary app catalog
- restore structural locale parity after the reverted-task dashboard UI landed
- include labeled patch release metadata

## Test plan
- `pnpm --filter @fusion/i18n test`
- `pnpm i18n:status`
- `pnpm check:changesets -- --strict`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added localized labels for reverted tasks, resolution actions, revision actions, and related task titles in French, Korean, Simplified Chinese, and Traditional Chinese.
  * Added Spanish locale entries for consistent support of these task actions.
  * Improved terminology coverage across supported secondary locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->