### PR TITLE
fix(engine): preserve manual handoff holds during recovery

### DIFF
--- a/.changeset/manual-handoff-limbo.md
+++ b/.changeset/manual-handoff-limbo.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Keep completed manual-review tasks parked instead of retrying automatic merge handoffs.
+category: fix
+dev: Reuses the shared merge-recovery consent gate for completion-handoff self-healing.

--- a/packages/engine/src/__tests__/reliability-interactions/completion-handoff-limbo.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/completion-handoff-limbo.test.ts
@@ -27,6 +27,7 @@ function createStore(task: Task, mergeQueuedTaskIds: string[] = []) {
   return {
     getSettings: vi.fn(async () => ({ globalPause: false, enginePaused: false })),
     listTasks: vi.fn(async () => [current]),
+    getBranchGroup: vi.fn(async () => null),
     updateTask: vi.fn(async (_id: string, updates: Partial<Task>) => {
       current = { ...current, ...updates } as Task;
       return current;
@@ -102,6 +103,69 @@ describe("FN-4999 reliability interactions: completion-handoff-limbo", () => {
     const manager = new SelfHealingManager(store, { rootDir: "/repo", requeueForAutoMerge, isTaskActive: () => true });
     await manager.recoverCompletionHandoffLimbo();
     expect(requeueForAutoMerge).not.toHaveBeenCalled();
+  });
+
+  // FNXC:CompletionHandoffRecovery 2026-08-11-12:05: Manual holds suppress recovery unless a permitted live shared group owns the integration path.
+  it.each([
+    {
+      label: "task-level user hold while project auto-merge is on",
+      task: { autoMerge: false, autoMergeProvenance: "user" as const },
+      projectAutoMerge: true,
+    },
+    {
+      label: "standalone mission-policy hold while project auto-merge is on",
+      task: { autoMerge: false, autoMergeProvenance: "mission" as const },
+      projectAutoMerge: true,
+    },
+    {
+      label: "inherited hold while project auto-merge is off",
+      task: {},
+      projectAutoMerge: false,
+    },
+  ])("preserves $label instead of recreating merge work", async ({ task, projectAutoMerge }) => {
+    const store = createStore(limboTask(task));
+    store.getSettings.mockResolvedValue({
+      globalPause: false,
+      enginePaused: false,
+      autoMerge: projectAutoMerge,
+      integrationBranch: "main",
+    });
+    const requeueForAutoMerge = vi.fn(() => true);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo", requeueForAutoMerge });
+
+    await manager.recoverCompletionHandoffLimbo();
+
+    expect(requeueForAutoMerge).not.toHaveBeenCalled();
+    expect(store.enqueueMergeQueue).not.toHaveBeenCalled();
+    expect(store.updateTask).not.toHaveBeenCalled();
+    expect(store.recordRunAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps a permitted live shared-group member recovery flowing", async () => {
+    const store = createStore(limboTask({
+      autoMerge: false,
+      autoMergeProvenance: "mission",
+      branchContext: { assignmentMode: "shared", groupId: "BG-4999", source: "mission" },
+    }));
+    store.getSettings.mockResolvedValue({
+      globalPause: false,
+      enginePaused: false,
+      autoMerge: true,
+      integrationBranch: "main",
+    });
+    store.getBranchGroup.mockResolvedValue({
+      id: "BG-4999",
+      status: "open",
+      branchName: "mission/M-4999",
+    });
+    const requeueForAutoMerge = vi.fn(() => true);
+    const manager = new SelfHealingManager(store, { rootDir: "/repo", requeueForAutoMerge });
+
+    await manager.recoverCompletionHandoffLimbo();
+
+    expect(store.getBranchGroup).toHaveBeenCalledWith("BG-4999");
+    expect(store.enqueueMergeQueue).toHaveBeenCalledWith("FN-4999-T");
+    expect(requeueForAutoMerge).toHaveBeenCalledWith("FN-4999-T");
   });
 
   it("honors legitimate merge blockers", async () => {
@@ -191,12 +255,21 @@ describe("FN-4999 reliability interactions: completion-handoff-limbo", () => {
     expect(store.logEntry).not.toHaveBeenCalled();
   });
 
+  // FNXC:CompletionHandoffRecovery 2026-08-11-12:05: Merge-queue ownership clears false exhaustion before auto-merge admission is evaluated.
   it("clears false handoff exhaustion for tasks already held by the merge queue", async () => {
     const store = createStore(limboTask({
       status: "failed",
       error: "Completion handoff limbo recovery exhausted",
       completionHandoffLimboRecoveryCount: MAX_COMPLETION_HANDOFF_LIMBO_RECOVERIES,
+      autoMerge: false,
+      autoMergeProvenance: "user",
     }), ["FN-4999-T"]);
+    store.getSettings.mockResolvedValue({
+      globalPause: false,
+      enginePaused: false,
+      autoMerge: true,
+      integrationBranch: "main",
+    });
     const requeueForAutoMerge = vi.fn(() => false);
     const manager = new SelfHealingManager(store, { rootDir: "/repo", requeueForAutoMerge });
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -8628,6 +8628,29 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
   }
 
   /**
+   * FNXC:MergeRecoveryConsent 2026-08-11-11:46:
+   * Every self-healing path that can create merge work must preserve the same
+   * operator consent boundary. Standalone effective Off tasks remain parked for
+   * manual integration, while a live shared-group member may still advance only
+   * when project/task policy permits its intermediate member-to-group merge.
+   */
+  private async canRecoverMergeRequest(task: Task, settings: Settings): Promise<boolean> {
+    if (hasSharedBranchMemberAutoMergeHold(task, settings)) return false;
+
+    const groupId = task.branchContext?.groupId?.trim();
+    if (groupId) {
+      const branchGroup = await this.store.getBranchGroup(groupId);
+      const projectDefaultBranch = await resolveIntegrationBranch(this.options.rootDir, settings);
+      if (isLiveSharedBranchGroupMemberIntegration(task, branchGroup, projectDefaultBranch)) {
+        return true;
+      }
+    }
+
+    return allowsAutoMergeProcessing(task, settings)
+      && resolveEffectiveAutoMerge(task, settings) !== false;
+  }
+
+  /**
    * Recover `in-review` tasks that are fully mergeable but never had
    * `mergeTask()` invoked.
    *
@@ -8695,38 +8718,9 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
       */
       const executingIds = this.options.getExecutingTaskIds?.() ?? new Set<string>();
 
-      /*
-      FNXC:SharedBranchMemberHold 2026-08-05-23:14:
-      Recovery is a merge requester, not merely cleanup. It must use the same
-      member→group admission rule as ProjectEngine: an open intermediate group
-      keeps mission-policy/inherited Off flowing, while an operator-authored Off
-      remains a durable manual hold. Filtering only with allowsAutoMergeProcessing
-      stranded mission members whenever the project switch was Off and, conversely,
-      would enqueue a user hold when the project switch was On.
-      */
-      const canRecoverMergeableReviewTask = async (task: Task): Promise<boolean> => {
-        if (hasSharedBranchMemberAutoMergeHold(task, settings)) return false;
-
-        const groupId = task.branchContext?.groupId?.trim();
-        const branchGroup = groupId ? await this.store.getBranchGroup(groupId) : null;
-        const projectDefaultBranch = await resolveIntegrationBranch(this.options.rootDir, settings);
-        if (isLiveSharedBranchGroupMemberIntegration(task, branchGroup, projectDefaultBranch)) {
-          return true;
-        }
-
-        /*
-        FNXC:SharedBranchMemberHold 2026-08-05-23:22:
-        A stale or default-branch group is not an intermediate member integration.
-        Its false task value must retain the standalone manual-hold path even when
-        the project switch is On; recovery must not turn that durable hold into a
-        fresh merge request merely because it runs after the graph paused.
-        */
-        return allowsAutoMergeProcessing(task, settings)
-          && resolveEffectiveAutoMerge(task, settings) !== false;
-      };
       const mergeAdmission = await Promise.all(tasks.map(async (task) => [
         task.id,
-        await canRecoverMergeableReviewTask(task),
+        await this.canRecoverMergeRequest(task, settings),
       ] as const));
       const mergeAdmissionByTaskId = new Map(mergeAdmission);
       const mergeable = tasks.filter((t) =>
@@ -12224,7 +12218,6 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
       if (task.paused) continue;
       const limboReviewLanes = await ownLimboReviewLanes(task);
       if (!limboReviewLanes.has(task.column)) continue;
-      if (!allowsAutoMergeProcessing(task, settings)) continue;
       if (await this.isFalseCompletionHandoffExhaustionWhileMergeOwned(task)) {
         await this.store.updateTask(task.id, {
           status: null,
@@ -12237,6 +12230,7 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
         );
         continue;
       }
+      if (!(await this.canRecoverMergeRequest(task, settings))) continue;
       if (task.status != null || task.mergeDetails != null || task.review != null || task.reviewState != null) continue;
       if (this.options.isTaskActive?.(task.id)) continue;
       if (await this.isMergeLaneOwned(task.id)) continue;


### PR DESCRIPTION
## Summary
- reuse the existing merge-recovery consent decision for completion-handoff self-healing
- keep standalone tasks with effective auto-merge Off parked for manual integration
- preserve the permitted live shared-group member path and the merge-owned exhaustion cleanup

## Symptom Verification

**Original symptom:** A completed task deliberately configured with auto-merge Off reached review, then the FN-4999 sweep repeatedly recreated merge work instead of leaving the manual handoff parked.

**Exact reproduction:** An in-review task with a done marker older than the handoff grace period, no merge fan-out, and a task-level or inherited manual hold is passed to recoverCompletionHandoffLimbo while project auto-merge is enabled or disabled as appropriate.

**Assertion it is gone:** The sweep does not enqueue or re-emit merge work, mutate the task, or emit a recovery audit event for the manual hold. Existing merge-owned false-exhaustion cleanup remains active.

## Surface Enumeration
- normal mergeable-review recovery and completion-handoff-limbo recovery
- task-level user Off, standalone mission-policy Off, and inherited project Off
- live shared-group member integration remains governed by the existing project/task consent rule
- merge-queue-owned false exhaustion remains recoverable

## Verification
- completion-handoff-limbo.test.ts: 15 passed
- focused shared-member recovery tests in self-healing.test.ts: 3 passed
- @fusion/engine typecheck
- targeted ESLint (0 errors)
- changeset and FNXC date checks
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed manual-review tasks now remain parked instead of being automatically requeued for merge handoff.
  * Merge recovery consistently respects manual holds, inherited restrictions, and auto-merge settings.
  * Permitted shared-group tasks can continue merge processing when integration is allowed.
  * Prevented unnecessary queue entries, task updates, and audit events when recovery is blocked.
  * Improved handling of exhausted recovery attempts while preserving relevant auto-merge settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->