### PR TITLE
fix(dashboard): resolve archived recommendation columns

### DIFF
--- a/.changeset/quiet-otters-resolve-archives.md
+++ b/.changeset/quiet-otters-resolve-archives.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Resolve archived recommendation children through workflow traits.
+category: fix
+dev: Preserves legacy archived tombstones without misclassifying declared live columns.

--- a/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
+++ b/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
@@ -141,6 +141,10 @@ function installCustomRecommendationWorkflow(
   options: {
     declareLegacyArchivedAsLive?: boolean;
     traitlessLegacyColumns?: boolean;
+    /*
+    FNXC:TaskRecommendations 2026-08-09-08:18:
+    Workflow-definition resolution failures must preserve the legacy `archived` fallback behavior.
+    */
     unresolvableSelection?: boolean;
   } = {},
 ): void {

--- a/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
+++ b/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
@@ -138,7 +138,11 @@ function parent(overrides: Partial<Task> = {}): Task {
 function installCustomRecommendationWorkflow(
   store: Partial<TaskStore>,
   taskIds: readonly string[],
-  options: { declareLegacyArchivedAsLive?: boolean; traitlessLegacyColumns?: boolean } = {},
+  options: {
+    declareLegacyArchivedAsLive?: boolean;
+    traitlessLegacyColumns?: boolean;
+    unresolvableSelection?: boolean;
+  } = {},
 ): void {
   Object.assign(store, {
     getTaskWorkflowSelection: vi.fn((id: string) => taskIds.includes(id)
@@ -147,28 +151,31 @@ function installCustomRecommendationWorkflow(
     getTaskWorkflowSelectionAsync: vi.fn(async (id: string) => taskIds.includes(id)
       ? { workflowId: "recommendation-workflow", stepIds: [] }
       : undefined),
-    getWorkflowDefinition: vi.fn(async () => ({
-      id: "recommendation-workflow",
-      name: "Recommendation workflow",
-      kind: "workflow",
-      ir: {
-        version: "v2",
+    getWorkflowDefinition: vi.fn(async () => {
+      if (options.unresolvableSelection) throw new Error("workflow definition unavailable");
+      return {
         id: "recommendation-workflow",
         name: "Recommendation workflow",
-        nodes: [{ id: "start", kind: "start", column: "backlog" }],
-        edges: [],
-        columns: options.traitlessLegacyColumns
-          ? ["todo", "in-progress", "in-review", "done", "archived"]
-              .map((id) => ({ id, name: id, traits: [] }))
-          : [
-              { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
-              ...(options.declareLegacyArchivedAsLive
-                ? [{ id: "archived", name: "Live archived", traits: [] }]
-                : []),
-              { id: "boxed", name: "Boxed", traits: [{ trait: "archived" }] },
-            ],
-      },
-    })),
+        kind: "workflow",
+        ir: {
+          version: "v2",
+          id: "recommendation-workflow",
+          name: "Recommendation workflow",
+          nodes: [{ id: "start", kind: "start", column: "backlog" }],
+          edges: [],
+          columns: options.traitlessLegacyColumns
+            ? ["todo", "in-progress", "in-review", "done", "archived"]
+                .map((id) => ({ id, name: id, traits: [] }))
+            : [
+                { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+                ...(options.declareLegacyArchivedAsLive
+                  ? [{ id: "archived", name: "Live archived", traits: [] }]
+                  : []),
+                { id: "boxed", name: "Boxed", traits: [{ trait: "archived" }] },
+              ],
+        },
+      };
+    }),
   });
 }
 
@@ -575,6 +582,53 @@ describe("recommendation task creation route", () => {
 
     expect(response.status).toBe(409);
     expect(legacy.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the legacy archived tombstone when the selected workflow cannot resolve", async () => {
+    const linkedChild = task({ id: "FN-9", description: "Archived child", column: "archived" });
+    const unresolved = buildApp([
+      parent({ recommendations: [{ ...parent().recommendations![0], createdTaskId: "FN-9" }] }),
+      linkedChild,
+    ]);
+    installCustomRecommendationWorkflow(unresolved.store, ["FN-9"], { unresolvableSelection: true });
+
+    const response = await performRequest(
+      unresolved.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(409);
+    expect(unresolved.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("restores an archived durable claim when the selected workflow cannot resolve", async () => {
+    const claimedChild = task({
+      id: "FN-9",
+      title: "Add task export",
+      description: "Add CSV export outside this task's scope.",
+      column: "archived",
+      proposalClaimId: "recommendation:FN-1:rec-1",
+      sourceMetadata: { deterministicDuplicateOf: "FN-8" },
+    });
+    const unresolved = buildApp([parent(), claimedChild]);
+    installCustomRecommendationWorkflow(unresolved.store, ["FN-9"], { unresolvableSelection: true });
+    (unresolved.store.findRecentTasksByContentFingerprint as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (unresolved.store.searchTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const response = await performRequest(
+      unresolved.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ task: { id: "FN-9", column: "todo" } });
+    expect(unresolved.store.unarchiveTask).toHaveBeenCalledWith("FN-9");
+    expect(unresolved.store.createTask).not.toHaveBeenCalled();
+    expect(unresolved.tasks[0]?.recommendations?.[0]?.createdTaskId).toBe("FN-9");
   });
 
   it.each([

--- a/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
+++ b/packages/dashboard/src/routes/__tests__/task-recommendation-routes.test.ts
@@ -135,6 +135,43 @@ function parent(overrides: Partial<Task> = {}): Task {
   });
 }
 
+function installCustomRecommendationWorkflow(
+  store: Partial<TaskStore>,
+  taskIds: readonly string[],
+  options: { declareLegacyArchivedAsLive?: boolean; traitlessLegacyColumns?: boolean } = {},
+): void {
+  Object.assign(store, {
+    getTaskWorkflowSelection: vi.fn((id: string) => taskIds.includes(id)
+      ? { workflowId: "recommendation-workflow", stepIds: [] }
+      : undefined),
+    getTaskWorkflowSelectionAsync: vi.fn(async (id: string) => taskIds.includes(id)
+      ? { workflowId: "recommendation-workflow", stepIds: [] }
+      : undefined),
+    getWorkflowDefinition: vi.fn(async () => ({
+      id: "recommendation-workflow",
+      name: "Recommendation workflow",
+      kind: "workflow",
+      ir: {
+        version: "v2",
+        id: "recommendation-workflow",
+        name: "Recommendation workflow",
+        nodes: [{ id: "start", kind: "start", column: "backlog" }],
+        edges: [],
+        columns: options.traitlessLegacyColumns
+          ? ["todo", "in-progress", "in-review", "done", "archived"]
+              .map((id) => ({ id, name: id, traits: [] }))
+          : [
+              { id: "backlog", name: "Backlog", traits: [{ trait: "intake" }] },
+              ...(options.declareLegacyArchivedAsLive
+                ? [{ id: "archived", name: "Live archived", traits: [] }]
+                : []),
+              { id: "boxed", name: "Boxed", traits: [{ trait: "archived" }] },
+            ],
+      },
+    })),
+  });
+}
+
 describe("recommendation task creation route", () => {
   beforeEach(() => locks?.clear());
   afterEach(() => { locks?.clear(); vi.restoreAllMocks(); });
@@ -452,6 +489,92 @@ describe("recommendation task creation route", () => {
     const archivedResponse = await performRequest(archived.app, "POST", "/api/tasks/FN-1/recommendations/rec-1/create", undefined);
     expect(archivedResponse.status).toBe(409);
     expect(archived.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects a linked child in a custom workflow archived-trait lane", async () => {
+    const linkedChild = task({ id: "FN-9", description: "Archived child", column: "boxed" as Column });
+    const custom = buildApp([
+      parent({ recommendations: [{ ...parent().recommendations![0], createdTaskId: "FN-9" }] }),
+      linkedChild,
+    ]);
+    installCustomRecommendationWorkflow(custom.store, ["FN-9"]);
+
+    const response = await performRequest(
+      custom.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(409);
+    expect(custom.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("restores an unlinked durable claim from a custom workflow archived-trait lane", async () => {
+    const claimedChild = task({
+      id: "FN-9",
+      title: "Add task export",
+      description: "Add CSV export outside this task's scope.",
+      column: "boxed" as Column,
+      proposalClaimId: "recommendation:FN-1:rec-1",
+      sourceMetadata: { deterministicDuplicateOf: "FN-8" },
+    });
+    const custom = buildApp([parent(), claimedChild]);
+    installCustomRecommendationWorkflow(custom.store, ["FN-9"]);
+    (custom.store.findRecentTasksByContentFingerprint as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (custom.store.searchTasks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const response = await performRequest(
+      custom.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ task: { id: "FN-9", column: "backlog" } });
+    expect(custom.store.moveTask).toHaveBeenCalledWith("FN-9", "backlog");
+    expect(custom.store.createTask).not.toHaveBeenCalled();
+    expect(custom.tasks[0]?.recommendations?.[0]?.createdTaskId).toBe("FN-9");
+  });
+
+  it("keeps a linked child live in an explicitly declared untraited archived column", async () => {
+    const linkedChild = task({ id: "FN-9", description: "Live child", column: "archived" });
+    const custom = buildApp([
+      parent({ recommendations: [{ ...parent().recommendations![0], createdTaskId: "FN-9" }] }),
+      linkedChild,
+    ]);
+    installCustomRecommendationWorkflow(custom.store, ["FN-9"], { declareLegacyArchivedAsLive: true });
+
+    const response = await performRequest(
+      custom.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ task: { id: "FN-9", column: "archived" } });
+    expect(custom.store.createTask).not.toHaveBeenCalled();
+  });
+
+  it("keeps archived terminal for a traitless legacy workflow", async () => {
+    const linkedChild = task({ id: "FN-9", description: "Archived child", column: "archived" });
+    const legacy = buildApp([
+      parent({ recommendations: [{ ...parent().recommendations![0], createdTaskId: "FN-9" }] }),
+      linkedChild,
+    ]);
+    installCustomRecommendationWorkflow(legacy.store, ["FN-9"], { traitlessLegacyColumns: true });
+
+    const response = await performRequest(
+      legacy.app,
+      "POST",
+      "/api/tasks/FN-1/recommendations/rec-1/create",
+      undefined,
+    );
+
+    expect(response.status).toBe(409);
+    expect(legacy.store.createTask).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -64,6 +64,7 @@ import {
   resolveWorkflowIrForTask,
   resolveWorkflowIrForTaskWithProvenance,
   resolveReviewColumns,
+  declaresAnyLifecycleTrait,
   workflowHasColumn,
   workflowPlansInColumn,
   workflowDeclaresColumnModel,
@@ -354,6 +355,24 @@ async function resolveTerminalColumnsForTask(store: TaskStore, taskId: string): 
     return all.length > 0 ? new Set(all) : new Set(["done", "archived"]);
   } catch {
     return new Set(["done", "archived"]);
+  }
+}
+
+/*
+FNXC:TaskRecommendations 2026-08-09-05:22:
+Workflow traits identify current archived lanes. An undeclared legacy `archived` id remains a
+compatibility tombstone for persisted pre-migration tasks, while an explicitly declared untraited
+`archived` column stays live on a trait-aware board. Traitless v1-upgraded workflows and resolution
+failures retain the legacy terminal id.
+*/
+async function resolveArchivedColumnsForTask(store: TaskStore, taskId: string): Promise<Set<string>> {
+  try {
+    const ir = await resolveWorkflowIrForTask(store, taskId);
+    const archived = columnsWithFlag(ir, "archived");
+    if (!declaresAnyLifecycleTrait(ir)) return new Set([...archived, "archived"]);
+    return new Set(workflowHasColumn(ir, "archived") ? archived : [...archived, "archived"]);
+  } catch {
+    return new Set(["archived"]);
   }
 }
 
@@ -2349,13 +2368,16 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
           throw conflict("Recommendation link is malformed");
         }
         const linked = await scopedStore.getTask(recommendation.createdTaskId).catch(() => null);
+        const linkedArchiveColumns = linked
+          ? await resolveArchivedColumnsForTask(scopedStore, linked.id)
+          : new Set<string>();
         /*
         FNXC:TaskRecommendations 2026-08-08-06:34:
         A prior link is reusable only while its child remains in a live task lane. Archived and
         soft-deleted children are historical records, not an actionable Created result; conflict
         rather than silently resurrecting or linking a second child.
         */
-        if (!linked || linked.deletedAt || linked.column === "archived") {
+        if (!linked || linked.deletedAt || linkedArchiveColumns.has(linked.column)) {
           throw conflict("Recommendation link points to an unavailable task");
         }
         return res.status(200).json({ task: linked, parent });
@@ -2370,16 +2392,9 @@ export function registerTaskWorkflowRoutes(ctx: ApiRoutesContext, deps: TaskWork
       */
       const existing = (await scopedStore.listTasks({ slim: false, includeArchived: true, includeDeleted: true }))
         .find((task) => task.proposalClaimId === proposalClaimId);
-      const existingArchiveColumns = await (async () => {
-        if (!existing) return new Set<string>();
-        try {
-          const ir = await resolveWorkflowIrForTask(scopedStore, existing.id);
-          const columns = columnsWithFlag(ir, "archived");
-          return new Set(columns.length > 0 ? columns : ["archived"]);
-        } catch {
-          return new Set(["archived"]);
-        }
-      })();
+      const existingArchiveColumns = existing
+        ? await resolveArchivedColumnsForTask(scopedStore, existing.id)
+        : new Set<string>();
       /*
       FNXC:TaskRecommendations 2026-08-08-08:44:
       Deterministic reconciliation moves a child to its workflow's archived trait, which may be

--- a/packages/dashboard/src/routes/register-task-workflow-routes.ts
+++ b/packages/dashboard/src/routes/register-task-workflow-routes.ts
@@ -367,7 +367,9 @@ failures retain the legacy terminal id.
 */
 async function resolveArchivedColumnsForTask(store: TaskStore, taskId: string): Promise<Set<string>> {
   try {
-    const ir = await resolveWorkflowIrForTask(store, taskId);
+    const resolved = await resolveWorkflowIrForTaskWithProvenance(store, taskId);
+    if (resolved.source !== "selection") return new Set(["archived"]);
+    const { ir } = resolved;
     const archived = columnsWithFlag(ir, "archived");
     if (!declaresAnyLifecycleTrait(ir)) return new Set([...archived, "archived"]);
     return new Set(workflowHasColumn(ir, "archived") ? archived : [...archived, "archived"]);


### PR DESCRIPTION
## Summary
- resolve recommendation child archive state from workflow traits instead of a hardcoded column ID
- preserve legacy archived tombstones while allowing explicitly declared, untraited `archived` columns to remain live
- cover linked-child and durable proposal-claim recovery across custom, upgraded, and unresolvable workflows

## Test plan
- `corepack pnpm check:lifecycle-columns`
- `FUSION_DASHBOARD_DEEP=1 corepack pnpm --filter @fusion/dashboard exec vitest run src/routes/__tests__/task-recommendation-routes.test.ts --project dashboard-api --silent=passed-only --reporter=dot`
- `corepack pnpm --filter @fusion/dashboard typecheck`
- `corepack pnpm check:changesets`
- `corepack pnpm lint`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recommendation task handling for archived workflow columns.
  * Prevented reuse of linked archived tasks while restoring eligible unlinked claims to the appropriate workflow intake or legacy state.
  * Preserved explicitly live archived columns and legacy behavior when workflow details are unavailable.
* **Tests**
  * Added coverage for archived traits, live archived columns, legacy tasks, and unresolved workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->