### PR TITLE
test(engine): align failed notification fixture with recovery ownership

### DIFF
--- a/packages/engine/src/__tests__/self-healing.test.ts
+++ b/packages/engine/src/__tests__/self-healing.test.ts
@@ -7329,7 +7329,14 @@ describe("SelfHealingManager", () => {
       const now = new Date().toISOString();
       const tasks = new Map<string, Task>([["FN-1", { id: "FN-1", column: "in-review", paused: false, status: "failed", mergeRetries: 3, mergeDetails: undefined, baseBranch: "main", branch: "fusion/fn-1", worktree: "/tmp/wt", dependencies: [], steps: [], currentStep: 0, description: "x", log: [], createdAt: now, updatedAt: now } as Task]]);
       const eventedStore = createMockStore({
-        getSettings: vi.fn().mockResolvedValue({ globalPause: false, enginePaused: false, ntfyEnabled: true, ntfyTopic: "topic", failureNotificationMode: "sticky-only", failureNotificationDelayMs: 50 }),
+        /*
+        FNXC:SelfHealingNotifications 2026-08-11-02:16:
+        When maintenance retries are disabled, no sweep owns terminal failures; task-wedged notifications must fail open.
+
+        FNXC:SelfHealingNotifications 2026-08-11-21:10:
+        Disable the wedge settle window here so this fixture isolates recovery ownership instead of waiting through the production debounce.
+        */
+        getSettings: vi.fn().mockResolvedValue({ globalPause: false, enginePaused: false, maintenanceIntervalMs: 0, wedgeNotificationSettleMs: 0, ntfyEnabled: true, ntfyTopic: "topic", failureNotificationMode: "sticky-only", failureNotificationDelayMs: 50 }),
         listTasks: vi.fn().mockImplementation(async () => Array.from(tasks.values())),
         getTask: vi.fn().mockImplementation(async (id: string) => tasks.get(id)),
       });


### PR DESCRIPTION
## Summary
- make the already-merged recovery fixture explicit that no maintenance sweep owns terminal-failure recovery
- preserve the fail-open `task-wedged` notification assertion when no landed commit is found

## Test plan
- `corepack pnpm --filter @fusion/engine exec vitest run --silent=passed-only --reporter=dot src/__tests__/self-healing.test.ts` (460 passed)
- `corepack pnpm --filter @fusion/engine typecheck`
- `node scripts/run-static-gate-checks.mjs` (12 passed)
- `corepack pnpm --filter @fusion/engine test:core` (422 passed)
- `corepack pnpm --filter @fusion/core test:unit-gate` (184 passed)
- `corepack pnpm --filter @runfusion/fusion test:ci-shape` (71 passed)
- `corepack pnpm test:gate` reaches the PostgreSQL harness but cannot authenticate locally (`empty password returned by client`) before product assertions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated failure-notification test conditions to cover scenarios without automatic maintenance processing.
  * Added coverage confirming terminal-failure notifications fail open when no maintenance sweep owns the task.
  * Bypassed production debounce timing to make the test behavior deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->