### PR TITLE
fix(engine): allow pre-merge remediation with project auto-merge off

### DIFF
--- a/.changeset/premerge-remediation-project-off.md
+++ b/.changeset/premerge-remediation-project-off.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep pre-merge review remediation available when project auto-merge is disabled.
+category: fix
+dev: Only an explicit user-authored task hold blocks remediation; the project-level manual merge gate remains enforced separately.

--- a/packages/engine/src/__tests__/executor-live-branch-group-auto-merge-hold.test.ts
+++ b/packages/engine/src/__tests__/executor-live-branch-group-auto-merge-hold.test.ts
@@ -153,6 +153,23 @@ describe("executor shared-branch autoMerge:false liveness gates", () => {
     expect(sendBack).not.toHaveBeenCalled();
   });
 
+  it("allows pre-merge remediation when project auto-merge is off but the member is not user-held", async () => {
+    const { executor } = makeExecutor({ status: "open", branchName: "mission/M-1980" });
+    const task = makeInReviewTask({ autoMerge: undefined, autoMergeProvenance: "mission" });
+    const sendBack = vi.spyOn(executor as any, "sendTaskBackForFix").mockResolvedValue(undefined);
+
+    await expect((executor as any).requestPreMergeOptionalStepFix(task.id, task, {
+      stepName: "Code Review",
+      feedback: "Please revise",
+      phase: "pre-merge",
+      status: "failed",
+      verdict: "REVISE",
+      nodeId: "code-review",
+    })).resolves.toBe(true);
+
+    expect(sendBack).toHaveBeenCalledOnce();
+  });
+
   it("does not let failed-step recovery reopen an operator-held member", async () => {
     const { executor } = makeExecutor({ status: "open", branchName: "mission/M-1980" });
     const task = makeInReviewTask({
@@ -171,6 +188,26 @@ describe("executor shared-branch autoMerge:false liveness gates", () => {
     await expect(executor.recoverFailedPreMergeWorkflowStep(task)).resolves.toBe(false);
 
     expect(sendBack).not.toHaveBeenCalled();
+  });
+
+  it("allows failed-step recovery for a non-user-held member under project auto-merge off", async () => {
+    const { executor } = makeExecutor({ status: "open", branchName: "mission/M-1980" });
+    const task = makeInReviewTask({
+      autoMerge: undefined,
+      autoMergeProvenance: "mission",
+      workflowStepResults: [{
+        workflowStepId: "code-review",
+        workflowStepName: "Code Review",
+        phase: "pre-merge",
+        status: "failed",
+        output: "Please revise",
+      }],
+    });
+    const sendBack = vi.spyOn(executor as any, "sendTaskBackForFix").mockResolvedValue(undefined);
+
+    await expect(executor.recoverFailedPreMergeWorkflowStep(task)).resolves.toBe(true);
+
+    expect(sendBack).toHaveBeenCalledOnce();
   });
 
   it("holds an open shared group that would integrate directly into main", async () => {

--- a/packages/engine/src/executor.ts
+++ b/packages/engine/src/executor.ts
@@ -16,7 +16,7 @@ import { DEFAULT_PROVIDER_INSTANCE_ID, type ProviderInstanceRef, type TaskStore,
 import { getUnmetSchedulingDependencies } from "./scheduler.js";
 import type { ImplementationExit, ImplementationExitReporter } from "./executor/implementation-exit.js";
 import { emitWorkflowLifecycleEvent } from "@fusion/core";
-import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, hasSharedBranchMemberAutoMergeHold, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, PLAN_REVIEW_GROUP_ID, upsertWorkflowStepResult, normalizeWorkflowReviewFindings, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, classifyWorkflowAgentNode, isWorkflowAgentRole, resolveExecutorFallbackModel, resolveValidatorFallbackModel, parseExplicitDuplicateMarker, nonExecutableDuplicateRedirectReason } from "@fusion/core";
+import { resolveTaskLifecycleColumns, resolveProjectColumnsForRoles, resolveWipTargetForTask, resolveTerminalColumns, RetryStormError, serializeRetryStormError, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, resolveWorkflowIrForTask, columnsWithFlag, evaluateForeachMergeProof, resolveCompleteColumn, resolveMergeOrchestrationColumn, resolveReboundTarget, resolveLifecycleColumns, resolveColumnAgentBinding, resolveEffectiveAgent, instanceNodeId, getWorkflowExtensionRegistry, getBuiltinWorkflow, parseNoOpCompletionMarker, allowsAutoMergeProcessing, hasSharedBranchMemberAutoMergeHold, hasUserAutoMergeHold, resolveEffectiveAutoMerge, isLiveSharedBranchGroupMemberIntegration, resolveMaxAutoMergeRetries, resolveMaxConsecutiveToolFailureRetries, resolveConsecutiveToolFailureRetryBackoffMs, resolveConsecutiveToolFailureThreshold, resolveExecutorEscalationTarget, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, DEFAULT_MAX_POST_REVIEW_FIXES, COMPLETION_SUMMARY_NODE_ID, PLAN_REVIEW_GROUP_ID, upsertWorkflowStepResult, normalizeWorkflowReviewFindings, AWAITING_APPROVAL_PAUSE_REASON, THINKING_LEVELS, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AgentStore, classifyWorkflowAgentNode, isWorkflowAgentRole, resolveExecutorFallbackModel, resolveValidatorFallbackModel, parseExplicitDuplicateMarker, nonExecutableDuplicateRedirectReason } from "@fusion/core";
 import {
   BLOCKED_THRASH_LIMIT,
   buildExternalBlockMetadataPatch,
@@ -5749,7 +5749,7 @@ export class TaskExecutor {
      * implementation and thereby bypass that checkpoint before the operator
      * releases or revises the held member.
      */
-    if (hasSharedBranchMemberAutoMergeHold(liveTask, await this.store.getSettings())) return false;
+    if (hasUserAutoMergeHold(liveTask)) return false;
     const missingArtifactKeys = parseRequiredArtifactMissingValue(info.failureValue);
     if (missingArtifactKeys) {
       await this.recoverMissingRequiredArtifacts(liveTask, missingArtifactKeys, {
@@ -6075,7 +6075,7 @@ export class TaskExecutor {
        * Do not let it send a user-held member back to execution: only an explicit
        * operator release or revision may advance that manual checkpoint.
        */
-      if (hasSharedBranchMemberAutoMergeHold(task, await this.store.getSettings())) return false;
+      if (hasUserAutoMergeHold(task)) return false;
       /*
       FNXC:WorkflowPostMerge 2026-06-26-14:00:
       U7c: gate-ness is now sourced from the recorded `WorkflowStepResult.status`, NOT a


### PR DESCRIPTION
## Summary

Fixes the project-level `autoMerge: false` interaction described in #3388.

`hasSharedBranchMemberAutoMergeHold` is intentionally broad under project-level auto-merge off, because the project setting is the manual merge gate. Using that predicate to block pre-merge remediation also blocks every review-driven fix for shared-branch members, including members that were never explicitly held by an operator. The remediation node then returns `remediation-not-scheduled`, and the workflow graph terminates instead of returning to the review lane.

This patch keeps the operator checkpoint intact while using the narrow `hasUserAutoMergeHold` predicate for the two pre-merge remediation entry points. Explicit task-level user holds remain blocked; project-level auto-merge off no longer suppresses review remediation for non-user-held members.

## Verification

- `pnpm --filter @fusion/engine exec vitest run src/__tests__/executor-live-branch-group-auto-merge-hold.test.ts --run` — 12 passed
- `pnpm --filter @fusion/core exec vitest run src/__tests__/task-merge.test.ts --run` — 119 passed
- `pnpm --filter @fusion/engine typecheck` — passed
- `pnpm check:changesets` — passed
- `git diff --check` — passed

The broader `executor-graph-requeue-gate` project could not load in this Windows checkout because the generated gate bundle contains a shebang parse error; that is recorded as an environment/test-harness limitation, not treated as a pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pre-merge remediation and failed-step recovery now continue for tasks without an explicit user-set hold, even when project auto-merge is disabled.
  - Preserved protections for tasks intentionally placed on hold by an operator.

- **Tests**
  - Added regression coverage for auto-merge hold behavior across shared-branch tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->