### PR TITLE
test(core): align schema-applier assertions with migration 0047

### DIFF
--- a/packages/core/src/__tests__/postgres/schema-applier.test.ts
+++ b/packages/core/src/__tests__/postgres/schema-applier.test.ts
@@ -745,10 +745,10 @@ pgDescribe("schema-applier: VAL-SCHEMA-001 final-schema parity (table counts)", 
     const bySchema = Object.fromEntries(rows.map((r) => [r.table_schema, r.n]));
     /*
     FNXC:PgSchemaApplier 2026-08-03-02:16:
-    Project table count = historical core baseline plus later migrations. 0040 adds 2 lifecycle
-    outbox tables; 0041 adds 4 lifecycle consumer tables; 0043 adds the durable unplanned-dispatch
-    refusal marker, and 0046 adds workflow_agent_capacity_leases (100 → 106). Plugin tables are
-    added separately by the schema-init hook and are excluded here.
+    Project table count starts from the 98-table historical core baseline. Migration 0040 adds 2
+    lifecycle outbox tables, 0041 adds 4 lifecycle consumer tables, 0043 adds the durable
+    unplanned-dispatch refusal marker, and 0046 adds workflow_agent_capacity_leases: 98 + 2 + 4 + 1
+    + 1 = 106. Plugin tables are added separately by the schema-init hook and are excluded here.
     */
     expect(bySchema.project).toBe(106);
     /*

--- a/packages/core/src/__tests__/postgres/schema-applier.test.ts
+++ b/packages/core/src/__tests__/postgres/schema-applier.test.ts
@@ -89,6 +89,7 @@ import {
   QUEUED_EPISODE_SIGNATURE_VERSION,
   MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
   WORKFLOW_PRINCIPAL_FENCE_VERSION,
+  TASK_RECOMMENDATIONS_VERSION,
 } from "../../postgres/schema-applier.js";
 import { ProjectPartitionRekeyError, rekeyFallbackProjectPartition } from "../../postgres/migration-stamping.js";
 import type { PluginSchemaInitHook } from "../../postgres/plugin-schema-hook.js";
@@ -111,7 +112,8 @@ describe("schema-applier: immutable migration identities", () => {
     expect(QUEUED_EPISODE_SIGNATURE_VERSION).toBe("0044");
     expect(MULTI_ROLE_WORKFLOW_AGENTS_VERSION).toBe("0045");
     expect(WORKFLOW_PRINCIPAL_FENCE_VERSION).toBe("0046");
-    expect(SCHEMA_BASELINE_VERSION).toBe("0046");
+    expect(TASK_RECOMMENDATIONS_VERSION).toBe("0047");
+    expect(SCHEMA_BASELINE_VERSION).toBe("0047");
   });
 
   it("keeps monitor and approval isolation assigned to version 0003", () => {
@@ -726,7 +728,7 @@ pgDescribe("schema-applier: VAL-SCHEMA-001 final-schema parity (table counts)", 
     ctx = null;
   });
 
-  it("creates all 105 project tables, 17 central tables, 1 archive table", async () => {
+  it("creates all 106 project tables, 17 central tables, 1 archive table", async () => {
     ctx = await setupFreshDb();
     // FNXC:PostgresCutover 2026-07-05-15:55: apply the BASELINE only.
     // applySchemaBaseline now runs the plugin schema-init hooks by default,
@@ -745,9 +747,10 @@ pgDescribe("schema-applier: VAL-SCHEMA-001 final-schema parity (table counts)", 
     FNXC:PgSchemaApplier 2026-08-03-02:16:
     Project table count = historical core baseline plus later migrations. 0040 adds 2 lifecycle
     outbox tables; 0041 adds 4 lifecycle consumer tables; 0043 adds the durable unplanned-dispatch
-    refusal marker (100 → 105). Plugin tables are added separately by the schema-init hook and are excluded here.
+    refusal marker, and 0046 adds workflow_agent_capacity_leases (100 → 106). Plugin tables are
+    added separately by the schema-init hook and are excluded here.
     */
-    expect(bySchema.project).toBe(105);
+    expect(bySchema.project).toBe(106);
     /*
     FNXC:CapacityModel 2026-07-29-08:10 (drop the cross-project cap — table half):
     17, not 18: `central.global_concurrency` is dropped by migration 0037. A fresh
@@ -1770,6 +1773,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       QUEUED_EPISODE_SIGNATURE_VERSION,
       MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
       WORKFLOW_PRINCIPAL_FENCE_VERSION,
+      TASK_RECOMMENDATIONS_VERSION,
     ]);
     expect((await applySchemaBaseline(ctx.db, { pluginHooks: [] })).applied).toBe(false);
   });
@@ -1842,6 +1846,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       QUEUED_EPISODE_SIGNATURE_VERSION,
       MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
       WORKFLOW_PRINCIPAL_FENCE_VERSION,
+      TASK_RECOMMENDATIONS_VERSION,
     ]);
   });
 
@@ -2047,6 +2052,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       QUEUED_EPISODE_SIGNATURE_VERSION,
       MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
       WORKFLOW_PRINCIPAL_FENCE_VERSION,
+      TASK_RECOMMENDATIONS_VERSION,
     ]);
   });
 
@@ -2133,6 +2139,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       QUEUED_EPISODE_SIGNATURE_VERSION,
       MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
       WORKFLOW_PRINCIPAL_FENCE_VERSION,
+      TASK_RECOMMENDATIONS_VERSION,
     ]);
   });
 
@@ -2219,6 +2226,7 @@ pgDescribe("schema-applier: automation project-isolation upgrade", () => {
       QUEUED_EPISODE_SIGNATURE_VERSION,
       MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
       WORKFLOW_PRINCIPAL_FENCE_VERSION,
+      TASK_RECOMMENDATIONS_VERSION,
     ]);
   });
 });

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -357,6 +357,16 @@ async function resolveTerminalColumnsForTask(store: TaskStore, taskId: string): 
   }
 }
 
+async function resolveArchivedColumnsForTask(store: TaskStore, taskId: string): Promise<ReadonlySet<string>> {
+  try {
+    const ir = await resolveWorkflowIrForTask(store, taskId);
+    const archived = columnsWithFlag(ir, "archived");
+    return archived.length > 0 ? new Set(archived) : LEGACY_ARCHIVE_LANES;
+  } catch {
+    return LEGACY_ARCHIVE_LANES;
+  }
+}
+
 
 function isArtifactType(value: string): value is ArtifactType {
   return ARTIFACT_TYPES.has(value as ArtifactType);
@@ -2345,7 +2355,10 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
         soft-deleted children are historical records, not an actionable Created result; conflict
         rather than silently resurrecting or linking a second child.
         */
-        if (!linked || linked.deletedAt || linked.column === "archived") {
+        const linkedArchiveColumns = linked
+          ? await resolveArchivedColumnsForTask(scopedStore, linked.id)
+          : LEGACY_ARCHIVE_LANES;
+        if (!linked || linked.deletedAt || linkedArchiveColumns.has(linked.column)) {
           throw conflict("Recommendation link points to an unavailable task");
         }
         return res.status(200).json({ task: linked, parent });
@@ -2360,16 +2373,9 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       */
       const existing = (await scopedStore.listTasks({ slim: false, includeArchived: true, includeDeleted: true }))
         .find((task) => task.proposalClaimId === proposalClaimId);
-      const existingArchiveColumns = await (async () => {
-        if (!existing) return new Set<string>();
-        try {
-          const ir = await resolveWorkflowIrForTask(scopedStore, existing.id);
-          const columns = columnsWithFlag(ir, "archived");
-          return new Set(columns.length > 0 ? columns : ["archived"]);
-        } catch {
-          return new Set(["archived"]);
-        }
-      })();
+      const existingArchiveColumns = existing
+        ? await resolveArchivedColumnsForTask(scopedStore, existing.id)
+        : new Set<string>();
       /*
       FNXC:TaskRecommendations 2026-08-08-08:44:
       Deterministic reconciliation moves a child to its workflow's archived trait, which may be


### PR DESCRIPTION
## Summary
- advance schema-applier migration identity assertions through 0047
- include the 0047 marker in upgrade and concurrency ledgers
- update project-table parity for the 0046 capacity-lease table
- resolve recommendation archive checks through workflow traits, clearing a current-main lifecycle census failure

## Test plan
- `corepack pnpm --filter @fusion/core exec vitest run src/__tests__/postgres/schema-applier.test.ts --silent=passed-only --reporter=dot` (78 passed)
- `FUSION_DASHBOARD_DEEP=1 corepack pnpm --filter @fusion/dashboard exec vitest run src/routes/__tests__/task-recommendation-routes.test.ts --project dashboard-api --silent=passed-only --reporter=dot` (20 passed)
- `corepack pnpm check:lifecycle-columns`
- `corepack pnpm --filter @fusion/core typecheck`
- `corepack pnpm --filter @fusion/dashboard typecheck`
- `corepack pnpm lint` (passes with two pre-existing warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task recommendation handling for workflows with renamed or multiple archived lanes.
  * Added a fallback to recognize legacy archived lanes when workflow configuration cannot be resolved.
  * Improved recovery when claiming task recommendation proposals.
* **Reliability**
  * Updated database migration tracking to ensure schema upgrades and concurrent deployments remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->