### PR TITLE
fix: keep self-healing sweeps alive across stale task links

### DIFF
--- a/.changeset/stale-agent-link-sweep.md
+++ b/.changeset/stale-agent-link-sweep.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep self-healing agent-link sweeps running when a linked task is deleted or missing.
+category: fix
+dev: Task-gone lookup races are treated as stale links, while unrelated lookup failures stay isolated to the affected candidate.

--- a/packages/engine/src/__tests__/self-healing-agent-link-drift.test.ts
+++ b/packages/engine/src/__tests__/self-healing-agent-link-drift.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { isEphemeralAgent, type Agent, type AgentStore, type Task } from "@fusion/core";
+import { TaskDeletedError, TaskNotFoundError, isEphemeralAgent, type Agent, type AgentStore, type Task } from "@fusion/core";
 
 import { SelfHealingManager } from "../self-healing.js";
 
@@ -182,6 +182,43 @@ describe("FN-4296: self-healing agent link drift", () => {
     const { manager } = buildManager(agents, { "FN-1": null });
     await manager.recoverDriftedAgentTaskLinks();
     expect(agents[0].taskId).toBeUndefined();
+    manager.stop();
+  });
+
+  it("continues after task-gone lookup races and clears later drifted links", async () => {
+    const agents = [
+      makeAgent("agent-deleted", "FN-DELETED"),
+      makeAgent("agent-missing", "FN-MISSING"),
+      makeAgent("agent-error", "FN-ERROR"),
+      makeAgent("agent-done", "FN-DONE"),
+    ];
+    const store = {
+      getTask: vi.fn(async (taskId: string) => {
+        if (taskId === "FN-DELETED") throw new TaskDeletedError(taskId, new Date().toISOString());
+        if (taskId === "FN-MISSING") throw new TaskNotFoundError(taskId);
+        if (taskId === "FN-ERROR") throw new Error("database unavailable");
+        return { id: taskId, column: "done" } as Task;
+      }),
+      recordRunAuditEvent: vi.fn(async () => {}),
+    } as any;
+    const agentStore = {
+      listAgents: vi.fn(async (filter?: { includeEphemeral?: boolean }) => filter?.includeEphemeral === false ? agents.filter((agent) => !isEphemeralAgent(agent)) : agents),
+      getActiveHeartbeatRun: vi.fn(async () => null),
+      updateAgentState: vi.fn(async (agentId: string, state: Agent["state"]) => {
+        const agent = agents.find((candidate) => candidate.id === agentId);
+        if (agent) agent.state = state;
+      }),
+      syncExecutionTaskLink: vi.fn(async (agentId: string, taskId?: string) => {
+        const agent = agents.find((candidate) => candidate.id === agentId);
+        if (agent) agent.taskId = taskId;
+      }),
+    } as unknown as AgentStore;
+    const manager = new SelfHealingManager(store, { rootDir: "/tmp/test-project", agentStore });
+
+    const cleared = await manager.recoverDriftedAgentTaskLinks();
+
+    expect(cleared).toBe(3);
+    expect(agentStore.syncExecutionTaskLink).toHaveBeenCalledWith("agent-done", undefined);
     manager.stop();
   });
 

--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -143,7 +143,7 @@ vi.mock("../merger.js", () => ({
 
 import { SelfHealingManager, isBranchAheadOfBase, MAX_AUTO_MERGE_RETRIES } from "../self-healing.js";
 import { HEARTBEAT_ERROR_RECOVERY_METADATA_KEY, HEARTBEAT_ERROR_RETRY_EXHAUSTED_PAUSE_REASON, HEARTBEAT_ERROR_UNRECOVERABLE_PAUSE_REASON, readHeartbeatErrorRetryCount } from "../agent-heartbeat.js";
-import type { TaskStore, Settings, Task, AgentStore, Agent, NotificationProvider } from "@fusion/core";
+import { TaskDeletedError, TaskNotFoundError, type TaskStore, type Settings, type Task, type AgentStore, type Agent, type NotificationProvider } from "@fusion/core";
 import { EventEmitter } from "node:events";
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
@@ -1949,6 +1949,43 @@ describe("SelfHealingManager", () => {
       expect(agentStore.updateAgentState).toHaveBeenCalledWith("agent-recover", "active");
       expect(agentStore.syncExecutionTaskLink).toHaveBeenCalledWith("agent-recover", undefined);
       expect(agentStore.updateAgentState).not.toHaveBeenCalledWith("agent-keep", "active");
+      managerWithAgents.stop();
+    });
+
+    it("continues after task-gone lookup races and recovers later agents", async () => {
+      const agents: Agent[] = [
+        { id: "agent-deleted", state: "running", taskId: "FN-DELETED", updatedAt: new Date(Date.now() - 120_000).toISOString() } as Agent,
+        { id: "agent-missing", state: "running", taskId: "FN-MISSING", updatedAt: new Date(Date.now() - 120_000).toISOString() } as Agent,
+        { id: "agent-error", state: "running", taskId: "FN-ERROR", updatedAt: new Date(Date.now() - 120_000).toISOString() } as Agent,
+        { id: "agent-later", state: "running", taskId: "FN-LATER", updatedAt: new Date(Date.now() - 120_000).toISOString() } as Agent,
+      ];
+      const getTask = vi.fn(async (taskId: string) => {
+        if (taskId === "FN-DELETED") throw new TaskDeletedError(taskId, new Date().toISOString());
+        if (taskId === "FN-MISSING") throw new TaskNotFoundError(taskId);
+        if (taskId === "FN-ERROR") throw new Error("database unavailable");
+        return { id: taskId, column: "todo" } as Task;
+      });
+      const agentStore = {
+        listAgents: vi.fn(async () => agents),
+        getActiveHeartbeatRun: vi.fn(async () => null),
+        updateAgentState: vi.fn(async (agentId: string, state: Agent["state"]) => {
+          const agent = agents.find((candidate) => candidate.id === agentId);
+          if (agent) agent.state = state;
+        }),
+        syncExecutionTaskLink: vi.fn(async (agentId: string, taskId?: string) => {
+          const agent = agents.find((candidate) => candidate.id === agentId);
+          if (agent) agent.taskId = taskId;
+        }),
+      } as unknown as AgentStore;
+      const managerWithAgents = new SelfHealingManager(
+        createMockStore({ getTask }),
+        { rootDir: "/tmp/test-project", agentStore },
+      );
+
+      const recovered = await managerWithAgents.recoverAgentsRunningOnInactiveTasks();
+
+      expect(recovered).toBe(3);
+      expect(agentStore.syncExecutionTaskLink).toHaveBeenCalledWith("agent-later", undefined);
       managerWithAgents.stop();
     });
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -30,7 +30,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync,
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { type TaskMoveLanes, resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, hasSharedBranchMemberAutoMergeHold, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isLiveSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, resolveReboundTargetForTask, resolveArchiveTargetForTask, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
+import { TaskDeletedError, type TaskMoveLanes, resolveColumnFlags, IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX, IN_REVIEW_STALL_LOG_PREFIX, IN_REVIEW_STALL_TERMINAL_LOG_PREFIX, allowsAutoMergeProcessing, hasSharedBranchMemberAutoMergeHold, resolveEffectiveAutoMerge, countRecentIdenticalStallEntries, detectDependencyCycle, detectSelfDefeatingDependency, evaluateNoCommitsNoOpFinalize, evaluateCompletedPromotionFailureProvenance, evaluateSkipBypassTaint, getInReviewStalledSignal, getInReviewStallReason, getPrimaryPrInfo, getStalePausedReviewSignal, getStalePausedTodoSignal, getTaskHardMergeBlocker, getTaskMergeBlocker, isEphemeralAgent, isMergeRequestContractShadowEnabled, isWorkspaceTask, isSharedBranchGroupMemberIntegration, isLiveSharedBranchGroupMemberIntegration, isNearDuplicateCanonicalInactive, parseExplicitDuplicateMarker, flagTriageDuplicate, isTriageDuplicateKeepAcknowledged, resolveMaxAutoMergeRetries, resolveOptionalStepRevisionBudget, resolveOptionalReviewRevisionBudget, getBuiltinWorkflow, isBuiltinWorkflowId, resolveWorkflowIrForTask, resolveWorkflowIrForTaskWithProvenance, resolveReboundTarget, resolveReboundTargetForTask, resolveArchiveTargetForTask, columnsWithFlag, resolveLifecycleColumns, resolveTaskLifecycleColumns, workflowHasColumn, planLegacyAdoption, resolveOrphanedPendingStepResults, classifyReviewLease, PLAN_REVIEW_LEASE_STALENESS_MS, DEFAULT_MAX_POST_REVIEW_FIXES, ACTIVE_WORKFLOW_WORK_ITEM_STATES, AWAITING_APPROVAL_PAUSE_REASON, type Agent, type AgentStore, type ChatStore, type MessageStore, type TaskStore, type Settings, type Task, type MergeDetails, type TaskPriority, type MergeResult, type WorkflowStepResult, type WorkflowIr,
   resolveNearDuplicateCanonicalFlags,
   LEGACY_COLUMN_IDS_BY_ROLE,
   TERMINAL_ROLES,
@@ -185,6 +185,46 @@ import {
 
 
 const log = createLogger("self-healing");
+
+/*
+FNXC:SelfHealingAgentLinks 2026-08-10-05:47:
+A durable agent may outlive its task when a soft-delete races the self-healing
+read. Treat typed and serialized task-gone errors as a missing link, while
+quarantining unrelated lookup failures to this candidate so later agents in
+the same sweep still get evaluated.
+*/
+type SelfHealingTaskLookup =
+  | { status: "found"; task: Task }
+  | { status: "missing" }
+  | { status: "error" };
+
+function isTaskDeletedLookupError(error: unknown): boolean {
+  if (error instanceof TaskDeletedError) return true;
+  if (!error || typeof error !== "object") return false;
+  return (error as { name?: unknown }).name === "TaskDeletedError";
+}
+
+function isTaskNotFoundLookupError(error: unknown): boolean {
+  if (isTaskNotFoundError(error)) return true;
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return candidate.name === "TaskNotFoundError" || candidate.code === "TASK_NOT_FOUND";
+}
+
+async function lookupTaskForSelfHealing(store: Pick<TaskStore, "getTask">, taskId: string): Promise<SelfHealingTaskLookup> {
+  try {
+    const task = await store.getTask(taskId);
+    return task ? { status: "found", task } : { status: "missing" };
+  } catch (error) {
+    if (isTaskNotFoundLookupError(error) || isTaskDeletedLookupError(error)) {
+      return { status: "missing" };
+    }
+    log.warn(
+      `[self-healing] task lookup failed for ${taskId}; skipping this agent candidate: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { status: "error" };
+  }
+}
 
 /*
 DELIBERATE-LITERAL — the no-metadata fallback for dependency satisfaction, mirroring
@@ -13227,7 +13267,11 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
         continue;
       }
 
-      const linkedTask = await this.store.getTask(agent.taskId);
+      const linkedTaskLookup = await lookupTaskForSelfHealing(this.store, agent.taskId);
+      if (linkedTaskLookup.status === "error") {
+        continue;
+      }
+      const linkedTask = linkedTaskLookup.status === "found" ? linkedTaskLookup.task : null;
       /* FNXC:WorkflowResolvedColumns 2026-07-31-16:50 (fleet, round 2): WIP u REVIEW u TERMINAL. Keyed on
          ids none matched on a renamed board, so this sweep evaluated agents whose task was still executing. */
       if (linkedTask && (agentLinkLiveColumns.has(linkedTask.column) || agentLinkTerminalColumns.has(linkedTask.column))) {
@@ -13315,7 +13359,11 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
       }
 
       const linkedTaskId = agent.taskId;
-      const linkedTask = await this.store.getTask(linkedTaskId);
+      const linkedTaskLookup = await lookupTaskForSelfHealing(this.store, linkedTaskId);
+      if (linkedTaskLookup.status === "error") {
+        continue;
+      }
+      const linkedTask = linkedTaskLookup.status === "found" ? linkedTaskLookup.task : null;
       let shouldClear = false;
       let reason = "";
       let hadFreshRun = false;


### PR DESCRIPTION
## Summary

Closes the stale-agent-link failure mode reported in #3397. Self-healing task-link sweeps now treat typed or serialized task-gone errors as stale links and isolate unrelated lookup failures to the affected candidate, so later agents in the same sweep are still evaluated.

## Verification

- pnpm --filter @fusion/engine exec vitest run src/__tests__/self-healing.test.ts src/__tests__/self-healing-agent-link-drift.test.ts --silent=passed-only --reporter=dot -t continues-after-task-gone — 2/2 passed
- pnpm --filter @fusion/engine typecheck — passed
- node scripts/check-changeset-format.mjs — passed
- git diff --check — passed

The repository-wide static gate was also checked; its existing Windows invocation of check-capacity-pool-id.mjs fails before this patch because a quoted Git pathspec is passed literally by cmd.exe. No production configuration or secrets are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent-link cleanup now remains active when linked tasks are deleted or unavailable.
  * Self-healing scans continue processing other agents when an individual task lookup fails.
  * Missing, deleted, or unavailable tasks are handled safely without blocking recovery or cleanup of later candidates.

* **Tests**
  * Added coverage for deleted tasks, missing tasks, unexpected lookup failures, and continued processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->