### PR TITLE
fix(ci): classify workflowRole as role vocabulary

### DIFF
--- a/scripts/__tests__/lifecycle-census-workflow-role.test.mjs
+++ b/scripts/__tests__/lifecycle-census-workflow-role.test.mjs
@@ -1,0 +1,23 @@
+/*
+FNXC:LifecycleColumnCensus 2026-08-10-06:00:
+Workflow work-item `workflowRole` uses the triage/executor/reviewer/merger role vocabulary, not task
+column ids. A triage-only comparison has no sibling role literal for the AST classifier to infer from,
+so it must be named as a role receiver or the clean-main lifecycle ratchet reports a phantom column
+guard and blocks every unrelated pull request.
+*/
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { findComparisons } from "../lib/lifecycle-column-census-ast.mjs";
+
+test("workflowRole triage comparisons stay in the role vocabulary", () => {
+  const findings = findComparisons(
+    "t.ts",
+    'const held = items.find((item) => item.workflowRole === "triage");',
+  );
+
+  assert.deepEqual(
+    findings.map(({ columnId, receiver, kind }) => ({ columnId, receiver, kind })),
+    [{ columnId: "triage", receiver: "workflowRole", kind: "role" }],
+  );
+});

--- a/scripts/lib/lifecycle-column-census-ast.mjs
+++ b/scripts/lib/lifecycle-column-census-ast.mjs
@@ -60,7 +60,9 @@ export const LEGACY_COLUMN_IDS = ["triage", "todo", "in-progress", "in-review", 
 
 /** Receiver names that denote an agent role / lane rather than a task column. */
 export const ROLE_RECEIVER_TOKENS = [
-  "role", "agentType", "agent", "lane", "capability", "sessionPurpose", "surface", "purpose", "agentRole", "workflowRole",
+  "role", "agentType", "agent", "lane", "capability", "sessionPurpose", "surface", "purpose", "agentRole",
+  /* FNXC:LifecycleColumnCensus 2026-08-10-06:00: Workflow work items persist the triage/executor/reviewer/merger role vocabulary. */
+  "workflowRole",
   /*
   FNXC:LifecycleColumnCensus 2026-07-30-22:00 (fleet phase — the work order was sending workers at
   non-columns):


### PR DESCRIPTION
## Summary
- Classify workflow work-item `workflowRole` comparisons as role vocabulary in the lifecycle-column census.
- Add a regression test so triage role comparisons cannot raise a phantom lifecycle-column guard.

## Test Plan
- `node --test scripts/__tests__/lifecycle-census*.test.mjs`
- `corepack pnpm check:lifecycle-columns`
- `corepack pnpm lint`
- `corepack pnpm check:changesets --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of workflow role comparisons, including `workflowRole === "triage"`, so they are recognized separately from lifecycle-column comparisons.
  * Ensured workflow role values are correctly identified as role vocabulary rather than lifecycle-column values.

* **Tests**
  * Added automated coverage to verify accurate workflow role and column identification across comparison patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->