### PR TITLE
fix(dashboard): align List browser smoke fixture

### DIFF
--- a/.changeset/repair-list-browser-smoke-single-pane.md
+++ b/.changeset/repair-list-browser-smoke-single-pane.md
@@ -1,7 +1,0 @@
----
-"@runfusion/fusion": patch
----
-
-summary: Keep the native List layout smoke aligned with measured single-pane routing
-category: fix
-dev: Mark the mobile List smoke fixture with the production single-pane class and lock the fixture contract with a regression test.

--- a/.changeset/repair-list-browser-smoke-single-pane.md
+++ b/.changeset/repair-list-browser-smoke-single-pane.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep the native List layout smoke aligned with measured single-pane routing
+category: fix
+dev: Mark the mobile List smoke fixture with the production single-pane class and lock the fixture contract with a regression test.

--- a/packages/dashboard/app/__tests__/browser-layout-smoke-fixture.test.ts
+++ b/packages/dashboard/app/__tests__/browser-layout-smoke-fixture.test.ts
@@ -84,4 +84,9 @@ describe("browser layout smoke fixture", () => {
       expect(html).toContain(label);
     }
   });
+
+  it("marks the mobile List fixture as the production single-pane surface", () => {
+    const html = createSmokeHtml();
+    expect(html).toContain('class="list-view list-view--single-pane" data-smoke="list"');
+  });
 });

--- a/packages/dashboard/app/__tests__/browser-layout-smoke-fixture.test.ts
+++ b/packages/dashboard/app/__tests__/browser-layout-smoke-fixture.test.ts
@@ -85,8 +85,14 @@ describe("browser layout smoke fixture", () => {
     }
   });
 
+  /*
+  FNXC:ListView 2026-08-03-07:00:
+  The mobile List smoke fixture must carry the production list-view--single-pane marker without coupling the regression to HTML attribute order or spacing.
+  */
   it("marks the mobile List fixture as the production single-pane surface", () => {
     const html = createSmokeHtml();
-    expect(html).toContain('class="list-view list-view--single-pane" data-smoke="list"');
+    const listSectionTag = html.match(/<section\b[^>]*\bdata-smoke="list"[^>]*>/)?.[0];
+    expect(listSectionTag).toBeDefined();
+    expect(listSectionTag).toMatch(/\bclass="[^"]*\blist-view--single-pane\b[^"]*"/);
   });
 });

--- a/packages/dashboard/scripts/browser-layout-smoke.mjs
+++ b/packages/dashboard/scripts/browser-layout-smoke.mjs
@@ -379,7 +379,7 @@ export function createSmokeHtml() {
 
       <main class="project-content project-content--with-footer project-content--with-mobile-nav">
         <section class="board" data-smoke="board">${columnMarkup}</section>
-        <!-- FNXC:ListView 2026-08-03-06:41: Mirror ListView's measured single-pane marker so the native mobile smoke exercises the production CSS selector introduced by FN-8754 instead of rendering both the table and cards. -->
+        <!-- FNXC:ListView 2026-08-03-06:41: Mirror ListView's measured single-pane marker so the native mobile smoke exercises the production CSS selector introduced by FN-8754 instead of showing both the table and cards. -->
         <section class="list-view list-view--single-pane" data-smoke="list" hidden>
           <div class="list-create-area">
             <div class="quick-entry-box quick-entry-box--collapsed" data-testid="quick-entry-box">

--- a/packages/dashboard/scripts/browser-layout-smoke.mjs
+++ b/packages/dashboard/scripts/browser-layout-smoke.mjs
@@ -379,7 +379,8 @@ export function createSmokeHtml() {
 
       <main class="project-content project-content--with-footer project-content--with-mobile-nav">
         <section class="board" data-smoke="board">${columnMarkup}</section>
-        <section class="list-view" data-smoke="list" hidden>
+        <!-- FNXC:ListView 2026-08-03-06:41: Mirror ListView's measured single-pane marker so the native mobile smoke exercises the production CSS selector introduced by FN-8754 instead of rendering both the table and cards. -->
+        <section class="list-view list-view--single-pane" data-smoke="list" hidden>
           <div class="list-create-area">
             <div class="quick-entry-box quick-entry-box--collapsed" data-testid="quick-entry-box">
               <div class="quick-entry-main-row">


### PR DESCRIPTION
## Summary
- mark the native mobile List fixture with the production single-pane class introduced by FN-8754
- add fixture coverage so the production selector cannot drift silently

## Test Plan
- `pnpm --filter @fusion/dashboard exec vitest run app/__tests__/browser-layout-smoke-fixture.test.ts --silent=passed-only --reporter=dot`
- `pnpm check:changesets`
- `pnpm build`
- `pnpm --filter @fusion/dashboard test:browser-smoke -- --require-browser`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the mobile list layout fixture to include the production single-pane styling class, improving alignment with the app’s mobile layout behavior.

* **Tests**
  * Added a browser smoke test to verify the expected mobile list layout class is generated reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->