### PR TITLE
test(engine): fix moved skill resolver fixture import

### DIFF
--- a/packages/engine/src/__tests__/ce-workflow-step-executor.test.ts
+++ b/packages/engine/src/__tests__/ce-workflow-step-executor.test.ts
@@ -175,7 +175,7 @@ async function expectCapturedSkillBody(
   distinctiveBody: string,
 ) {
   const { DefaultResourceLoader } = await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>("@earendil-works/pi-coding-agent");
-  const { createSkillsOverrideFromSelection, resolveSessionSkills } = await vi.importActual<typeof import("../cli-runtime/skill-resolver.js")>("../skill-resolver.js");
+  const { createSkillsOverrideFromSelection, resolveSessionSkills } = await vi.importActual<typeof import("../cli-runtime/skill-resolver.js")>("../cli-runtime/skill-resolver.js");
   const requestedSkillNames = cap.last?.skillSelection?.requestedSkillNames;
   const selection = resolveSessionSkills({ projectRootDir, requestedSkillNames, sessionPurpose: "executor" });
   const loader = new DefaultResourceLoader({


### PR DESCRIPTION
## Summary
- update the CE workflow-step fixture runtime import to the moved `cli-runtime/skill-resolver.js` path
- align the runtime specifier with the existing type-only import

## Test plan
- `pnpm --filter @fusion/engine exec vitest run --project=engine-default src/__tests__/ce-workflow-step-executor.test.ts --silent=passed-only --reporter=dot --maxWorkers=1 --no-file-parallelism` (52 passed)
- `pnpm --filter @fusion/engine typecheck`
- `pnpm check:changesets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to reference the correct skill resolver location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->