### PR TITLE
fix(i18n): restore settings locale parity

### DIFF
--- a/.changeset/restore-fn-8752-8753-locale-parity.md
+++ b/.changeset/restore-fn-8752-8753-locale-parity.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Restore locale parity for project escalation models and voice input states
+category: fix
+dev: Add the FN-8752 and FN-8753 settings keys to every supported secondary locale catalog.

--- a/packages/i18n/locales/es/app.json
+++ b/packages/i18n/locales/es/app.json
@@ -6539,7 +6539,11 @@
       "selectChatDefaultAgent": "Select a chat default agent",
       "chatDefaultAgentEmpty": "No agents are available for this project yet.",
       "chatDefaultAgentHelp": "Agent-mode New Chat starts a Direct chat with the selected durable agent.",
-      "chatDefaultReset": "Reset Chat default"
+      "chatDefaultReset": "Reset Chat default",
+      "executorEscalationModel": "",
+      "executorEscalationModelHelp": "",
+      "selectExecutorEscalationModel": "",
+      "noExecutorEscalationModel": ""
     },
     "remote": {
       "acceptRoutes": "",
@@ -6923,7 +6927,13 @@
       "notInstalled": "Not installed",
       "download": "Download",
       "remove": "Remove",
-      "error": "Model error: {{message}}"
+      "error": "Model error: {{message}}",
+      "modelRequired": "",
+      "modelPreparing": "",
+      "modelFailed": "",
+      "runtimeModuleMissing": "",
+      "runtimePlatformLoadFailed": "",
+      "runtimeIncompatible": ""
     }
   },
   "setup": {

--- a/packages/i18n/locales/fr/app.json
+++ b/packages/i18n/locales/fr/app.json
@@ -6539,7 +6539,11 @@
       "selectChatDefaultAgent": "Select a chat default agent",
       "chatDefaultAgentEmpty": "No agents are available for this project yet.",
       "chatDefaultAgentHelp": "Agent-mode New Chat starts a Direct chat with the selected durable agent.",
-      "chatDefaultReset": "Reset Chat default"
+      "chatDefaultReset": "Reset Chat default",
+      "executorEscalationModel": "",
+      "executorEscalationModelHelp": "",
+      "selectExecutorEscalationModel": "",
+      "noExecutorEscalationModel": ""
     },
     "remote": {
       "acceptRoutes": "",
@@ -6923,7 +6927,13 @@
       "notInstalled": "Not installed",
       "download": "Download",
       "remove": "Remove",
-      "error": "Model error: {{message}}"
+      "error": "Model error: {{message}}",
+      "modelRequired": "",
+      "modelPreparing": "",
+      "modelFailed": "",
+      "runtimeModuleMissing": "",
+      "runtimePlatformLoadFailed": "",
+      "runtimeIncompatible": ""
     }
   },
   "setup": {

--- a/packages/i18n/locales/ko/app.json
+++ b/packages/i18n/locales/ko/app.json
@@ -6539,7 +6539,11 @@
       "selectChatDefaultAgent": "Select a chat default agent",
       "chatDefaultAgentEmpty": "No agents are available for this project yet.",
       "chatDefaultAgentHelp": "Agent-mode New Chat starts a Direct chat with the selected durable agent.",
-      "chatDefaultReset": "Reset Chat default"
+      "chatDefaultReset": "Reset Chat default",
+      "executorEscalationModel": "",
+      "executorEscalationModelHelp": "",
+      "selectExecutorEscalationModel": "",
+      "noExecutorEscalationModel": ""
     },
     "remote": {
       "acceptRoutes": "",
@@ -6923,7 +6927,13 @@
       "notInstalled": "Not installed",
       "download": "Download",
       "remove": "Remove",
-      "error": "Model error: {{message}}"
+      "error": "Model error: {{message}}",
+      "modelRequired": "",
+      "modelPreparing": "",
+      "modelFailed": "",
+      "runtimeModuleMissing": "",
+      "runtimePlatformLoadFailed": "",
+      "runtimeIncompatible": ""
     }
   },
   "setup": {

--- a/packages/i18n/locales/zh-CN/app.json
+++ b/packages/i18n/locales/zh-CN/app.json
@@ -6539,7 +6539,11 @@
       "selectChatDefaultAgent": "Select a chat default agent",
       "chatDefaultAgentEmpty": "No agents are available for this project yet.",
       "chatDefaultAgentHelp": "Agent-mode New Chat starts a Direct chat with the selected durable agent.",
-      "chatDefaultReset": "Reset Chat default"
+      "chatDefaultReset": "Reset Chat default",
+      "executorEscalationModel": "",
+      "executorEscalationModelHelp": "",
+      "selectExecutorEscalationModel": "",
+      "noExecutorEscalationModel": ""
     },
     "remote": {
       "acceptRoutes": "",
@@ -6923,7 +6927,13 @@
       "notInstalled": "Not installed",
       "download": "Download",
       "remove": "Remove",
-      "error": "Model error: {{message}}"
+      "error": "Model error: {{message}}",
+      "modelRequired": "",
+      "modelPreparing": "",
+      "modelFailed": "",
+      "runtimeModuleMissing": "",
+      "runtimePlatformLoadFailed": "",
+      "runtimeIncompatible": ""
     }
   },
   "setup": {

--- a/packages/i18n/locales/zh-TW/app.json
+++ b/packages/i18n/locales/zh-TW/app.json
@@ -6539,7 +6539,11 @@
       "selectChatDefaultAgent": "Select a chat default agent",
       "chatDefaultAgentEmpty": "No agents are available for this project yet.",
       "chatDefaultAgentHelp": "Agent-mode New Chat starts a Direct chat with the selected durable agent.",
-      "chatDefaultReset": "Reset Chat default"
+      "chatDefaultReset": "Reset Chat default",
+      "executorEscalationModel": "",
+      "executorEscalationModelHelp": "",
+      "selectExecutorEscalationModel": "",
+      "noExecutorEscalationModel": ""
     },
     "remote": {
       "acceptRoutes": "",
@@ -6923,7 +6927,13 @@
       "notInstalled": "Not installed",
       "download": "Download",
       "remove": "Remove",
-      "error": "Model error: {{message}}"
+      "error": "Model error: {{message}}",
+      "modelRequired": "",
+      "modelPreparing": "",
+      "modelFailed": "",
+      "runtimeModuleMissing": "",
+      "runtimePlatformLoadFailed": "",
+      "runtimeIncompatible": ""
     }
   },
   "setup": {


### PR DESCRIPTION
## Summary
- add FN-8752 executor escalation model keys to every secondary locale
- add FN-8753 voice input runtime-state keys to every secondary locale
- preserve existing aggregate-only locale keys removed by raw i18n sync

## Test Plan
- `pnpm i18n:status`
- `pnpm --filter @fusion/i18n test`
- `pnpm check:changesets`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added Spanish, French, Korean, Simplified Chinese, and Traditional Chinese translations for chat reset and escalation model settings.
  * Added translated voice-input status messages covering preparation, errors, loading, compatibility, and runtime issues.
* **Release**
  * Prepared a patch release to restore translation parity across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->