### PR TITLE
fix(engine): keep orphaned planning recovery alive

### DIFF
--- a/.changeset/orphaned-planning-segments.md
+++ b/.changeset/orphaned-planning-segments.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep soft-deleted planning snapshots from aborting self-healing sweeps.
+category: fix
+dev: Skip archived task snapshots that cannot be mutated and isolate per-task recovery errors so other planning segments continue to finalize.

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -8903,6 +8903,27 @@ describe("SelfHealingManager", () => {
 
       recovery.stop();
     });
+
+    it("keeps a no-action sweep successful when audit recording fails", async () => {
+      const task = { id: "FN-PLAN-AUDIT-ERROR", planningStartedAt: "2026-01-01T00:00:00.000Z" } as Task;
+      const recordRunAuditEvent = vi.fn().mockRejectedValue(new Error("audit unavailable"));
+      const recoveryStore = createMockStore({
+        listTasks: vi.fn().mockResolvedValue([task]),
+        recordRunAuditEvent,
+      });
+      const recovery = new SelfHealingManager(recoveryStore, {
+        rootDir: "/tmp/test-project",
+        getPlanningTaskIds: () => new Set([task.id]),
+        hasActivePlanningWorkflowSession: () => false,
+      });
+
+      await expect(recovery.finalizeOrphanedPlanningSegments()).resolves.toBe(0);
+      expect(recordRunAuditEvent).toHaveBeenCalledWith(expect.objectContaining({
+        mutationType: "task:reconcile-orphaned-planning-segment-no-action",
+      }));
+
+      recovery.stop();
+    });
   });
 
   describe("recoverOrphanedPlanningTasks", () => {

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -8874,6 +8874,35 @@ describe("SelfHealingManager", () => {
 
       recovery.stop();
     });
+
+    it("reports when every eligible orphan attempt fails", async () => {
+      const failedTasks = [
+        { id: "FN-PLAN-ERROR-1", planningStartedAt: "2026-01-01T00:00:00.000Z" },
+        { id: "FN-PLAN-ERROR-2", planningStartedAt: "2026-01-01T00:00:00.000Z" },
+      ] as Task[];
+      const updateTaskAtomic = vi.fn(async () => {
+        throw new Error("reconciliation unavailable");
+      });
+      const recoveryStore = createMockStore({
+        listTasks: vi.fn().mockResolvedValue(failedTasks),
+        updateTaskAtomic,
+      });
+      const recovery = new SelfHealingManager(recoveryStore, {
+        rootDir: "/tmp/test-project",
+        getPlanningTaskIds: () => new Set<string>(),
+        hasActivePlanningWorkflowSession: () => false,
+      });
+      vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+
+      expect(await recovery.finalizeOrphanedPlanningSegments()).toBe(0);
+      expect(updateTaskAtomic).toHaveBeenCalledTimes(2);
+      expect(recoveryStore.recordRunAuditEvent).toHaveBeenLastCalledWith(expect.objectContaining({
+        mutationType: "task:reconcile-orphaned-planning-segment-no-action",
+        metadata: { finalizedCount: 0, reason: "all-attempts-failed", attemptedCount: 2 },
+      }));
+
+      recovery.stop();
+    });
   });
 
   describe("recoverOrphanedPlanningTasks", () => {

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -8834,6 +8834,46 @@ describe("SelfHealingManager", () => {
 
       recovery.stop();
     });
+
+    it("skips soft-deleted archive snapshots and continues after a per-task failure", async () => {
+      const deletedTask = {
+        id: "FN-PLAN-DELETED",
+        deletedAt: "2026-01-01T00:00:30.000Z",
+        planningStartedAt: "2026-01-01T00:00:00.000Z",
+      } as Task;
+      const failedTask = {
+        id: "FN-PLAN-ERROR",
+        planningStartedAt: "2026-01-01T00:00:00.000Z",
+      } as Task;
+      const healthyTask = {
+        id: "FN-PLAN-HEALTHY",
+        planningStartedAt: "2026-01-01T00:00:00.000Z",
+        cumulativePlanningMs: 10,
+      } as Task;
+      const updateTaskAtomic = vi.fn(async (id: string, updater: (live: Task) => Partial<Task> | null) => {
+        if (id === failedTask.id) throw new Error("soft-deleted archive snapshot");
+        const patch = updater(healthyTask);
+        if (patch) Object.assign(healthyTask, patch);
+        return patch;
+      });
+      const recoveryStore = createMockStore({
+        listTasks: vi.fn().mockResolvedValue([deletedTask, failedTask, healthyTask]),
+        updateTaskAtomic,
+      });
+      const recovery = new SelfHealingManager(recoveryStore, {
+        rootDir: "/tmp/test-project",
+        getPlanningTaskIds: () => new Set<string>(),
+        hasActivePlanningWorkflowSession: () => false,
+      });
+      vi.setSystemTime(new Date("2026-01-01T00:00:01.000Z"));
+
+      expect(await recovery.finalizeOrphanedPlanningSegments()).toBe(1);
+      expect(updateTaskAtomic).toHaveBeenCalledTimes(2);
+      expect(updateTaskAtomic).not.toHaveBeenCalledWith(deletedTask.id, expect.any(Function));
+      expect(healthyTask).toMatchObject({ planningStartedAt: null, cumulativePlanningMs: 1010 });
+
+      recovery.stop();
+    });
   });
 
   describe("recoverOrphanedPlanningTasks", () => {

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -14699,10 +14699,13 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
     const planningIds = this.options.getPlanningTaskIds?.() ?? new Set<string>();
     const tasks = await this.store.listTasks({});
     let finalized = 0;
+    let attempted = 0;
+    let failedAttempts = 0;
     for (const task of tasks) {
       // Archived snapshots can still contain the planning marker, but their
       // corresponding live row is soft-deleted and must never be mutated.
       if (task.deletedAt || !task.planningStartedAt || planningIds.has(task.id) || this.options.hasActivePlanningWorkflowSession?.(task.id)) continue;
+      attempted++;
       try {
         let applied = false;
         const endMs = Date.now();
@@ -14725,17 +14728,23 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
           // FNXC:TaskTiming 2026-07-30-21:40: this recovery is operator-auditable
           // without persisting duration prose; the atomically finalized task id
           // and fixed no-live-owner reason are sufficient forensic evidence.
-          await this.store.recordRunAuditEvent?.({
-            taskId: task.id,
-            agentId: "self-healing",
-            runId: generateSyntheticRunId("orphaned-planning-segment", task.id),
-            domain: "database",
-            mutationType: "task:reconcile-orphaned-planning-segment",
-            target: task.id,
-            metadata: { taskId: task.id, finalizedCount: 1, reason: "no-live-planning-owner" },
-          });
+          try {
+            await this.store.recordRunAuditEvent?.({
+              taskId: task.id,
+              agentId: "self-healing",
+              runId: generateSyntheticRunId("orphaned-planning-segment", task.id),
+              domain: "database",
+              mutationType: "task:reconcile-orphaned-planning-segment",
+              target: task.id,
+              metadata: { taskId: task.id, finalizedCount: 1, reason: "no-live-planning-owner" },
+            });
+          } catch (auditError) {
+            const errorType = auditError instanceof Error && auditError.name ? auditError.name : "unknown-error";
+            log.warn(`[self-healing] orphaned planning segment ${task.id} audit could not be recorded: errorType=${errorType}`);
+          }
         }
       } catch (error) {
+        failedAttempts++;
         // Keep recovery logs bounded and secret-free; the task id and stable
         // error type are sufficient to correlate the failed row in run audit.
         const errorType = error instanceof Error && error.name ? error.name : "unknown-error";
@@ -14743,13 +14752,18 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
       }
     }
     if (finalized === 0) {
+      const noActionMetadata = attempted === 0
+        ? { finalizedCount: 0, reason: "no-eligible-orphan" }
+        : failedAttempts === attempted
+          ? { finalizedCount: 0, reason: "all-attempts-failed", attemptedCount: attempted }
+          : { finalizedCount: 0, reason: "no-finalization", attemptedCount: attempted, failedAttemptCount: failedAttempts };
       await this.store.recordRunAuditEvent?.({
         agentId: "self-healing",
         runId: generateSyntheticRunId("orphaned-planning-segment", "global"),
         domain: "database",
         mutationType: "task:reconcile-orphaned-planning-segment-no-action",
         target: "planning-segments",
-        metadata: { finalizedCount: 0, reason: "no-eligible-orphan" },
+        metadata: noActionMetadata,
       });
     }
     return finalized;

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -14736,8 +14736,10 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
           });
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        log.warn(`[self-healing] orphaned planning segment ${task.id} could not be finalized: ${message}`);
+        // Keep recovery logs bounded and secret-free; the task id and stable
+        // error type are sufficient to correlate the failed row in run audit.
+        const errorType = error instanceof Error && error.name ? error.name : "unknown-error";
+        log.warn(`[self-healing] orphaned planning segment ${task.id} could not be finalized: errorType=${errorType}`);
       }
     }
     if (finalized === 0) {

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -14694,6 +14694,10 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
    * A planning anchor is safe because triage ownership and graph Plan Review are
    * exclusive. Recovery finalizes only when neither in-process owner is live;
    * the atomic null-check makes restart and repeated maintenance idempotent.
+   * Archived snapshots can retain the planning marker, but their soft-deleted
+   * live rows must never be mutated. Candidate failures are isolated per task;
+   * audit emission is best-effort so it cannot turn a successful recovery into
+   * a failed sweep.
    */
   async finalizeOrphanedPlanningSegments(): Promise<number> {
     const planningIds = this.options.getPlanningTaskIds?.() ?? new Set<string>();
@@ -14702,8 +14706,6 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
     let attempted = 0;
     let failedAttempts = 0;
     for (const task of tasks) {
-      // Archived snapshots can still contain the planning marker, but their
-      // corresponding live row is soft-deleted and must never be mutated.
       if (task.deletedAt || !task.planningStartedAt || planningIds.has(task.id) || this.options.hasActivePlanningWorkflowSession?.(task.id)) continue;
       attempted++;
       try {
@@ -14757,14 +14759,19 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
         : failedAttempts === attempted
           ? { finalizedCount: 0, reason: "all-attempts-failed", attemptedCount: attempted }
           : { finalizedCount: 0, reason: "no-finalization", attemptedCount: attempted, failedAttemptCount: failedAttempts };
-      await this.store.recordRunAuditEvent?.({
-        agentId: "self-healing",
-        runId: generateSyntheticRunId("orphaned-planning-segment", "global"),
-        domain: "database",
-        mutationType: "task:reconcile-orphaned-planning-segment-no-action",
-        target: "planning-segments",
-        metadata: noActionMetadata,
-      });
+      try {
+        await this.store.recordRunAuditEvent?.({
+          agentId: "self-healing",
+          runId: generateSyntheticRunId("orphaned-planning-segment", "global"),
+          domain: "database",
+          mutationType: "task:reconcile-orphaned-planning-segment-no-action",
+          target: "planning-segments",
+          metadata: noActionMetadata,
+        });
+      } catch (auditError) {
+        const errorType = auditError instanceof Error && auditError.name ? auditError.name : "unknown-error";
+        log.warn(`[self-healing] orphaned planning segment no-action audit could not be recorded: errorType=${errorType}`);
+      }
     }
     return finalized;
   }

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -14700,37 +14700,44 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
     const tasks = await this.store.listTasks({});
     let finalized = 0;
     for (const task of tasks) {
-      if (!task.planningStartedAt || planningIds.has(task.id) || this.options.hasActivePlanningWorkflowSession?.(task.id)) continue;
-      let applied = false;
-      const endMs = Date.now();
-      if (typeof this.store.updateTaskAtomic === "function") {
-        await this.store.updateTaskAtomic(task.id, (live) => {
-          if (!live.planningStartedAt || planningIds.has(live.id) || this.options.hasActivePlanningWorkflowSession?.(live.id)) return null;
-          const patch = finalizePlanningSegment(live, endMs);
-          applied = patch.planningStartedAt === null;
-          return patch;
-        });
-      } else {
-        const live = await this.store.getTask(task.id);
-        if (live?.planningStartedAt && !planningIds.has(live.id) && !this.options.hasActivePlanningWorkflowSession?.(live.id)) {
-          const patch = finalizePlanningSegment(live, endMs);
-          if (patch.planningStartedAt === null) { await this.store.updateTask(task.id, patch); applied = true; }
+      // Archived snapshots can still contain the planning marker, but their
+      // corresponding live row is soft-deleted and must never be mutated.
+      if (task.deletedAt || !task.planningStartedAt || planningIds.has(task.id) || this.options.hasActivePlanningWorkflowSession?.(task.id)) continue;
+      try {
+        let applied = false;
+        const endMs = Date.now();
+        if (typeof this.store.updateTaskAtomic === "function") {
+          await this.store.updateTaskAtomic(task.id, (live) => {
+            if (!live.planningStartedAt || planningIds.has(live.id) || this.options.hasActivePlanningWorkflowSession?.(live.id)) return null;
+            const patch = finalizePlanningSegment(live, endMs);
+            applied = patch.planningStartedAt === null;
+            return patch;
+          });
+        } else {
+          const live = await this.store.getTask(task.id);
+          if (live?.planningStartedAt && !planningIds.has(live.id) && !this.options.hasActivePlanningWorkflowSession?.(live.id)) {
+            const patch = finalizePlanningSegment(live, endMs);
+            if (patch.planningStartedAt === null) { await this.store.updateTask(task.id, patch); applied = true; }
+          }
         }
-      }
-      if (applied) {
-        finalized++;
-        // FNXC:TaskTiming 2026-07-30-21:40: this recovery is operator-auditable
-        // without persisting duration prose; the atomically finalized task id
-        // and fixed no-live-owner reason are sufficient forensic evidence.
-        await this.store.recordRunAuditEvent?.({
-          taskId: task.id,
-          agentId: "self-healing",
-          runId: generateSyntheticRunId("orphaned-planning-segment", task.id),
-          domain: "database",
-          mutationType: "task:reconcile-orphaned-planning-segment",
-          target: task.id,
-          metadata: { taskId: task.id, finalizedCount: 1, reason: "no-live-planning-owner" },
-        });
+        if (applied) {
+          finalized++;
+          // FNXC:TaskTiming 2026-07-30-21:40: this recovery is operator-auditable
+          // without persisting duration prose; the atomically finalized task id
+          // and fixed no-live-owner reason are sufficient forensic evidence.
+          await this.store.recordRunAuditEvent?.({
+            taskId: task.id,
+            agentId: "self-healing",
+            runId: generateSyntheticRunId("orphaned-planning-segment", task.id),
+            domain: "database",
+            mutationType: "task:reconcile-orphaned-planning-segment",
+            target: task.id,
+            metadata: { taskId: task.id, finalizedCount: 1, reason: "no-live-planning-owner" },
+          });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log.warn(`[self-healing] orphaned planning segment ${task.id} could not be finalized: ${message}`);
       }
     }
     if (finalized === 0) {


### PR DESCRIPTION
## Summary

Fixes the self-healing failure described in #3386.

`finalizeOrphanedPlanningSegments` receives archived task snapshots from the
store, but a soft-deleted live task cannot be read or mutated. A stale
`planningStartedAt` marker therefore made the entire sweep throw and prevented
healthy tasks from being finalized. The sweep now skips snapshots that already
carry `deletedAt` and isolates each remaining task's reconciliation in a
per-task error boundary. One stale or racing row is logged and does not abort
the batch.

## Verification

- `pnpm --filter @fusion/engine exec vitest run src/__tests__/self-healing.test.ts --run -t "skips soft-deleted archive snapshots"` — passed
- `pnpm --filter @fusion/engine typecheck` — passed
- `pnpm check:changesets` — passed
- `git diff --check` — passed

The complete `self-healing.test.ts` file still has two unrelated baseline
failures in this Windows checkout (`recoverMergedReviewTasks` and path
normalization); the new regression test passes independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Archived or soft-deleted tasks are now skipped during planning reconciliation.
  - A failure processing one task no longer prevents other eligible tasks from being finalized.
  - Reconciliation now distinguishes between no eligible tasks, partial completion, and attempts where all finalizations fail.
  - Audit-recording failures no longer interrupt reconciliation, and no-action outcomes are recorded when appropriate.
- **Tests**
  - Added coverage for skipped tasks, isolated processing failures, continued processing, and all-failed reconciliation sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->