### PR TITLE
fix(dashboard): resolve archived recommendation columns

### DIFF
--- a/.changeset/quiet-otters-resolve-archives.md
+++ b/.changeset/quiet-otters-resolve-archives.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Resolve archived recommendation children through workflow traits.
+category: fix
+dev: Preserves legacy archived tombstones without misclassifying declared live columns.

--- a/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
+++ b/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
@@ -135,6 +135,40 @@ function parent(overrides: Partial<Task> = {}): Task {
   });
 }
 
+function installCustomRecommendationWorkflow(
+  store: Partial<TaskStore>,
+  taskIds: readonly string[],
+  options: { declareLegacyArchivedAsLive?: boolean } = {},
+): void {
+  Object.assign(store, {
+    getTaskWorkflowSelection: vi.fn((id: string) => taskIds.includes(id)
+      ? { workflowId: "recommendation-workflow", stepIds: [] }
+      : undefined),
+    getTaskWorkflowSelectionAsync: vi.fn(async (id: string) => taskIds.includes(id)
+      ? { workflowId: "recommendation-workflow", stepIds: [] }
+      : undefined),
+    getWorkflowDefinition: vi.fn(async () => ({
+      id: "recommendation-workflow",
+      name: "Recommendation workflow",
+      kind: "workflow",
+      ir: {
+        version: "v2",
+        id: "recommendation-workflow",
+        name: "Recommendation workflow",
+        nodes: [{ id: "start", kind: "start", column: "backlog" }],
+        edges: [],
+        columns: [
+          { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+          ...(options.declareLegacyArchivedAsLive
+            ? [{ id: "archived", name: "Live archived", traits: [] }]
+            : []),
+          { id: "boxed", name: "Boxed", traits: [{ trait: "archived" }] },
+        ],
+      },
+    })),
+  });
+}
+
 describe("recommendation task creation route", () => {
   beforeEach(() => locks?.clear());
   afterEach(() => { locks?.clear(); vi.restoreAllMocks(); });
@@ -452,6 +486,45 @@ describe("recommendation task creation route", () => {
     const archivedResponse = await performRequest(archived.app, "POST", "/api/tasks/FN-1/recommendations/rec-1/create", undefined);
     expect(archivedResponse.status).toBe(409);
     expect(archived.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects a linked child in a custom workflow archived-trait lane", async () => {
+    const linkedChild = task({ id: "FN-9", description: "Archived child", column: "boxed" as Column });
+    const custom = buildApp([
+      parent({ recommendations: [{ ...parent().recommendations![0], createdTaskId: "FN-9" }] }),
+      linkedChild,
+    ]);
+    installCustomRecommendationWorkflow(custom.store, ["FN-9"]);
+
+    const response = await performRequest(
+      custom.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(409);
+    expect(custom.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("keeps a linked child live in an explicitly declared untraited archived column", async () => {
+    const linkedChild = task({ id: "FN-9", description: "Live child", column: "archived" });
+    const custom = buildApp([
+      parent({ recommendations: [{ ...parent().recommendations![0], createdTaskId: "FN-9" }] }),
+      linkedChild,
+    ]);
+    installCustomRecommendationWorkflow(custom.store, ["FN-9"], { declareLegacyArchivedAsLive: true });
+
+    const response = await performRequest(
+      custom.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ task: { id: "FN-9", column: "archived" } });
+    expect(custom.store.createTask).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -357,6 +357,22 @@ async function resolveTerminalColumnsForTask(store: TaskStore, taskId: string): 
   }
 }
 
+/*
+FNXC:TaskRecommendations 2026-08-09-05:22:
+Workflow traits identify current archived lanes. An undeclared legacy `archived` id remains a
+compatibility tombstone for persisted pre-migration tasks, while an explicitly declared untraited
+`archived` column stays live under flags-first semantics. Resolution failures degrade to the legacy id.
+*/
+async function resolveArchivedColumnsForTask(store: TaskStore, taskId: string): Promise<Set<string>> {
+  try {
+    const ir = await resolveWorkflowIrForTask(store, taskId);
+    const archived = columnsWithFlag(ir, "archived");
+    return new Set(workflowHasColumn(ir, "archived") ? archived : [...archived, "archived"]);
+  } catch {
+    return new Set(["archived"]);
+  }
+}
+
 
 function isArtifactType(value: string): value is ArtifactType {
   return ARTIFACT_TYPES.has(value as ArtifactType);
@@ -2339,13 +2355,16 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
           throw conflict("Recommendation link is malformed");
         }
         const linked = await scopedStore.getTask(recommendation.createdTaskId).catch(() => null);
+        const linkedArchiveColumns = linked
+          ? await resolveArchivedColumnsForTask(scopedStore, linked.id)
+          : new Set<string>();
         /*
         FNXC:TaskRecommendations 2026-08-08-06:34:
         A prior link is reusable only while its child remains in a live task lane. Archived and
         soft-deleted children are historical records, not an actionable Created result; conflict
         rather than silently resurrecting or linking a second child.
         */
-        if (!linked || linked.deletedAt || linked.column === "archived") {
+        if (!linked || linked.deletedAt || linkedArchiveColumns.has(linked.column)) {
           throw conflict("Recommendation link points to an unavailable task");
         }
         return res.status(200).json({ task: linked, parent });
@@ -2360,16 +2379,9 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       */
       const existing = (await scopedStore.listTasks({ slim: false, includeArchived: true, includeDeleted: true }))
         .find((task) => task.proposalClaimId === proposalClaimId);
-      const existingArchiveColumns = await (async () => {
-        if (!existing) return new Set<string>();
-        try {
-          const ir = await resolveWorkflowIrForTask(scopedStore, existing.id);
-          const columns = columnsWithFlag(ir, "archived");
-          return new Set(columns.length > 0 ? columns : ["archived"]);
-        } catch {
-          return new Set(["archived"]);
-        }
-      })();
+      const existingArchiveColumns = existing
+        ? await resolveArchivedColumnsForTask(scopedStore, existing.id)
+        : new Set<string>();
       /*
       FNXC:TaskRecommendations 2026-08-08-08:44:
       Deterministic reconciliation moves a child to its workflow's archived trait, which may be


### PR DESCRIPTION
## Summary
- resolve archived recommendation children through workflow traits instead of a hardcoded column id
- preserve legacy archived tombstones without treating an explicitly declared live `archived` column as terminal
- reuse the same archive-column resolver for linked children and proposal claims

## Test plan
- `corepack pnpm check:lifecycle-columns`
- `FUSION_DASHBOARD_DEEP=1 corepack pnpm --filter @fusion/dashboard exec vitest run src/routes/__tests__/task-recommendation-routes.test.ts --project dashboard-api --reporter=dot`
- `corepack pnpm --filter @fusion/dashboard typecheck`
- `corepack pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed recommendation workflows using custom archived lanes when validating linked tasks.
  - Archived child tasks now correctly return conflicts without creating duplicate tasks.
  - Preserved compatibility for legacy archived entries while allowing explicitly live archived columns to continue working.
  - Improved recovery of previously claimed child tasks across custom workflow configurations.

- **Tests**
  - Added coverage for archived-trait lanes, legacy archived columns, and custom workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->