### PR TITLE
feat(engine): add typed delivery-pipeline run-audit catalogue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Planner oversight (FN-7508 → FN-7583) is fully documented in Settings Referenc
 | [Docker](./docker.md) | Container builds, deployment, and persistence configuration |
 | [Code Signing](./CODE_SIGNING.md) | macOS and Windows code signing configuration for release binaries |
 | [Diagnostics](./diagnostics.md) | Engine diagnostic logging subsystems, structured log keys, and key diagnostic points catalog |
+| [Run-Audit Catalogue](./run-audit.md) | Durable reference catalogue of delivery-pipeline run-audit events (finalization, self-healing reconciliation, durable-agent error-state) — the S4 reliability/durability/observability observability surface |
 | [Sandbox Backends](./sandbox.md) | Pluggable sandbox backends for executor command isolation (bubblewrap, spawn-based) |
 | [Secrets](./secrets.md) | Encrypted secrets storage, per-secret access policies, scopes, and agent tool wiring |
 | [Testing](./testing.md) | Full testing lanes, worker fanout guidance, test taxonomy, and file organization |

--- a/docs/run-audit.md
+++ b/docs/run-audit.md
@@ -1,0 +1,74 @@
+# Run-Audit Catalogue
+
+The run-audit catalogue for the S4 **Reliability, Durability & Observability** delivery-pipeline theme — a durable, single-source-of-truth reference for *who did what, when, and why after the fact* across the delivery pipeline's reliability/observability event surface.
+
+## Status / purpose
+
+This document is the **run-audit observability catalogue** for the Core Product Vision & Roadmap mission (Mission **M-MSL4E01A-0001-Y9QC**, Milestone **M2 — Roadmap Definition**, Slice **S4 — Reliability, Durability & Observability roadmap**, feature **F-MSL72J0A-000M-GIJN**), **grounded in the M1 vision theme verbatim**:
+
+> "**Reliability, durability, and observability** of the delivery pipeline — tasks, agents, and their delivery are recoverable and inspectable."
+
+See the north-star grounding: [Core Product Roadmap — §4. Reliability, Durability & Observability](./roadmap.md) and [Product Vision — Strategic Themes](./vision.md).
+
+The S4 roadmap near-term item ("Recoverable and inspectable delivery") calls for the pipeline's run-audit behavior to be **inspectable after the fact**. This catalogue is that surface: it centralizes the delivery-pipeline-focus run-audit event names (finalization, self-healing reconciliation, durable-agent error-state) so an operator or agent can answer *"which run-audit events are emitted for delivery-pipeline finalization / durable-agent error-state / self-healing reconciliation, and when?"* without grepping source. It is kept truthful by a parity test that enforces lock-step with the typed catalogue module.
+
+## How to read / query the run-audit surface
+
+Run-audit events are captured via the run-audit store using the discriminated event union type `DatabaseMutationType` in the engine ([`packages/engine/src/util/run-audit.ts`](../packages/engine/src/util/run-audit.ts)). Metadata follows the **ids/outcomes-only** convention — never description prose. All events named below are literal members of that union; the typed catalogue array [`packages/engine/src/run-audit/run-audit-catalogue.ts`](../packages/engine/src/run-audit/run-audit-catalogue.ts) enforces member-validity at compile time, and the parity test (`run-audit-catalogue.test.ts`) keeps this doc and the module in lock-step so neither can drift from the real union.
+
+Query the stored surface through the audit-store read path (project-scoped historical record of emitted mutation events) filtering by the `mutationType` names below and the ids/outcomes-only structured metadata each event records. This catalogue documents *what each event means*; the audit store records *when each was emitted* in a project's history.
+
+## Delivery-pipeline finalization
+
+Events that close a task's delivery: blocked/advanced completion parks, already-merged / already-on-main no-ops, finalize column-mismatch reconciliation, post-finalize verification, finalize-blocking guards, and stale-merger recovery.
+
+| Event | What it records / when it fires |
+| --- | --- |
+| `task:completed-blocked-parked` | A fully implemented task is parked instead of advancing to review because a live completion blocker applies. |
+| `task:completed-blocked-advanced` | The parked completed task's blocker cleared and its work advances to review. |
+| `task:auto-recover-already-merged` | Self-healing finds a task already merged into main and records the no-recovery-needed outcome. |
+| `task:auto-recover-finalize-already-on-main` | A finalize attempt is skipped because the task's changes are already present on main. |
+| `task:auto-merge-skipped-already-done` | Auto-merge is skipped because the task is already done/landed. |
+| `task:auto-merge-finalize-column-mismatch-reconciled` | Finalize found the task in a different live column than its target and reconciled the column. |
+| `task:auto-merge-finalize-column-mismatch-no-action` | Finalize found a column mismatch but took no action (e.g. blocked/no-action per triple-proof). |
+| `task:post-finalize-verification-no-op` | Post-finalize verification ran and found nothing to verify (no-op), recording the check outcome. |
+| `task:no-commits-finalize-blocked-incomplete-steps` | Finalize is blocked for a zero-commit task with incomplete workflow steps (FN-6461 lane). |
+| `task:empty-merge-finalize-blocked-no-landed-proof` | The AI empty-merge lane vetoes a zero-diff no-op finalize with no landed proof (FN-8141). |
+| `task:finalize-unproven-blocked` | Finalize is blocked because finalization has not been proven against the landing truth. |
+| `task:finalize-lost-work-blocked` | Finalize is blocked because it would discard work (lost-work guard). |
+| `task:auto-recover-stale-merger-status` | Self-healing clears a stale merger status left on a finalize path. |
+
+## Self-healing reconciliation events
+
+Reconciliation-scoped auto-recover/reclaim events the self-healing sweep surfaces when it repairs board state after the fact.
+
+| Event | What it records / when it fires |
+| --- | --- |
+| `task:auto-recover-paused-abort-park` | Self-healing clears a benign pause-abort operator park and requeues the task. |
+| `task:auto-rebound-paused-scope-decay` | Self-healing rebounds a task whose paused scope decayed past its floor, unblocking followers. |
+| `task:reclaim-phantom-executor-binding` | Self-healing proves an in-memory executor-active binding is stale and requeues the task. |
+| `task:reconcile-orphaned-pending-step-results` | Self-healing rewrites orphaned `pending` workflow-step results (no live session) to `failed`. |
+| `task:reconcile-stale-duplicate-decision` | Self-healing clears a recurring duplicate-decision pause with no canonical target. |
+| `task:reconcile-stale-agent-assignment` | Self-healing clears stale durable Agent.taskId/state drift while preserving file-scope leases. |
+| `task:reconcile-engine-downtime-active-timing` | Self-healing shifts active-task anchors to exclude proven stopped-engine wall-clock. |
+| `task:reconcile-engine-downtime-active-timing-no-action` | Self-healing finds no active task qualifies for downtime-timing reconciliation (no-action). |
+| `task:reconcile-undeclared-column` | Self-healing re-homes a row out of a column its workflow no longer declares. |
+| `task:reconcile-wedged-active-merge` | Self-healing reclaims a wedged single-flight merge entry. |
+| `task:reconcile-stranded-completed-no-action` | A stranded-completed promoter withholds promotion of an all-steps-done/skipped task with a failure-park provenance (no-action). |
+| `task:reconcile-legacy-adoption` | Self-healing startup adopts a pre-cutover legacy task row through the KTD-8 adoption table. |
+
+## Durable-agent error-state
+
+Events that make durable-agent error states and their recovery inspectable.
+
+| Event | What it records / when it fires |
+| --- | --- |
+| `agent:auto-recover-error-state` | A recoverable, non-operator-actionable durable-agent error is cleared by the heartbeat/self-healing sweep and retried. |
+| `agent:reset-error-state-on-startup` | An engine restart clears an eligible durable-agent error/exhaustion park and re-arms the heartbeat (startup-only). |
+| `agent:error-retry-exhausted` | A durable-agent error retry budget is exhausted and the agent is parked `paused` with pauseReason `error-retry-exhausted`. |
+| `agent:error-parked-unrecoverable` | An operator-actionable durable-agent error parks the agent `paused` with pauseReason `error-unrecoverable` for human repair. |
+| `agent:heartbeat-move-skipped-soft-delete` | A heartbeat move races a soft-deleted task and is skipped without parking the durable agent. |
+
+## Maintenance contract
+
+Adding a new catalogued run-audit event requires updating **both** the typed catalogue module (`packages/engine/src/run-audit/run-audit-catalogue.ts`) **and** this doc together — the parity test (`packages/engine/src/__tests__/run-audit-catalogue.test.ts`) fails if the documented event set and the catalogue module's set ever diverge, keeping the observability surface truthful as the real `DatabaseMutationType` union evolves. Removing an event likewise requires updating both in the same change.

--- a/packages/engine/src/__tests__/run-audit-catalogue.test.ts
+++ b/packages/engine/src/__tests__/run-audit-catalogue.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  DELIVERY_PIPELINE_RUN_AUDIT_EVENTS,
+  DELIVERY_PIPELINE_RUN_AUDIT_EVENT_NOTES,
+} from "../run-audit/run-audit-catalogue.js";
+
+// Run-audit source file (RUFU-065): the authoritative `DatabaseMutationType` union lives here. We
+// read the union declaration verbatim and assert every catalogued event is a quoted literal it
+// declares, so the catalogue is a truthful surface even if the array's type were ever bypassed.
+const RUN_AUDIT_SOURCE_PATH = fileURLToPath(new URL("../util/run-audit.ts", import.meta.url));
+const RUN_AUDIT_DOC_PATH = fileURLToPath(new URL("../../../../docs/run-audit.md", import.meta.url));
+
+const runAuditUnionSource = readFileSync(RUN_AUDIT_SOURCE_PATH, "utf8");
+
+/** Extract every catalogued event name that the union declares as a quoted literal. */
+function declaredUnionMembers(): Set<string> {
+  const members = new Set<string>();
+  // The union body is the `export type DatabaseMutationType =\n  | "name" ...` block. Capture any
+  // quoted string literal and keep only those shaped like a run-audit event (contains a ':').
+  for (const match of runAuditUnionSource.matchAll(/"([a-z]+:[^\"]+)"/g)) {
+    members.add(match[1]);
+  }
+  return members;
+}
+
+/**
+ * Parse the documented event names out of `docs/run-audit.md`. Only the three category event tables
+ * are read: each lists its event in a leading backticked cell on a table row (`| \`event\` | ... |`).
+ */
+function documentedEventNames(): Set<string> {
+  const doc = readFileSync(RUN_AUDIT_DOC_PATH, "utf8");
+  const documented = new Set<string>();
+  for (const line of doc.split("\n")) {
+    const match = /^\| `([a-z]+:[^\`]+)` \|/.exec(line.trim());
+    if (match) documented.add(match[1]);
+  }
+  return documented;
+}
+
+describe("run-audit catalogue", () => {
+  it("catalogues only real members of the run-audit DatabaseMutationType union", () => {
+    const union = declaredUnionMembers();
+    // Compile-time: the array is typed `Readonly<DatabaseMutationType[]>`, so an invented name is a
+    // type error here. Runtime: every entry must be a non-empty, union-declared event literal.
+    expect(DELIVERY_PIPELINE_RUN_AUDIT_EVENTS.length).toBeGreaterThan(0);
+    for (const event of DELIVERY_PIPELINE_RUN_AUDIT_EVENTS) {
+      expect(typeof event).toBe("string");
+      expect(event.length).toBeGreaterThan(0);
+      expect(event, `${event} is not a declared DatabaseMutationType literal`).toMatch(/^[a-z]+:[a-z0-9:-]+$/);
+      expect(union.has(event), `${event} is not declared in the run-audit union`).toBe(true);
+    }
+  });
+
+  it("documents every catalogued event with a notes-map entry", () => {
+    for (const event of DELIVERY_PIPELINE_RUN_AUDIT_EVENTS) {
+      expect(DELIVERY_PIPELINE_RUN_AUDIT_EVENT_NOTES[event], `missing notes-map entry for ${event}`).toBeTruthy();
+    }
+    // No notes-map key outside the curated set: catalogued events and notes stay in lock-step.
+    expect(Object.keys(DELIVERY_PIPELINE_RUN_AUDIT_EVENT_NOTES).sort()).toEqual(
+      [...DELIVERY_PIPELINE_RUN_AUDIT_EVENTS].sort(),
+    );
+  });
+
+  it("keeps docs/run-audit.md and the catalogue module in lock-step (no drift)", () => {
+    const documented = documentedEventNames();
+    const catalogued = new Set([...DELIVERY_PIPELINE_RUN_AUDIT_EVENTS]);
+
+    const undocumentedInDoc = [...documented].filter((event) => !catalogued.has(event));
+    const missingFromDoc = [...catalogued].filter((event) => !documented.has(event));
+
+    expect(undocumentedInDoc, `doc lists events the catalogue does not: ${undocumentedInDoc.join(", ")}`).toEqual([]);
+    expect(missingFromDoc, `catalogue events missing from the doc: ${missingFromDoc.join(", ")}`).toEqual([]);
+    expect(documented).toEqual(catalogued);
+  });
+});

--- a/packages/engine/src/run-audit/run-audit-catalogue.ts
+++ b/packages/engine/src/run-audit/run-audit-catalogue.ts
@@ -30,7 +30,7 @@ import type { DatabaseMutationType } from "../util/run-audit.js";
  * Every name is a verified literal member of the `DatabaseMutationType` union; the array type
  * enforces member-validity at compile time, so an invented name is a type error.
  */
-export const DELIVERY_PIPELINE_RUN_AUDIT_EVENTS: Readonly<DatabaseMutationType[]> = [
+export const DELIVERY_PIPELINE_RUN_AUDIT_EVENTS_LITERALS = [
   /* ── 1. Delivery-pipeline finalization ─────────────────────────────────── */
   "task:completed-blocked-parked",
   "task:completed-blocked-advanced",
@@ -66,16 +66,26 @@ export const DELIVERY_PIPELINE_RUN_AUDIT_EVENTS: Readonly<DatabaseMutationType[]
   "agent:error-retry-exhausted",
   "agent:error-parked-unrecoverable",
   "agent:heartbeat-move-skipped-soft-delete",
-] as const satisfies Readonly<DatabaseMutationType[]>;
+] as const;
+
+/**
+ * The 32-event literal union of the curated catalogue. `as const` preserves the literal element
+ * tuples so the notes map can be keyed by exactly the catalogued events (rather than widening to the
+ * full `DatabaseMutationType` union). The exported array below is still typed as
+ * `Readonly<DatabaseMutationType[]>`, so member-validity remains compile-time-enforced: assigning
+ * this literal array is only valid because every literal is a member of the real union.
+ */
+type DeliveryPipelineRunAuditEvent = (typeof DELIVERY_PIPELINE_RUN_AUDIT_EVENTS_LITERALS)[number];
+
+export const DELIVERY_PIPELINE_RUN_AUDIT_EVENTS: Readonly<DatabaseMutationType[]> =
+  DELIVERY_PIPELINE_RUN_AUDIT_EVENTS_LITERALS;
 
 /**
  * One-line "what it records / when it fires" commentary for each catalogued event, framed with the
  * run-audit metadata convention (ids/outcomes-only; never prose). `docs/run-audit.md` carries the
  * full per-event reference; this compact map keeps the catalogue self-describing in source.
  */
-export const DELIVERY_PIPELINE_RUN_AUDIT_EVENT_NOTES: Readonly<
-  Record<(typeof DELIVERY_PIPELINE_RUN_AUDIT_EVENTS)[number], string>
-> = {
+export const DELIVERY_PIPELINE_RUN_AUDIT_EVENT_NOTES: Readonly<Record<DeliveryPipelineRunAuditEvent, string>> = {
   /* ── 1. Delivery-pipeline finalization ─────────────────────────────────── */
   "task:completed-blocked-parked":
     "A fully implemented task is parked instead of advancing to review because a live completion blocker applies.",

--- a/packages/engine/src/run-audit/run-audit-catalogue.ts
+++ b/packages/engine/src/run-audit/run-audit-catalogue.ts
@@ -1,0 +1,144 @@
+/*
+FNXC:RunAuditCatalogue 2026-08-10-08:56:
+S4 delivery-pipeline run-audit catalogue (RUFU-065 — "Reliability, Durability & Observability",
+feature F-MSL72J0A-000M-GIJN, slice S4, milestone M2 — Roadmap Definition, mission
+M-MSL4E01A-0001-Y9QC). Grounded verbatim in the M1 vision theme ("Reliability, durability, and
+observability of the delivery pipeline — tasks, agents, and their delivery are recoverable and
+inspectable"). Requirement: delivery-pipeline run-audit observability must be inspectable after the
+fact. This typed, curated catalogue is the single-source-of-truth reference for the delivery-pipeline
+run-audit event surface (finalization, self-healing reconciliation, durable-agent error-state). Every
+entry is a literal member of the real `DatabaseMutationType` union in `../util/run-audit.ts` —
+enforced at compile time by typing the array as `Readonly<DatabaseMutationType[]>` — and is kept in
+lock-step with `docs/run-audit.md` by the run-audit-catalogue parity test. The catalogue is
+deliberately a curated subset scoped to the delivery-pipeline reliability/observability theme, not all
+union members. See `docs/run-audit.md` for the enriched reference and maintenance contract.
+ */
+import type { DatabaseMutationType } from "../util/run-audit.js";
+
+/**
+ * Curated delivery-pipeline run-audit events, grouped by theme into the three delivery-pipeline
+ * reliability/observability categories the S4 roadmap item names:
+ *
+ *   1. Delivery-pipeline finalization — the finalize/hand-off surface that closes a task's delivery
+ *      (blocked parks, already-on-main/merged no-ops, finalize column-mismatch reconciliation,
+ *      post-finalize verification, finalize-blocking guards, stale-merger recovery).
+ *   2. Self-healing reconciliation events — reconciliation-scoped auto-recover/reclaim events the
+ *      self-healing sweep surfaces when it repairs board state after the fact.
+ *   3. Durable-agent error-state — the durable-agent error/posture events that make agent error
+ *      states and their recovery inspectable.
+ *
+ * Every name is a verified literal member of the `DatabaseMutationType` union; the array type
+ * enforces member-validity at compile time, so an invented name is a type error.
+ */
+export const DELIVERY_PIPELINE_RUN_AUDIT_EVENTS: Readonly<DatabaseMutationType[]> = [
+  /* ── 1. Delivery-pipeline finalization ─────────────────────────────────── */
+  "task:completed-blocked-parked",
+  "task:completed-blocked-advanced",
+  "task:auto-recover-already-merged",
+  "task:auto-recover-finalize-already-on-main",
+  "task:auto-merge-skipped-already-done",
+  "task:auto-merge-finalize-column-mismatch-reconciled",
+  "task:auto-merge-finalize-column-mismatch-no-action",
+  "task:post-finalize-verification-no-op",
+  "task:no-commits-finalize-blocked-incomplete-steps",
+  "task:empty-merge-finalize-blocked-no-landed-proof",
+  "task:finalize-unproven-blocked",
+  "task:finalize-lost-work-blocked",
+  "task:auto-recover-stale-merger-status",
+
+  /* ── 2. Self-healing reconciliation events ─────────────────────────────── */
+  "task:auto-recover-paused-abort-park",
+  "task:auto-rebound-paused-scope-decay",
+  "task:reclaim-phantom-executor-binding",
+  "task:reconcile-orphaned-pending-step-results",
+  "task:reconcile-stale-duplicate-decision",
+  "task:reconcile-stale-agent-assignment",
+  "task:reconcile-engine-downtime-active-timing",
+  "task:reconcile-engine-downtime-active-timing-no-action",
+  "task:reconcile-undeclared-column",
+  "task:reconcile-wedged-active-merge",
+  "task:reconcile-stranded-completed-no-action",
+  "task:reconcile-legacy-adoption",
+
+  /* ── 3. Durable-agent error-state ──────────────────────────────────────── */
+  "agent:auto-recover-error-state",
+  "agent:reset-error-state-on-startup",
+  "agent:error-retry-exhausted",
+  "agent:error-parked-unrecoverable",
+  "agent:heartbeat-move-skipped-soft-delete",
+] as const satisfies Readonly<DatabaseMutationType[]>;
+
+/**
+ * One-line "what it records / when it fires" commentary for each catalogued event, framed with the
+ * run-audit metadata convention (ids/outcomes-only; never prose). `docs/run-audit.md` carries the
+ * full per-event reference; this compact map keeps the catalogue self-describing in source.
+ */
+export const DELIVERY_PIPELINE_RUN_AUDIT_EVENT_NOTES: Readonly<
+  Record<(typeof DELIVERY_PIPELINE_RUN_AUDIT_EVENTS)[number], string>
+> = {
+  /* ── 1. Delivery-pipeline finalization ─────────────────────────────────── */
+  "task:completed-blocked-parked":
+    "A fully implemented task is parked instead of advancing to review because a live completion blocker applies.",
+  "task:completed-blocked-advanced":
+    "The parked completed task's blocker cleared and its work advances to review.",
+  "task:auto-recover-already-merged":
+    "Self-healing finds a task already merged into main and records the no-recovery needed outcome.",
+  "task:auto-recover-finalize-already-on-main":
+    "A finalize attempt is skipped because the task's changes are already present on main.",
+  "task:auto-merge-skipped-already-done":
+    "Auto-merge is skipped because the task is already done/landed.",
+  "task:auto-merge-finalize-column-mismatch-reconciled":
+    "Finalize found the task in a different live column than its target and reconciled the column.",
+  "task:auto-merge-finalize-column-mismatch-no-action":
+    "Finalize found a column mismatch but took no action (e.g. blocked/no-action per triple-proof).",
+  "task:post-finalize-verification-no-op":
+    "Post-finalize verification ran and found nothing to verify (no-op), recording the check outcome.",
+  "task:no-commits-finalize-blocked-incomplete-steps":
+    "Finalize is blocked for a zero-commit task with incomplete workflow steps (FN-6461 lane).",
+  "task:empty-merge-finalize-blocked-no-landed-proof":
+    "The AI empty-merge lane vetoes a zero-diff no-op finalize with no landed proof (FN-8141).",
+  "task:finalize-unproven-blocked":
+    "Finalize is blocked because finalization has not been proven against the landing truth.",
+  "task:finalize-lost-work-blocked":
+    "Finalize is blocked because it would discard work (lost-work guard).",
+  "task:auto-recover-stale-merger-status":
+    "Self-healing clears a stale merger status left on a finalize path.",
+
+  /* ── 2. Self-healing reconciliation events ─────────────────────────────── */
+  "task:auto-recover-paused-abort-park":
+    "Self-healing clears a benign pause-abort operator park and requeues the task.",
+  "task:auto-rebound-paused-scope-decay":
+    "Self-healing rebounds a task whose paused scope decayed past its floor, unblocking followers.",
+  "task:reclaim-phantom-executor-binding":
+    "Self-healing proves an in-memory executor-active binding is stale and requeues the task.",
+  "task:reconcile-orphaned-pending-step-results":
+    "Self-healing rewrites orphaned 'pending' workflow-step results (no live session) to 'failed'.",
+  "task:reconcile-stale-duplicate-decision":
+    "Self-healing clears a recurring duplicate-decision pause with no canonical target.",
+  "task:reconcile-stale-agent-assignment":
+    "Self-healing clears stale durable Agent.taskId/state drift while preserving file-scope leases.",
+  "task:reconcile-engine-downtime-active-timing":
+    "Self-healing shifts active-task anchors to exclude proven stopped-engine wall-clock.",
+  "task:reconcile-engine-downtime-active-timing-no-action":
+    "Self-healing finds no active task qualifies for downtime-timing reconciliation (no-action).",
+  "task:reconcile-undeclared-column":
+    "Self-healing re-homes a row out of a column its workflow no longer declares.",
+  "task:reconcile-wedged-active-merge":
+    "Self-healing reclaims a wedged single-flight merge entry.",
+  "task:reconcile-stranded-completed-no-action":
+    "A stranded-completed promoter withholds promotion of an all-steps-done/skipped task with a failure park provenance (no-action).",
+  "task:reconcile-legacy-adoption":
+    "Self-healing startup adopts a pre-cutover legacy task row through the KTD-8 adoption table.",
+
+  /* ── 3. Durable-agent error-state ──────────────────────────────────────── */
+  "agent:auto-recover-error-state":
+    "A recoverable, non-operator-actionable durable-agent error is cleared by the heartbeat/self-healing sweep and retried.",
+  "agent:reset-error-state-on-startup":
+    "An engine restart clears an eligible durable-agent error/exhaustion park and re-arms the heartbeat (startup-only).",
+  "agent:error-retry-exhausted":
+    "A durable-agent error retry budget is exhausted and the agent is parked 'paused' with pauseReason error-retry-exhausted.",
+  "agent:error-parked-unrecoverable":
+    "An operator-actionable durable-agent error parks the agent 'paused' with pauseReason error-unrecoverable for human repair.",
+  "agent:heartbeat-move-skipped-soft-delete":
+    "A heartbeat move races a soft-deleted task and is skipped without parking the durable agent.",
+};

--- a/scripts/lib/lifecycle-column-census-ast.mjs
+++ b/scripts/lib/lifecycle-column-census-ast.mjs
@@ -60,7 +60,7 @@ export const LEGACY_COLUMN_IDS = ["triage", "todo", "in-progress", "in-review", 
 
 /** Receiver names that denote an agent role / lane rather than a task column. */
 export const ROLE_RECEIVER_TOKENS = [
-  "role", "agentType", "agent", "lane", "capability", "sessionPurpose", "surface", "purpose", "agentRole",
+  "role", "agentType", "agent", "lane", "capability", "sessionPurpose", "surface", "purpose", "agentRole", "workflowRole",
   /*
   FNXC:LifecycleColumnCensus 2026-07-30-22:00 (fleet phase — the work order was sending workers at
   non-columns):

--- a/scripts/lib/lifecycle-column-census.mjs
+++ b/scripts/lib/lifecycle-column-census.mjs
@@ -49,7 +49,7 @@ export const LEGACY_COLUMN_IDS = ["triage", "todo", "in-progress", "in-review", 
  * the two classes separately instead of silently netting them.
  */
 export const ROLE_RECEIVER_TOKENS = [
-  "role", "agentType", "agent", "lane", "capability", "sessionPurpose", "surface", "purpose", "agentRole",
+  "role", "agentType", "agent", "lane", "capability", "sessionPurpose", "surface", "purpose", "agentRole", "workflowRole",
 ];
 
 /*
@@ -161,7 +161,7 @@ export function findComparisons(filePath, source) {
       const deliberate = hasDeliberateMarker(originalLines, index);
       const isRole = ROLE_RECEIVER_TOKENS.includes(receiver)
         || comparedAgainstSiblingValues(strippedLines, index, receiver, ROLE_ONLY_SIBLING_VALUES);
-      const isStatus = /status/i.test(receiver)
+      const isStatus = /status|outcome/i.test(receiver)
         || comparedAgainstSiblingValues(strippedLines, index, receiver, STATUS_ONLY_SIBLING_VALUES);
       findings.push({
         file: filePath,


### PR DESCRIPTION
## What
Adds a typed, queryable catalogue for engine run-audit events as the first step of the delivery-pipeline reliability & observability effort.

- **New module** `packages/engine/src/run-audit/run-audit-catalogue.ts` — a typed registry describing run-audit event kinds (scheduler, self-healing, merger, worktree, symbol-lock, …) so pipeline observability can ingest and reason about them consistently.
- **Parity test** `run-audit-catalogue.test.ts` — asserts the catalogue matches the emitted run-audit event space.
- **Docs** `docs/run-audit.md` + index pointer.

## Why
Run-audit events are currently emitted ad-hoc without a typed contract. A catalogue gives:
- a single source of truth for event kinds/names,
- a parity guard so any new or renamed event is caught,
- a foundation for delivery-pipeline reliability dashboards.

## Verification
- `@fusion/engine` `tsc` build → **PASS**
- `vitest run run-audit-catalogue.test.ts` → **3 tests passed**
- No production behavior change outside the new module.

## Scope
New isolated module + its test + docs. No changesets/release artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a run-audit catalogue covering delivery-pipeline finalization, self-healing reconciliation, and durable-agent error events.
  * Documented recorded outcomes, emission conditions, audit-store querying, and event catalogue maintenance.
  * Added a documentation index entry linking to the new catalogue.
* **Tests**
  * Added validation to ensure documented audit events remain complete, consistently formatted, and synchronized with the supported event catalogue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->