### PR TITLE
refactor(engine): thread mutation context through remaining engine source (3/5)

### DIFF
--- a/packages/engine/src/agent-heartbeat.ts
+++ b/packages/engine/src/agent-heartbeat.ts
@@ -17,7 +17,7 @@
  * - onTerminated: Called when a heartbeat run is terminated
  */
 
-import { DEFAULT_PROVIDER_INSTANCE_ID, toRunMutationContext, type AgentStore, type AgentHeartbeatRun, type HeartbeatInvocationSource, type AgentHeartbeatConfig, type AgentBudgetStatus, type Message, type MessageStore, type TaskStore, type TaskDetail, type AgentRole, type Agent, type InboxTask, type RunMutationContext, type Settings, type AgentConfigRevision, type ReflectionStore, type ChatStore, type ChatRoom, type ChatRoomMessage, type AgentMemoryInclusionMode } from "@fusion/core";
+import { DEFAULT_PROVIDER_INSTANCE_ID, type AgentStore, type AgentHeartbeatRun, type HeartbeatInvocationSource, type AgentHeartbeatConfig, type AgentBudgetStatus, type Message, type MessageStore, type TaskStore, type TaskDetail, type AgentRole, type Agent, type InboxTask, type RunMutationContext, type Settings, type AgentConfigRevision, type ReflectionStore, type ChatStore, type ChatRoom, type ChatRoomMessage, type AgentMemoryInclusionMode } from "@fusion/core";
 import { AutoClaimSnapshotManager, resolveFreshAutoClaimCandidates, type AutoClaimCandidate } from "./scheduling/auto-claim-snapshot.js";
 import {
   ApprovalRequestStore,
@@ -41,6 +41,9 @@ import {
   resolveWorkflowIrForTask,
   columnsWithFlag,
   resolveTaskLifecycleColumns,
+  /* FNXC:Identity 2026-08-09-03:04 (U18 Stage B): the gating helpers know the agent whose tool call
+     they are pausing for approval, so they derive from it rather than marking. */
+  mutationContextForAgent,
 } from "@fusion/core";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type, type Static } from "@earendil-works/pi-ai";
@@ -96,6 +99,8 @@ heartbeat-model-unavailable parks from assignment/on-demand runs were terminal u
 import { acquireTaskWorktree, WorktreeBaseRefreshError } from "./worktree/worktree-acquisition.js";
 import { createRunAuditor, generateSyntheticRunId, type DatabaseMutationType, type EngineRunContext } from "./util/run-audit.js";
 import { promptWithFallback } from "./pi.js";
+// FNXC:Identity 2026-08-09-03:04: actor threading for the required RunMutationContext.actor field.
+import { actorContextForAgent } from "@fusion/core";
 import { withRateLimitRetry } from "./errors/rate-limit-retry.js";
 import type { CredentialInstanceRotator } from "./credential-instance-rotation.js";
 import { buildAgentGatedActionSummary } from "./agents/permanent-agent-gating.js";
@@ -1116,7 +1121,7 @@ export class HeartbeatMonitor {
           await this.taskStore.pauseTask(taskId, true, undefined, { pausedByAgentId: agent.id, pausedReason: AWAITING_APPROVAL_PAUSE_REASON });
           await this.taskStore.logEntry(
             taskId,
-            `Approval required for ${decision.toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`,
+            `Approval required for ${decision.toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`, undefined, mutationContextForAgent(agent.id, runId),
           );
         }
         void emitApprovalMail({ messageStore: this.messageStore, approvalRequestId, toolName: decision.toolName, taskId, agentId: agent.id, agentName: agent.name });
@@ -1187,7 +1192,7 @@ export class HeartbeatMonitor {
           await this.taskStore.pauseTask(taskId, true, undefined, { pausedByAgentId: agent.id, pausedReason: AWAITING_APPROVAL_PAUSE_REASON });
           await this.taskStore.logEntry(
             taskId,
-            `Approval required for ${toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`,
+            `Approval required for ${toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`, undefined, mutationContextForAgent(agent.id, runId),
           );
         }
         await this.store.updateAgentState(agent.id, "paused");
@@ -2175,24 +2180,21 @@ export class HeartbeatMonitor {
       });
 
       // Build run context for mutation correlation
-      /*
-      FNXC:Identity 2026-08-24-02:20:
-      Heartbeat already knows the acting agent; derive `actor` rather than leaving the 1/5-required
-      field off the carrier (which fails typecheck against main).
-      */
-      const runContext: RunMutationContext = toRunMutationContext({
+      const runContext: RunMutationContext = {
         runId: run.id,
         agentId,
         source,
-      });
+        // FNXC:Identity 2026-08-09-03:04: a heartbeat run acts as its own agent; nothing is delegated (R28).
+        actor: actorContextForAgent(agentId),
+      };
 
       // Build engine run context for audit instrumentation
-      const engineRunContext: EngineRunContext = toRunMutationContext({
+      const engineRunContext: EngineRunContext = {
         runId: run.id,
         agentId,
         source,
         phase: "heartbeat",
-      });
+      };
 
       // Create run auditor for audit trail (FN-1404)
       // Uses TaskStore.recordRunAuditEvent when available; no-ops otherwise
@@ -2757,7 +2759,7 @@ export class HeartbeatMonitor {
             sourceAgentId: agentId,
             requireMissionLineage: true,
           }));
-          heartbeatTools.push(createTaskAssignTool(this.store, taskStore));
+          heartbeatTools.push(createTaskAssignTool(this.store, taskStore, runContext));
           heartbeatTools.push(createGetAgentConfigTool(this.store, agentId));
           heartbeatTools.push(createUpdateAgentConfigTool(this.store, agentId));
           // FNXC:AgentProvisioningGate 2026-07-26-13:15: real settings + approval store so the provisioning policy actually gates idle-heartbeat lanes.
@@ -3056,12 +3058,12 @@ export class HeartbeatMonitor {
                 await taskStore.logEntry(
                   taskDetail.id,
                   `Worktree base refresh blocked heartbeat execution (${refreshKind})`,
-                  detail,
+                  detail, runContext,
                 );
                 await taskStore.moveTask(
                   taskDetail.id,
                   await resolveHeartbeatReboundColumn(taskStore, taskDetail.id),
-                  { preserveProgress: true },
+                  { preserveProgress: true }, runContext,
                 );
               }
               await this.completeRun(agentId, run.id, {
@@ -3093,8 +3095,8 @@ export class HeartbeatMonitor {
                   status: "failed",
                   error: exhaustionMessage,
                   recoveryRetryCount: null,
-                });
-                await taskStore.logEntry(taskDetail.id, `Worktree acquisition retry cap reached (${MAX_HEARTBEAT_WORKTREE_ACQUISITION_RETRIES} attempts); task marked failed`, exhaustionMessage);
+                }, runContext);
+                await taskStore.logEntry(taskDetail.id, `Worktree acquisition retry cap reached (${MAX_HEARTBEAT_WORKTREE_ACQUISITION_RETRIES} attempts); task marked failed`, exhaustionMessage, runContext);
                 /*
                  * FNXC:WorktreeAcquisition 2026-07-09-00:00:
                  * `moveTask(..., "todo", ...)` reopen-to-todo semantics clear
@@ -3106,11 +3108,11 @@ export class HeartbeatMonitor {
                  * reassigned and retried from scratch, defeating the terminal-
                  * failure intent of this fix (FN-7721).
                  */
-                await taskStore.moveTask(taskDetail.id, await resolveHeartbeatReboundColumn(taskStore, taskDetail.id), { preserveProgress: true, preserveStatus: true });
+                await taskStore.moveTask(taskDetail.id, await resolveHeartbeatReboundColumn(taskStore, taskDetail.id), { preserveProgress: true, preserveStatus: true }, runContext);
                 this.onTaskAcquisitionExhausted?.(taskDetail.id, exhaustionMessage);
               } else {
-                await taskStore.updateTask(taskDetail.id, { recoveryRetryCount: attemptsSoFar });
-                await taskStore.moveTask(taskDetail.id, await resolveHeartbeatReboundColumn(taskStore, taskDetail.id), { preserveProgress: true });
+                await taskStore.updateTask(taskDetail.id, { recoveryRetryCount: attemptsSoFar }, runContext);
+                await taskStore.moveTask(taskDetail.id, await resolveHeartbeatReboundColumn(taskStore, taskDetail.id), { preserveProgress: true }, runContext);
               }
             }
             await this.completeRun(agentId, run.id, {
@@ -4173,7 +4175,11 @@ export class HeartbeatMonitor {
    * @param agentId - The agent ID (used for tracking and logging)
    * @param taskStore - TaskStore for task creation and logging
    * @param taskId - The assigned task ID (for fn_task_log context)
-   * @param runContext - Optional run context for mutation correlation
+   * @param runContext - the heartbeat run's mutation context.
+   *
+   * FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): REQUIRED, not optional. `executeHeartbeat`
+   * builds the run context before any tool is constructed and is the sole caller, so the optional
+   * marker only ever meant "this run's store writes may go out unattributed".
    * @param audit - Optional run auditor for audit trail (FN-1404)
    * @param messageStore - Optional MessageStore for messaging tools
    * @returns Array of ToolDefinitions for the heartbeat session
@@ -4182,7 +4188,7 @@ export class HeartbeatMonitor {
     agentId: string,
     taskStore: TaskStore,
     taskId: string,
-    runContext?: RunMutationContext,
+    runContext: RunMutationContext,
     audit?: ReturnType<typeof createRunAuditor>,
     messageStore?: MessageStore,
   ): ToolDefinition[] {
@@ -4254,7 +4260,7 @@ export class HeartbeatMonitor {
     // Agent delegation tools — discover and delegate work to other agents
     tools.push(createListAgentsTool(this.store));
     tools.push(createDelegateTaskTool(this.store, taskStore, { rootDir: this.rootDir, sourceTaskId: taskId, sourceAgentId: agentId }));
-    tools.push(createTaskAssignTool(this.store, taskStore));
+    tools.push(createTaskAssignTool(this.store, taskStore, runContext));
     tools.push(createGetAgentConfigTool(this.store, agentId));
     tools.push(createUpdateAgentConfigTool(this.store, agentId));
     // FNXC:AgentProvisioningGate 2026-07-26-13:15: real settings + approval store so the provisioning policy actually gates task-scoped heartbeat lanes.

--- a/packages/engine/src/auth/fallback-model-observer.ts
+++ b/packages/engine/src/auth/fallback-model-observer.ts
@@ -1,9 +1,19 @@
-import type { AgentLogType } from "@fusion/core";
+import type { AgentLogType, RunMutationContext } from "@fusion/core";
 import { notifyFallbackUsed } from "../util/notifier.js";
 import type { FallbackModelUsedPayload } from "../pi.js";
 
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — a structural seam must RESTATE the required context):
+This seam re-declares `logEntry` with its own narrow signature instead of picking it off `TaskStore`,
+so it does not inherit U18's canonical/deprecated overload pair. Left at the old three-argument
+arity it would keep accepting unattributed writes forever — the engine call-site sweep would report
+done while this hole stayed open, which is exactly the `resolved-seams-nobody-wired.md` failure the
+census exists to catch. The signature below mirrors the CANONICAL store arity (`outcome` explicit,
+`runContext` required and last), which is also what keeps a real `TaskStore` structurally assignable
+here: the deprecated overload cannot absorb a `RunMutationContext` in the `outcome` position.
+*/
 type FallbackLogStore = {
-  logEntry?(taskId: string, action: string): Promise<unknown>;
+  logEntry?(taskId: string, action: string, outcome: string | undefined, runContext: RunMutationContext): Promise<unknown>;
   appendAgentLog?(
     taskId: string,
     text: string,
@@ -21,6 +31,15 @@ type FallbackModelObserverOptions = {
   store?: FallbackLogStore;
   taskId?: string;
   taskTitle?: string;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+  Required, not optional-with-a-default. `agent` above is a LANE LABEL ("merger", "triage"), not an
+  agent id, so deriving an actor from it would mint a fake identity that reads as real in audit. The
+  lane that constructs the observer is the only place that knows its own run, so the requirement is
+  restated here and each construction site must answer it — with `toRunMutationContext` when it holds
+  a run context, or the marker when it genuinely has none.
+  */
+  runContext: RunMutationContext;
 };
 
 function buildFallbackLogMessage(
@@ -50,7 +69,7 @@ export function createFallbackModelObserver(options: FallbackModelObserverOption
     const message = buildFallbackLogMessage(options.label, payload);
 
     if (taskId && options.store?.logEntry) {
-      await options.store.logEntry(taskId, message).catch(() => undefined);
+      await options.store.logEntry(taskId, message, undefined, options.runContext).catch(() => undefined);
     }
     if (taskId && options.store?.appendAgentLog) {
       await options.store.appendAgentLog(taskId, message, "status", undefined, options.agent).catch(() => undefined);

--- a/packages/engine/src/auto-recovery-handlers/branch-worktree.ts
+++ b/packages/engine/src/auto-recovery-handlers/branch-worktree.ts
@@ -2,7 +2,7 @@ import { exec } from "node:child_process";
 import { existsSync } from "node:fs";
 import { promisify } from "node:util";
 import type { Task, TaskStore } from "@fusion/core";
-import { isFusionDeletableBranch, resolveWorkflowIrForTask, columnsWithFlag, resolveContainedBackwardTarget, TransitionRejectionError } from "@fusion/core";
+import { isFusionDeletableBranch, resolveWorkflowIrForTask, columnsWithFlag, resolveContainedBackwardTarget, TransitionRejectionError, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import {
   classifyBootstrapMisbinding,
   inspectBranchConflict,
@@ -210,8 +210,7 @@ export class BranchWorktreeAutoRecoveryHandler {
     if (!reboundTarget) {
       await this.deps.taskStore.logEntry(
         task.id,
-        `Lifecycle rebound contained in '${task.column}' — branch/worktree recovery has no adjacent backward destination`,
-      ).catch(() => undefined);
+        `Lifecycle rebound contained in '${task.column}' — branch/worktree recovery has no adjacent backward destination`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       await this.deps.runAudit.database({
         type: "branch-worktree:auto-requeue-skipped",
         target: task.id,
@@ -236,7 +235,7 @@ export class BranchWorktreeAutoRecoveryHandler {
         preserveResumeState: true,
         preserveProgress: true,
         preserveWorktree: false,
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
     } catch (err) {
       const code = err instanceof TransitionRejectionError ? err.rejection.code : undefined;
       moveFailure = {
@@ -266,7 +265,7 @@ export class BranchWorktreeAutoRecoveryHandler {
     }
 
     if (wipColumns.has(task.column)) {
-      await this.deps.taskStore.updateTask(task.id, { branch: null, branchWriteOrigin: "engine" as const, baseCommitSha: null });
+      await this.deps.taskStore.updateTask(task.id, { branch: null, branchWriteOrigin: "engine" as const, baseCommitSha: null }, UNATTRIBUTED_MUTATION_CONTEXT);
     }
     await this.deps.runAudit.database({
       type: "branch-worktree:auto-requeue",

--- a/packages/engine/src/auto-recovery-handlers/contamination.ts
+++ b/packages/engine/src/auto-recovery-handlers/contamination.ts
@@ -6,6 +6,7 @@ import { createLogger, type Logger } from "../logger.js";
 import { recoverForeignOnlyContamination } from "../recovery/foreign-only-contamination.js";
 import { resolveIntegrationBranch } from "../merge/integration-branch.js";
 import type { RunAuditor } from "../util/run-audit.js";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 
 const baseLog = createLogger("auto-recovery:contamination");
 
@@ -104,7 +105,7 @@ export class ContaminationAutoRecoveryHandler implements Pick<AutoRecoveryHandle
         paused: false,
         pausedReason: null,
         error: null,
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
     }
 
     await this.deps.runAudit.database({

--- a/packages/engine/src/errors/retry-burned-logger.ts
+++ b/packages/engine/src/errors/retry-burned-logger.ts
@@ -5,6 +5,8 @@ import {
   type TaskDetail,
   type TaskStore,
 } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent } from "@fusion/core";
 import { createLogger } from "../logger.js";
 
 const retryBurnedLog = createLogger("retry-burned");
@@ -67,7 +69,9 @@ export async function recordRetry(options: {
 
   if (!skipIncrement) {
     const current = (task[column] as number | undefined) ?? 0;
-    await store.updateTask(task.id, { [column]: current + 1 });
+    /* FNXC:Identity 2026-08-09-03:04 (U18 Stage B): the burn is recorded against the agent/role that burned
+       it — both are already parameters of this call, so nothing here needs the marker. */
+    await store.updateTask(task.id, { [column]: current + 1 }, mutationContextForAgent(agentId ?? role));
   }
 
   const refreshed = await store.getTask(task.id);

--- a/packages/engine/src/errors/usage-limit-detector.ts
+++ b/packages/engine/src/errors/usage-limit-detector.ts
@@ -11,6 +11,8 @@
  */
 
 import type { Task, TaskStore } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import type { CredentialInstanceRotator } from "../credential-instance-rotation.js";
 // FNXC:WorkflowLifecycleColumns 2026-07-30-11:00: `agentType` is an AGENT ROLE, not a column.
 // The planner lane is named `triage` and keeps that name; only the COLUMN was removed by U11.
@@ -125,7 +127,7 @@ export class UsageLimitPauser {
     Provider recovery is a health-state transition, never a task call used as a probe. The daemon's independent authenticated usage/capacity monitor invokes this seam only after positive health, and this exact-reason filter ensures recovery cannot clear manual parks, unrelated failure reasons, or another provider's outage.
     */
     await Promise.all(recoverableTasks.map(async (task) => {
-      await this.store.logEntry(task.id, `Provider ${providerId} is available again; resuming task`);
+      await this.store.logEntry(task.id, `Provider ${providerId} is available again; resuming task`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await this.store.pauseTask(task.id, false);
     }));
 
@@ -229,7 +231,7 @@ export class UsageLimitPauser {
     // Log the triggering error on the task
     await this.store.logEntry(
       taskId,
-      `Usage limit detected (${agentType}${providerId ? `/${providerId}` : ""}): ${errorMessage}`,
+      `Usage limit detected (${agentType}${providerId ? `/${providerId}` : ""}): ${errorMessage}`, undefined, mutationContextForAgent(agentType),
     );
 
     const [settings, tasks] = await Promise.all([
@@ -346,7 +348,7 @@ export class UsageLimitPauser {
       if (task.id !== taskId) {
         await this.store.logEntry(
           task.id,
-          `Paused because provider ${providerId} reached a usage limit on ${taskId}`,
+          `Paused because provider ${providerId} reached a usage limit on ${taskId}`, undefined, mutationContextForAgent(agentType),
         );
       }
       await this.store.pauseTask(task.id, true, undefined, { pausedReason });

--- a/packages/engine/src/eval/eval-followups.ts
+++ b/packages/engine/src/eval/eval-followups.ts
@@ -7,6 +7,8 @@ import {
   type FollowUpDraft,
   type TaskStore,
 } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent } from "@fusion/core";
 import { resolveTerminalColumnsFor } from "../executor.js";
 import type { resolveWorkflowIrForTask } from "@fusion/core";
 
@@ -296,7 +298,7 @@ export async function materializeEvalFollowUps(input: MaterializeEvalFollowUpsIn
           dedupeKey: followUp.dedupeKey,
         },
       },
-    })).id;
+    }, undefined, mutationContextForAgent("eval", runId))).id;
 
     created.push({
       ...followUp,

--- a/packages/engine/src/execution/reviewer.ts
+++ b/packages/engine/src/execution/reviewer.ts
@@ -43,7 +43,7 @@ import {
 } from "../agents/agent-instructions.js";
 import { buildPromptLayers, collapsePromptLayers } from "./prompt-layers.js";
 import { createFallbackModelObserver } from "../auth/fallback-model-observer.js";
-import { createRunAuditor, generateSyntheticRunId } from "../util/run-audit.js";
+import { createRunAuditor, generateSyntheticRunId, toRunMutationContext, type EngineRunContext } from "../util/run-audit.js";
 import { createMemoryGetTool, createMemorySearchTool, createTaskPromptWriteTool, createWebFetchTool } from "../agent-tools.js";
 import { buildUserCommentsPromptSection } from "../agents/agent-user-comments.js";
 import { resolveMcpServersForStore } from "../mcp/mcp-resolution.js";
@@ -213,6 +213,18 @@ export async function reviewStep(
   baseline?: string,
   options: ReviewOptions = {},
 ): Promise<ReviewResult> {
+  /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2, hoisted again in Stage B): one reviewer run context for
+     the WHOLE function, not just the session block. The pause-gate, skip, and failure paths write to
+     the task log before a reviewer session is ever created, and those writes have the same actor as
+     the session's own — the reviewer lane, or the explicitly routed `options.agentId`. Declaring it
+     at function scope is what lets every one of them say so instead of writing unattributed. */
+  const reviewerRunContext: EngineRunContext = {
+    runId: generateSyntheticRunId("reviewer", options.taskId ?? "review"),
+    agentId: options.agentId ?? "reviewer",
+    taskId: options.taskId,
+    phase: "review",
+    source: "reviewer",
+  };
   // Pause gate: do not spawn a reviewer subprocess while the engine is paused.
   // Re-read settings from the store so a stale `options.settings` snapshot can't
   // leak a reviewer past a pause that flipped on after the parent agent started.
@@ -240,7 +252,7 @@ export async function reviewStep(
       try {
         await options.store.logEntry(
           options.taskId,
-          `${reviewType} review skipped — ${reason} active`,
+          `${reviewType} review skipped — ${reason} active`, undefined, toRunMutationContext(reviewerRunContext),
         );
       } catch {
         // best-effort
@@ -496,7 +508,7 @@ export async function reviewStep(
     if (options.store && options.taskId) {
       await options.store.logEntry(
         options.taskId,
-        `${reviewType} review aborted before spawn — ${reason} active`,
+        `${reviewType} review aborted before spawn — ${reason} active`, undefined, toRunMutationContext(reviewerRunContext),
       ).catch(() => undefined);
     }
     return {
@@ -528,18 +540,10 @@ export async function reviewStep(
         options.onText?.(delta);
       }
     };
-    const runAuditor = options.store
-      ? createRunAuditor(options.store, {
-        runId: generateSyntheticRunId("reviewer", options.taskId ?? "review"),
-        agentId: options.agentId ?? "reviewer",
-        taskId: options.taskId,
-        phase: "review",
-        source: "reviewer",
-      })
-      : undefined;
+    const runAuditor = options.store ? createRunAuditor(options.store, reviewerRunContext) : undefined;
     const reviewCustomTools = [
       createWebFetchTool(),
-      ...(canWritePromptInline && options.store && options.taskId ? [createTaskPromptWriteTool(options.store, options.taskId)] : []),
+      ...(canWritePromptInline && options.store && options.taskId ? [createTaskPromptWriteTool(options.store, options.taskId, toRunMutationContext(reviewerRunContext))] : []),
       ...(memoryTools ?? []),
     ];
 
@@ -582,6 +586,7 @@ export async function reviewStep(
         store: options.store,
         taskId: options.taskId,
         taskTitle: options.taskTitle,
+        runContext: toRunMutationContext(reviewerRunContext),
       }),
       beforeSpawnSession: async () => {
         if (!options.store) return;
@@ -619,7 +624,7 @@ export async function reviewStep(
     reviewerLog.log(`${taskId}: reviewer using model ${reviewerModelDetails}`);
     if (options.store && options.taskId && reviewerModelMarker !== lastEmittedModelMarker) {
       lastEmittedModelMarker = reviewerModelMarker;
-      await options.store.logEntry(options.taskId, reviewerModelMarker);
+      await options.store.logEntry(options.taskId, reviewerModelMarker, undefined, toRunMutationContext(reviewerRunContext));
       await options.store.appendAgentLog(options.taskId, reviewerModelMarker, "status", undefined, "reviewer").catch(() => undefined);
     }
 
@@ -675,7 +680,7 @@ export async function reviewStep(
           : `${reviewType} review hit context limit — retrying with compacted request`;
         reviewerLog.warn(`${taskId}: ${retryLogMessage}`);
         if (options.store && options.taskId && retrySettings && typeof options.store.getTask === "function") {
-          await options.store.logEntry(options.taskId, retryLogMessage).catch(() => undefined);
+          await options.store.logEntry(options.taskId, retryLogMessage, undefined, toRunMutationContext(reviewerRunContext)).catch(() => undefined);
           const taskForRetry = await options.store.getTask(options.taskId);
           await recordRetry({
             store: options.store,
@@ -750,7 +755,7 @@ export async function reviewStep(
         const message = `${reviewType} review hit a transient network error — retry ${attempt}/${REVIEWER_TRANSIENT_MAX_RETRIES} in ${Math.round(delayMs / 1000)}s: ${error.message}`;
         reviewerLog.warn(`${taskId}: ${message}`);
         if (options.store && options.taskId) {
-          void options.store.logEntry(options.taskId, message).catch(() => undefined);
+          void options.store.logEntry(options.taskId, message, undefined, toRunMutationContext(reviewerRunContext)).catch(() => undefined);
         }
       },
     });
@@ -761,7 +766,7 @@ export async function reviewStep(
     const message = `${reviewType} review retry with fallback model after ${reason} (${mode})`;
     reviewerLog.warn(`${taskId}: ${message}`);
     if (options.store && options.taskId) {
-      await options.store.logEntry(options.taskId, message).catch(() => undefined);
+      await options.store.logEntry(options.taskId, message, undefined, toRunMutationContext(reviewerRunContext)).catch(() => undefined);
     }
   };
 
@@ -774,7 +779,7 @@ export async function reviewStep(
     if (!options.store || !options.taskId || typeof options.store.updateTask !== "function") {
       return;
     }
-    await options.store.updateTask(options.taskId, { reviewerFallbackRetryCount: 0 }).catch(() => undefined);
+    await options.store.updateTask(options.taskId, { reviewerFallbackRetryCount: 0 }, toRunMutationContext(reviewerRunContext)).catch(() => undefined);
   };
 
   let firstAttempt: { verdict: ReviewVerdict; summary: string; review: string };
@@ -794,7 +799,7 @@ export async function reviewStep(
       const escalationMessage = `${reviewType} review could not reach the model (${classification}) — escalating to the engine retry path: ${providerErrorMessage}`;
       reviewerLog.warn(`${taskId}: ${escalationMessage}`);
       if (options.store && options.taskId) {
-        await options.store.logEntry(options.taskId, escalationMessage).catch(() => undefined);
+        await options.store.logEntry(options.taskId, escalationMessage, undefined, toRunMutationContext(reviewerRunContext)).catch(() => undefined);
       }
       throw new ReviewerProviderError(providerErrorMessage, classification, {
         cause: err,

--- a/packages/engine/src/execution/session-token-usage.ts
+++ b/packages/engine/src/execution/session-token-usage.ts
@@ -1,4 +1,6 @@
 import type { AgentRole, RunMutationContext, TaskStore, TaskTokenUsage, TaskTokenUsagePerModel } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "../logger.js";
 import { enforceTaskTokenBudgetForPersist } from "../concurrency/token-budget-enforcer.js";
@@ -182,7 +184,16 @@ export async function accumulateSessionTokenUsage(
       hitRatio: computeCacheHitRatio(tokenUsage.inputTokens, tokenUsage.cachedTokens),
     }));
 
-    await store.updateTask(taskId, { tokenUsage }, options?.runContext);
+    /*
+    FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B):
+    Prefer the caller's run context; fall back to the agent/role the accounting is ALREADY keyed on
+    (both are recorded on the usage row a few lines above), and only mark when the caller gave neither.
+    */
+    const usageRunContext = options?.runContext
+      ?? (options?.agentId ? mutationContextForAgent(options.agentId) : undefined)
+      ?? (options?.role ? mutationContextForAgent(options.role) : undefined)
+      ?? UNATTRIBUTED_MUTATION_CONTEXT;
+    await store.updateTask(taskId, { tokenUsage }, usageRunContext);
     await enforceTaskTokenBudgetForPersist(store, taskId, options?.runContext);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/engine/src/execution/step-runner.ts
+++ b/packages/engine/src/execution/step-runner.ts
@@ -29,7 +29,7 @@ import { exec } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { promisify } from "node:util";
 
-import type { TaskStore } from "@fusion/core";
+import type { RunMutationContext, TaskStore } from "@fusion/core";
 import type { ImplementationExit } from "@fusion/core";
 
 const execAsync = promisify(exec);
@@ -241,6 +241,14 @@ export interface ResetStepDeps {
   summary?: string;
   /** Optional auditor for the blast-radius guard refusal warning (KTD-2). */
   audit?: Pick<RunAuditor, "database">;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage C):
+  Required, not optional. The RETHINK rewind is reached only from `executor.ts`, so Stage B could
+  only mark its two log rows; with the executor's run carrier threaded, the caller always has a real
+  context and the seam demands it. A rewind is a destructive write (git reset + step reset) — it is
+  exactly the kind of row an audit reader needs an actor on.
+  */
+  runContext: RunMutationContext;
   /**
    * Blast-radius guard hook (KTD-2, shared isolation). Returns `null` when the
    * reset is safe, or a refusal `reason` string when it would destroy other
@@ -362,13 +370,13 @@ export async function resetStepToBaseline(
     await store.logEntry(
       taskId,
       `RETHINK: Step ${step} plan rewound — session checkpoint ${checkpointId || "N/A"}`,
-      deps.summary,
+      deps.summary, deps.runContext,
     );
   } else {
     await store.logEntry(
       taskId,
       `RETHINK: Step ${step} rewound — git reset to ${baselineSha || "N/A"}, session checkpoint ${checkpointId || "N/A"}`,
-      deps.summary,
+      deps.summary, deps.runContext,
     );
   }
 

--- a/packages/engine/src/execution/step-session-executor.ts
+++ b/packages/engine/src/execution/step-session-executor.ts
@@ -19,7 +19,7 @@ import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import type { AgentHeartbeatRun, AgentStore, MessageStore, PermanentAgentGatingContext, ProviderInstanceRef, ResolvedMcpServerDefinition, TaskDetail, Settings, SteeringComment, TaskStore, TaskStep } from "@fusion/core";
-import { isFastExecutionMode, isValidProviderInstanceId, resolvePersistAgentThinkingLog, resolveExecutorFallbackModel, resolveTrailingVerificationStepIndex, resolveAuthoredStepHeadingOffset } from "@fusion/core";
+import { isFastExecutionMode, isValidProviderInstanceId, mutationContextForAgent, resolvePersistAgentThinkingLog, resolveExecutorFallbackModel, resolveTrailingVerificationStepIndex, resolveAuthoredStepHeadingOffset } from "@fusion/core";
 
 export { resolveAuthoredStepHeadingOffset };
 
@@ -1537,7 +1537,9 @@ export class StepSessionExecutor {
           // Task log and create tools — task context for step sessions.
           const taskLogTool = this.options.store
             ? [
-                createTaskLogTool(this.options.store, taskDetail.id),
+                /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage C): same derivation this file already
+                   uses for `createTaskAssignTool` below — the agent RUNNING the step session. */
+                createTaskLogTool(this.options.store, taskDetail.id, mutationContextForAgent(this.options.effectiveAgentId ?? taskDetail.assignedAgentId ?? "executor")),
                 createTaskLogsReadTool(this.options.store, taskDetail.id),
               ]
             : [];
@@ -1562,7 +1564,7 @@ export class StepSessionExecutor {
             ? [
                 createListAgentsTool(this.options.agentStore),
                 // FN-125: delegation creates board tasks and is unavailable in this lane.
-                createTaskAssignTool(this.options.agentStore, this.options.store!),
+                createTaskAssignTool(this.options.agentStore, this.options.store!, mutationContextForAgent(this.options.effectiveAgentId ?? taskDetail.assignedAgentId ?? "executor")),
               ]
             : [];
 
@@ -1685,12 +1687,18 @@ Follow instructions precisely and avoid unrelated changes.`,
               permanentAgentGating: this.options.permanentAgentGating,
               taskId: taskDetail.id,
               taskTitle: taskDetail.title,
+              /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2): derived — the step session resolves a
+                 REAL acting agent (column/effective agent, else the task's assignee), which is the
+                 agent doing the write, not the agent being written about. */
               onFallbackModelUsed: createFallbackModelObserver({
                 agent: "executor",
                 label: "workflow step agent",
                 store: this.store,
                 taskId: taskDetail.id,
                 taskTitle: taskDetail.title,
+                runContext: mutationContextForAgent(
+                  this.options.effectiveAgentId ?? taskDetail.assignedAgentId ?? "executor",
+                ),
               }),
               taskEnv: this.options.taskEnv,
             });

--- a/packages/engine/src/execution/task-revert.ts
+++ b/packages/engine/src/execution/task-revert.ts
@@ -50,7 +50,7 @@
 import { exec } from "node:child_process";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { isWorkspaceTask, type Settings, type Task, type TaskCommitAssociation, type TaskCreateInput, type TaskStore } from "@fusion/core";
+import { isWorkspaceTask, type RunMutationContext, type Settings, type Task, type TaskCommitAssociation, type TaskCreateInput, type TaskStore } from "@fusion/core";
 import { collectOwnTaskCommitsForRange } from "./branch-attribution.js";
 import { type IntegrationBranchSettings } from "../merge/integration-branch.js";
 import { recordWorkspaceBaseBranchDecision, resolveWorkspaceRepoBaseBranch } from "../worktree/workspace-base-branch.js";
@@ -1713,7 +1713,21 @@ export function buildAiUndoTaskDescription(params: {
  * that misrepresents the relationship in dependency UIs.
  */
 export interface CreateAiUndoTaskDeps {
-  createTask(input: TaskCreateInput): Promise<Task>;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+  Hand-declared at one argument, so it inherits neither of U18's `TaskStore.createTask` overloads.
+  Creating a board task is the most attributable mutation there is — an operator pressed Undo — and
+  at the old arity that authorship was structurally impossible to record no matter what the sweep
+  did. The shape below mirrors the CANONICAL store arity, which is also what keeps a real
+  `TaskStore.createTask` assignable here.
+  */
+  createTask(input: TaskCreateInput, options: undefined, runContext: RunMutationContext): Promise<Task>;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+  Required. The only caller is the dashboard's task-revert route, where the actor is the human who
+  pressed Undo; U9 supplies it there and the marker holds the place until then.
+  */
+  runContext: RunMutationContext;
   /** Idempotency lookup — see `REVERT_OF_METADATA_KEY`. Implemented by `TaskStore.findOpenRevertTaskForSource` (core). */
   findOpenRevertTaskForSource(sourceTaskId: string): Promise<Task | null>;
   sourceTask: Pick<Task, "id" | "title" | "description" | "prompt" | "mergeDetails" | "priority">;
@@ -1761,7 +1775,7 @@ export async function createAiUndoTask(deps: CreateAiUndoTaskDeps): Promise<AiUn
       sourceMetadata: { [REVERT_OF_METADATA_KEY]: sourceTask.id },
     },
     ...(workflowId !== undefined ? { workflowId } : {}),
-  });
+  }, undefined, deps.runContext);
 
   return { mode: "ai", createdTaskId: created.id };
 }

--- a/packages/engine/src/execution/verification-utils.ts
+++ b/packages/engine/src/execution/verification-utils.ts
@@ -3,6 +3,8 @@
  * Used by both the merger and executor verification gates.
  */
 import type { TaskStore, AgentRole } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent } from "@fusion/core";
 import { resolveSandboxBackend } from "../sandbox/index.js";
 import type { SandboxBackend, SandboxRunStreamingOptions, SandboxStreamingResult } from "../sandbox/types.js";
 import { withVerificationSlot } from "../concurrency/verification-concurrency.js";
@@ -424,6 +426,13 @@ async function runVerificationCommandUnlocked(
   const logger = log ?? { log: console.log, error: console.error, warn: console.warn };
   const label = (agentLabel ?? "merger") as AgentRole;
   /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B):
+  Derived, not marked: this function already resolves the acting lane for its agent-log rows
+  (`agentLabel ?? "merger"`), so the verification task-log rows are attributed to the same lane rather
+  than being the one line in the pair that says nobody ran the command.
+  */
+  const runContext = mutationContextForAgent(label);
+  /*
   FNXC:EngineDiagnostics 2026-07-26-09:33:
   Start + success lines for test/build verification fire on every green run and drown real events in the TUI. Prefer logger.debug when the caller supplies it (createLogger instances); never fall back to log for success chatter. Failures stay on error.
   */
@@ -439,7 +448,7 @@ async function runVerificationCommandUnlocked(
   }
 
   debugLog(`${taskId}: running ${type} command: ${command}`);
-  await store.logEntry(taskId, `[verification] Running ${type} command: ${command}`);
+  await store.logEntry(taskId, `[verification] Running ${type} command: ${command}`, undefined, runContext);
   await store.appendAgentLog(taskId, `Running ${type} command`, "tool", command, label);
 
   const result: VerificationCommandResult = {
@@ -492,7 +501,7 @@ async function runVerificationCommandUnlocked(
       debugLog(`${taskId}: ${type} command succeeded (exit 0, output exceeded buffer) in ${verificationDurationMs}ms`);
       await store.logEntry(
         taskId,
-        `[timing] [verification] ${type} command succeeded (exit 0, output exceeded buffer) in ${verificationDurationMs}ms`,
+        `[timing] [verification] ${type} command succeeded (exit 0, output exceeded buffer) in ${verificationDurationMs}ms`, undefined, runContext,
       );
       await store.appendAgentLog(
         taskId,
@@ -503,7 +512,7 @@ async function runVerificationCommandUnlocked(
       );
     } else {
       debugLog(`${taskId}: ${type} command succeeded in ${verificationDurationMs}ms`);
-      await store.logEntry(taskId, `[timing] [verification] ${type} command succeeded (exit 0) in ${verificationDurationMs}ms`);
+      await store.logEntry(taskId, `[timing] [verification] ${type} command succeeded (exit 0) in ${verificationDurationMs}ms`, undefined, runContext);
       await store.appendAgentLog(
         taskId,
         `${type} command succeeded (exit 0)`,
@@ -553,7 +562,7 @@ async function runVerificationCommandUnlocked(
       debugLog(`${taskId}: ${type} command succeeded (exit 0, output exceeded buffer) in ${verificationDurationMs}ms`);
       await store.logEntry(
         taskId,
-        `[timing] [verification] ${type} command succeeded (exit 0, output exceeded buffer) in ${verificationDurationMs}ms`,
+        `[timing] [verification] ${type} command succeeded (exit 0, output exceeded buffer) in ${verificationDurationMs}ms`, undefined, runContext,
       );
       await store.appendAgentLog(
         taskId,
@@ -570,7 +579,7 @@ async function runVerificationCommandUnlocked(
     logger.error(`${taskId}: ${type} command failed (exit ${result.exitCode}) in ${verificationDurationMs}ms; output captured in task log`);
     await store.logEntry(
       taskId,
-      `[timing] [verification] ${type} command failed (exit ${result.exitCode}) after ${verificationDurationMs}ms:\n${summary}`,
+      `[timing] [verification] ${type} command failed (exit ${result.exitCode}) after ${verificationDurationMs}ms:\n${summary}`, undefined, runContext,
     );
     await store.appendAgentLog(
       taskId,

--- a/packages/engine/src/goals/goal-injection-diagnostics.ts
+++ b/packages/engine/src/goals/goal-injection-diagnostics.ts
@@ -1,9 +1,12 @@
 import type { Goal } from "@fusion/core";
 import { buildGoalContextSection, type GoalInjectionResult } from "./goal-context-injector.js";
 import type { TaskStore } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import type { GoalAnchoringLane } from "./goal-anchoring-audit.js";
 import { emitGoalAnchoringAudit } from "./goal-anchoring-audit.js";
 import type { EngineRunContext } from "../util/run-audit.js";
+import { toRunMutationContext } from "../util/run-audit.js";
 import type { RunAuditor } from "../util/run-audit.js";
 import { createLogger } from "../logger.js";
 import { emitBoundedRunAudit } from "../util/emit-bounded-run-audit.js";
@@ -239,7 +242,12 @@ export async function emitGoalInjectionDiagnostic(
 
   if (input.store && record.taskId) {
     try {
-      await input.store.logEntry(record.taskId, formatAgentLogLine(record), undefined, input.runContext ?? undefined);
+      // FNXC:Identity 2026-08-09-03:04: the engine run context is converted at the store boundary so the log entry carries an actor.
+      await input.store.logEntry(record.taskId, formatAgentLogLine(record), undefined, input.runContext
+          ? toRunMutationContext(input.runContext)
+          /* FNXC:Identity 2026-08-09-03:04 (U18 Stage B): no run context on this call still leaves the
+             injecting agent in scope on the diagnostic record itself, so derive from it. */
+          : (input.agentId ? mutationContextForAgent(input.agentId) : UNATTRIBUTED_MUTATION_CONTEXT));
     } catch (error) {
       diagnosticsLog.warn(
         `failed to append goal-injection task log for ${record.taskId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/engine/src/healing/restart-recovery-coordinator.ts
+++ b/packages/engine/src/healing/restart-recovery-coordinator.ts
@@ -1,7 +1,7 @@
 import type { Task, TaskStore } from "@fusion/core";
 import type { TaskExecutor } from "../executor.js";
 import { createLogger } from "../logger.js";
-import { resolveProjectColumnsForRoles } from "@fusion/core";
+import { resolveProjectColumnsForRoles, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { moveTaskToContainedBackwardTarget } from "../execution/lifecycle-move.js";
 import { setImmediate as setImmediateCb } from "node:timers";
 import { NO_PROGRESS_REQUEUE_BUDGET_EXHAUSTED_PREFIX } from "./no-progress-requeue-budget.js";
@@ -241,11 +241,10 @@ export class RestartRecoveryCoordinator {
       branch: null, branchWriteOrigin: "engine" as const,
       sessionFile: null,
       error: null,
-    });
+    }, UNATTRIBUTED_MUTATION_CONTEXT);
     await this.store.logEntry(
       task.id,
-      "Restart recovery: interrupted run had no step progress and no fn_task_done — queued for contained safe retry",
-    );
+      "Restart recovery: interrupted run had no step progress and no fn_task_done — queued for contained safe retry", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     /*
     FNXC:LifecycleContainment 2026-08-28-03:03:
     Restart recovery uses the live source column and the task's own workflow to choose exactly one

--- a/packages/engine/src/healing/stale-task-reporter.ts
+++ b/packages/engine/src/healing/stale-task-reporter.ts
@@ -1,3 +1,12 @@
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+Extracted helper of the unattended self-healing / scheduler sweeps, so its store writes carry
+the same MARKER as the sweeps that call it: a timer-driven repair has no session, no request,
+and no acting agent, and the only ids in scope name the SUBJECT of the write rather than its
+author. Counted by `unattributed-actor-census.test.ts`; U13 owns whether these lanes get a real
+system actor.
+*/
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import {
   getTaskAgeStalenessSignal,
   resolveProjectColumnsForRoles,
@@ -117,7 +126,7 @@ export class StaleTaskReporter {
       }
 
       const message = `${STALE_LOG_PREFIX} [${signal.level}]: column=${signal.column} paused=${String(signal.paused)} ageMs=${signal.ageMs} warningThresholdMs=${signal.warningThresholdMs} criticalThresholdMs=${signal.criticalThresholdMs}`;
-      await this.store.logEntry(task.id, message);
+      await this.store.logEntry(task.id, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       this.logger.log(message);
       surfaced++;
     }

--- a/packages/engine/src/healing/stuck-task-detector.ts
+++ b/packages/engine/src/healing/stuck-task-detector.ts
@@ -31,6 +31,15 @@ capacity / slot in this file. Live and wired (in-process-runtime.ts).
  * default while keeping workflow-step execution timeouts independent.
  */
 
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+Extracted helper of the unattended self-healing / scheduler sweeps, so its store writes carry
+the same MARKER as the sweeps that call it: a timer-driven repair has no session, no request,
+and no acting agent, and the only ids in scope name the SUBJECT of the write rather than its
+author. Counted by `unattributed-actor-census.test.ts`; U13 owns whether these lanes get a real
+system actor.
+*/
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { createHash } from "node:crypto";
 import type { TaskStore, Settings } from "@fusion/core";
 import { createLogger } from "../logger.js";
@@ -660,7 +669,7 @@ export class StuckTaskDetector {
         `no progress for ~${noProgressMin}min, ` +
         `no activity for ~${elapsedMin}min, ` +
         `${activitySinceProgress} events since last progress, ` +
-        `${ignoredStepUpdateCount} ignored step-update rebuffs)`,
+        `${ignoredStepUpdateCount} ignored step-update rebuffs)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT,
       );
     } catch (err) {
       stuckLog.error(`Failed to log stuck event for ${canonicalId}:`, err);

--- a/packages/engine/src/merge/merger-ai.ts
+++ b/packages/engine/src/merge/merger-ai.ts
@@ -98,7 +98,7 @@ import { withRateLimitRetry } from "../errors/rate-limit-retry.js";
 import { checkSessionError } from "../errors/usage-limit-detector.js";
 import { accumulateSessionTokenUsage } from "../execution/session-token-usage.js";
 import { moveTaskToContainedBackwardTarget } from "../execution/lifecycle-move.js";
-import { createRunAuditor, generateSyntheticRunId, type RunAuditor } from "../util/run-audit.js";
+import { createRunAuditor, generateSyntheticRunId, toRunMutationContext, type EngineRunContext, type RunAuditor } from "../util/run-audit.js";
 import { emitBoundedRunAudit, type RunAuditSinkHost } from "../util/emit-bounded-run-audit.js";
 import { deriveExecutorSignalMemory, evaluateNoOpFinalizeExecutorVeto } from "../overseer/overseer-noop-finalize-veto.js";
 import { createLogger } from "../logger.js";
@@ -1635,12 +1635,18 @@ export async function runAiMerge(
   });
   const mergeTarget = groupRouting?.mergeTarget ?? resolveTaskMergeTarget(task, { projectDefaultBranch });
   const integrationBranch = mergeTarget.branch;
-  const audit = createRunAuditor(store, {
+  /*
+  FNXC:Identity 2026-09-04-04:46:
+  Hoist the merge lane's run context out of the inline createRunAuditor argument so the run-audit
+  stream and every store mutation on this path carry the SAME run id and the SAME actor.
+  */
+  const mergeRunContext: EngineRunContext = {
     runId: generateSyntheticRunId("ai-merge", taskId),
     agentId: "merger",
     taskId,
     phase: "merge",
-  });
+  };
+  const audit = createRunAuditor(store, mergeRunContext);
 
   const fence = createMergeWriteFence({
     taskId,
@@ -1653,7 +1659,7 @@ export async function runAiMerge(
   });
   // Surface progress on the task detail (status pill) + the task log stream.
   const log = async (message: string): Promise<void> => {
-    await fence.write("log", () => store.logEntry(taskId, message, "AiMerge").catch(() => undefined));
+    await fence.write("log", () => store.logEntry(taskId, message, "AiMerge", toRunMutationContext(mergeRunContext)).catch(() => undefined));
     await fence.write("log", () => store.appendAgentLog(taskId, message, "status", undefined, "merger").catch(() => undefined));
   };
   /*
@@ -2455,12 +2461,18 @@ export async function landWorkspaceTask(
   assertMergeGenerationOwned(options.signal, taskId);
   const settings = await store.getSettings();
   const publishToRemote = isPushAfterMergeEnabled(settings, { lane: "workspace" });
-  const audit = createRunAuditor(store, {
+  /*
+  FNXC:Identity 2026-09-04-04:46:
+  Hoist the merge lane's run context out of the inline createRunAuditor argument so the run-audit
+  stream and every store mutation on this path carry the SAME run id and the SAME actor.
+  */
+  const mergeRunContext: EngineRunContext = {
     runId: generateSyntheticRunId("ai-merge", taskId),
     agentId: "merger",
     taskId,
     phase: "merge",
-  });
+  };
+  const audit = createRunAuditor(store, mergeRunContext);
   const fence = createMergeWriteFence({
     taskId,
     signal: options.signal,
@@ -2471,7 +2483,7 @@ export async function landWorkspaceTask(
     }, { log: aiMergeLog }),
   });
   const log = async (message: string): Promise<void> => {
-    await fence.write("log", () => store.logEntry(taskId, message, "AiMerge").catch(() => undefined));
+    await fence.write("log", () => store.logEntry(taskId, message, "AiMerge", toRunMutationContext(mergeRunContext)).catch(() => undefined));
     await fence.write("log", () => store.appendAgentLog(taskId, message, "status", undefined, "merger").catch(() => undefined));
   };
   /*
@@ -3182,7 +3194,7 @@ export async function landWorkspaceTask(
     callback: its already-pushed commits remain recoverable through landedSha/intent evidence, but
     this stale generation must not write the task outcome. Renewal only improves liveness.
     */
-    const finalize = () => finalizeWorkspaceTask(store, taskId, task, repos, workspaceRootDir, fence);
+    const finalize = () => finalizeWorkspaceTask(store, taskId, task, repos, workspaceRootDir, fence, toRunMutationContext(mergeRunContext));
     const withValidDispatchLease = (store as Partial<TaskStore>).withValidWorkspaceLease;
     if (options.workspaceDispatchFence && typeof withValidDispatchLease === "function") {
       try {
@@ -3307,6 +3319,7 @@ async function finalizeWorkspaceTask(
   repos: WorkspaceRepoLandResult[],
   workspaceRootDir: string,
   fence?: MergeWriteFence,
+  runContext?: import("@fusion/core").RunMutationContext,
 ): Promise<boolean> {
   const landed = repos.filter((r) => r.status === "landed" && r.landedSha);
   const workspaceLandedShas: Record<string, string> = {};
@@ -3351,9 +3364,9 @@ async function finalizeWorkspaceTask(
       fence,
       log: async (message) => {
         if (fence) {
-          await fence.write("log", () => store.logEntry(taskId, message, "AiMerge").catch(() => undefined));
+          await fence.write("log", () => store.logEntry(taskId, message, "AiMerge", runContext).catch(() => undefined));
         } else {
-          await store.logEntry(taskId, message, "AiMerge").catch(() => undefined);
+          await store.logEntry(taskId, message, "AiMerge", runContext).catch(() => undefined);
         }
       },
     });
@@ -3361,9 +3374,9 @@ async function finalizeWorkspaceTask(
   } catch (error) {
     const message = `Workspace post-landing worktree cleanup failed non-fatally: ${error instanceof Error ? error.message : String(error)}`;
     if (fence) {
-      await fence.write("log", () => store.logEntry(taskId, message, "AiMerge").catch(() => undefined));
+      await fence.write("log", () => store.logEntry(taskId, message, "AiMerge", runContext).catch(() => undefined));
     } else {
-      await store.logEntry(taskId, message, "AiMerge").catch(() => undefined);
+      await store.logEntry(taskId, message, "AiMerge", runContext).catch(() => undefined);
     }
   }
 

--- a/packages/engine/src/merge/pr-comment-handler.ts
+++ b/packages/engine/src/merge/pr-comment-handler.ts
@@ -1,4 +1,6 @@
 import type { TaskStore } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent } from "@fusion/core";
 import type { PrInfo } from "@fusion/core";
 import { prMonitorLog } from "../logger.js";
 import { resolveTerminalColumnsFor } from "../executor.js";
@@ -253,10 +255,10 @@ export class PrCommentHandler {
         },
         "queued",
       );
-      await this.store.moveTask(taskId, wipTarget);
+      await this.store.moveTask(taskId, wipTarget, undefined, mutationContextForAgent("pr-comment-handler"));
       await this.store.logEntry(
         taskId,
-        `PR #${prInfo.number}: changes requested by @${reviewerLogin} — moved back to in-progress`,
+        `PR #${prInfo.number}: changes requested by @${reviewerLogin} — moved back to in-progress`, undefined, mutationContextForAgent("pr-comment-handler"),
       );
       prMonitorLog.log(`Task ${taskId} moved to in-progress after changes requested on PR #${prInfo.number}`);
     } catch (err) {
@@ -320,7 +322,7 @@ Please review the PR comments and address any remaining issues.`;
           sourceParentTaskId: originalTaskId,
           sourceMetadata: { prNumber: prInfo.number, prUrl: prInfo.url },
         },
-      });
+      }, undefined, mutationContextForAgent("pr-comment-handler"));
       prMonitorLog.log(`Created follow-up task ${task.id} for PR #${prInfo.number}`);
     } catch (err) {
       prMonitorLog.error(`Failed to create follow-up task:`, err);
@@ -400,6 +402,6 @@ Please review the PR comments and address any remaining issues.`;
         summary: currentReviewState.summary,
         items: nextReviewStateItems,
       },
-    });
+    }, mutationContextForAgent("pr-comment-handler"));
   }
 }

--- a/packages/engine/src/merger.ts
+++ b/packages/engine/src/merger.ts
@@ -130,9 +130,9 @@ import {
   resolveTaskLifecycleColumns,
   isFusionDeletableBranch,
   classifyTaskBranchOrigin,
-  type WorkflowIr,
-  toRunMutationContext,
+  type WorkflowIr
 } from "@fusion/core";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { evaluateAutoMergeFactProviders } from "./merge/auto-merge-fact-providers.js";
 import { resolveMergePolicy } from "./merge/merge-trait.js";
 import { describeModel, promptWithFallback } from "./pi.js";
@@ -705,7 +705,7 @@ async function syncDependenciesForMerge(
     signal,
     context: "before merge verification",
     logger: mergerLog,
-    log: async (message) => { await store.logEntry(taskId, message); },
+    log: async (message) => { await store.logEntry(taskId, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT); },
   });
 }
 
@@ -842,7 +842,7 @@ export async function runDeterministicVerification(
     */
     result.notRun = true;
     const message = "Deterministic merge verification not executed because no test or build command is configured — NOTHING WAS VERIFIED.";
-    await store.logEntry(taskId, message);
+    await store.logEntry(taskId, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.appendAgentLog(taskId, message, "status", undefined, "merger");
     return result;
   }
@@ -870,7 +870,7 @@ export async function runDeterministicVerification(
       const sha7 = treeSha.slice(0, 7);
       const msg = `Skipping deterministic verification — cached pass for tree ${sha7} (recorded at ${cacheHit.recordedAt}, by ${cacheHit.taskId ?? "unknown"})`;
       mergerLog.debug(`${taskId}: ${msg}`);
-      await store.logEntry(taskId, msg);
+      await store.logEntry(taskId, msg, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(taskId, msg, "status", undefined, "merger");
       const syntheticResult: VerificationCommandResult = {
         command: "",
@@ -901,7 +901,7 @@ export async function runDeterministicVerification(
     "Running deterministic merge verification" +
     (hasTestCommand ? ` (test${testSourceDisplayLabel}: ${normalizedTestCommand})` : "") +
     (hasBuildCommand ? ` (build${buildSource === "inferred" ? " [inferred]" : ""}: ${normalizedBuildCommand})` : "");
-  await store.logEntry(taskId, deterministicVerificationMessage);
+  await store.logEntry(taskId, deterministicVerificationMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   await store.appendAgentLog(taskId, deterministicVerificationMessage, "status", undefined, "merger");
 
   const bootstrapScriptPath = join(rootDir, "scripts/ensure-test-artifacts.mjs");
@@ -909,11 +909,11 @@ export async function runDeterministicVerification(
     if (!existsSync(bootstrapScriptPath)) {
       const bootstrapMissingMessage = `${taskId}: [verification:bootstrap] script missing at scripts/ensure-test-artifacts.mjs — skipping preamble`;
       mergerLog.warn(bootstrapMissingMessage);
-      await store.logEntry(taskId, bootstrapMissingMessage);
+      await store.logEntry(taskId, bootstrapMissingMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(taskId, bootstrapMissingMessage, "status", undefined, "merger");
     } else {
       const bootstrapCommand = "node scripts/ensure-test-artifacts.mjs";
-      await store.logEntry(taskId, `[verification:bootstrap] running: ${bootstrapCommand}`);
+      await store.logEntry(taskId, `[verification:bootstrap] running: ${bootstrapCommand}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(taskId, "[verification:bootstrap] running bootstrap preamble", "tool", bootstrapCommand, "merger");
       try {
         throwIfAborted(signal, taskId);
@@ -924,7 +924,7 @@ export async function runDeterministicVerification(
           signal,
         });
         throwIfAborted(signal, taskId);
-        await store.logEntry(taskId, "[verification:bootstrap] bootstrap preamble succeeded");
+        await store.logEntry(taskId, "[verification:bootstrap] bootstrap preamble succeeded", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         await store.appendAgentLog(taskId, "[verification:bootstrap] bootstrap preamble succeeded", "tool_result", undefined, "merger");
       } catch (error) {
         throwIfAborted(signal, taskId);
@@ -941,8 +941,7 @@ export async function runDeterministicVerification(
         await store.logEntry(
           taskId,
           `[verification:bootstrap] bootstrap preamble failed (exit ${bootstrapExitCode ?? "unknown"}): ${truncateWithEllipsis(bootstrapOutput, VERIFICATION_LOG_MAX_CHARS)}`,
-          "VerificationError",
-        );
+          "VerificationError", UNATTRIBUTED_MUTATION_CONTEXT);
         await store.appendAgentLog(
           taskId,
           "[verification:bootstrap] bootstrap preamble failed",
@@ -980,7 +979,7 @@ export async function runDeterministicVerification(
     missingEntryRetryAttempted = true;
     const packageName = missingWorkspaceEntry.packageName;
     const rebuildCommand = `pnpm --filter ${packageName} build`;
-    await store.logEntry(taskId, `[verification:retry] bootstrap-built: detected missing workspace entry for ${packageName}; running ${rebuildCommand}`);
+    await store.logEntry(taskId, `[verification:retry] bootstrap-built: detected missing workspace entry for ${packageName}; running ${rebuildCommand}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.appendAgentLog(taskId, "[verification:retry] bootstrap-built", "tool", rebuildCommand, "merger");
 
     try {
@@ -994,7 +993,7 @@ export async function runDeterministicVerification(
       throwIfAborted(signal, taskId);
     } catch (_error) {
       throwIfAborted(signal, taskId);
-      await store.logEntry(taskId, `[verification:retry] retry-different-failure: workspace rebuild failed for ${packageName}`);
+      await store.logEntry(taskId, `[verification:retry] retry-different-failure: workspace rebuild failed for ${packageName}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(taskId, "[verification:retry] retry-different-failure", "tool_error", packageName, "merger");
       return firstAttempt;
     }
@@ -1008,7 +1007,7 @@ export async function runDeterministicVerification(
         packageName,
         recovered: true,
       };
-      await store.logEntry(taskId, `[verification:retry] retry-success: rebuilt ${packageName} and ${failedCommandLabel} now passes`);
+      await store.logEntry(taskId, `[verification:retry] retry-success: rebuilt ${packageName} and ${failedCommandLabel} now passes`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(taskId, "[verification:retry] retry-success", "tool_result", packageName, "merger");
       return retryAttempt;
     }
@@ -1020,12 +1019,12 @@ export async function runDeterministicVerification(
         packageName,
         recovered: false,
       };
-      await store.logEntry(taskId, `[verification:retry] retry-still-missing: ${packageName} still missing after rebuild`);
+      await store.logEntry(taskId, `[verification:retry] retry-still-missing: ${packageName} still missing after rebuild`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(taskId, "[verification:retry] retry-still-missing", "tool_error", packageName, "merger");
       return retryAttempt;
     }
 
-    await store.logEntry(taskId, `[verification:retry] retry-different-failure: rebuild fixed entry point but ${failedCommandLabel} still failed`);
+    await store.logEntry(taskId, `[verification:retry] retry-different-failure: rebuild fixed entry point but ${failedCommandLabel} still failed`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.appendAgentLog(taskId, "[verification:retry] retry-different-failure", "tool_error", packageName, "merger");
     return retryAttempt;
   };
@@ -1043,8 +1042,7 @@ export async function runDeterministicVerification(
       await store.logEntry(
         taskId,
         `Deterministic test verification failed (exit ${testResult.exitCode}) — see prior [verification] entry for truncated output`,
-        "VerificationError",
-      );
+        "VerificationError", UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(
         taskId,
         "Verification failed",
@@ -1072,8 +1070,7 @@ export async function runDeterministicVerification(
       await store.logEntry(
         taskId,
         `Deterministic build verification failed (exit ${buildResult.exitCode}) — see prior [verification] entry for truncated output`,
-        "VerificationError",
-      );
+        "VerificationError", UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(
         taskId,
         "Verification failed",
@@ -1090,7 +1087,7 @@ export async function runDeterministicVerification(
 
   // FNXC:EngineDiagnostics 2026-07-26-09:33: merge verification success/cache bookkeeping is expected steady-state; failures stay error/warn.
   mergerLog.debug(`${taskId}: deterministic verification passed`);
-  await store.logEntry(taskId, "Deterministic merge verification passed");
+  await store.logEntry(taskId, "Deterministic merge verification passed", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   await store.appendAgentLog(taskId, "Deterministic merge verification passed", "status", undefined, "merger");
 
   // ── Record cache pass ──────────────────────────────────────────────────
@@ -1098,7 +1095,7 @@ export async function runDeterministicVerification(
     try {
       await store.recordVerificationCachePass(treeSha, effectiveTestCommand, effectiveBuildCommand, taskId);
       mergerLog.debug(`${taskId}: Recorded verification pass for tree ${treeSha.slice(0, 7)}`);
-      await store.logEntry(taskId, `Recorded verification pass for tree ${treeSha.slice(0, 7)}`);
+      await store.logEntry(taskId, `Recorded verification pass for tree ${treeSha.slice(0, 7)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     } catch (err) {
       mergerLog.warn(`${taskId}: could not record verification cache pass: ${String(err)}`);
     }
@@ -1301,8 +1298,7 @@ Do not refactor, rename broadly, or make opportunistic improvements.
     const agentId = mergeRunContext?.agentId ?? "merger";
     await store.logEntry(
       taskId,
-      `In-merge verification fix agent started (model: ${describeModel(session)}, runId: ${runId ?? "unknown"}, agentId: ${agentId})`,
-    );
+      `In-merge verification fix agent started (model: ${describeModel(session)}, runId: ${runId ?? "unknown"}, agentId: ${agentId})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.appendAgentLog(
       taskId,
       `Fix agent started (model: ${describeModel(session)})`,
@@ -1368,8 +1364,7 @@ ${failureContext.output.slice(0, VERIFICATION_LOG_MAX_CHARS)}
         mergerLog.warn(`${taskId}: in-merge fix agent made no changes — skipping verification re-run`);
         await store.logEntry(
           taskId,
-          `In-merge fix agent made no changes — skipping verification re-run (attempt ${fixAttemptNumber ?? "unknown"})`,
-        );
+          `In-merge fix agent made no changes — skipping verification re-run (attempt ${fixAttemptNumber ?? "unknown"})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         await store.appendAgentLog(
           taskId,
           `Fix agent made no changes — skipping verification re-run`,
@@ -1406,7 +1401,7 @@ ${failureContext.output.slice(0, VERIFICATION_LOG_MAX_CHARS)}
                   `Merge verification failed in files outside branch scope — likely pre-existing flake on ${baseBranch}. ` +
                   `Failing files: [${failingFiles.join(", ")}]. Branch diff files: [${branchFiles.slice(0, 10).join(", ")}${branchFiles.length > 10 ? ", ..." : ""}].`;
                 mergerLog.warn(`${taskId}: ${msg}`);
-                await store.logEntry(taskId, msg);
+                await store.logEntry(taskId, msg, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 await store.appendAgentLog(taskId, "Out-of-scope verification failure detected — not retrying", "status", undefined, "merger");
                 throw new OutOfScopeVerificationError(msg, failingFiles, branchFiles);
               }
@@ -1420,8 +1415,7 @@ ${failureContext.output.slice(0, VERIFICATION_LOG_MAX_CHARS)}
       // Re-run deterministic verification command after the fix attempt.
       await store.logEntry(
         taskId,
-        `Re-running deterministic merge verification (attempt ${fixAttemptNumber ?? "unknown"})`,
-      );
+        `Re-running deterministic merge verification (attempt ${fixAttemptNumber ?? "unknown"})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.appendAgentLog(
         taskId,
         `Re-running verification (attempt ${fixAttemptNumber ?? "unknown"})`,
@@ -1474,7 +1468,7 @@ ${failureContext.output.slice(0, VERIFICATION_LOG_MAX_CHARS)}
     }
     const errorMessage = err instanceof Error ? err.message : String(err);
     mergerLog.warn(`${taskId}: in-merge fix agent error: ${errorMessage}`);
-    await store.logEntry(taskId, "In-merge verification fix agent encountered an error", errorMessage);
+    await store.logEntry(taskId, "In-merge verification fix agent encountered an error", errorMessage, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.appendAgentLog(taskId, "Fix agent encountered an error", "tool_error", errorMessage, "merger");
     return false;
   }
@@ -2057,8 +2051,7 @@ async function sweepAutostashOrphans(
       .logEntry(
         taskId,
         `Cleaned up ${subsumed.length} subsumed autostash orphan(s) — their content already on HEAD`,
-        subsumed.map((o) => `${o.ref}@${o.sha.slice(0, 7)} (${o.label})`).join("\n"),
-      )
+        subsumed.map((o) => `${o.ref}@${o.sha.slice(0, 7)} (${o.label})`).join("\n"), UNATTRIBUTED_MUTATION_CONTEXT)
       .catch(() => undefined);
   }
 
@@ -2076,8 +2069,7 @@ async function sweepAutostashOrphans(
             (o) =>
               `${o.ref}@${o.sha.slice(0, 7)} (${o.label})\n  recover: git stash apply ${o.sha}`,
           )
-          .join("\n\n"),
-      )
+          .join("\n\n"), UNATTRIBUTED_MUTATION_CONTEXT)
       .catch(() => undefined);
   }
 
@@ -2408,8 +2400,7 @@ export async function dropAutostashHandle(
     await options.store.logEntry(
       taskId,
       `${options.context}: autostash cleanup dropped ${dropped}, preserved ${keptLive} live, failed ${failed}`,
-      entries.map((entry) => `${entry.kind} ${entry.sha.slice(0, 7)} (${entry.label})`).join("\n"),
-    ).catch(() => undefined);
+      entries.map((entry) => `${entry.kind} ${entry.sha.slice(0, 7)} (${entry.label})`).join("\n"), UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
   }
 
   return { dropped, keptLive, failed };
@@ -2610,7 +2601,7 @@ ${fileList}
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     mergerLog.warn(`${taskId}: autostash-conflict agent error: ${msg}`);
-    await store.logEntry(taskId, "Autostash conflict agent encountered an error", msg);
+    await store.logEntry(taskId, "Autostash conflict agent encountered an error", msg, UNATTRIBUTED_MUTATION_CONTEXT);
     return { success: false, error: msg };
   } finally {
     try {
@@ -2733,8 +2724,7 @@ async function tryRecoverHardFailApply(params: {
     await ctx.store.logEntry(
       taskId,
       `Autostash apply hit hard failure but recovered via git apply --3way (stash ${sha.slice(0, 7)})`,
-      `Original error: ${applyErrorMsg}\n${applyStderr ? `\nGit stderr:\n${applyStderr}\n` : ""}${dropResult.dropped ? "" : `\nStash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`,
-    ).catch(() => undefined);
+      `Original error: ${applyErrorMsg}\n${applyStderr ? `\nGit stderr:\n${applyStderr}\n` : ""}${dropResult.dropped ? "" : `\nStash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     return { status: "restored", stashSha: sha };
   }
 
@@ -2758,8 +2748,7 @@ async function tryRecoverHardFailApply(params: {
       await ctx.store.logEntry(
         taskId,
         `Autostash 3-way left conflict markers — manual resolution required (smart resolution disabled)`,
-        message,
-      ).catch(() => undefined);
+        message, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       return { status: "conflict-needs-manual", stashSha: sha, conflictedFiles: aiConflictedFiles, message };
     }
 
@@ -2768,16 +2757,14 @@ async function tryRecoverHardFailApply(params: {
       await ctx.store.logEntry(
         taskId,
         "Autostash hard-fail recovered via 3-way scope partition (no in-scope conflicts remained)",
-        `${dropResult.dropped ? "" : `Stash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`,
-      ).catch(() => undefined);
+        `${dropResult.dropped ? "" : `Stash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       return { status: "ai-resolved", stashSha: sha, conflictedFiles: [] };
     }
 
     await ctx.store.logEntry(
       taskId,
       `Autostash 3-way left conflicts in ${aiConflictedFiles.length} file(s) — invoking AI to resolve`,
-      aiConflictedFiles.join("\n"),
-    ).catch(() => undefined);
+      aiConflictedFiles.join("\n"), UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
 
     const aiResult = await runAiAgentForAutostashConflict({
       store: ctx.store,
@@ -2797,13 +2784,12 @@ async function tryRecoverHardFailApply(params: {
       await ctx.store.logEntry(
         taskId,
         `Autostash hard-fail recovered via 3-way + AI conflict resolution (${aiConflictedFiles.length} file(s))`,
-        `Resolved files:\n${aiConflictedFiles.join("\n")}${dropResult.dropped ? "" : `\n\nStash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`,
-      ).catch(() => undefined);
+        `Resolved files:\n${aiConflictedFiles.join("\n")}${dropResult.dropped ? "" : `\n\nStash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       return { status: "ai-resolved", stashSha: sha, conflictedFiles: aiConflictedFiles };
     }
 
     const failureMsg = `3-way+AI resolution incomplete; markers remain in ${stillConflicted.join(", ") || "(unknown)"}. Stash ${sha.slice(0, 7)} left intact.`;
-    await ctx.store.logEntry(taskId, `Autostash 3-way+AI resolution failed`, failureMsg).catch(() => undefined);
+    await ctx.store.logEntry(taskId, `Autostash 3-way+AI resolution failed`, failureMsg, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     return { status: "conflict-needs-manual", stashSha: sha, conflictedFiles: stillConflicted, message: failureMsg };
   }
 
@@ -2814,16 +2800,14 @@ async function tryRecoverHardFailApply(params: {
     await ctx.store.logEntry(
       taskId,
       `Autostash apply failed — stash ${sha.slice(0, 7)} left intact for manual recovery`,
-      `${applyErrorMsg}${applyStderr ? `\n\nGit stderr:\n${applyStderr}` : ""}\n\nRecover with:\n  cd ${rootDir} && git stash apply ${sha}`,
-    ).catch(() => undefined);
+      `${applyErrorMsg}${applyStderr ? `\n\nGit stderr:\n${applyStderr}` : ""}\n\nRecover with:\n  cd ${rootDir} && git stash apply ${sha}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     return { status: "failed", stashSha: sha, errorMessage: applyErrorMsg };
   }
 
   await ctx.store.logEntry(
     taskId,
     `Autostash apply hard-failed — invoking AI patch-recovery agent (${stashFiles.length} file(s))`,
-    `${applyErrorMsg}${applyStderr ? `\n\nGit stderr:\n${applyStderr}` : ""}\n\nFiles in stash:\n${stashFiles.join("\n")}`,
-  ).catch(() => undefined);
+    `${applyErrorMsg}${applyStderr ? `\n\nGit stderr:\n${applyStderr}` : ""}\n\nFiles in stash:\n${stashFiles.join("\n")}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
 
   const patchAiResult = await runAiAgentForAutostashHardFail({
     store: ctx.store,
@@ -2839,7 +2823,7 @@ async function tryRecoverHardFailApply(params: {
 
   if (!patchAiResult.success) {
     const failMsg = `AI patch-recovery failed (${patchAiResult.error ?? "unknown"}). Stash ${sha.slice(0, 7)} left intact.`;
-    await ctx.store.logEntry(taskId, `Autostash AI patch-recovery failed`, failMsg).catch(() => undefined);
+    await ctx.store.logEntry(taskId, `Autostash AI patch-recovery failed`, failMsg, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     return { status: "failed", stashSha: sha, errorMessage: failMsg };
   }
 
@@ -2847,7 +2831,7 @@ async function tryRecoverHardFailApply(params: {
   const remainingMarkers = await findFilesWithConflictMarkers(rootDir, stashFiles);
   if (remainingMarkers.length > 0) {
     const failMsg = `AI patch-recovery left conflict markers in: ${remainingMarkers.join(", ")}. Stash ${sha.slice(0, 7)} left intact.`;
-    await ctx.store.logEntry(taskId, `AI patch-recovery incomplete — manual recovery required`, failMsg).catch(() => undefined);
+    await ctx.store.logEntry(taskId, `AI patch-recovery incomplete — manual recovery required`, failMsg, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     return { status: "conflict-needs-manual", stashSha: sha, conflictedFiles: remainingMarkers, message: failMsg };
   }
 
@@ -2855,8 +2839,7 @@ async function tryRecoverHardFailApply(params: {
   await ctx.store.logEntry(
     taskId,
     `Autostash hard-fail recovered by AI patch-recovery agent (${stashFiles.length} file(s))`,
-    `Recovered files:\n${stashFiles.join("\n")}${dropResult.dropped ? "" : `\n\nStash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`,
-  ).catch(() => undefined);
+    `Recovered files:\n${stashFiles.join("\n")}${dropResult.dropped ? "" : `\n\nStash drop failed (${dropResult.reason ?? "unknown"}); clean up manually.`}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
   return { status: "ai-resolved", stashSha: sha, conflictedFiles: stashFiles };
 }
 
@@ -3058,7 +3041,7 @@ ${fileList}
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     mergerLog.warn(`${taskId}: autostash hard-fail agent error: ${msg}`);
-    await store.logEntry(taskId, "Autostash hard-fail recovery agent encountered an error", msg);
+    await store.logEntry(taskId, "Autostash hard-fail recovery agent encountered an error", msg, UNATTRIBUTED_MUTATION_CONTEXT);
     return { success: false, error: msg };
   } finally {
     try {
@@ -3128,8 +3111,7 @@ async function restoreRescueAutostashes(
   await ctx.store.logEntry(
     taskId,
     `Race-rescue autostash restore attempted: ${rescueShas.length - unresolvedCount} restored, ${unresolvedCount} preserved`,
-    rescueShas.map((r) => `${r.sha.slice(0, 7)} (${r.label})`).join("\n"),
-  ).catch(() => undefined);
+    rescueShas.map((r) => `${r.sha.slice(0, 7)} (${r.label})`).join("\n"), UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
 
   return { unresolvedCount };
 }
@@ -3196,8 +3178,7 @@ export async function restoreUnrelatedRootDirChanges(
       await ctx.store
         .logEntry(
           taskId,
-          `Restored pre-merge autostash ${sha.slice(0, 7)} cleanly`,
-        )
+          `Restored pre-merge autostash ${sha.slice(0, 7)} cleanly`, undefined, UNATTRIBUTED_MUTATION_CONTEXT)
         .catch(() => undefined);
     } else {
       // Apply succeeded but drop failed — the working tree has the dev's
@@ -3207,8 +3188,7 @@ export async function restoreUnrelatedRootDirChanges(
         .logEntry(
           taskId,
           `Restored pre-merge autostash ${sha.slice(0, 7)} (apply clean), but stash entry failed to drop and is still in the list`,
-          `Drop failure: ${dropResult.reason ?? "unknown"}\n\nClean up manually with:\n  cd ${rootDir} && git stash list | grep ${sha.slice(0, 7)} && git stash drop <ref>`,
-        )
+          `Drop failure: ${dropResult.reason ?? "unknown"}\n\nClean up manually with:\n  cd ${rootDir} && git stash list | grep ${sha.slice(0, 7)} && git stash drop <ref>`, UNATTRIBUTED_MUTATION_CONTEXT)
         .catch(() => undefined);
     }
     return { status: "restored", stashSha: sha };
@@ -3238,8 +3218,7 @@ export async function restoreUnrelatedRootDirChanges(
       .logEntry(
         taskId,
         `Autostash apply conflicted in ${aiConflictedFiles.length} file(s) — manual resolution required (smart resolution disabled)`,
-        message,
-      )
+        message, UNATTRIBUTED_MUTATION_CONTEXT)
       .catch(() => undefined);
     return {
       status: "conflict-needs-manual",
@@ -3252,7 +3231,7 @@ export async function restoreUnrelatedRootDirChanges(
   if (aiConflictedFiles.length === 0) {
     const aiDropResult = await dropAutostashBySha(rootDir, taskId, sha);
     if (aiDropResult.dropped) {
-      await ctx.store.logEntry(taskId, "Autostash conflict resolved by Layer 3 scope partition (no in-scope conflicts remained)");
+      await ctx.store.logEntry(taskId, "Autostash conflict resolved by Layer 3 scope partition (no in-scope conflicts remained)", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     }
     return {
       status: "ai-resolved",
@@ -3264,8 +3243,7 @@ export async function restoreUnrelatedRootDirChanges(
   await ctx.store.logEntry(
     taskId,
     `Autostash apply conflicted in ${aiConflictedFiles.length} file(s) — invoking AI to resolve`,
-    aiConflictedFiles.join("\n"),
-  );
+    aiConflictedFiles.join("\n"), UNATTRIBUTED_MUTATION_CONTEXT);
 
   const aiResult = await runAiAgentForAutostashConflict({
     store: ctx.store,
@@ -3280,7 +3258,7 @@ export async function restoreUnrelatedRootDirChanges(
     const message = `Autostash apply conflict, AI resolution failed (${aiResult.error ?? "unknown error"}). Stash ${sha.slice(0, 7)} left intact; recover with: cd ${rootDir} && git status (conflicts in working tree) && # resolve, then git stash drop <ref>`;
     mergerLog.warn(`${taskId}: ${message}`);
     await ctx.store
-      .logEntry(taskId, `Autostash AI conflict resolution failed — manual recovery required`, message)
+      .logEntry(taskId, `Autostash AI conflict resolution failed — manual recovery required`, message, UNATTRIBUTED_MUTATION_CONTEXT)
       .catch(() => undefined);
     return {
       status: "conflict-needs-manual",
@@ -3296,7 +3274,7 @@ export async function restoreUnrelatedRootDirChanges(
     const message = `AI agent reported success but conflict markers remain in: ${stillConflicted.join(", ")}. Stash ${sha.slice(0, 7)} left intact; recover manually.`;
     mergerLog.warn(`${taskId}: ${message}`);
     await ctx.store
-      .logEntry(taskId, `Autostash AI conflict resolution incomplete — manual recovery required`, message)
+      .logEntry(taskId, `Autostash AI conflict resolution incomplete — manual recovery required`, message, UNATTRIBUTED_MUTATION_CONTEXT)
       .catch(() => undefined);
     return {
       status: "conflict-needs-manual",
@@ -3316,14 +3294,12 @@ export async function restoreUnrelatedRootDirChanges(
     await ctx.store.logEntry(
       taskId,
       `Autostash conflict resolved by AI in ${aiConflictedFiles.length} file(s)`,
-      aiConflictedFiles.join("\n"),
-    );
+      aiConflictedFiles.join("\n"), UNATTRIBUTED_MUTATION_CONTEXT);
   } else {
     await ctx.store.logEntry(
       taskId,
       `Autostash conflict resolved by AI in ${aiConflictedFiles.length} file(s), but stash entry failed to drop`,
-      `Resolved files:\n${aiConflictedFiles.join("\n")}\n\nDrop failure: ${aiDropResult.reason ?? "unknown"}\n\nClean up manually with:\n  cd ${rootDir} && git stash list | grep ${sha.slice(0, 7)} && git stash drop <ref>`,
-    );
+      `Resolved files:\n${aiConflictedFiles.join("\n")}\n\nDrop failure: ${aiDropResult.reason ?? "unknown"}\n\nClean up manually with:\n  cd ${rootDir} && git stash list | grep ${sha.slice(0, 7)} && git stash drop <ref>`, UNATTRIBUTED_MUTATION_CONTEXT);
   }
 
   return {
@@ -3653,8 +3629,7 @@ async function persistFinalizeResetLeftovers(rootDir: string, taskId: string, st
       await store.logEntry(
         taskId,
         `Persisted ${dirtyPaths.length} dirty rootDir path(s) before finalize reset/amend cleanup`,
-        `stash: ${sha}\nlabel: ${label}\nphase: finalize-reset\npaths:\n${dirtyPaths.join("\n")}`,
-      ).catch(() => undefined);
+        `stash: ${sha}\nlabel: ${label}\nphase: finalize-reset\npaths:\n${dirtyPaths.join("\n")}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       await notifyAutostashOrphans(store, rootDir, { detectedByTaskId: taskId }).catch(() => undefined);
     }
   } catch (err: unknown) {
@@ -4339,7 +4314,7 @@ export async function applyLayer3ConflictScopePartition(params: {
   if (outOfScope.length > 0) {
     const summary = `Layer 3 arbiter: skipped ${outOfScope.length} foreign file(s) — took main's version for: ${outOfScope.join(", ")}`;
     await store.appendAgentLog(taskId, summary, "status", undefined, "merger");
-    await store.logEntry(taskId, summary, "Layer3AIArbiterScopeSkip");
+    await store.logEntry(taskId, summary, "Layer3AIArbiterScopeSkip", UNATTRIBUTED_MUTATION_CONTEXT);
     if (auditor) {
       await auditor.git({
         type: "merge:layer3:foreign-file-skipped",
@@ -4835,9 +4810,9 @@ async function applyBranchCommitsPreservingHistory(params: {
 
   const fullySubsumedByMain = landedCommitShas.length === 0 && skippedEmptyCount === commitShas.length && commitShas.length > 0;
   if (fullySubsumedByMain) {
-    await store.logEntry(taskId, `Auto-merge skipped: branch fully subsumed by main (${skippedEmptyCount} commit(s) already present)`);
+    await store.logEntry(taskId, `Auto-merge skipped: branch fully subsumed by main (${skippedEmptyCount} commit(s) already present)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   } else if (skippedEmptyCount > 0 && landedCommitShas.length > 0) {
-    await store.logEntry(taskId, `Auto-merge skipped ${skippedEmptyCount} empty cherry-pick(s); proceeded with ${landedCommitShas.length} non-empty commit(s)`);
+    await store.logEntry(taskId, `Auto-merge skipped ${skippedEmptyCount} empty cherry-pick(s); proceeded with ${landedCommitShas.length} non-empty commit(s)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   }
 
   try {
@@ -5622,7 +5597,7 @@ export async function handleDirtyPostMergeAuditOutcome(opts: {
       formatSquashAuditAgentLog(opts.findings),
       "merger",
     );
-    await opts.store.updateTask(opts.taskId, { status: null });
+    await opts.store.updateTask(opts.taskId, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
     throw auditError;
   }
 
@@ -6520,7 +6495,7 @@ async function tryEarlyEmptyOwnDiffFinalize(input: {
      * FNXC:Lifecycle 2026-06-14-20:06:
      * FN-6461/FN-6455 requires the early empty-own-diff fast-path to block before mergeDetails writes or branch/worktree cleanup so incomplete release/ops work remains recoverable.
      */
-    await store.updateTask(taskId, { error: reason });
+    await store.updateTask(taskId, { error: reason }, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.logEntry(
       taskId,
       `Finalize blocked (no-commits incomplete-work guard): ${reason} — moving back to todo with progress preserved`,
@@ -6530,8 +6505,7 @@ async function tryEarlyEmptyOwnDiffFinalize(input: {
         branch,
         mergeTargetBranch,
         lane: "early-empty-own-diff",
-      }, null, 2),
-    );
+      }, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
     await audit.database({
       type: "task:no-commits-finalize-blocked-incomplete-steps" as Parameters<typeof audit.database>[0]["type"],
       target: taskId,
@@ -6571,11 +6545,10 @@ async function tryEarlyEmptyOwnDiffFinalize(input: {
     mergeTargetBranch,
     mergeTargetSource,
   };
-  await store.updateTask(taskId, { mergeDetails, modifiedFiles: [] });
+  await store.updateTask(taskId, { mergeDetails, modifiedFiles: [] }, UNATTRIBUTED_MUTATION_CONTEXT);
   await store.logEntry(
     taskId,
-    `Auto-finalized no-op (early fast-path, FN-5345/FN-5377): ${noOpReason}`,
-  );
+    `Auto-finalized no-op (early fast-path, FN-5345/FN-5377): ${noOpReason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   try {
     await audit.database({
       type: "task:auto-recover-finalize-already-on-main",
@@ -6687,7 +6660,7 @@ async function tryEarlyEmptyOwnDiffFinalize(input: {
       await store.updateTask(taskId, {
         ...(worktreeRemoved ? { worktree: null } : {}),
         ...(branchDeleted ? { branch: null, branchWriteOrigin: "engine" as const } : {}),
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
       // Keep the in-memory task in sync with the DB so the returned
       // MergeResult.task does not advertise a removed path / deleted branch.
       // (updateTask uses null as the "clear this field" sentinel; the
@@ -7005,13 +6978,13 @@ export async function aiMergeTask(
   let branch = resolveTaskWorkingBranch(task);
 
   const mergeRunId = generateSyntheticRunId("merge", taskId);
-  const engineRunContext: EngineRunContext = toRunMutationContext({
+  const engineRunContext: EngineRunContext = {
     runId: mergeRunId,
     agentId: "merger",
     taskId,
     taskLineageId: task.lineageId,
     phase: "merge",
-  });
+  };
   const audit = createRunAuditor(store, engineRunContext);
   const emitReuseHandoffAuditEvent = async (
     type:
@@ -7222,7 +7195,7 @@ export async function aiMergeTask(
            * FNXC:BranchWriteOrigin 2026-08-28-10:12: merge-reuse can re-pin an operator-override branch, so the stamp derives from the
            * classifier (#3523 Greptile P1) — hardcoding "engine" here made cleanup eligible to delete operator-supplied branches.
            */
-          await store.updateTask(taskId, { worktree: reusableMatch.path, branch: reusableMatch.branch, branchWriteOrigin: classifyTaskBranchOrigin(task, reusableMatch.branch) === "operator-supplied" ? "operator" : "engine" });
+          await store.updateTask(taskId, { worktree: reusableMatch.path, branch: reusableMatch.branch, branchWriteOrigin: classifyTaskBranchOrigin(task, reusableMatch.branch) === "operator-supplied" ? "operator" : "engine" }, UNATTRIBUTED_MUTATION_CONTEXT);
           await emitReuseHandoffAuditEvent(
             "merge:reuse-fallback-reused-existing-registration",
             {
@@ -7616,8 +7589,8 @@ export async function aiMergeTask(
         prNumber: task.prInfo?.number,
         mergeTargetBranch: aheadInfo.baseRef,
       };
-      await store.updateTask(taskId, { mergeDetails });
-      await store.logEntry(taskId, `Auto-finalized: recovered owned landed commit ${classification.commit.sha.slice(0, 8)}`);
+      await store.updateTask(taskId, { mergeDetails }, UNATTRIBUTED_MUTATION_CONTEXT);
+      await store.logEntry(taskId, `Auto-finalized: recovered owned landed commit ${classification.commit.sha.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       const result: MergeResult = {
         task,
         branch,
@@ -7651,7 +7624,7 @@ export async function aiMergeTask(
          * FNXC:Lifecycle 2026-06-14-20:08:
          * FN-6461/FN-6455 extends the FN-5490 no-op demotion pattern to no-commits tasks whose skipped/incomplete steps outweigh completed work.
          */
-        await store.updateTask(taskId, { error: reason });
+        await store.updateTask(taskId, { error: reason }, UNATTRIBUTED_MUTATION_CONTEXT);
         await store.logEntry(
           taskId,
           `Finalize blocked (no-commits incomplete-work guard): ${reason} — moving back to todo with progress preserved`,
@@ -7661,8 +7634,7 @@ export async function aiMergeTask(
             classification: classification.kind,
             baseRef: classification.baseRef,
             lane: "legacy-no-op-classifier",
-          }, null, 2),
-        );
+          }, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
         await emitBoundedRunAudit(store, {
           domain: "database",
           mutationType: "task:no-commits-finalize-blocked-incomplete-steps",
@@ -7692,15 +7664,14 @@ export async function aiMergeTask(
       }
       if (task.modifiedFiles && task.modifiedFiles.length > 0) {
         const reason = `lost-work-detected: ${task.modifiedFiles.length} modifiedFiles claimed but no commit landed`;
-        await store.updateTask(taskId, { error: reason });
+        await store.updateTask(taskId, { error: reason }, UNATTRIBUTED_MUTATION_CONTEXT);
         await store.logEntry(
           taskId,
           `Finalize blocked (lost-work guard): task claims ${task.modifiedFiles.length} modifiedFiles but classification would finalize as no-op — moving back to todo with progress preserved`,
           JSON.stringify({
             modifiedFilesSample: task.modifiedFiles.slice(0, 5),
             classification: classification.kind,
-          }, null, 2),
-        );
+          }, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
         await emitBoundedRunAudit(store, {
           domain: "database",
           mutationType: "task:finalize-lost-work-blocked",
@@ -7734,13 +7705,12 @@ export async function aiMergeTask(
         prNumber: task.prInfo?.number,
         mergeTargetBranch: classification.baseRef,
       };
-      await store.updateTask(taskId, { mergeDetails, modifiedFiles: [] });
+      await store.updateTask(taskId, { mergeDetails, modifiedFiles: [] }, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.logEntry(
         taskId,
         classification.kind === "proven-no-op"
           ? `Auto-finalized no-op (proven): start point on ${classification.baseRef}; modifiedFiles cleared`
-          : "Auto-finalized verification-only no-change task: branch absent with no owned commits; modifiedFiles cleared",
-      );
+          : "Auto-finalized verification-only no-change task: branch absent with no owned commits; modifiedFiles cleared", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       const result: MergeResult = {
         task,
         branch,
@@ -7761,12 +7731,11 @@ export async function aiMergeTask(
     }
 
     const unprovenError = `finalize-unproven: ${classification.reason}`;
-    await store.updateTask(taskId, { error: unprovenError });
+    await store.updateTask(taskId, { error: unprovenError }, UNATTRIBUTED_MUTATION_CONTEXT);
     await store.logEntry(
       taskId,
       `Finalize blocked: unproven ownership evidence (${classification.reason}); no owned landed commit was found — auto-retrying via todo requeue`,
-      JSON.stringify(classification.details, null, 2),
-    );
+      JSON.stringify(classification.details, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
     await emitBoundedRunAudit(store, {
       domain: "database",
       mutationType: "task:finalize-unproven-blocked",
@@ -7810,8 +7779,8 @@ export async function aiMergeTask(
       // Surface to the task feed so the developer sees their edits are still
       // in the working tree (not destroyed) — we just refused to proceed.
       const message = `Merge aborted: could not autostash dirty working tree in ${rootDir} (${err.message}). Your uncommitted changes are intact. Commit, stash, or revert them and retry the merge.`;
-      await store.logEntry(taskId, "Merge aborted: autostash creation failed (dirty edits preserved)", message).catch(() => undefined);
-      await store.updateTask(taskId, { error: "autostash-create-failed" }).catch(() => undefined);
+      await store.logEntry(taskId, "Merge aborted: autostash creation failed (dirty edits preserved)", message, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
+      await store.updateTask(taskId, { error: "autostash-create-failed" }, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       clearActiveMergerStatus(activeStatusPath, taskId);
       await releaseReuseHandoffEarly("autostash-create-failed");
       return {
@@ -7833,8 +7802,7 @@ export async function aiMergeTask(
       await store.logEntry(
         taskId,
         `Race-rescue stash created during pre-merge autostash: ${r.sha.slice(0, 7)} (${r.label})`,
-        `These are working-tree changes that landed AFTER the initial autostash snapshot but BEFORE the destructive reset. Recover with:\n  cd ${rootDir} && git stash apply ${r.sha}`,
-      ).catch(() => undefined);
+        `These are working-tree changes that landed AFTER the initial autostash snapshot but BEFORE the destructive reset. Recover with:\n  cd ${rootDir} && git stash apply ${r.sha}`, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     }
   }
   // Hoisted so the finally block (below) can attach the autostash outcome
@@ -7896,12 +7864,11 @@ export async function aiMergeTask(
     const classification = await classifyOwnedLandedEvidence(rootDir, task, { mergeTargetBranch: mergeTarget.branch });
     if (classification.kind === "unproven") {
       result.error = `finalize-unproven: ${classification.reason}`;
-      await store.updateTask(taskId, { error: result.error });
+      await store.updateTask(taskId, { error: result.error }, UNATTRIBUTED_MUTATION_CONTEXT);
       await store.logEntry(
         taskId,
         `Finalize blocked: unproven ownership evidence (${classification.reason}); branch missing and no owned landed commit was found — auto-retrying via todo requeue`,
-        JSON.stringify(classification.details, null, 2),
-      );
+        JSON.stringify(classification.details, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
       await emitBoundedRunAudit(store, {
         domain: "database",
         mutationType: "task:finalize-unproven-blocked",
@@ -7935,7 +7902,7 @@ export async function aiMergeTask(
           mergeTargetBranch: mergeTarget.branch,
           mergeTargetSource: mergeTarget.source,
         },
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
       result.merged = true;
       result.mergeConfirmed = true;
       result.commitSha = classification.commit.sha;
@@ -7960,7 +7927,7 @@ export async function aiMergeTask(
         result.error = reason;
         result.reason = reason;
         result.noOp = false;
-        await store.updateTask(taskId, { error: reason });
+        await store.updateTask(taskId, { error: reason }, UNATTRIBUTED_MUTATION_CONTEXT);
         await store.logEntry(
           taskId,
           `Finalize blocked (no-commits incomplete-work guard): ${reason} — moving back to todo with progress preserved`,
@@ -7970,8 +7937,7 @@ export async function aiMergeTask(
             classification: classification.kind,
             baseRef: classification.baseRef,
             lane: "legacy-branch-missing-no-op",
-          }, null, 2),
-        );
+          }, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
         await emitBoundedRunAudit(store, {
           domain: "database",
           mutationType: "task:no-commits-finalize-blocked-incomplete-steps",
@@ -8003,7 +7969,7 @@ export async function aiMergeTask(
           mergeTargetBranch: classification.baseRef,
           mergeTargetSource: mergeTarget.source,
         },
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
       result.merged = true;
       result.mergeConfirmed = true;
       result.noOp = true;
@@ -8012,7 +7978,7 @@ export async function aiMergeTask(
       result.mergedAt = mergedAt;
       result.mergeTargetBranch = classification.baseRef;
       result.mergeTargetSource = mergeTarget.source;
-      await store.logEntry(taskId, `Auto-finalized no-op (proven): start point on ${classification.baseRef}; modifiedFiles cleared`);
+      await store.logEntry(taskId, `Auto-finalized no-op (proven): start point on ${classification.baseRef}; modifiedFiles cleared`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     }
 
     // Audit trail: record merge completion (FN-1404)
@@ -8408,8 +8374,7 @@ export async function aiMergeTask(
           );
           await store.logEntry(
             taskId,
-            `Pre-merge recovery (Layer 1): dropped dependency commits from ${task.executionStartBranch} via rebase --onto ${rebaseTarget.slice(0, 8)} ${depTip.slice(0, 8)} ${branch}; the merge will proceed against the cleaned branch`,
-          );
+            `Pre-merge recovery (Layer 1): dropped dependency commits from ${task.executionStartBranch} via rebase --onto ${rebaseTarget.slice(0, 8)} ${depTip.slice(0, 8)} ${branch}; the merge will proceed against the cleaned branch`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         } catch (layer1Err) {
           rethrowIfMergeAborted(layer1Err);
           mergerLog.warn(
@@ -8516,8 +8481,7 @@ export async function aiMergeTask(
               );
               await store.logEntry(
                 taskId,
-                `Pre-merge recovery (Layer 2): patch-id matched ${dropped} branch commit(s) against the last 500 main commits and dropped them as duplicates; cherry-picked ${surviving.length} unique commit(s) onto ${rebaseTarget.slice(0, 8)}`,
-              );
+                `Pre-merge recovery (Layer 2): patch-id matched ${dropped} branch commit(s) against the last 500 main commits and dropped them as duplicates; cherry-picked ${surviving.length} unique commit(s) onto ${rebaseTarget.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             } catch (replayErr) {
               await restoreOriginalBranch();
               throw replayErr;
@@ -8552,8 +8516,7 @@ export async function aiMergeTask(
       await store.logEntry(
         taskId,
         `Pre-merge recovery (Layer 3): both surgical and patch-id recovery failed; AI arbiter takes over. SAFETY CONSTRAINT for the AI: do NOT re-introduce content that current main has deleted. If hunks are ambiguous, prefer main's version. Post-merge test/build verification will reject any resolution that breaks main's intent.`,
-        "PreMergeRebaseFallthrough",
-      );
+        "PreMergeRebaseFallthrough", UNATTRIBUTED_MUTATION_CONTEXT);
     }
   }
 
@@ -8618,7 +8581,7 @@ export async function aiMergeTask(
         `for smart-prefer-main (${mergeStrategyOverlapBehavior}): ${overlapSummary}`;
       mergerLog.warn(`${taskId}: ${overlapMessage}`);
       await store.appendAgentLog(taskId, overlapMessage, "status", undefined, "merger");
-      await store.logEntry(taskId, overlapMessage);
+      await store.logEntry(taskId, overlapMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
       if (mergeStrategyOverlapBehavior === "flip-to-prefer-branch") {
         for (const file of overlap.overlappingFiles) {
@@ -8703,12 +8666,12 @@ export async function aiMergeTask(
     const scopeResult = await validateDiffScope(store, taskId, diffStat, settings.strictScopeEnforcement);
     for (const warning of scopeResult.warnings) {
       mergerLog.warn(`${taskId}: ${warning}`);
-      await store.logEntry(taskId, warning);
+      await store.logEntry(taskId, warning, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     }
   } catch (scopeError: any) {
     if (settings.strictScopeEnforcement && scopeError.message?.includes("Scope enforcement failed")) {
       // Strict mode — block the merge
-      await store.logEntry(taskId, `Merge blocked: ${scopeError.message}`);
+      await store.logEntry(taskId, `Merge blocked: ${scopeError.message}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       throw scopeError;
     }
     // Soft mode — scope validation is best-effort
@@ -8723,7 +8686,7 @@ export async function aiMergeTask(
       `Cannot merge ${taskId}: task ${activeMerge} is already merging (cross-process conflict)`,
     );
   }
-  await store.updateTask(taskId, { status: "merging" });
+  await store.updateTask(taskId, { status: "merging" }, UNATTRIBUTED_MUTATION_CONTEXT);
 
   // Normalize explicit verification commands from settings
   const explicitTestCommand = settings.testCommand?.trim() || undefined;
@@ -8881,8 +8844,8 @@ export async function aiMergeTask(
         await store.updateTask(taskId, {
           status: "failed",
           error: outOfScopeMsg,
-        });
-        await store.logEntry(taskId, outOfScopeMsg, "OutOfScopeVerificationError");
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
+        await store.logEntry(taskId, outOfScopeMsg, "OutOfScopeVerificationError", UNATTRIBUTED_MUTATION_CONTEXT);
         // Re-throw so the outer merge runner does not attempt further retries.
         throw error;
       }
@@ -8899,7 +8862,7 @@ export async function aiMergeTask(
 
         if (maxFixRetries > 0 && (verificationErr.verificationResult.testResult || verificationErr.verificationResult.buildResult)) {
           mergerLog.log(`${taskId}: deterministic verification failed — attempting in-merge fix (up to ${maxFixRetries} attempts)`);
-          await store.logEntry(taskId, `Verification failed during merge — attempting in-merge fix (up to ${maxFixRetries} attempts)`);
+          await store.logEntry(taskId, `Verification failed during merge — attempting in-merge fix (up to ${maxFixRetries} attempts)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await store.appendAgentLog(
             taskId,
             `Verification failed — attempting in-merge fix (up to ${maxFixRetries} attempts)`,
@@ -8924,7 +8887,7 @@ export async function aiMergeTask(
             for (let fixAttempt = 1; fixAttempt <= maxFixRetries; fixAttempt++) {
               const fixAttemptStartedAt = Date.now();
               mergerLog.log(`${taskId}: in-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`);
-              await store.logEntry(taskId, `In-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`);
+              await store.logEntry(taskId, `In-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await store.appendAgentLog(
                 taskId,
                 `In-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`,
@@ -8944,7 +8907,7 @@ export async function aiMergeTask(
                 },
                 settings,
                 options,
-                toRunMutationContext({ runId: mergeRunId, agentId: engineRunContext.agentId }),
+                { runId: mergeRunId, agentId: engineRunContext.agentId },
                 fixAttempt,
                 effectiveTestCommand,
                 effectiveBuildCommand,
@@ -8958,7 +8921,7 @@ export async function aiMergeTask(
               const fixAttemptDurationMs = Date.now() - fixAttemptStartedAt;
               if (fixSuccess) {
                 mergerLog.log(`${taskId}: in-merge verification fix succeeded on attempt ${fixAttempt} in ${fixAttemptDurationMs}ms`);
-                await store.logEntry(taskId, `[timing] In-merge verification fix succeeded on attempt ${fixAttempt} in ${fixAttemptDurationMs}ms — verification now passes`);
+                await store.logEntry(taskId, `[timing] In-merge verification fix succeeded on attempt ${fixAttempt} in ${fixAttemptDurationMs}ms — verification now passes`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 await store.appendAgentLog(
                   taskId,
                   `In-merge verification fix succeeded on attempt ${fixAttempt}`,
@@ -8970,7 +8933,7 @@ export async function aiMergeTask(
               }
 
               mergerLog.warn(`${taskId}: in-merge verification fix attempt ${fixAttempt} — verification still fails (${fixAttemptDurationMs}ms)`);
-              await store.logEntry(taskId, `[timing] In-merge verification fix attempt ${fixAttempt} — verification still fails (${fixAttemptDurationMs}ms)`);
+              await store.logEntry(taskId, `[timing] In-merge verification fix attempt ${fixAttempt} — verification still fails (${fixAttemptDurationMs}ms)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await store.appendAgentLog(
                 taskId,
                 `In-merge verification fix attempt ${fixAttempt} failed`,
@@ -9016,7 +8979,7 @@ export async function aiMergeTask(
                   `via=${finalized.strategy} sha=${finalized.mergeSha?.slice(0, 8)}`,
                   "merger",
                 );
-                await store.logEntry(taskId, `Auto-recovered: verification fix produced no content but task already landed on main at ${finalized.mergeSha?.slice(0, 8)} via ${finalized.strategy}`);
+                await store.logEntry(taskId, `Auto-recovered: verification fix produced no content but task already landed on main at ${finalized.mergeSha?.slice(0, 8)} via ${finalized.strategy}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 return true;
               }
               if (!finalized.ok) {
@@ -9059,7 +9022,7 @@ export async function aiMergeTask(
         // Try in-merge fix before falling back to build retry
         if (maxFixRetries > 0 && (effectiveTestCommand || effectiveBuildCommand)) {
           mergerLog.log(`${taskId}: build verification failed — attempting in-merge fix`);
-          await store.logEntry(taskId, `Build verification failed during merge — attempting in-merge fix`);
+          await store.logEntry(taskId, `Build verification failed during merge — attempting in-merge fix`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await store.appendAgentLog(
             taskId,
             "Build verification failed — attempting in-merge fix",
@@ -9078,7 +9041,7 @@ export async function aiMergeTask(
           for (let fixAttempt = 1; fixAttempt <= maxFixRetries; fixAttempt++) {
             const fixAttemptStartedAt = Date.now();
             mergerLog.log(`${taskId}: in-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`);
-            await store.logEntry(taskId, `In-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`);
+            await store.logEntry(taskId, `In-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await store.appendAgentLog(
               taskId,
               `In-merge verification fix attempt ${fixAttempt}/${maxFixRetries}`,
@@ -9098,7 +9061,7 @@ export async function aiMergeTask(
               },
               settings,
               options,
-              toRunMutationContext({ runId: mergeRunId, agentId: engineRunContext.agentId }),
+              { runId: mergeRunId, agentId: engineRunContext.agentId },
               fixAttempt,
               effectiveTestCommand,
               effectiveBuildCommand,
@@ -9112,7 +9075,7 @@ export async function aiMergeTask(
             const fixAttemptDurationMs = Date.now() - fixAttemptStartedAt;
             if (fixSuccess) {
               mergerLog.log(`${taskId}: in-merge verification fix succeeded on attempt ${fixAttempt} in ${fixAttemptDurationMs}ms`);
-              await store.logEntry(taskId, `[timing] In-merge verification fix succeeded on attempt ${fixAttempt} in ${fixAttemptDurationMs}ms`);
+              await store.logEntry(taskId, `[timing] In-merge verification fix succeeded on attempt ${fixAttempt} in ${fixAttemptDurationMs}ms`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await store.appendAgentLog(
                 taskId,
                 `In-merge verification fix succeeded on attempt ${fixAttempt}`,
@@ -9122,7 +9085,7 @@ export async function aiMergeTask(
               );
               break;
             }
-            await store.logEntry(taskId, `[timing] In-merge verification fix attempt ${fixAttempt} — verification still fails (${fixAttemptDurationMs}ms)`);
+            await store.logEntry(taskId, `[timing] In-merge verification fix attempt ${fixAttempt} — verification still fails (${fixAttemptDurationMs}ms)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await store.appendAgentLog(
               taskId,
               `In-merge verification fix attempt ${fixAttempt} failed`,
@@ -9165,7 +9128,7 @@ export async function aiMergeTask(
                 `via=${finalized.strategy} sha=${finalized.mergeSha?.slice(0, 8)}`,
                 "merger",
               );
-              await store.logEntry(taskId, `Auto-recovered: verification fix produced no content but task already landed on main at ${finalized.mergeSha?.slice(0, 8)} via ${finalized.strategy}`);
+              await store.logEntry(taskId, `Auto-recovered: verification fix produced no content but task already landed on main at ${finalized.mergeSha?.slice(0, 8)} via ${finalized.strategy}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               return true;
             }
             if (!finalized.ok) {
@@ -9201,7 +9164,7 @@ export async function aiMergeTask(
         if (buildRetryCount > 0 && !result._buildRetried) {
           // Allow one build retry — reset merge state and re-attempt same strategy
           mergerLog.log(`${taskId}: build failed, retrying (${buildRetryCount} retry allowed)...`);
-          await store.logEntry(taskId, "Build failed — retrying merge attempt");
+          await store.logEntry(taskId, "Build failed — retrying merge attempt", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           result._buildRetried = true;
           try {
             execSync("git reset --merge", { cwd: rootDir, stdio: "pipe" });
@@ -9309,8 +9272,7 @@ export async function aiMergeTask(
       await store.logEntry(
         taskId,
         `Attempt 3 (-X ours fallback) suppressed: pre-merge rebase recovery layers 1+2 failed under smart-prefer-main, so the unsafe ours-side fallback is skipped to honor the strategy's safety contract. Verification-gated AI Attempts 1+2 already exhausted; merge cannot complete safely without manual intervention.`,
-        "PreMergeRebaseFallthrough",
-      );
+        "PreMergeRebaseFallthrough", UNATTRIBUTED_MUTATION_CONTEXT);
     }
 
     // Bubble the empty-merge flag up to the metadata block.
@@ -9535,8 +9497,8 @@ export async function aiMergeTask(
           await store.updateTask(taskId, {
             status: "failed",
             error: captureError.message,
-          });
-          await store.moveTask(taskId, await resolveMergerLifecycleColumn(store, taskId, "merge"), { preserveProgress: true, moveSource: "engine" } as any);
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
+          await store.moveTask(taskId, await resolveMergerLifecycleColumn(store, taskId, "merge"), { preserveProgress: true, moveSource: "engine" } as any, UNATTRIBUTED_MUTATION_CONTEXT);
           throw captureError;
         }
         // non-fatal
@@ -9586,7 +9548,7 @@ export async function aiMergeTask(
     await store.updateTask(taskId, {
       mergeDetails,
       modifiedFiles: noOpVerifiedShortCircuit ? undefined : landedFiles && landedFiles.length > 0 ? landedFiles : undefined,
-    });
+    }, UNATTRIBUTED_MUTATION_CONTEXT);
     if (recordedSha) {
       const currentTask = await store.getTask(taskId);
       if (currentTask?.lineageId) {
@@ -9699,7 +9661,7 @@ export async function aiMergeTask(
           if (currentMergeDetails && !currentMergeDetails.mergeConfirmed) {
             await store.updateTask(taskId, {
               mergeDetails: { ...currentMergeDetails, mergeConfirmed: true },
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
           }
         } catch (promoteErr: unknown) {
           // Non-fatal: log + continue. The ref already advanced; the worst
@@ -9828,7 +9790,7 @@ export async function aiMergeTask(
         }
         if (result.worktreeRemoved) {
           try {
-            await store.updateTask(taskId, { worktree: null, branch: null, branchWriteOrigin: "engine" });
+            await store.updateTask(taskId, { worktree: null, branch: null, branchWriteOrigin: "engine" }, UNATTRIBUTED_MUTATION_CONTEXT);
           } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : String(err);
             mergerLog.warn(`${taskId}: failed to clear worktree pointer after removal: ${msg}`);
@@ -9913,7 +9875,7 @@ export async function aiMergeTask(
                   insertions: updatedStats.insertions,
                   deletions: updatedStats.deletions,
                 },
-              });
+              }, UNATTRIBUTED_MUTATION_CONTEXT);
               mergerLog.log(
                 `${taskId}: post-push HEAD changed from ${existingDetails.commitSha.slice(0, 8)} to ${postPushSha.slice(0, 8)} — refreshed mergeDetails.commitSha (stats: ${updatedStats.filesChanged ?? 0}f/${updatedStats.insertions ?? 0}i/${updatedStats.deletions ?? 0}d, was ${existingDetails.filesChanged ?? 0}f/${existingDetails.insertions ?? 0}i/${existingDetails.deletions ?? 0}d)`,
               );
@@ -9937,8 +9899,7 @@ export async function aiMergeTask(
         await store.logEntry(
           taskId,
           `Push to remote failed after merge — task marked done anyway; local main may diverge from origin: ${pushResult.error}`,
-          "PushToRemoteFailed",
-        ).catch(() => undefined);
+          "PushToRemoteFailed", UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       }
       result.pushedToRemote = pushResult.pushed;
       if (pushResult.error) {
@@ -9960,7 +9921,7 @@ export async function aiMergeTask(
             outcome: "aborted",
           },
         }).catch(() => undefined);
-        await store.logEntry(taskId, message, "PushToRemoteFailed").catch(() => undefined);
+        await store.logEntry(taskId, message, "PushToRemoteFailed", UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       } else {
         mergerLog.error(`${taskId}: push to remote error: ${err.message}`);
         result.pushedToRemote = false;
@@ -9978,8 +9939,7 @@ export async function aiMergeTask(
         await store.logEntry(
           taskId,
           `Push to remote threw after merge — task marked done anyway; local main may diverge from origin: ${err.message}`,
-          "PushToRemoteFailed",
-        ).catch(() => undefined);
+          "PushToRemoteFailed", UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       }
     }
   }
@@ -10590,7 +10550,7 @@ export async function executeMergeAttempt(
       // amended the *previous* task's commit because HEAD looked unchanged
       // and there was nothing left of the current task's branch to commit.
       const errorMessage = agentResult.error || "Build verification failed";
-      await store.logEntry(taskId, "Build verification failed during merge", errorMessage);
+      await store.logEntry(taskId, "Build verification failed during merge", errorMessage, UNATTRIBUTED_MUTATION_CONTEXT);
       throw new Error(`Build verification failed for ${taskId}: ${errorMessage}`);
     }
 
@@ -11177,7 +11137,7 @@ async function runAiAgentForCommit(params: AiAgentParams): Promise<{ success: bo
       const errorMessage = err instanceof Error ? err.message : String(err);
       if (isContextLimitError(errorMessage)) {
         mergerLog.warn(`${taskId}: context limit hit after auto-compaction — retrying with minimal merge prompt`);
-        await store.logEntry(taskId, "Context limit reached during merge after auto-compaction — retrying with reduced prompt");
+        await store.logEntry(taskId, "Context limit reached during merge after auto-compaction — retrying with reduced prompt", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
         // Build minimal prompt: omit diff stat, use placeholder for commit log.
         // The fall-through preamble is preserved (it's the safety constraint,
@@ -11504,7 +11464,7 @@ export async function completeTask(
   mergerLog.log(`${taskId}: completeTask — clearing status, moving to done`);
   const preMoveTask = await store.getTask(taskId);
   // Clear transient status before moving to done
-  await store.updateTask(taskId, { status: null });
+  await store.updateTask(taskId, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
   /*
   FNXC:MergerMoveAttribution 2026-08-29-07:37:
   Legacy merger completion remains a forward merge authority. Its own neutral provenance keeps the
@@ -11514,7 +11474,7 @@ export async function completeTask(
   // Use moveTask for proper event emission.
   const task = await store.moveTask(taskId, await resolveMergerLifecycleColumn(store, taskId, "complete"), {
     workflowMoveSource: "merger-complete-task",
-  });
+  }, UNATTRIBUTED_MUTATION_CONTEXT);
   const settings = await store.getSettings();
   if (isMergeRequestContractShadowEnabled(settings) && preMoveTask?.autoMerge !== false) {
     const mergeRequestRecord = await store.getMergeRequestRecordAsync(taskId);

--- a/packages/engine/src/missions/mission-autopilot.ts
+++ b/packages/engine/src/missions/mission-autopilot.ts
@@ -21,6 +21,8 @@
 
 import { AsyncMissionStore, resolveTaskLifecycleColumns } from "@fusion/core";
 import { reconcileMissionState } from "./mission-state-reconcile.js";
+/* FNXC:Identity 2026-08-15-22:52 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent } from "@fusion/core";
 import type {
   TaskStore,
   MissionStore,
@@ -339,7 +341,7 @@ export class MissionAutopilot {
       const failedTask = await this.taskStore.getTask(taskId).catch(() => null);
       if (failedTask?.error && isOperatorActionableAgentError(failedTask.error)) {
         await this.missionStore.updateFeatureStatus(feature.id, "blocked");
-        await this.taskStore.updateTask(taskId, { status: "failed", paused: true });
+        await this.taskStore.updateTask(taskId, { status: "failed", paused: true }, mutationContextForAgent("mission-autopilot"));
         await this.logMissionEventSafe(
           missionId,
           "error",
@@ -359,7 +361,7 @@ export class MissionAutopilot {
 
       if (retryCount > maxRetries) {
         await this.missionStore.updateFeatureStatus(feature.id, "blocked");
-        await this.taskStore.updateTask(taskId, { status: "failed", paused: true });
+        await this.taskStore.updateTask(taskId, { status: "failed", paused: true }, mutationContextForAgent("mission-autopilot"));
         await this.logMissionEventSafe(
           missionId,
           "error",
@@ -410,10 +412,10 @@ export class MissionAutopilot {
         return;
       }
       if (task?.column !== holdColumn) {
-        await this.taskStore.moveTask(taskId, holdColumn);
+        await this.taskStore.moveTask(taskId, holdColumn, undefined, mutationContextForAgent("mission-autopilot"));
       }
 
-      await this.taskStore.updateTask(taskId, { error: null, status: null, paused: false });
+      await this.taskStore.updateTask(taskId, { error: null, status: null, paused: false }, mutationContextForAgent("mission-autopilot"));
     } catch (err) {
       autopilotLog.error(`Error handling task failure for ${taskId}:`, err);
     }

--- a/packages/engine/src/missions/mission-execution-loop.ts
+++ b/packages/engine/src/missions/mission-execution-loop.ts
@@ -26,6 +26,7 @@ import type {
   Mission,
   ValidationDiagnostics,
 } from "@fusion/core";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { MissionRemediationStoppedError, normalizeMissionAssertionType, normalizeValidationDiagnostics, renderValidationFailureDescription,
   resolveTaskLifecycleColumns, resolveWorkflowIrForTask, columnsWithFlag,
 } from "@fusion/core";
@@ -969,12 +970,16 @@ export class MissionExecutionLoop extends EventEmitter {
         },
         taskId: prepared?.taskId ?? task?.id,
         taskTitle: prepared?.taskTitle ?? task?.title,
+        /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2): marker — the mission validation loop runs
+           unattended with no run context and no acting agent id in scope; `agent: "reviewer"` is a
+           lane label. U13 decides whether unattended engine lanes get a real system actor. */
         onFallbackModelUsed: createFallbackModelObserver({
           agent: "reviewer",
           label: "mission validator",
           store: this.taskStore,
           taskId: prepared?.taskId ?? task?.id,
           taskTitle: prepared?.taskTitle ?? task?.title,
+          runContext: UNATTRIBUTED_MUTATION_CONTEXT,
         }),
       });
       session = { session: sessionResult.session, sessionFile: sessionResult.sessionFile };

--- a/packages/engine/src/missions/unlinked-missions-advisory-reporter.ts
+++ b/packages/engine/src/missions/unlinked-missions-advisory-reporter.ts
@@ -1,3 +1,12 @@
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+Extracted helper of the unattended self-healing / scheduler sweeps, so its store writes carry
+the same MARKER as the sweeps that call it: a timer-driven repair has no session, no request,
+and no acting agent, and the only ids in scope name the SUBJECT of the write rather than its
+author. Counted by `unattributed-actor-census.test.ts`; U13 owns whether these lanes get a real
+system actor.
+*/
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { computeInsightFingerprint, type AsyncMissionStore, type Mission, type MissionStore, type TaskStore } from "@fusion/core";
 import { createLogger } from "../logger.js";
 
@@ -75,7 +84,7 @@ export class UnlinkedMissionsAdvisoryReporter {
       } catch (error) {
         await this.store.logEntry(
           missionIds[0],
-          `[unlinked-missions-advisory] ${content}`,
+          `[unlinked-missions-advisory] ${content}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT,
         );
         this.logger.warn("[unlinked-missions-advisory] insight store unavailable; logged fallback payload", error);
         return { alerted: true };

--- a/packages/engine/src/overseer/planner-overseer.ts
+++ b/packages/engine/src/overseer/planner-overseer.ts
@@ -14,7 +14,7 @@
  * the seam every later planner-oversight subtask reads from.
  */
 
-import { DEFAULT_PLANNER_OVERSEER_EXECUTOR_STUCK_AFTER_MS, type PlannerOversightLevel, type PrInfo, type Task, type TraitFlags } from "@fusion/core";
+import { DEFAULT_PLANNER_OVERSEER_EXECUTOR_STUCK_AFTER_MS, UNATTRIBUTED_MUTATION_CONTEXT, type PlannerOversightLevel, type PrInfo, type RunMutationContext, type Task, type TraitFlags } from "@fusion/core";
 
 /*
 FNXC:WorkflowResolvedColumns 2026-07-31-13:40 (fleet — inline fallback arms):
@@ -425,9 +425,16 @@ function deriveSignalAndSources(
 }
 
 /** Minimal store seam the monitor records best-effort observations through —
- *  mirrors `fallback-model-observer.ts`'s `FallbackLogStore` seam. */
+ *  mirrors `fallback-model-observer.ts`'s `FallbackLogStore` seam.
+ *
+ *  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+ *  Hand-declared rather than `Pick<TaskStore, "logEntry">`, so it does not inherit U18's
+ *  canonical/deprecated overload pair and would otherwise keep accepting unattributed writes after
+ *  the engine sweep. `logEntry` here mirrors the CANONICAL store arity — explicit `outcome`,
+ *  required trailing `runContext` — which both closes the hole and is what keeps a real `TaskStore`
+ *  assignable (the deprecated overload cannot take a `RunMutationContext` in the `outcome` slot). */
 export interface OverseerLogStore {
-  logEntry?(taskId: string, action: string): Promise<unknown>;
+  logEntry?(taskId: string, action: string, outcome: string | undefined, runContext: RunMutationContext): Promise<unknown>;
   appendAgentLog?(
     taskId: string,
     text: string,
@@ -544,8 +551,15 @@ export class PlannerOverseerMonitor {
           FNXC:PlannerOversight 2026-07-19-00:00:
           Activity feed label is short "planner" (not "planner-overseer") so operators scanning the task feed can tell this is planner lifecycle observation without the longer overseer product name.
           */
+          /*
+          FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — marker, not a derived actor):
+          The monitor is constructed once at engine startup and observes every in-flight task; it
+          holds no run, no session, and no agent id of its own, so there is nothing here to derive
+          from. Whether an unattended observer gets a real system actor is U13's decision, and
+          minting one here would bury that semantic choice inside a mechanical conversion.
+          */
           await this.store
-            .logEntry(task.id, `[planner] stage=${stage} signal=${signal}: ${reason}`)
+            .logEntry(task.id, `[planner] stage=${stage} signal=${signal}: ${reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT)
             .catch(() => undefined);
         }
       }

--- a/packages/engine/src/plan-artifact-writeback.ts
+++ b/packages/engine/src/plan-artifact-writeback.ts
@@ -2,6 +2,8 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { TaskStore } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 
 /*
 FNXC:PlanArtifactPersistence 2026-09-01-14:49:
@@ -110,7 +112,7 @@ export async function reconcileWorktreePlanArtifact(
     // The single validated persistence path: File Scope validation + root PROMPT.md write + task.json sync.
     const persisted = options.writeAuthoritativePrompt
       ? await options.writeAuthoritativePrompt(worktreeContent)
-      : (await store.updateTask(taskId, { prompt: worktreeContent }), true);
+      : (await store.updateTask(taskId, { prompt: worktreeContent }, UNATTRIBUTED_MUTATION_CONTEXT), true);
     if (!persisted) return { outcome: "recovery-fenced", content: rootContent ?? undefined };
     logger?.log?.(
       `${taskId}: recovered a worktree-local PROMPT.md into the project .fusion folder (${planningCwd})`,

--- a/packages/engine/src/project/mesh-lease-manager.ts
+++ b/packages/engine/src/project/mesh-lease-manager.ts
@@ -1,4 +1,6 @@
 import { resolveReboundTarget, resolveWorkflowIrForTask } from "@fusion/core";
+/* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): mutation-context constructors for this lane. */
+import { mutationContextForAgent } from "@fusion/core";
 import type {
   AgentStore,
   CentralClaimStore,
@@ -173,20 +175,22 @@ export class MeshLeaseManager {
         checkoutLeaseRenewedAt: null,
         checkoutLeaseEpoch: nextEpoch,
       },
-      context.runContext,
+      /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage B): the recovering lane, derived from the id this
+         manager already stamps on its own lease-audit rows (`agentId: "mesh-lease-manager"`). */
+      context.runContext ?? mutationContextForAgent("mesh-lease-manager"),
     );
     await this.options.taskStore.logEntry(
       task.id,
       "Recovered abandoned lease",
       `${reason}; epoch=${nextEpoch}`,
-      context.runContext,
+      context.runContext ?? mutationContextForAgent("mesh-lease-manager"),
     );
     if (task.column !== reboundColumn) {
       await this.options.taskStore.moveTask(task.id, reboundColumn, {
         preserveProgress:
           context.preserveProgress ??
           (task.currentStep > 0 || task.steps.some((step) => step.status !== "pending")),
-      });
+      }, context.runContext ?? mutationContextForAgent("mesh-lease-manager"));
     }
   }
 
@@ -286,7 +290,7 @@ export class MeshLeaseManager {
         checkoutRunId: null,
         checkoutLeaseRenewedAt: null,
         checkoutLeaseEpoch: nextEpoch,
-      });
+      }, mutationContextForAgent("mesh-lease-manager"));
       await this.emitLeaseAudit(task, "task:auto-recover-lease-reconciled", {
         direction: "central-cleared->local-cleared",
         priorEpoch: task.checkoutLeaseEpoch ?? 0,

--- a/packages/engine/src/scheduler.ts
+++ b/packages/engine/src/scheduler.ts
@@ -16,8 +16,7 @@ import {
   type PrInfo,
   type AgentStore,
   type Settings,
-  type FileScopeLeaseClassification,
-} from "@fusion/core";
+  type FileScopeLeaseClassification, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -1250,7 +1249,7 @@ export class Scheduler {
             lastDispatchAt: null,
             executeRequeueLoopCount: null,
             executeRequeueLoopSignature: null,
-          }).catch((error) => {
+          }, UNATTRIBUTED_MUTATION_CONTEXT).catch((error) => {
             schedulerLog.warn(`Failed to reset dispatch oscillation state for ${task.id} on move to ${to}: ${error instanceof Error ? error.message : String(error)}`);
           });
         }
@@ -1309,17 +1308,16 @@ export class Scheduler {
                   await this.store.updateTask(dependent.id, {
                     status: "queued",
                     blockedBy: unresolvedDeps[0],
-                  });
+                  }, UNATTRIBUTED_MUTATION_CONTEXT);
                   await this.store.logEntry(
                     dependent.id,
-                    `Auto-reblocked: unresolved dependency ${unresolvedDeps[0]} remains after ${task.id} reached ${to}`,
-                  );
+                    `Auto-reblocked: unresolved dependency ${unresolvedDeps[0]} remains after ${task.id} reached ${to}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 } else {
-                  await this.store.updateTask(dependent.id, { blockedBy: null, ...clearBlockedStatusOnly(dependent) });
+                  await this.store.updateTask(dependent.id, { blockedBy: null, ...clearBlockedStatusOnly(dependent) }, UNATTRIBUTED_MUTATION_CONTEXT);
                   const unblockMessage = currentlyBlockedByCompletedTask
                     ? `Auto-unblocked: blocker ${task.id} reached ${to}`
                     : `Auto-unblocked: blocker ${task.id} reached ${to} — all dependencies satisfied`;
-                  await this.store.logEntry(dependent.id, unblockMessage);
+                  await this.store.logEntry(dependent.id, unblockMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 }
               } catch (error) {
                 schedulerLog.error(
@@ -1419,7 +1417,7 @@ export class Scheduler {
             lastDispatchAt: null,
             executeRequeueLoopCount: null,
             executeRequeueLoopSignature: null,
-          }).catch((error) => {
+          }, UNATTRIBUTED_MUTATION_CONTEXT).catch((error) => {
             schedulerLog.warn(`Failed to reset dispatch oscillation state for ${task.id} on unpause: ${error instanceof Error ? error.message : String(error)}`);
           });
         }
@@ -1607,17 +1605,16 @@ export class Scheduler {
                 await this.store.updateTask(dependent.id, {
                   blockedBy: nextBlocker,
                   status: "queued",
-                });
+                }, UNATTRIBUTED_MUTATION_CONTEXT);
                 await this.store.logEntry(
                   dependent.id,
-                  `Auto-reblocked (FN-5496): unresolved dependency ${nextBlocker} remains after blocker ${task.id} was soft-deleted`,
-                );
+                  `Auto-reblocked (FN-5496): unresolved dependency ${nextBlocker} remains after blocker ${task.id} was soft-deleted`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               } else if (dependent.column === deletedParked.hold) {
-                await this.store.updateTask(dependent.id, { blockedBy: null, ...clearBlockedStatusOnly(dependent) });
-                await this.store.logEntry(dependent.id, `Auto-unblocked (FN-5496): blocker ${task.id} was soft-deleted`);
+                await this.store.updateTask(dependent.id, { blockedBy: null, ...clearBlockedStatusOnly(dependent) }, UNATTRIBUTED_MUTATION_CONTEXT);
+                await this.store.logEntry(dependent.id, `Auto-unblocked (FN-5496): blocker ${task.id} was soft-deleted`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               } else {
-                await this.store.updateTask(dependent.id, { blockedBy: null });
-                await this.store.logEntry(dependent.id, `Auto-unblocked (FN-5496): blocker ${task.id} was soft-deleted`);
+                await this.store.updateTask(dependent.id, { blockedBy: null }, UNATTRIBUTED_MUTATION_CONTEXT);
+                await this.store.logEntry(dependent.id, `Auto-unblocked (FN-5496): blocker ${task.id} was soft-deleted`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               }
             } catch (error) {
               schedulerLog.error(`Failed to reconcile dependent ${dependent.id} for soft-deleted blocker ${task.id}`, error);
@@ -1767,7 +1764,7 @@ export class Scheduler {
     /*
     FNXC:RUFU-075 2026-08-13-03:16:
     The review-lease and dependency overlap-queue writes historically went straight through
-    `store.updateTask(…, { status: "queued", …, overlapBlockedBy })`. FN-8785 moved them onto the
+    `store.updateTask(…, { status: "queued", …, overlapBlockedBy }, UNATTRIBUTED_MUTATION_CONTEXT)`. FN-8785 moved them onto the
     store's atomic `transitionQueuedEpisode` helper (advisory-locked, edge-triggered queue logging).
     A minimal/legacy store that does not implement `transitionQueuedEpisode` (as several scheduler
     test mocks and older store shims do not) must still receive a correct queue write, or the lease
@@ -1782,7 +1779,7 @@ export class Scheduler {
       status: "queued",
       blockedBy: input.blockedBy ?? null,
       overlapBlockedBy: input.overlapBlockedBy ?? null,
-    });
+    }, UNATTRIBUTED_MUTATION_CONTEXT);
     await this.logDispatchQueuedReason(task.id, input.action);
     return true;
   }
@@ -1795,7 +1792,7 @@ export class Scheduler {
 
     this.clearDispatchQueuedReasonMemo(taskId);
     this.wasDispatchQueuedReasonLogged.add(key);
-    await this.store.logEntry(taskId, reason);
+    await this.store.logEntry(taskId, reason, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     return true;
   }
 
@@ -1961,7 +1958,7 @@ export class Scheduler {
 
       const message = `Overlap bottleneck: ${blockerId} is currently blocking ${fanout.overlapBlockedTodoCount} todo task(s) via blockedBy (${state}).`;
       schedulerLog.warn(message);
-      await this.store.logEntry(blockerId, message);
+      await this.store.logEntry(blockerId, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       this.lastHighOverlapFanoutWarningKey.set(blockerId, dedupeKey);
     }
 
@@ -2361,7 +2358,7 @@ export class Scheduler {
             "warn",
           );
           if (appended) {
-            await this.store.logEntry(task.id, `symbol-lock renewal lost: ${result.lost.join(", ")}`);
+            await this.store.logEntry(task.id, `symbol-lock renewal lost: ${result.lost.join(", ")}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           }
         } else {
           this.symbolLockRenewalLog.clear(task.id);
@@ -2713,14 +2710,14 @@ export class Scheduler {
           return { overlapBlockedBy: null };
         };
         if (typeof this.store.updateTaskAtomic === "function") {
-          await this.store.updateTaskAtomic(candidate.id, clearIfUnchanged);
+          await this.store.updateTaskAtomic(candidate.id, clearIfUnchanged, UNATTRIBUTED_MUTATION_CONTEXT);
           return cleared;
         }
         // Compatibility only for structural test/extension stores; production TaskStore is atomic.
         const live = await this.store.getTask(candidate.id).catch(() => null);
         if (!live) return false;
         const patch = clearIfUnchanged(live);
-        if (patch) await this.store.updateTask(candidate.id, patch);
+        if (patch) await this.store.updateTask(candidate.id, patch, UNATTRIBUTED_MUTATION_CONTEXT);
         return cleared;
       };
 
@@ -2805,7 +2802,7 @@ export class Scheduler {
               const milestone = slice ? await this.options.missionStore.getMilestone(slice.milestoneId) : undefined;
               const mission = milestone ? await this.options.missionStore.getMission(milestone.missionId) : undefined;
               if (mission?.status === "blocked") {
-                await this.store.updateTask(task.id, { status: "queued" });
+                await this.store.updateTask(task.id, { status: "queued" }, UNATTRIBUTED_MUTATION_CONTEXT);
                 await this.logDispatchQueuedReason(task.id, "queued — mission is blocked");
                 return null;
               }
@@ -2842,8 +2839,8 @@ export class Scheduler {
                 error,
                 recoveryRetryCount: null,
                 nextRecoveryAt: null,
-              });
-              await this.store.logEntry(task.id, error, validation.reason);
+              }, UNATTRIBUTED_MUTATION_CONTEXT);
+              await this.store.logEntry(task.id, error, validation.reason, UNATTRIBUTED_MUTATION_CONTEXT);
               return null;
             }
             const attempt = decision.nextState.recoveryRetryCount ?? MAX_RECOVERY_RETRIES;
@@ -2852,12 +2849,11 @@ export class Scheduler {
               error: null,
               recoveryRetryCount: decision.nextState.recoveryRetryCount,
               nextRecoveryAt: decision.nextState.nextRecoveryAt,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
               `Task retained in ${task.column} for in-place specification repair — filesystem validation failed (attempt ${attempt}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)})`,
-              validation.reason,
-            );
+              validation.reason, UNATTRIBUTED_MUTATION_CONTEXT);
             return null;
           }
 
@@ -2871,8 +2867,8 @@ export class Scheduler {
             });
             if (staleness.isStale) {
               schedulerLog.warn(`Task ${task.id} specification is stale — ${staleness.reason}`);
-              await this.store.updateTask(task.id, { status: "needs-replan" });
-              await this.store.logEntry(task.id, staleness.reason);
+              await this.store.updateTask(task.id, { status: "needs-replan" }, UNATTRIBUTED_MUTATION_CONTEXT);
+              await this.store.logEntry(task.id, staleness.reason, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               return null;
             }
           }
@@ -2880,7 +2876,7 @@ export class Scheduler {
           const freshTask = await this.store.getTask(task.id);
           if (!freshTask || freshTask.column !== task.column || freshTask.paused || freshTask.userPaused) {
             if (freshTask?.userPaused === true && freshTask.status !== "queued") {
-              await this.store.updateTask(task.id, { status: "queued" });
+              await this.store.updateTask(task.id, { status: "queued" }, UNATTRIBUTED_MUTATION_CONTEXT);
               await this.logDispatchQueuedReason(task.id, "queued — user paused (manual move to todo)");
             }
             return null;
@@ -2895,7 +2891,7 @@ export class Scheduler {
             );
             if (!recovered) {
               await this.options.leaseManager.reconcileLeaseRow(freshTask.id);
-              await this.store.updateTask(freshTask.id, { status: "queued" });
+              await this.store.updateTask(freshTask.id, { status: "queued" }, UNATTRIBUTED_MUTATION_CONTEXT);
               await this.logDispatchQueuedReason(freshTask.id, "queued — checkout lease recovery blocked dispatch");
               return null;
             }
@@ -2920,7 +2916,7 @@ export class Scheduler {
               if (!this.wasNodeDispatchValidationBlocked.has(task.id)) {
                 this.wasNodeDispatchValidationBlocked.add(task.id);
                 schedulerLog.log(`Task ${task.id} dispatch blocked — ${nodeValidation.reason}`);
-                await this.store.logEntry(task.id, nodeValidation.reason);
+                await this.store.logEntry(task.id, nodeValidation.reason, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               }
               return null;
             }
@@ -2956,7 +2952,7 @@ export class Scheduler {
                   }
                   const reason = `Owning-node handoff parked dispatch: ${handoffDecision.reason}`;
                   schedulerLog.log(`Task ${task.id} dispatch blocked — ${reason}`);
-                  await this.store.logEntry(task.id, reason);
+                  await this.store.logEntry(task.id, reason, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                   try {
                     await emitBoundedRunAudit(this.store, {
                       taskId: freshTask.id,
@@ -2985,7 +2981,7 @@ export class Scheduler {
                 return null;
               }
 
-              await this.store.logEntry(task.id, `Owning-node handoff applied: ${handoffDecision.reason}`);
+              await this.store.logEntry(task.id, `Owning-node handoff applied: ${handoffDecision.reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               try {
                 await emitBoundedRunAudit(this.store, {
                   taskId: freshTask.id,
@@ -3042,14 +3038,14 @@ export class Scheduler {
                 if (!this.wasNodeBlocked.has(task.id)) {
                   this.wasNodeBlocked.add(task.id);
                   schedulerLog.log(`Task ${task.id} dispatch blocked — ${decision.reason}`);
-                  await this.store.logEntry(task.id, decision.reason);
+                  await this.store.logEntry(task.id, decision.reason, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 }
                 return null;
               }
               this.wasNodeBlocked.delete(task.id);
               if (decision.fallbackToLocal) {
                 schedulerLog.log(`Task ${task.id} falling back to local — ${decision.reason}`);
-                await this.store.logEntry(task.id, decision.reason);
+                await this.store.logEntry(task.id, decision.reason, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 effectiveNode = { nodeId: undefined, source: "local" };
               }
             }
@@ -3100,11 +3096,10 @@ export class Scheduler {
               pausedReason: "dispatch-oscillation",
               status: freshTask.status ?? "queued",
               error: oscillationError,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
-              `Dispatch oscillation auto-paused after ${nextDispatchStormCount} cycles within ${dispatchOscillationWindowMs}ms`,
-            );
+              `Dispatch oscillation auto-paused after ${nextDispatchStormCount} cycles within ${dispatchOscillationWindowMs}ms`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.appendAgentLog?.(
               task.id,
               "Dispatch oscillation detected — task auto-paused for operator review",
@@ -3146,7 +3141,7 @@ export class Scheduler {
               const cleared = await clearObservedOverlapIfStillStale(freshTask, observedOverlapBlockedBy);
               if (cleared) observedOverlapBlockedBy = null;
             }
-            await this.store.updateTask(task.id, { status: "queued", blockedBy: null });
+            await this.store.updateTask(task.id, { status: "queued", blockedBy: null }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.logDispatchQueuedReason(task.id, `queued — mission lineage blocked: ${missionAdmission.reason}`);
             return null;
           }
@@ -3195,8 +3190,7 @@ export class Scheduler {
               if (isCoordinationOnlyTask(task, taskScope)) {
                 await this.store.logEntry(
                   task.id,
-                  "coordination/no-commit task bypassed non-implementation overlap lease",
-                );
+                  "coordination/no-commit task bypassed non-implementation overlap lease", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               }
             }
           }
@@ -3280,7 +3274,7 @@ export class Scheduler {
             const reason = exhausted
               ? formatConcurrencyLimitReason(freshDiagnostic)
               : `queued — higher-priority lifecycle admission started: task=${admittedTaskId}`;
-            await this.store.updateTask(task.id, { status: "queued" });
+            await this.store.updateTask(task.id, { status: "queued" }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.logDispatchQueuedReason(task.id, reason);
             return null;
           }
@@ -3311,7 +3305,7 @@ export class Scheduler {
                   const cleared = await clearObservedOverlapIfStillStale(freshTask, observedOverlapBlockedBy);
                   if (cleared) observedOverlapBlockedBy = null;
                 }
-                await this.store.updateTask(task.id, { status: "queued", blockedBy: null });
+                await this.store.updateTask(task.id, { status: "queued", blockedBy: null }, UNATTRIBUTED_MUTATION_CONTEXT);
                 await this.logDispatchQueuedReason(
                   task.id,
                   `queued — symbol contention: symbol=${conflict?.symbolKey ?? "unknown"} holder=${conflict?.ownerTaskId ?? "unknown"}`,
@@ -3319,7 +3313,7 @@ export class Scheduler {
                 return null;
               }
               acquiredSymbols = missionAdmission.symbols;
-              await this.store.logEntry(task.id, `symbol-lock admission acquired: ${missionAdmission.symbols.join(", ")}`);
+              await this.store.logEntry(task.id, `symbol-lock admission acquired: ${missionAdmission.symbols.join(", ")}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             }
 
             dispatchPrepByTaskId.set(task.id, {
@@ -3413,10 +3407,10 @@ export class Scheduler {
         */
         try {
           if (typeof this.store.updateTaskAtomic === "function") {
-            persistedTask = await this.store.updateTaskAtomic(taskId, buildDispatchPatch);
+            persistedTask = await this.store.updateTaskAtomic(taskId, buildDispatchPatch, UNATTRIBUTED_MUTATION_CONTEXT);
           } else {
             // Compatibility only for structural test/extension stores; production TaskStore is atomic.
-            persistedTask = await this.store.updateTask(taskId, buildDispatchPatch(persistedTask));
+            persistedTask = await this.store.updateTask(taskId, buildDispatchPatch(persistedTask), UNATTRIBUTED_MUTATION_CONTEXT);
           }
         } catch (error) {
           overlapClearApplied = false;
@@ -3451,7 +3445,7 @@ export class Scheduler {
         this.wasPermanentAgentUnavailable.delete(taskId);
         this.clearDispatchQueuedReasonMemo(taskId);
         try {
-          await this.store.logEntry(taskId, `Node routing resolved: ${prep.effectiveNodeId ?? "local"} (source: ${prep.effectiveNodeSource})`);
+          await this.store.logEntry(taskId, `Node routing resolved: ${prep.effectiveNodeId ?? "local"} (source: ${prep.effectiveNodeSource})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         } catch (error) {
           schedulerLog.error(`Post-release dispatch log failed for ${taskId}:`, error);
         }

--- a/packages/engine/src/scheduling/backlog-pressure-reporter.ts
+++ b/packages/engine/src/scheduling/backlog-pressure-reporter.ts
@@ -1,3 +1,12 @@
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+Extracted helper of the unattended self-healing / scheduler sweeps, so its store writes carry
+the same MARKER as the sweeps that call it: a timer-driven repair has no session, no request,
+and no acting agent, and the only ids in scope name the SUBJECT of the write rather than its
+author. Counted by `unattributed-actor-census.test.ts`; U13 owns whether these lanes get a real
+system actor.
+*/
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { computeInsightFingerprint, type Task, type TaskPriority, type TaskStore, resolveProjectColumnsForRoles} from "@fusion/core";
 import { createLogger } from "../logger.js";
 
@@ -154,7 +163,7 @@ export class BacklogPressureReporter {
         // so scheduled advisories persist instead of degrading to task logs.
         insightStore = this.store.getInsightStore();
       } catch (error) {
-        await this.store.logEntry(candidates[0].id, `[backlog-pressure] ${content}`);
+        await this.store.logEntry(candidates[0].id, `[backlog-pressure] ${content}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         this.logger.warn("[backlog-pressure] insight store unavailable; logged fallback payload", error);
         this.logger.warn(`[backlog-pressure] alert: todo=${todoCount} inProgress=${inProgressCount} ratio=${ratio.toFixed(2)} candidates=${candidateIds.join(",")}`);
         return { alerted: true };

--- a/packages/engine/src/scheduling/cron-runner.ts
+++ b/packages/engine/src/scheduling/cron-runner.ts
@@ -15,6 +15,7 @@ import {
   type TaskCreateInput,
   type TaskDetail,
 } from "@fusion/core";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { createLogger } from "../logger.js";
 import { defaultShell } from "../worktree/shell-utils.js";
 import { createFnAgent, promptWithFallback } from "../pi.js";
@@ -1000,7 +1001,13 @@ export class CronRunner {
     };
 
     try {
-      const task = await this.store.createTask(taskInput);
+      /*
+      FNXC:Identity 2026-08-09-03:04 (U18/KTD2): marker, not a derived actor.
+      A cron step creates this task on a timer; the schedule's author is not recorded on the run and
+      no agent is acting. Attributing it to the scheduler would invent a system identity, which is
+      U13's decision to make deliberately rather than a side effect of this mechanical conversion.
+      */
+      const task = await this.store.createTask(taskInput, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
       const output = `Created task ${task.id}: ${task.title || task.description.slice(0, 80)}`;
       log.log(`    ✓ Create-task step "${step.name}" created task ${task.id}`);

--- a/packages/engine/src/scheduling/routine-runner.ts
+++ b/packages/engine/src/scheduling/routine-runner.ts
@@ -7,6 +7,15 @@
  * - Triggers heartbeat execution for routines
  */
 
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+Extracted helper of the unattended self-healing / scheduler sweeps, so its store writes carry
+the same MARKER as the sweeps that call it: a timer-driven repair has no session, no request,
+and no acting agent, and the only ids in scope name the SUBJECT of the write rather than its
+author. Counted by `unattributed-actor-census.test.ts`; U13 owns whether these lanes get a real
+system actor.
+*/
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { CronExpressionParser } from "cron-parser";
 import { isInProcessBackupCommand, isInProcessMemoryBackupCommand } from "./cron-runner.js";
 import {
@@ -534,7 +543,7 @@ export class RoutineRunner {
         },
       };
       try {
-        const task = await this.options.taskStore.createTask(taskInput);
+        const task = await this.options.taskStore.createTask(taskInput, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         return { stepId: step.id, stepName: step.name, stepIndex, success: true, output: `Created task ${task.id}: ${task.title || task.description.slice(0, 80)}`, startedAt, completedAt: new Date().toISOString() };
       } catch (err) {
         return { stepId: step.id, stepName: step.name, stepIndex, success: false, output: "", error: err instanceof Error ? err.message : String(err), startedAt, completedAt: new Date().toISOString() };

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -44,9 +44,7 @@ import { loadWorkspaceConfig, type TaskMoveLanes, resolveColumnFlags, IN_REVIEW_
   isFusionDeletableBranch,
   isTaskExternallyBlocked,
   fileScopeLeaseBlocksCandidate,
-  toRunMutationContext,
-  normalizeOverlapScopeForTask,
-} from "@fusion/core";
+  normalizeOverlapScopeForTask, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { finalizePlanningSegment, isLegacyWorkspaceWorktreeLayout, resolveWorkspaceTaskWorktreeDir } from "@fusion/core";
 import type { WorkspaceLandIntent } from "@fusion/core";
 import type { MeshLeaseManager } from "./project/mesh-lease-manager.js";
@@ -2458,8 +2456,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     */
     await this.store.logEntry(
       task.id,
-      `[recovery] already-merged rejected ${task.id} candidate=${candidateSha.slice(0, 12)} owner=${candidateOwner ?? "unknown"} branch=${taskBranch ?? "?"} base=${baseBranch} reason=${reason}`,
-    );
+      `[recovery] already-merged rejected ${task.id} candidate=${candidateSha.slice(0, 12)} owner=${candidateOwner ?? "unknown"} branch=${taskBranch ?? "?"} base=${baseBranch} reason=${reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     try {
       await emitBoundedRunAudit(this.store, {
         taskId: task.id,
@@ -2700,11 +2697,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         source,
         audit,
         log: async (message) => {
-          await this.store.logEntry(task.id, message).catch(() => undefined);
+          await this.store.logEntry(task.id, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
         },
       });
     }
-    return await this.store.moveTask(task.id, completeLane);
+    return await this.store.moveTask(task.id, completeLane, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   }
 
   /*
@@ -3243,8 +3240,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             try {
               await this.store.logEntry(
                 task.id,
-                `[self-healing] Auto-archive abandoned after ${count} consecutive ${reason} failures. ${remedy}`,
-              );
+                `[self-healing] Auto-archive abandoned after ${count} consecutive ${reason} failures. ${remedy}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             } catch (logErr: unknown) {
               log.warn(`Could not record auto-archive escalation for ${task.id}: ${logErr instanceof Error ? logErr.message : String(logErr)}`);
             }
@@ -3731,8 +3727,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (!moved.moved) continue;
           await this.store.logEntry(
             live.id,
-            `Auto-recovered workflow task stranded in triage — resumed at pinned ${resumeColumn} column`,
-          );
+            `Auto-recovered workflow task stranded in triage — resumed at pinned ${resumeColumn} column`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           recovered++;
         } catch (err: unknown) {
           const errorMessage = err instanceof Error ? err.message : String(err);
@@ -3872,12 +3867,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           let current: Task;
           if (typeof this.store.updateTaskAtomic === "function") {
             current = await this.store.updateTaskAtomic(task.id, (live) =>
-              clearIfStillStale(live) ? { status: null } : null,
-            );
+              clearIfStillStale(live) ? { status: null } : null, UNATTRIBUTED_MUTATION_CONTEXT);
           } else {
             // Compatibility only for structural test/extension stores; production TaskStore is atomic.
             current = await this.store.getTask(task.id);
-            if (clearIfStillStale(current)) await this.store.updateTask(task.id, { status: null });
+            if (clearIfStillStale(current)) await this.store.updateTask(task.id, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           if (previousStatus === undefined) continue;
 
@@ -3891,8 +3885,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           this.options.clearMergeActive?.(task.id);
           await this.store.logEntry(
             task.id,
-            `Auto-recovered: cleared stale '${previousStatus}' status (no active merger)`,
-          );
+            `Auto-recovered: cleared stale '${previousStatus}' status (no active merger)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           /*
           FNXC:MergeReliability 2026-08-10-05:32:
           Clearing the false badge is not permission to restart parked work. Check the live row returned
@@ -3989,13 +3982,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       this.options.clearMergeActive?.(activeId);
       if (task) {
         if (task.status && ACTIVE_MERGE_STATUSES.has(task.status)) {
-          await this.store.updateTask(activeId, { status: null, error: null }).catch(() => undefined);
+          await this.store.updateTask(activeId, { status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
         }
         await this.store
           .logEntry(
             activeId,
-            "Auto-recovered: wedged active merge reclaimed after merger agent silence — merge will be retried",
-          )
+            "Auto-recovered: wedged active merge reclaimed after merger agent silence — merge will be retried", undefined, UNATTRIBUTED_MUTATION_CONTEXT)
           .catch(() => undefined);
       }
       await this.emitWedgedActiveMergeAudit(activeId, {
@@ -4127,7 +4119,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         return withPerPr({ outcome: "skipped", reason: "stale" });
       }
       if (inspection.kind === "stale-resolved") {
-        await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" as const, baseCommitSha: null });
+        await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" as const, baseCommitSha: null }, UNATTRIBUTED_MUTATION_CONTEXT);
         await auditor.database({ type: "task:pr-conflict-reclaim", target: task.id, metadata: { outcome: "stale-resolved" } });
         return withPerPr({ outcome: "stale-resolved" });
       }
@@ -4173,7 +4165,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (isFusionDeletableBranch(task, task.branch)) {
             await execAsync(`git branch -D ${JSON.stringify(task.branch)}`, { cwd: this.options.rootDir, timeout: 120_000, maxBuffer: 10 * 1024 * 1024 });
           }
-          await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" as const, paused: false, pausedReason: undefined, status: null, error: null });
+          await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" as const, paused: false, pausedReason: undefined, status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT);
           await auditor.database({ type: "task:pr-conflict-reclaim", target: task.id, metadata: { outcome: "reclaimed", mode: "fully-subsumed", recoveredFromPaused: wasPausedBranchConflict } });
           return withPerPr({ outcome: "reclaimed" });
         }
@@ -4206,7 +4198,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             pausedReason: undefined,
             status: null,
             error: null,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.reboundTask(task.id, "self-healing-worktree-reclaim", task.column, {
             recoveryRehome: true,
             preserveWorktree: true,
@@ -4229,7 +4221,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           pausedReason: undefined,
           status: null,
           error: null,
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
       }
       await auditor.database({ type: "task:pr-conflict-reclaim", target: task.id, metadata: { outcome: "reclaimed", mode: inspection.kind } });
       return withPerPr({ outcome: "reclaimed" });
@@ -4246,12 +4238,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (!classification.class.startsWith("branch-conflict-")) {
         const reason = `reclaim deferred — non-conflict error, retrying next sweep: ${message}`;
         log.warn(`[self-healing] ${task.id} PR ${reason}`);
-        await this.store.logEntry(task.id, `Auto-recovery warning: PR ${reason}`).catch(() => undefined);
+        await this.store.logEntry(task.id, `Auto-recovery warning: PR ${reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
         return withPerPr({ outcome: "skipped", reason: message });
       }
       const patchPath = await preserveWorktreeChanges(this.options.rootDir, task.worktree, task.id);
       if (patchPath) {
-        await this.store.logEntry(task.id, `Preserved uncommitted worktree changes before pause: ${patchPath}`);
+        await this.store.logEntry(task.id, `Preserved uncommitted worktree changes before pause: ${patchPath}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       }
       const dispatcher = this.options.autoRecoveryDispatcher ?? new AutoRecoveryDispatcher({
         taskStore: this.store,
@@ -4279,9 +4271,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           error: `Task branch conflict: ${task.branch} is not safely reclaimable (${message})`,
           paused: true,
           pausedReason: "branch-conflict-unrecoverable",
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.handoffTaskToReview(task.id, "branch-conflict-unrecoverable-repromote");
-        await this.store.logEntry(task.id, `Auto-recovery failed: branch conflict unrecoverable — ${message}`);
+        await this.store.logEntry(task.id, `Auto-recovery failed: branch conflict unrecoverable — ${message}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       }
       return withPerPr({ outcome: "paused-unrecoverable", reason: message });
     }
@@ -4321,12 +4313,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       if (!recovered.recovered) return false;
       await this.store.logEntry(
         task.id,
-        `Auto-reanchored ${task.branch} to base (foreign-only contamination, subtype=${recovered.subtype ?? "unknown"})`,
-      );
+        `Auto-reanchored ${task.branch} to base (foreign-only contamination, subtype=${recovered.subtype ?? "unknown"})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       return true;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      await this.store.logEntry(task.id, `Foreign-only reanchor attempt failed: ${message}`).catch(() => undefined);
+      await this.store.logEntry(task.id, `Foreign-only reanchor attempt failed: ${message}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       return false;
     }
   }
@@ -4581,11 +4572,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               worktree: null,
               branch: null, branchWriteOrigin: "engine" as const,
               baseCommitSha: null,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
-              `[recovery] cache-invalidate ${task.id} branch=${task.branch ?? "?"} reason=stale-resolved-no-live-ref-or-mapping`,
-            );
+              `[recovery] cache-invalidate ${task.id} branch=${task.branch ?? "?"} reason=stale-resolved-no-live-ref-or-mapping`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             continue;
           }
           if (inspection.kind === "tip-already-merged") {
@@ -4684,11 +4674,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 pausedReason: undefined,
                 status: null,
                 error: null,
-              });
+              }, UNATTRIBUTED_MUTATION_CONTEXT);
               await this.store.logEntry(
                 task.id,
-                `[recovery] tip-already-merged ${task.id} branch=${branchName} tip=${inspection.tipSha.slice(0, 12)} integrationRef=${inspection.integrationRef} reason=stale-cached-metadata-ghost-conflict`,
-              );
+                `[recovery] tip-already-merged ${task.id} branch=${branchName} tip=${inspection.tipSha.slice(0, 12)} integrationRef=${inspection.integrationRef} reason=stale-cached-metadata-ghost-conflict`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
               /*
               FNXC:WorkflowResolvedColumns 2026-07-30-21:40 (SELF-AUDIT after #2916 found the same class):
@@ -4739,7 +4728,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               reclaimedCleanly = true;
             } catch (tipMergedErr: unknown) {
               const message = tipMergedErr instanceof Error ? tipMergedErr.message : String(tipMergedErr);
-              await this.store.logEntry(task.id, `Auto-recovery warning: tip-already-merged cleanup failed — ${message}`);
+              await this.store.logEntry(task.id, `Auto-recovery warning: tip-already-merged cleanup failed — ${message}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               log.warn(`Failed tip-already-merged cleanup for ${task.id}: ${message}`);
             }
 
@@ -4813,11 +4802,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                   pausedReason: undefined,
                   status: null,
                   error: null,
-                });
+                }, UNATTRIBUTED_MUTATION_CONTEXT);
                 await this.store.logEntry(
                   task.id,
-                  `[recovery] reclaim-live-zero-commits ${task.id} branch=${task.branch} worktree=${inspection.livePath} tip=${inspection.tipSha.slice(0, 12)} reason=zero-unique-commits-vs-main`,
-                );
+                  `[recovery] reclaim-live-zero-commits ${task.id} branch=${task.branch} worktree=${inspection.livePath} tip=${inspection.tipSha.slice(0, 12)} reason=zero-unique-commits-vs-main`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
                 if (lanesOfReclaim(task.id).review.has(task.column)) {
                   if (!reviewProof?.ok) {
@@ -4863,7 +4851,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 reclaimedCleanly = true;
               } catch (reclaimErr: unknown) {
                 const reclaimMessage = reclaimErr instanceof Error ? reclaimErr.message : String(reclaimErr);
-                await this.store.logEntry(task.id, `Auto-recovery warning: reclaim-live-zero-commits failed — ${reclaimMessage}`);
+                await this.store.logEntry(task.id, `Auto-recovery warning: reclaim-live-zero-commits failed — ${reclaimMessage}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 log.warn(`Failed reclaim-live-zero-commits for ${task.id}: ${reclaimMessage}`);
               }
 
@@ -4891,8 +4879,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (placement.kind === "deferred-live") {
             await this.store.logEntry(
               task.id,
-              `[recovery] deferred relocation of active preserved worktree ${placement.path}`,
-            );
+              `[recovery] deferred relocation of active preserved worktree ${placement.path}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             continue;
           }
           const reclaimedWorktreePath = placement.path;
@@ -4900,8 +4887,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             relocatedWorktreePath = reclaimedWorktreePath;
             await this.store.logEntry(
               task.id,
-              `[recovery] relocated preserved worktree from ${inspection.livePath} to ${reclaimedWorktreePath}`,
-            );
+              `[recovery] relocated preserved worktree from ${inspection.livePath} to ${reclaimedWorktreePath}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           const stepSignature = buildResumeLimboStepSignature(task);
           const hasActiveSessionSignal = Boolean(task.checkedOutBy) || activeTaskIds.has(task.id.toUpperCase());
@@ -4929,7 +4915,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               resumeLimboCount: 0,
               resumeLimboTipSha: inspection.tipSha,
               resumeLimboStepSignature: stepSignature,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
               `[recovery] resume-limbo-escalated ${task.id} moved to todo after ${resumeAttemptCount} no-progress reclaim/resume attempts`,
@@ -4938,8 +4924,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 idleMs,
                 resumeAttemptCount,
                 currentStep: task.currentStep ?? null,
-              }),
-            );
+              }), UNATTRIBUTED_MUTATION_CONTEXT);
             try {
               await createRunAuditor(this.store, {
                 runId: generateSyntheticRunId("self-heal", task.id),
@@ -4982,11 +4967,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             resumeLimboCount: resumeAttemptCount,
             resumeLimboTipSha: inspection.tipSha,
             resumeLimboStepSignature: stepSignature,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
-            `[recovery] ${wasPausedBranchConflict ? "reclaim-paused-review" : "reclaim-self-owned"} ${task.id} at ${reclaimedWorktreePath} (${preservedCommitCount} commits preserved, tip ${inspection.tipSha.slice(0, 12)})`,
-          );
+            `[recovery] ${wasPausedBranchConflict ? "reclaim-paused-review" : "reclaim-self-owned"} ${task.id} at ${reclaimedWorktreePath} (${preservedCommitCount} commits preserved, tip ${inspection.tipSha.slice(0, 12)})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
           if (lanesOfReclaim(task.id).review.has(task.column)) {
             if (!reviewProof?.ok) {
@@ -5047,22 +5031,22 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               A successful git worktree move and its task-row persist are not transactional. FN-213 keeps one reclaim commit point, then best-effort re-points only the worktree and relies on the immediately following registry-sourced metadata reconcile if that write also fails; a crash inside git worktree move remains git prune/repair territory.
               */
               try {
-                await this.store.updateTask(task.id, { worktree: relocatedWorktreePath });
-                await this.store.logEntry(task.id, `[recovery] re-pointed relocated worktree after deferred reclaim: ${relocatedWorktreePath}`);
+                await this.store.updateTask(task.id, { worktree: relocatedWorktreePath }, UNATTRIBUTED_MUTATION_CONTEXT);
+                await this.store.logEntry(task.id, `[recovery] re-pointed relocated worktree after deferred reclaim: ${relocatedWorktreePath}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               } catch (repointErr: unknown) {
                 const repointMessage = repointErr instanceof Error ? repointErr.message : String(repointErr);
                 log.warn(`[self-healing] failed to re-point relocated worktree for ${task.id}; registry reconcile will retry: ${repointMessage}`);
-                await this.store.logEntry(task.id, `Auto-recovery warning: relocated worktree re-point failed; registry reconcile will retry — ${repointMessage}`).catch(() => undefined);
+                await this.store.logEntry(task.id, `Auto-recovery warning: relocated worktree re-point failed; registry reconcile will retry — ${repointMessage}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
               }
             }
             const reason = `reclaim deferred — non-conflict error, retrying next sweep: ${message}`;
             log.warn(`[self-healing] ${task.id} ${reason}`);
-            await this.store.logEntry(task.id, `Auto-recovery warning: ${reason}`).catch(() => undefined);
+            await this.store.logEntry(task.id, `Auto-recovery warning: ${reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
             continue;
           }
           const patchPath = await preserveWorktreeChanges(this.options.rootDir, task.worktree, task.id);
           if (patchPath) {
-            await this.store.logEntry(task.id, `Preserved uncommitted worktree changes before pause: ${patchPath}`);
+            await this.store.logEntry(task.id, `Preserved uncommitted worktree changes before pause: ${patchPath}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           const dispatcher = this.options.autoRecoveryDispatcher ?? new AutoRecoveryDispatcher({
             taskStore: this.store,
@@ -5093,9 +5077,9 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               error: `Task branch conflict: ${task.branch} is not safely reclaimable (${message})`,
               paused: true,
               pausedReason: "branch-conflict-unrecoverable",
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.handoffTaskToReview(task.id, "branch-conflict-unrecoverable-repromote");
-            await this.store.logEntry(task.id, `Auto-recovery failed: branch conflict unrecoverable — ${message}`);
+            await this.store.logEntry(task.id, `Auto-recovery failed: branch conflict unrecoverable — ${message}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           }
         }
       }
@@ -5286,11 +5270,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           worktree: null,
           branch: null, branchWriteOrigin: "engine" as const,
           baseCommitSha: null,
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.logEntry(
           task.id,
-          `[recovery] stale-active-branch-reclaim ${task.id} branch=${branch} reason=${reclaimReason}`,
-        );
+          `[recovery] stale-active-branch-reclaim ${task.id} branch=${branch} reason=${reclaimReason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
         try {
           const auditor = createRunAuditor(this.store, {
@@ -5484,13 +5467,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           return { ...basePatch, ...overlapPatch };
         };
         if (typeof this.store.updateTaskAtomic === "function") {
-          await this.store.updateTaskAtomic(dependentId, buildPatch);
+          await this.store.updateTaskAtomic(dependentId, buildPatch, UNATTRIBUTED_MUTATION_CONTEXT);
           return overlapCleared;
         }
         // Compatibility only for structural test/extension stores; production TaskStore is atomic.
         const live = await this.store.getTask(dependentId).catch(() => null);
         if (!live) return false;
-        await this.store.updateTask(dependentId, buildPatch(live));
+        await this.store.updateTask(dependentId, buildPatch(live), UNATTRIBUTED_MUTATION_CONTEXT);
         return overlapCleared;
       };
       /*
@@ -5621,8 +5604,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               );
               await this.store.logEntry(
                 dependent.id,
-                `Auto-recovered (FN-4523): cleared stale blockedBy — blocker ${taskId} is done`,
-              );
+                `Auto-recovered (FN-4523): cleared stale blockedBy — blocker ${taskId} is done`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             }
           } else {
             await updateDependentWithOverlapClear(
@@ -5632,8 +5614,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             );
             await this.store.logEntry(
               dependent.id,
-              `Auto-recovered (FN-4523): cleared stale blockedBy — blocker ${taskId} is done`,
-            );
+              `Auto-recovered (FN-4523): cleared stale blockedBy — blocker ${taskId} is done`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           result.blockedByCleared++;
         } catch (err: unknown) {
@@ -5687,7 +5668,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               source: "self-healing-completion-convergence",
               audit,
               log: async (message) => {
-                await this.store.logEntry(taskId, message).catch(() => undefined);
+                await this.store.logEntry(taskId, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
               },
             });
             result.worktreeRemoved = cleanup.removed;
@@ -5706,7 +5687,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 worktree: null as string | null,
                 ...(task.branch === branchName ? { branch: null as string | null, branchWriteOrigin: "engine" as const } : {}),
               };
-              await this.store.updateTask(task.id, patch as Partial<Task>);
+              await this.store.updateTask(task.id, patch as Partial<Task>, UNATTRIBUTED_MUTATION_CONTEXT);
             }
           }
         } catch (err: unknown) {
@@ -6016,7 +5997,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             result.outcomes.push({ taskId: task.id, result: "skipped", reason: safety.reason });
             continue;
           }
-          await this.store.updateTask(task.id, patch);
+          await this.store.updateTask(task.id, patch, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.emitBranchRebindAuditEvent({
             taskId: task.id,
             mutationType: "task:auto-rebind-applied",
@@ -6131,7 +6112,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         const liveWorktree = branchMap.get(normalizedBranch);
 
         if (liveWorktree) {
-          await this.store.updateTask(task.id, { worktree: liveWorktree });
+          await this.store.updateTask(task.id, { worktree: liveWorktree }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.emitWorktreeMetadataAuditEvent({
             taskId: task.id,
             mutationType: "task:auto-recover-worktree-metadata-rebound",
@@ -6159,7 +6140,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
           FNXC:MissingWorktreeRecovery 2026-07-10 (code review): the FN-5256 guard immediately below exists precisely because column==="in-progress"/"in-review" tasks can be live even when this heuristic's existsSync/registered-path check calls them stale (that's the guard's own stated rationale). Restrict this scopeOverride bypass to the narrow #1992 bug shape reproduced in the task report — in-review AND a merge-active sub-status (merging/merging-pr/merging-fix) — so a scopeOverride task that is genuinely in-progress, or in-review mid-step (status: null) with a live but momentarily undetected session, still falls through to the FN-5256 protection instead of having its worktree/branch/sessionFile yanked out from under it.
           */
-          await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" as const, sessionFile: null });
+          await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" as const, sessionFile: null }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.emitWorktreeMetadataAuditEvent({
             taskId: task.id,
             mutationType: "task:auto-recover-worktree-metadata-cleared",
@@ -6194,7 +6175,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           continue;
         }
 
-        await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" });
+        await this.store.updateTask(task.id, { worktree: null, branch: null, branchWriteOrigin: "engine" }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.emitWorktreeMetadataAuditEvent({
           taskId: task.id,
           mutationType: "task:auto-recover-worktree-metadata-cleared",
@@ -6277,8 +6258,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       });
       await this.store.logEntry(
         task.id,
-        `Auto-rebounded (FN-4890): paused in-progress holder exceeded scope-decay threshold with ${followerCount} blocked follower(s)`,
-      );
+        `Auto-rebounded (FN-4890): paused in-progress holder exceeded scope-decay threshold with ${followerCount} blocked follower(s)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       const auditor = createRunAuditor(this.store, {
         runId: generateSyntheticRunId("fn4890-paused-scope-decay", task.id),
         agentId: "self-healing",
@@ -6724,14 +6704,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           return Object.keys(patch).length > 0 ? patch : null;
         };
         if (typeof this.store.updateTaskAtomic === "function") {
-          await this.store.updateTaskAtomic(taskId, buildPatch);
+          await this.store.updateTaskAtomic(taskId, buildPatch, UNATTRIBUTED_MUTATION_CONTEXT);
           return overlapCleared;
         }
         // Compatibility only for structural test/extension stores; production TaskStore is atomic.
         const live = await this.store.getTask(taskId).catch(() => null);
         if (!live) return false;
         const patch = buildPatch(live);
-        if (patch) await this.store.updateTask(taskId, patch);
+        if (patch) await this.store.updateTask(taskId, patch, UNATTRIBUTED_MUTATION_CONTEXT);
         return overlapCleared;
       };
 
@@ -6842,8 +6822,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             if (overlapCleared) {
               await this.store.logEntry(
                 task.id,
-                `Auto-recovered: cleared stale file-scope overlap blocker ${observedOverlapBlockerId}`,
-              );
+                `Auto-recovered: cleared stale file-scope overlap blocker ${observedOverlapBlockerId}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               markRecovered(task.id);
             }
           }
@@ -6936,8 +6915,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                   if (nextBlocker === blockerId) {
                     continue;
                   }
-                  await this.store.updateTask(task.id, { blockedBy: nextBlocker, status: "queued" });
-                  await this.store.logEntry(task.id, `Auto-recovered (FN-5488): refreshed stale blockedBy — blocker=${blockerId} blockerStatus=${blocker?.status ?? "none"} reason=${reasonCode ?? "unspecified"}; ${reason}; now blocked by ${nextBlocker}`);
+                  await this.store.updateTask(task.id, { blockedBy: nextBlocker, status: "queued" }, UNATTRIBUTED_MUTATION_CONTEXT);
+                  await this.store.logEntry(task.id, `Auto-recovered (FN-5488): refreshed stale blockedBy — blocker=${blockerId} blockerStatus=${blocker?.status ?? "none"} reason=${reasonCode ?? "unspecified"}; ${reason}; now blocked by ${nextBlocker}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                   didRecover = true;
                 } else if (hasActiveOverlapBlocker) {
                   const transition = await this.store.transitionQueuedEpisode(task.id, {
@@ -6954,12 +6933,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                     canClearOverlap ? observedOverlapBlockerId : null,
                     { blockedBy: null, ...clearBlockedStatusOnly(task) },
                   );
-                  await this.store.logEntry(task.id, `Auto-recovered (FN-5488): cleared stale blockedBy — blocker=${blockerId} blockerStatus=${blocker?.status ?? "none"} reason=${reasonCode ?? "unspecified"}; ${reason}`);
+                  await this.store.logEntry(task.id, `Auto-recovered (FN-5488): cleared stale blockedBy — blocker=${blockerId} blockerStatus=${blocker?.status ?? "none"} reason=${reasonCode ?? "unspecified"}; ${reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                   didRecover = true;
                 }
               } else {
-                await this.store.updateTask(task.id, { blockedBy: null });
-                await this.store.logEntry(task.id, `Auto-recovered (FN-4091): cleared stale blockedBy — ${reason}`);
+                await this.store.updateTask(task.id, { blockedBy: null }, UNATTRIBUTED_MUTATION_CONTEXT);
+                await this.store.logEntry(task.id, `Auto-recovered (FN-4091): cleared stale blockedBy — ${reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 didRecover = true;
               }
               if (didRecover) markRecovered(task.id);
@@ -7006,7 +6985,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         const nextBlocker = unresolvedDeps[0] ?? null;
         if (nextBlocker && task.blockedBy !== nextBlocker) {
           try {
-            await this.store.updateTask(task.id, { blockedBy: nextBlocker, status: "queued" });
+            await this.store.updateTask(task.id, { blockedBy: nextBlocker, status: "queued" }, UNATTRIBUTED_MUTATION_CONTEXT);
           } catch (err: unknown) {
             const errorMessage = err instanceof Error ? err.message : String(err);
             log.error(`Failed to refresh blockedBy for ${task.id}: ${errorMessage}`);
@@ -7176,12 +7155,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         recoveryRehome: true,
       });
       if (deadlockingDependency.overlapBlockedBy === holder.id) {
-        await this.store.updateTask(deadlockingDependency.id, { overlapBlockedBy: null, status: null });
+        await this.store.updateTask(deadlockingDependency.id, { overlapBlockedBy: null, status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
       }
       await this.store.logEntry(
         holder.id,
-        `Auto-rebounded (FN-6292): released dependency-blocking file-scope lease; dependency ${deadlockingDependency.id} can run before this task resumes`,
-      );
+        `Auto-rebounded (FN-6292): released dependency-blocking file-scope lease; dependency ${deadlockingDependency.id} can run before this task resumes`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await createRunAuditor(this.store, {
         runId: generateSyntheticRunId("fn6292-dependency-blocking-lease", holder.id),
         agentId: "self-healing",
@@ -7290,7 +7268,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           blockedBy: null,
           executeRequeueLoopCount: null,
           executeRequeueLoopSignature: null,
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         const fresh = await this.store.getTask(snapshot.id);
         const advanced = await this.options.recoverCompletedTask(fresh);
         if (!advanced) {
@@ -7298,13 +7276,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             paused: true,
             pausedReason: COMPLETED_BLOCKED_PAUSE_REASON,
             status: "queued",
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           continue;
         }
         await this.store.logEntry(
           snapshot.id,
-          "Auto-advanced completed blocked work to review after blocker cleared",
-        );
+          "Auto-advanced completed blocked work to review after blocker cleared", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         await createRunAuditor(this.store, {
           runId: generateSyntheticRunId("completed-blocked-advance", snapshot.id),
           agentId: "self-healing",
@@ -7438,11 +7415,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           recoveryRehome: true,
           bypassGuards: true,
         });
-        await this.store.updateTask(task.id, { status: "queued", blockedBy: unmetDeps[0] });
+        await this.store.updateTask(task.id, { status: "queued", blockedBy: unmetDeps[0] }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.logEntry(
           task.id,
-          `Auto-rebounded (FN-6793): in-review task had unmet dependencies: ${unmetDeps.join(", ")}`,
-        );
+          `Auto-rebounded (FN-6793): in-review task had unmet dependencies: ${unmetDeps.join(", ")}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         await createRunAuditor(this.store, {
           runId: generateSyntheticRunId("fn6793-in-review-unmet-dependencies", task.id),
           agentId: "self-healing",
@@ -7525,7 +7501,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           || this.options.isTaskActive?.(current.id) === true
           || !current.dependencies.includes(dependencyId)) continue;
         try {
-          await this.store.updateTaskDependencies(current.id, { operation: "remove", dependency: dependencyId });
+          await this.store.updateTaskDependencies(current.id, { operation: "remove", dependency: dependencyId }, UNATTRIBUTED_MUTATION_CONTEXT);
           removed += 1;
         } catch (error) {
           // A concurrent dependency replacement wins; a later sweep re-discovers any surviving residue.
@@ -7533,7 +7509,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         }
       }
       if (removed === 0) continue;
-      await this.store.logEntry(snapshot.id, `Auto-reconciled ${removed} missing dependency reference(s); replanning required.`);
+      await this.store.logEntry(snapshot.id, `Auto-reconciled ${removed} missing dependency reference(s); replanning required.`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       repaired += 1;
     }
     return repaired;
@@ -7564,11 +7540,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (nextDependencies.length === originalDependencies.length) continue;
 
         try {
-          await this.store.updateTask(task.id, { dependencies: nextDependencies });
+          await this.store.updateTask(task.id, { dependencies: nextDependencies }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
-            `Auto-reconciled self-defeating dependency: removed ${match.operandTaskId} (matched verb: "${match.matchedVerb}") from dependencies.`,
-          );
+            `Auto-reconciled self-defeating dependency: removed ${match.operandTaskId} (matched verb: "${match.matchedVerb}") from dependencies.`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
           const auditor = createRunAuditor(this.store, {
             runId: generateSyntheticRunId("self-heal-self-defeating-dep", task.id),
@@ -7680,11 +7655,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (isTwoNodeCycle && foundationTask && foundationChildId && umbrellaTaskId && umbrellaDependsOnFoundation && foundationDependsOnUmbrella) {
           const nextDependencies = foundationTask.dependencies.filter((dep) => dep.toUpperCase() !== umbrellaTaskId.toUpperCase());
           if (nextDependencies.length !== foundationTask.dependencies.length) {
-            await this.store.updateTask(foundationChildId, { dependencies: nextDependencies });
+            await this.store.updateTask(foundationChildId, { dependencies: nextDependencies }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               foundationChildId,
-              `Auto-cleared umbrella back-edge: removed ${umbrellaTaskId} from dependencies (cycle: ${cyclePath.join(" → ")})`,
-            );
+              `Auto-cleared umbrella back-edge: removed ${umbrellaTaskId} from dependencies (cycle: ${cyclePath.join(" → ")})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await auditor.database({
               type: "task:auto-reconciled-dependency-cycle",
               target: foundationChildId,
@@ -7772,7 +7746,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           const previousStatus = task.status;
           const updatedAtMs = Date.parse(task.updatedAt ?? "") || Date.now();
           const ageMs = Math.max(0, Date.now() - updatedAtMs);
-          await this.store.updateTask(task.id, { status: null });
+          await this.store.updateTask(task.id, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordIntegrityAudit(task.id, "task:auto-recover-stale-merger-status", {
             previousColumn: task.column,
             previousStatus,
@@ -7782,8 +7756,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           });
           await this.store.logEntry(
             task.id,
-            `Auto-recovered: cleared stale status="${previousStatus}" on ${task.column} task (age ${Math.round(ageMs / 1000)}s) — was blocking merger queue`,
-          );
+            `Auto-recovered: cleared stale status="${previousStatus}" on ${task.column} task (age ${Math.round(ageMs / 1000)}s) — was blocking merger queue`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           cleared++;
         } catch (err: unknown) {
           const errorMessage = err instanceof Error ? err.message : String(err);
@@ -7897,15 +7870,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             }
           }
           if (resolveExplicitDuplicateMarker(null, task.title).marker?.canonicalId === canonicalMarkerId) {
-            await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${canonicalMarkerId}` });
+            await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${canonicalMarkerId}` }, UNATTRIBUTED_MUTATION_CONTEXT);
           }
-          await this.store.updateTask(task.id, buildMarkerClearedReplanTaskPatch(canonicalId));
+          await this.store.updateTask(task.id, buildMarkerClearedReplanTaskPatch(canonicalId), UNATTRIBUTED_MUTATION_CONTEXT);
           if (typeof this.store.logEntry === "function") {
             await Promise.resolve(this.store.logEntry(
               task.id,
               TRIAGE_MARKER_CLEARED_REPLAN_LOG_ACTION,
-              buildInactiveDuplicateClearFeedback(canonicalId),
-            )).catch(() => {});
+              buildInactiveDuplicateClearFeedback(canonicalId), UNATTRIBUTED_MUTATION_CONTEXT)).catch(() => {});
           }
           await createRunAuditor(this.store, {
             runId: generateSyntheticRunId("reconcile-stale-duplicate-decision", task.id),
@@ -7986,7 +7958,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (plan.action === "skip" || !plan.patch) continue;
 
           try {
-            await this.store.updateTask(task.id, plan.patch);
+            await this.store.updateTask(task.id, plan.patch, UNATTRIBUTED_MUTATION_CONTEXT);
             await createRunAuditor(this.store, {
               runId: generateSyntheticRunId("reconcile-legacy-adoption", task.id),
               agentId: "self-healing",
@@ -8272,7 +8244,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
    * capacity-boundary continuation). Unowned by both lanes, not looping — silent.
    *
    * The repair restores the replan signal so triage retries the routing. It is deliberately signal-only: it
-   * does not retire the continuation (triage's own atomic replace does that when it takes the slot), does not
+   * does not retire the continuation (triage's own atomic replace does that when it takes the slot, UNATTRIBUTED_MUTATION_CONTEXT), does not
    * move columns, and never touches an operator pause. Routing exhaustion is usually transient — a busy or
    * momentarily disabled role agent — so retrying is the correct response, not parking for a human.
    */
@@ -8359,11 +8331,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 await audit("task:reconcile-principal-held-planning-no-action", "raced");
                 return false;
               }
-              await this.store.updateTask(task.id, { status: "needs-replan" });
+              await this.store.updateTask(task.id, { status: "needs-replan" }, UNATTRIBUTED_MUTATION_CONTEXT);
               await this.store.logEntry(
                 task.id,
-                `[recovery] planning re-queued — ${heldPlanning.blockedReason} held with no retry owner`,
-              );
+                `[recovery] planning re-queued — ${heldPlanning.blockedReason} held with no retry owner`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await audit("task:reconcile-principal-held-planning");
               return true;
             };
@@ -8480,8 +8451,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (verdict.action === "requeue") {
             await this.store.logEntry(
               item.taskId,
-              `[recovery] workflow continuation re-queued — ${item.nodeId} was stranded in '${item.state}' (${verdict.reason})`,
-            ).catch(() => undefined);
+              `[recovery] workflow continuation re-queued — ${item.nodeId} was stranded in '${item.state}' (${verdict.reason})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
           }
           await createRunAuditor(this.store, {
             runId: generateSyntheticRunId("reconcile-stranded-continuation", item.taskId),
@@ -8744,7 +8714,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (orphanedCount === 0) continue;
 
           try {
-            await this.store.updateTask(task.id, { workflowStepResults: results });
+            await this.store.updateTask(task.id, { workflowStepResults: results }, UNATTRIBUTED_MUTATION_CONTEXT);
             // Counted on the successful mutation; a failed audit emit below must not
             // understate how many tasks were actually recovered.
             recovered += 1;
@@ -8873,7 +8843,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               needsOperatorBypass: settings ? !allowsAutoMergeProcessing(live, settings) : undefined,
             };
             return { workflowStepResults: results };
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           if (!repair) continue;
           repairedTasks += 1;
         } catch (error) {
@@ -8883,8 +8853,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
         await this.store.logEntry(
           fresh.id,
-          `[pre-merge] Invalid proofless approval repaired for ${repair.stepIds.join(", ")}: ${repair.reason}`,
-        ).catch(() => undefined);
+          `[pre-merge] Invalid proofless approval repaired for ${repair.stepIds.join(", ")}: ${repair.reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
         await emitBoundedRunAudit(this.store, {
           taskId: fresh.id,
           agentId: "self-healing",
@@ -9006,8 +8975,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             await this.store.logEntry(
               task.id,
               `Finalize blocked: unproven ownership evidence (${classification.reason}); no owned landed commit was found — auto-retrying via todo requeue`,
-              JSON.stringify(classification.details, null, 2),
-            );
+              JSON.stringify(classification.details, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.updateTask(task.id, {
               mergeDetails: {
                 ...(task.mergeDetails || {}),
@@ -9016,7 +8984,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                   reason: classification.reason,
                 },
               },
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
           } else {
             // Hydrate the in-memory dedup Set from the persisted record so subsequent
             // checks in this process don't have to re-query the task.
@@ -9065,8 +9033,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             mergeTargetBranch: ahead.baseRef,
           };
           confirmedMergeDetails = mergeDetails;
-          await this.store.updateTask(task.id, { mergeDetails });
-          await this.store.logEntry(task.id, `Auto-finalized: recovered owned landed commit ${classification.commit.sha.slice(0, 8)}`);
+          await this.store.updateTask(task.id, { mergeDetails }, UNATTRIBUTED_MUTATION_CONTEXT);
+          await this.store.logEntry(task.id, `Auto-finalized: recovered owned landed commit ${classification.commit.sha.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         } else {
           // FN-5490/FN-5517/FN-5526/FN-5540 guard: same lost-work check as
           // merger.ts:aiMergeTask. The self-heal path was the historical
@@ -9084,7 +9052,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
              * FNXC:Lifecycle 2026-06-14-20:14:
              * FN-6461/FN-6455 requires self-healing no-op finalization to demote no-commits tasks with incomplete/skipped work and set an error so stranded-todo recovery will not immediately re-promote them.
              */
-            await this.store.updateTask(task.id, { error: reason });
+            await this.store.updateTask(task.id, { error: reason }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
               `Finalize blocked (no-commits incomplete-work guard): ${reason} — moving back to todo with progress preserved`,
@@ -9094,8 +9062,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 classification: "proven-no-op",
                 baseRef: classification.baseRef,
                 lane: "self-healing-finalize-no-op-review",
-              }, null, 2),
-            );
+              }, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
             await this.recordIntegrityAudit(task.id, "task:no-commits-finalize-blocked-incomplete-steps", {
               reason,
               doneCount: noCommitsFinalize.doneCount,
@@ -9117,8 +9084,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 modifiedFilesSample: task.modifiedFiles.slice(0, 5),
                 classification: "proven-no-op",
                 baseRef: classification.baseRef,
-              }, null, 2),
-            );
+              }, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
             await this.recordIntegrityAudit(task.id, "task:finalize-lost-work-blocked", {
               modifiedFilesCount: task.modifiedFiles.length,
               classification: "proven-no-op",
@@ -9143,12 +9109,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           // patch so a leaked `mergeActive` slot from a prior merge attempt cannot survive
           // this auto-finalize path. Same bug class as recoverBranchMisboundInReviewTasks().
           confirmedMergeDetails = mergeDetails;
-          await this.store.updateTask(task.id, { mergeDetails, modifiedFiles: [], status: null, error: null, paused: false });
+          await this.store.updateTask(task.id, { mergeDetails, modifiedFiles: [], status: null, error: null, paused: false }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordIntegrityAudit(task.id, "task:integrity-reconcile-modified-files", {
             reason: "proven-no-op-finalize",
             clearedCount: task.modifiedFiles?.length ?? 0,
           });
-          await this.store.logEntry(task.id, `Auto-finalized no-op (proven): start point on ${classification.baseRef}; modifiedFiles cleared`);
+          await this.store.logEntry(task.id, `Auto-finalized no-op (proven): start point on ${classification.baseRef}; modifiedFiles cleared`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         }
 
         const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
@@ -9292,7 +9258,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               deletions: classification.commit.deletions,
               mergeCommitMessage,
             },
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordIntegrityAudit(task.id, "task:integrity-reconcile-modified-files", {
             reason: "recovered-owned-commit",
             commitSha: classification.commit.sha,
@@ -9313,7 +9279,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               noOpReason: `branch has zero commits ahead of ${classification.baseRef}`,
               landedFiles: [],
             },
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordIntegrityAudit(task.id, "task:integrity-reconcile-modified-files", {
             reason: "proven-no-op",
             clearedCount: task.modifiedFiles?.length ?? 0,
@@ -9334,7 +9300,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               noOpReason: "verification-only finalize: no branch and no owned commits",
               landedFiles: [],
             },
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordIntegrityAudit(task.id, "task:integrity-reconcile-modified-files", {
             reason: "verification-only-finalize",
             clearedCount: task.modifiedFiles?.length ?? 0,
@@ -9343,8 +9309,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           });
           await this.store.logEntry(
             task.id,
-            "Finalize: verification-only task — no owned commits and no branch; cleared stale modifiedFiles snapshot",
-          );
+            "Finalize: verification-only task — no owned commits and no branch; cleared stale modifiedFiles snapshot", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           reconciled++;
           continue;
         }
@@ -9358,8 +9323,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.logEntry(
             task.id,
             `Integrity warning: done-task finalize evidence is unproven (${classification.reason})`,
-            JSON.stringify(classification.details, null, 2),
-          );
+            JSON.stringify(classification.details, null, 2), UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.updateTask(task.id, {
             mergeDetails: {
               ...(task.mergeDetails || {}),
@@ -9368,7 +9332,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 reason: classification.reason,
               },
             },
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordIntegrityAudit(task.id, "task:integrity-warning", {
             reason: classification.reason,
             modifiedFilesCount: task.modifiedFiles?.length ?? 0,
@@ -9452,7 +9416,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       workflowStepId: undefined,
     }));
     if (reroute.rerouted) {
-      await this.store.logEntry(task.id, "[pre-merge] Self-healing re-seeded Code Review after stale content evidence blocked merge.");
+      await this.store.logEntry(task.id, "[pre-merge] Self-healing re-seeded Code Review after stale content evidence blocked merge.", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       log.warn(`Stale content approval for ${task.id} re-seeded at ${reroute.nodeId ?? "code-review"}`);
     }
 
@@ -9487,7 +9451,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     const reroute = await rerouteUnrunPreMergeGateToReview(this.store, task, { requiredPreMergeStepIds: mergeGate.requiredPreMergeStepIds, mergeContent })
       .catch(() => ({ rerouted: false, reason: "no-unrun-gate" as const, nodeId: undefined, workflowStepId: undefined }));
     if (reroute.rerouted) {
-      await this.store.logEntry(task.id, "[pre-merge] Self-healing re-seeded the workflow graph at an enabled pre-merge gate that never ran.");
+      await this.store.logEntry(task.id, "[pre-merge] Self-healing re-seeded the workflow graph at an enabled pre-merge gate that never ran.", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       log.warn(`Unrun pre-merge gate for ${task.id} re-seeded at ${reroute.nodeId ?? "unknown"}`);
     }
     const auditKey = `${task.id}:${reroute.reason}:${reroute.nodeId ?? ""}`;
@@ -9669,8 +9633,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               );
               if (drops >= MAX_STARVATION_DROPS) {
                 const error = `Auto-merge starvation: ${MAX_STARVATION_DROPS} consecutive enqueue attempts were dropped by the engine merge queue; task requires manual intervention.`;
-                await this.store.updateTask(task.id, { status: "failed", error });
-                await this.store.logEntry(task.id, error);
+                await this.store.updateTask(task.id, { status: "failed", error }, UNATTRIBUTED_MUTATION_CONTEXT);
+                await this.store.logEntry(task.id, error, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 this.mergeStarvationDrops.delete(task.id);
                 recovered++;
               }
@@ -9684,8 +9648,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             task.id,
             enqueueMerge
               ? "Auto-recovered: eligible in-review task re-enqueued for merge"
-              : "Auto-recovered: eligible in-review task was merged and moved to done",
-          );
+              : "Auto-recovered: eligible in-review task was merged and moved to done", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           log.log(`Recovered mergeable review task ${task.id}`);
           recovered++;
         } catch (err: unknown) { const errorMessage = err instanceof Error ? err.message : String(err);
@@ -9966,12 +9929,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         const nextCount = budget.attempts + 1;
         const totalFixCount = (admittedTask.postReviewFixCount ?? 0) + 1;
         try {
-          await this.store.updateTask(task.id, { postReviewFixCount: totalFixCount });
+          await this.store.updateTask(task.id, { postReviewFixCount: totalFixCount }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
             `Auto-reviving in-review task with failed pre-merge workflow step (attempt ${nextCount}/${budget.label})`,
-            optionalStepRevisionLogOutcome(`Step: ${budget.stepName ?? budget.key}`, budget.key),
-          );
+            optionalStepRevisionLogOutcome(`Step: ${budget.stepName ?? budget.key}`, budget.key), UNATTRIBUTED_MUTATION_CONTEXT);
           /*
           FNXC:LifecycleContainment 2026-08-30-13:36:
           The claim must travel WITH the work it admitted. The claim-scoped recovery addresses the
@@ -10012,7 +9974,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 + "This review is not retried until its findings change. Re-run the review after addressing it manually, "
                 + "or use the privileged review bypass when the failed review is known to be non-blocking.",
             };
-            await this.store.logEntry(task.id, refusalEntry.action, refusalEntry.outcome);
+            await this.store.logEntry(task.id, refusalEntry.action, refusalEntry.outcome, UNATTRIBUTED_MUTATION_CONTEXT);
             continue;
           }
           if (outcome.kind === "scheduled") {
@@ -10160,13 +10122,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         }
 
         if (signal.code === "non-retryable-provider-error" && task.userPaused !== true) {
-          await this.store.logEntry(task.id, `${IN_REVIEW_STALL_TERMINAL_LOG_PREFIX}${signal.code}]: ${signal.reason}`);
+          await this.store.logEntry(task.id, `${IN_REVIEW_STALL_TERMINAL_LOG_PREFIX}${signal.code}]: ${signal.reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.updateTask(task.id, {
             paused: true,
             pausedReason: "non-retryable-provider-error",
             status: "failed",
             error: `Terminal provider error (non-retryable): ${signal.reason}`,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           const auditor = createRunAuditor(this.store, {
             runId: generateSyntheticRunId("self-healing-stall-terminal-provider-error", task.id),
             agentId: "self-healing",
@@ -10207,14 +10169,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (shouldDispose) {
           await this.store.logEntry(
             task.id,
-            `${IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX}${signal.code}]: deadlock-prevention threshold reached after ${nextCount} identical stalls — pausing task. last reason: ${signal.reason}`,
-          );
+            `${IN_REVIEW_STALL_DEADLOCK_LOG_PREFIX}${signal.code}]: deadlock-prevention threshold reached after ${nextCount} identical stalls — pausing task. last reason: ${signal.reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.updateTask(task.id, {
             paused: true,
             pausedReason: "in-review-stall-deadlock",
             status: "failed",
             error: `In-review stall deadlock: ${signal.code} repeated ${nextCount}× without progress. ${signal.reason}`,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           const auditor = createRunAuditor(this.store, {
             runId: generateSyntheticRunId("self-healing-stall-deadlock", task.id),
             agentId: "self-healing",
@@ -10237,7 +10198,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           continue;
         }
 
-        await this.store.logEntry(task.id, `${IN_REVIEW_STALL_LOG_PREFIX}${signal.code}]: ${signal.reason}`);
+        await this.store.logEntry(task.id, `${IN_REVIEW_STALL_LOG_PREFIX}${signal.code}]: ${signal.reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         surfaced += 1;
       }
 
@@ -10555,11 +10516,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (!errorText.includes("[transient-recovery-budget-exhausted]")) {
             await this.store.logEntry(
               task.id,
-              `[FN-5627] Transient merge failure auto-recovery budget exhausted (${transientClass}, ${currentCount}/${MAX_TRANSIENT_MERGE_RECOVERIES}). Task remains parked in in-review for manual review.`,
-            );
+              `[FN-5627] Transient merge failure auto-recovery budget exhausted (${transientClass}, ${currentCount}/${MAX_TRANSIENT_MERGE_RECOVERIES}). Task remains parked in in-review for manual review.`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.updateTask(task.id, {
               error: `${errorText} [transient-recovery-budget-exhausted]`,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             try {
               await audit.database({
                 type: "merger:transient-failure-budget-exhausted",
@@ -10592,8 +10552,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         // even though the task is being auto-recovered cleanly.
         await this.store.logEntry(
           task.id,
-          `Auto-recovered: transient merge failure (${transientClass}); resetting mergeRetries=0 and re-enqueueing (recovery ${nextCount}/${MAX_TRANSIENT_MERGE_RECOVERIES}) [FN-5627]`,
-        );
+          `Auto-recovered: transient merge failure (${transientClass}); resetting mergeRetries=0 and re-enqueueing (recovery ${nextCount}/${MAX_TRANSIENT_MERGE_RECOVERIES}) [FN-5627]`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.updateTask(task.id, {
           mergeRetries: 0,
           status: null,
@@ -10602,7 +10561,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             ...task.mergeDetails,
             transientRecoveryCount: nextCount,
           },
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         try {
           await audit.database({
             type: "merger:transient-failure-auto-recovered",
@@ -10734,12 +10693,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           repos. The partial-land reconciler (KTD2) is the standing recovery for a re-enqueue drop.
           */
           if (isWorkspaceTask(task)) {
-            await this.store.updateTask(task.id, { status: null, error: null });
+            await this.store.updateTask(task.id, { status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT);
             this.options.clearMergeActive?.(task.id);
             await this.store.logEntry(
               task.id,
-              "Auto-recovered (workspace): cleared stale 'merging' status; per-repo land will be re-enqueued (no single-commit finalize)",
-            );
+              "Auto-recovered (workspace): cleared stale 'merging' status; per-repo land will be re-enqueued (no single-commit finalize)", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             try {
               this.options.enqueueMerge?.(task.id);
             } catch (enqueueErr: unknown) {
@@ -10762,7 +10720,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               mergeTargetBranch: mergeTarget.branch,
               mergeTargetSource: mergeTarget.source ?? null,
             });
-            await this.store.updateTask(task.id, { status: null, error: null });
+            await this.store.updateTask(task.id, { status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT);
             try {
               this.options.enqueueMerge?.(task.id);
             } catch { /* rely on polling sweep */ }
@@ -10798,7 +10756,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               error: null,
               mergeRetries: 0,
               mergeDetails,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-interrupted-merging");
             const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
             const movedTask = await this.moveToCompleteLaneAfterLandedCleanup(task, completeLane, "recover-interrupted-merging", mergeDetails);
@@ -10806,8 +10764,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             await this.cleanupInterruptedMergeArtifacts(task);
             await this.store.logEntry(
               task.id,
-              `Auto-recovered: stale merge status finalized from landed commit ${landedCommit.sha.slice(0, 8)}`,
-            );
+              `Auto-recovered: stale merge status finalized from landed commit ${landedCommit.sha.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             log.log(`Recovered interrupted merge ${task.id}: finalized landed commit ${landedCommit.sha.slice(0, 8)}`);
             recovered++;
             continue;
@@ -10816,11 +10773,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.updateTask(task.id, {
             status: null,
             error: null,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
-            "Auto-recovered: stale merge status cleared; merge will be retried",
-          );
+            "Auto-recovered: stale merge status cleared; merge will be retried", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           log.log(`Recovered interrupted merge ${task.id}: cleared stale status for retry`);
           try {
             this.options.enqueueMerge?.(task.id);
@@ -11082,11 +11038,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             turn an unreadable repository into an infinite five-minute recovery loop.
             */
             const defers = (task.mergeTransientRetryCount ?? 0) + 1;
-            await this.store.updateTask(task.id, { mergeTransientRetryCount: defers });
+            await this.store.updateTask(task.id, { mergeTransientRetryCount: defers }, UNATTRIBUTED_MUTATION_CONTEXT);
             if (defers >= MAX_STARVATION_DROPS) {
               const error = `Workspace partial-land evidence unavailable: branch state could not be read after ${MAX_STARVATION_DROPS} sweeps for sub-repo(s) ${evidenceUnavailableRepos.join(", ")} — manual intervention required.`;
-              await this.store.updateTask(task.id, { status: "failed", error });
-              await this.store.logEntry(task.id, error);
+              await this.store.updateTask(task.id, { status: "failed", error }, UNATTRIBUTED_MUTATION_CONTEXT);
+              await this.store.logEntry(task.id, error, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await auditor.database({
                 type: "task:reconcile-workspace-partial-land",
                 target: task.id,
@@ -11122,8 +11078,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 branch: entry?.branch,
               }).catch(() => undefined);
             }
-            await this.store.updateTask(task.id, { status: "failed", error });
-            await this.store.logEntry(task.id, error);
+            await this.store.updateTask(task.id, { status: "failed", error }, UNATTRIBUTED_MUTATION_CONTEXT);
+            await this.store.logEntry(task.id, error, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await auditor.database({
               type: "task:reconcile-workspace-partial-land",
               target: task.id,
@@ -11209,7 +11165,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     if (!enqueueMerge) {
       // Option not wired (standalone/tests with no queue) → graceful no-op; rely on next sweep.
       this.workspacePartialLandDrops.delete(task.id);
-      await this.store.logEntry(task.id, `${input.successLog} (enqueue not wired — deferred to next sweep)`);
+      await this.store.logEntry(task.id, `${input.successLog} (enqueue not wired — deferred to next sweep)`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await auditor.database({
         type: "task:reconcile-workspace-partial-land",
         target: task.id,
@@ -11221,7 +11177,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     const queued = enqueueMerge(task.id);
     if (queued) {
       this.workspacePartialLandDrops.delete(task.id);
-      await this.store.logEntry(task.id, input.successLog);
+      await this.store.logEntry(task.id, input.successLog, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await auditor.database({
         type: "task:reconcile-workspace-partial-land",
         target: task.id,
@@ -11237,13 +11193,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     `mergeTransientRetryCount` is the established task-owned ceiling for transient merge attempts.
     */
     const drops = (task.mergeTransientRetryCount ?? 0) + 1;
-    await this.store.updateTask(task.id, { mergeTransientRetryCount: drops });
+    await this.store.updateTask(task.id, { mergeTransientRetryCount: drops }, UNATTRIBUTED_MUTATION_CONTEXT);
     this.workspacePartialLandDrops.set(task.id, drops);
     log.warn(`reconcileWorkspacePartialLands: enqueue dropped for ${task.id} (${drops}/${MAX_STARVATION_DROPS}); merge queue rejected re-enqueue`);
     if (drops >= MAX_STARVATION_DROPS) {
       const error = `Workspace partial-land starvation: ${MAX_STARVATION_DROPS} consecutive enqueue attempts were dropped by the merge queue; task requires manual intervention.`;
-      await this.store.updateTask(task.id, { status: "failed", error });
-      await this.store.logEntry(task.id, error);
+      await this.store.updateTask(task.id, { status: "failed", error }, UNATTRIBUTED_MUTATION_CONTEXT);
+      await this.store.logEntry(task.id, error, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       this.workspacePartialLandDrops.delete(task.id);
       await auditor.database({
         type: "task:reconcile-workspace-partial-land",
@@ -11285,13 +11241,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           : null;
       };
       if (typeof this.store.updateTaskAtomic === "function") {
-        const updated = await this.store.updateTaskAtomic(snapshot.id, clearIfStillOrphaned);
+        const updated = await this.store.updateTaskAtomic(snapshot.id, clearIfStillOrphaned, UNATTRIBUTED_MUTATION_CONTEXT);
         if (updated.status !== "contention-hold") cleared++;
       } else {
         const live = await this.store.getTask(snapshot.id).catch(() => null);
         const patch = live ? clearIfStillOrphaned(live) : null;
         if (!patch) continue;
-        await this.store.updateTask(snapshot.id, patch);
+        await this.store.updateTask(snapshot.id, patch, UNATTRIBUTED_MUTATION_CONTEXT);
         cleared++;
       }
     }
@@ -11851,7 +11807,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               Done-task metadata repair is not allowed to convert stale workflow proof into truth. Missing merge confirmation, pending workflow steps, or invalid no-op proof still block repair; stale branch residue does not, because finalization only needs durable evidence that the task patch landed.
               */
               log.warn(`recoverDoneTaskMergeMetadata: skipped ${task.id} — invalid done merge proof (${confirmedProofVerdict.reason})`);
-              await this.store.logEntry(task.id, `Done-task merge metadata repair skipped: invalid workflow merge proof (${confirmedProofVerdict.reason})`).catch(() => undefined);
+              await this.store.logEntry(task.id, `Done-task merge metadata repair skipped: invalid workflow merge proof (${confirmedProofVerdict.reason})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
               continue;
             }
             const landedFilesMismatch = Boolean(
@@ -11897,14 +11853,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 prNumber: getPrimaryPrInfo(task)?.number,
               },
               modifiedFiles: liveLandedFiles && liveLandedFiles.length > 0 ? liveLandedFiles : undefined,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             if ((statsMismatch && liveShortstat) || landedFilesMismatch) {
               await this.store.logEntry(
                 task.id,
-                `Auto-recovered: stale mergeDetails repaired (was ${task.mergeDetails?.filesChanged ?? "?"}/${task.mergeDetails?.insertions ?? "?"}/${task.mergeDetails?.deletions ?? "?"}, now ${liveShortstat?.filesChanged ?? nextFilesChanged}/${liveShortstat?.insertions ?? nextInsertions}/${liveShortstat?.deletions ?? nextDeletions})${landedFilesMismatch ? ` (files ${task.mergeDetails?.landedFiles?.length ?? 0} → ${liveLandedFiles?.length ?? task.mergeDetails?.landedFiles?.length ?? 0})` : ""} — sha unchanged ${storedSha.slice(0, 8)}`,
-              );
+                `Auto-recovered: stale mergeDetails repaired (was ${task.mergeDetails?.filesChanged ?? "?"}/${task.mergeDetails?.insertions ?? "?"}/${task.mergeDetails?.deletions ?? "?"}, now ${liveShortstat?.filesChanged ?? nextFilesChanged}/${liveShortstat?.insertions ?? nextInsertions}/${liveShortstat?.deletions ?? nextDeletions})${landedFilesMismatch ? ` (files ${task.mergeDetails?.landedFiles?.length ?? 0} → ${liveLandedFiles?.length ?? task.mergeDetails?.landedFiles?.length ?? 0})` : ""} — sha unchanged ${storedSha.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             } else {
-              await this.store.logEntry(task.id, `Auto-recovered: reconciled done-task mergeDetails to owned commit ${landed.sha.slice(0, 8)}`);
+              await this.store.logEntry(task.id, `Auto-recovered: reconciled done-task mergeDetails to owned commit ${landed.sha.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             }
             repaired++;
             continue;
@@ -11915,8 +11870,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             if (!storedSha) {
               continue;
             }
-            await this.store.updateTask(task.id, { mergeDetails: undefined });
-            await this.store.logEntry(task.id, "Auto-recovered: cleared unowned done-task mergeDetails commitSha");
+            await this.store.updateTask(task.id, { mergeDetails: undefined }, UNATTRIBUTED_MUTATION_CONTEXT);
+            await this.store.logEntry(task.id, "Auto-recovered: cleared unowned done-task mergeDetails commitSha", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             repaired++;
             continue;
           }
@@ -11938,7 +11893,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           } as Task);
           if (!repairedProofVerdict.ok) {
             log.warn(`recoverDoneTaskMergeMetadata: skipped ${task.id} — invalid repaired merge proof (${repairedProofVerdict.reason})`);
-            await this.store.logEntry(task.id, `Done-task merge metadata repair skipped: invalid repaired workflow merge proof (${repairedProofVerdict.reason})`).catch(() => undefined);
+            await this.store.logEntry(task.id, `Done-task merge metadata repair skipped: invalid repaired workflow merge proof (${repairedProofVerdict.reason})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
             continue;
           }
 
@@ -11976,8 +11931,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               prNumber: getPrimaryPrInfo(task)?.number,
             },
             modifiedFiles: landedFiles && landedFiles.length > 0 ? landedFiles : undefined,
-          });
-          await this.store.logEntry(task.id, `Auto-recovered: reconciled done-task mergeDetails to owned commit ${landed.sha.slice(0, 8)}`);
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
+          await this.store.logEntry(task.id, `Auto-recovered: reconciled done-task mergeDetails to owned commit ${landed.sha.slice(0, 8)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           repaired++;
         } catch (err: unknown) {
           log.error(`Failed done-task merge metadata recovery for ${task.id}: ${err instanceof Error ? err.message : String(err)}`);
@@ -12104,7 +12059,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 mergeTargetBranch: task.mergeDetails?.mergeTargetBranch ?? mergeTarget.branch,
                 mergeTargetSource: task.mergeDetails?.mergeTargetSource ?? mergeTarget.source,
               },
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-merged-review");
           /*
@@ -12131,15 +12086,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           if (finalization.outcome === "blocked") {
             await this.store.logEntry(
               task.id,
-              `Auto-recovery skipped: merge confirmed but finalization blocked — ${finalization.reason ?? "unknown"}`,
-            );
+              `Auto-recovery skipped: merge confirmed but finalization blocked — ${finalization.reason ?? "unknown"}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             continue;
           }
           this.emitTaskMerged(finalization.task, { mergeConfirmed: true });
           await this.store.logEntry(
             task.id,
-            `Auto-finalized from ${task.column}: content proven via mergeConfirmed metadata. Cleared soft state paused=${clearedFlags.paused}, status=${clearedFlags.status}, error=${clearedFlags.error}, blockedBy=${clearedFlags.blockedBy}, overlapBlockedBy=${clearedFlags.overlapBlockedBy}`,
-          );
+            `Auto-finalized from ${task.column}: content proven via mergeConfirmed metadata. Cleared soft state paused=${clearedFlags.paused}, status=${clearedFlags.status}, error=${clearedFlags.error}, blockedBy=${clearedFlags.blockedBy}, overlapBlockedBy=${clearedFlags.overlapBlockedBy}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           try {
             await auditor.database({
               type: "task:auto-recover-finalize-already-on-main",
@@ -12309,12 +12262,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           workspace task backward here.
           */
           if (isWorkspaceTask(task)) {
-            if (task.status) await this.store.updateTask(task.id, { status: null, error: null });
+            if (task.status) await this.store.updateTask(task.id, { status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT);
             this.options.clearMergeActive?.(task.id);
             await this.store.logEntry(
               task.id,
-              "Auto-recovery (workspace): cleared stale deadlock 'failed' status; partial-land reconciler owns per-repo re-land (no single-commit finalize)",
-            );
+              "Auto-recovery (workspace): cleared stale deadlock 'failed' status; partial-land reconciler owns per-repo re-land (no single-commit finalize)", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             log.warn(`self-heal:deadlock-recovery-workspace-skip ${JSON.stringify({ stuckTaskId: task.id, blockedTaskIds, action: "cleared-status-deferred-to-partial-land-reconciler" })}`);
             recovered++;
             continue;
@@ -12362,7 +12314,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               mergeRetries: 0,
               branch: null, branchWriteOrigin: "engine" as const,
               mergeDetails,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-stuck-merge-deadlocks");
             const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
             const movedTask = await this.moveToCompleteLaneAfterLandedCleanup(task, completeLane, "recover-stuck-merge-deadlocks", mergeDetails);
@@ -12372,8 +12324,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             const clearedDependents: string[] = [];
             for (const dep of blockedDependents) {
               try {
-                await this.store.updateTask(dep.id, { blockedBy: null });
-                await this.store.logEntry(dep.id, `Auto-recovered: cleared stale blockedBy ${task.id} after deadlock recovery`);
+                await this.store.updateTask(dep.id, { blockedBy: null }, UNATTRIBUTED_MUTATION_CONTEXT);
+                await this.store.logEntry(dep.id, `Auto-recovered: cleared stale blockedBy ${task.id} after deadlock recovery`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
                 clearedDependents.push(dep.id);
               } catch (depErr: unknown) {
                 const depErrMessage = depErr instanceof Error ? depErr.message : String(depErr);
@@ -12383,8 +12335,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
             await this.store.logEntry(
               task.id,
-              `Auto-recovered: merge deadlock resolved via landed commit ${landedCommit.sha.slice(0, 8)}${clearedDependents.length > 0 ? `; cleared blockedBy on ${clearedDependents.join(", ")}` : ""}`,
-            );
+              `Auto-recovered: merge deadlock resolved via landed commit ${landedCommit.sha.slice(0, 8)}${clearedDependents.length > 0 ? `; cleared blockedBy on ${clearedDependents.join(", ")}` : ""}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             log.log(`self-heal:deadlock-recovered ${JSON.stringify({ stuckTaskId: task.id, blockedTaskIds, attributedSha: landedCommit.sha, action: "reattributed" })}`);
             recovered++;
           } else {
@@ -12403,8 +12354,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               but it must carry durable automation provenance. That lets stale-stamp recovery repair only
               this engine-owned false badge without treating a no-reason human pause as eligible.
               */
-              await this.store.updateTask(task.id, { paused: true, pausedReason: "merge-deadlock-detected" });
-              await this.store.logEntry(task.id, "merge-deadlock-detected: requires manual intervention — verified content not on main");
+              await this.store.updateTask(task.id, { paused: true, pausedReason: "merge-deadlock-detected" }, UNATTRIBUTED_MUTATION_CONTEXT);
+              await this.store.logEntry(task.id, "merge-deadlock-detected: requires manual intervention — verified content not on main", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               log.warn(`self-heal:deadlock-recovered ${JSON.stringify({ stuckTaskId: task.id, blockedTaskIds, attributedSha: null, action: "paused-for-manual" })}`);
               recovered++;
             }
@@ -12587,11 +12538,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               status: "failed",
               error: `Confirmed merge finalization deferred: ${postMergeBlocker}`,
               mergeDetails,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
-              `Auto-recovery parked task in in-review: merged content found on ${baseBranch} (${landed.sha.slice(0, 8)}) but finalization deferred — ${postMergeBlocker}`,
-            );
+              `Auto-recovery parked task in in-review: merged content found on ${baseBranch} (${landed.sha.slice(0, 8)}) but finalization deferred — ${postMergeBlocker}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             continue;
           }
 
@@ -12610,15 +12560,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             mergeDetails,
             steps: (task.steps ?? []).map((step, index) => checklistReconciliation.skippedStepIndexes.includes(index) ? { ...step, status: reconciledWorkflowStatus } : step),
             workflowStepResults: (task.workflowStepResults ?? []).map((result) => checklistReconciliation.reconciledWorkflowStepIds.includes(result.workflowStepId) ? { ...result, status: reconciledWorkflowStatus } : result),
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-orphan-only-scope-violations");
           const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
           const movedTask = await this.moveToCompleteLaneAfterLandedCleanup(task, completeLane, "recover-orphan-only-scope-violations", mergeDetails);
           this.emitTaskMerged(movedTask, { mergeConfirmed: true });
           await this.store.logEntry(
             task.id,
-            `Auto-finalized from in-review/paused: content proven on ${baseBranch} (${landed.sha.slice(0, 8)}). Cleared soft state paused=${clearedFlags.paused}, status=${clearedFlags.status}, error=${clearedFlags.error}`,
-          );
+            `Auto-finalized from in-review/paused: content proven on ${baseBranch} (${landed.sha.slice(0, 8)}). Cleared soft state paused=${clearedFlags.paused}, status=${clearedFlags.status}, error=${clearedFlags.error}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.cleanupWorktreeOnly(task);
           try {
             const auditor = createRunAuditor(this.store, {
@@ -12852,11 +12801,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               status: "failed",
               error: `Confirmed merge finalization deferred: ${postMergeBlocker}`,
               mergeDetails,
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.logEntry(
               task.id,
-              `Auto-recovery parked task in in-review: merged content found on ${baseBranch} (${landed.sha.slice(0, 8)}) but finalization deferred — ${postMergeBlocker}`,
-            );
+              `Auto-recovery parked task in in-review: merged content found on ${baseBranch} (${landed.sha.slice(0, 8)}) but finalization deferred — ${postMergeBlocker}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             continue;
           }
 
@@ -12875,7 +12823,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             mergeDetails,
             steps: (task.steps ?? []).map((step, index) => checklistReconciliation.skippedStepIndexes.includes(index) ? { ...step, status: reconciledWorkflowStatus } : step),
             workflowStepResults: (task.workflowStepResults ?? []).map((result) => checklistReconciliation.reconciledWorkflowStepIds.includes(result.workflowStepId) ? { ...result, status: reconciledWorkflowStatus } : result),
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           const worktreeHint = task.worktree;
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-already-merged-review");
           const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
@@ -12883,8 +12831,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           this.emitTaskMerged(movedTask, { mergeConfirmed: true });
           await this.store.logEntry(
             task.id,
-            `Auto-finalized from in-review/paused: content proven on ${baseBranch} (${landed.sha.slice(0, 8)}). Cleared soft state paused=${clearedFlags.paused}, status=${clearedFlags.status}, error=${clearedFlags.error}`,
-          );
+            `Auto-finalized from in-review/paused: content proven on ${baseBranch} (${landed.sha.slice(0, 8)}). Cleared soft state paused=${clearedFlags.paused}, status=${clearedFlags.status}, error=${clearedFlags.error}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.reconcileCompletedTask(task.id, { worktreeHint });
           try {
             const auditor = createRunAuditor(this.store, {
@@ -13042,12 +12989,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           completionHandoffLimboRecoveryCount: currentCount + 1,
           status: null,
           error: null,
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.logEntry(
           task.id,
           "Auto-recovered completed-task non-continuable wedge — cleared failed status after post-done session continuation error",
-          evidence,
-        );
+          evidence, UNATTRIBUTED_MUTATION_CONTEXT);
         await audit.database({
           type: "task:auto-recover-post-done-noncontinuable-wedge",
           target: task.id,
@@ -13204,7 +13150,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     */
     if (recoverableCandidates.length !== 1) {
       if (recoverableCandidates.length > 1) {
-        await this.store.logEntry(task.id, `Skipped stranded AI merge recovery: ${recoverableCandidates.length} approved clean-room candidates were ambiguous`).catch(() => undefined);
+        await this.store.logEntry(task.id, `Skipped stranded AI merge recovery: ${recoverableCandidates.length} approved clean-room candidates were ambiguous`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       }
       return false;
     }
@@ -13257,14 +13203,13 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
       source: "self-healing",
       rootDir: this.options.rootDir,
       log: async (message) => {
-        await this.store.logEntry(task.id, message).catch(() => undefined);
+        await this.store.logEntry(task.id, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       },
     });
     if (finalized.outcome === "done" || finalized.outcome === "already-done") {
       await this.store.logEntry(
         task.id,
-        `Auto-recovered stranded AI merge clean-room commit ${selected.strandedSha.slice(0, 8)} — advanced ${integrationBranch} and finalized task`,
-      );
+        `Auto-recovered stranded AI merge clean-room commit ${selected.strandedSha.slice(0, 8)} — advanced ${integrationBranch} and finalized task`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await auditor.git({
         type: "merge:ai-landed",
         target: integrationBranch,
@@ -13322,11 +13267,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           status: null,
           error: null,
           completionHandoffLimboRecoveryCount: 0,
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.logEntry(
           task.id,
-          "Auto-recovered: cleared false completion-handoff exhaustion while task is already owned by merge queue",
-        );
+          "Auto-recovered: cleared false completion-handoff exhaustion while task is already owned by merge queue", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         continue;
       }
       if (!(await this.canRecoverMergeRequest(task, settings))) continue;
@@ -13351,7 +13295,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         await this.store.updateTask(task.id, {
           status: "failed",
           error: "Completion handoff limbo recovery exhausted",
-        });
+        }, UNATTRIBUTED_MUTATION_CONTEXT);
         const exhaustedAudit = createRunAuditor(this.store, {
           runId: generateSyntheticRunId("self-heal", task.id),
           agentId: "self-healing",
@@ -13393,7 +13337,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
 
       await this.store.updateTask(task.id, {
         completionHandoffLimboRecoveryCount: currentCount + 1,
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
 
       const audit = createRunAuditor(this.store, {
         runId: generateSyntheticRunId("self-heal", task.id),
@@ -13408,7 +13352,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         metadata: { ageMs, source: "self-healing-in-review-sweep", attempts: currentCount + 1 },
       });
 
-      await this.store.logEntry(task.id, "Auto-recovered (FN-4999): task in 'in-review' past handoff grace with no merge fan-out — re-emitting auto-merge handoff");
+      await this.store.logEntry(task.id, "Auto-recovered (FN-4999): task in 'in-review' past handoff grace with no merge fan-out — re-emitting auto-merge handoff", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     }
   }
 
@@ -13507,14 +13451,14 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             branch: null, branchWriteOrigin: "engine" as const,
             status: null,
             error: null,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
 
           // FN-5092 hotfix: clear transient merger-queue status (`status: "merging"` set
           // by the original merger attempt) before transitioning to done. Without this,
           // a stale `mergeActive` slot for this task leaks indefinitely and blocks the
           // entire merger queue until engine restart. Mirrors the pattern in
           // merger.ts completeTask() and project-engine.ts auto-merge already-confirmed path.
-          await this.store.updateTask(task.id, { status: null, error: null, paused: false });
+          await this.store.updateTask(task.id, { status: null, error: null, paused: false }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.recordSelfHealingBranchGroupMemberLanding(task, mergeTarget, "recover-branch-misbound-in-review");
           const completeLane = (await resolveTaskLifecycleColumns(this.store, task.id))?.complete ?? "done";
           const movedTask = await this.moveToCompleteLaneAfterLandedCleanup(task, completeLane, "recover-branch-misbound-in-review", mergeDetails);
@@ -13522,8 +13466,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.clearCompletionBranchIfSubsumed(task, branch).catch(() => false);
           await this.store.logEntry(
             task.id,
-            `Auto-recovered: branch tip misbound but content found on ${baseBranch} at ${check.landed.sha.slice(0, 8)} via ${check.landed.strategy}`,
-          );
+            `Auto-recovered: branch tip misbound but content found on ${baseBranch} at ${check.landed.sha.slice(0, 8)} via ${check.landed.strategy}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.reconcileCompletedTask(task.id, { worktreeHint: task.worktree ?? undefined });
 
           try {
@@ -13753,7 +13696,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             }),
           });
           if (result.recovered) {
-            await this.store.logEntry(task.id, `Auto-recovered foreign-only contamination via ${result.subtype ?? "unknown"}`);
+            await this.store.logEntry(task.id, `Auto-recovered foreign-only contamination via ${result.subtype ?? "unknown"}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             recovered += 1;
           }
         } catch (err: unknown) {
@@ -13824,11 +13767,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
           await this.store.updateTask(task.id, {
             status: null,
             error: null,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
-            "Auto-recovered: all steps complete despite 'no fn_task_done' failure — cleared error for normal review",
-          );
+            "Auto-recovered: all steps complete despite 'no fn_task_done' failure — cleared error for normal review", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           log.log(`Recovered misclassified failure ${task.id}: ${task.title || task.description?.slice(0, 60) || "(untitled)"}`);
           recovered++;
         } catch (err: unknown) { const errorMessage = err instanceof Error ? err.message : String(err);
@@ -13980,7 +13922,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             ...(fresh.column === requeueTarget && workflowTransitionNotification
               ? { workflowTransitionNotification }
               : {}),
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           if (route.kind === "node-requeue" && fresh.column !== requeueTarget) {
             await this.store.moveTask(task.id, requeueTarget, {
               preserveProgress: true,
@@ -13988,8 +13930,8 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               moveSource: "engine",
               lifecycleReason: "self-healing-session-recovery",
               recoveryRehome: true,
-            });
-            await this.store.updateTask(task.id, { workflowTransitionNotification });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
+            await this.store.updateTask(task.id, { workflowTransitionNotification }, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           /*
           FNXC:NodeWorktreeIsolation 2026-07-29-06:05 (FN-6756 — ordering, PR #2531 review):
@@ -14026,8 +13968,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                router did — a literal here describes a renamed-board recovery as the wrong kind. */
             freshColumns.review.has(fresh.column)
               ? "Auto-recovered: in-review pause-abort park cleared — preserved for normal review progression"
-              : "Auto-recovered: pause-abort park cleared — requeued for normal scheduling",
-          );
+              : "Auto-recovered: pause-abort park cleared — requeued for normal scheduling", UNATTRIBUTED_MUTATION_CONTEXT);
           /*
           FNXC:RunAudit 2026-08-20-04:15:
           FN-9175 routes this post-mutation telemetry through the bounded shared seam. A failed
@@ -14223,8 +14164,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         reaped++;
         await this.store.logEntry(
           taskId,
-          "Auto-recovered: released leaked worktree/concurrency slot (holder no longer in-progress)",
-        );
+          "Auto-recovered: released leaked worktree/concurrency slot (holder no longer in-progress)", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         log.warn(`Reaped leaked worktree slot held by ${taskId} (column=${task?.column ?? "missing"})`);
       } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -15561,11 +15501,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             error: null,
             sessionFile: null,
             taskDoneRetryCount: nextCount,
-          });
+          }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
-            `Auto-retry ${nextCount}/${MAX_TASK_DONE_RETRIES}: agent finished without fn_task_done — requeuing to todo to resume partial work`,
-          );
+            `Auto-retry ${nextCount}/${MAX_TASK_DONE_RETRIES}: agent finished without fn_task_done — requeuing to todo to resume partial work`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           // #1411: backward recovery — skip order-derived adjacency.
           await this.reboundTask(task.id, "self-healing-stranded-recovery", task.column, { preserveProgress: true, preserveWorktree: true, recoveryRehome: true });
           recovered++;
@@ -15677,11 +15616,11 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
         if (!isTaskStillInPlanningStage(live)) return null;
         persisted = true;
         return patch;
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
     } else {
       const live = await this.store.getTask(task.id);
       if (live && isTaskStillInPlanningStage(live)) {
-        await this.store.updateTask(task.id, patch);
+        await this.store.updateTask(task.id, patch, UNATTRIBUTED_MUTATION_CONTEXT);
         persisted = true;
       }
     }
@@ -15690,7 +15629,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
     const action = decision.shouldRetry
       ? `Planning lifecycle lock transport failure during approved triage recovery — retry ${decision.nextState.recoveryRetryCount}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)}: ${error.message}`
       : exhaustedMessage;
-    await this.store.logEntry(task.id, action).catch(() => undefined);
+    await this.store.logEntry(task.id, action, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
   }
 
   async recoverApprovedTriageTasks(): Promise<number> {
@@ -15847,19 +15786,18 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               // FNXC:DuplicateIntake 2026-08-09-02:14: preserve a real PROMPT.md for a title-only redirect.
               if (duplicateResolution.source !== "title") rmSync(promptPath, { force: true });
               if (resolveExplicitDuplicateMarker(null, task.title).marker?.canonicalId === marker.canonicalId) {
-                await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${marker.canonicalId}` });
+                await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${marker.canonicalId}` }, UNATTRIBUTED_MUTATION_CONTEXT);
               }
               const priorClearCount = typeof task.sourceMetadata?.duplicateMarkerClearCount === "number"
                 ? task.sourceMetadata.duplicateMarkerClearCount
                 : 0;
               const patch = buildMarkerClearedReplanTaskPatch(marker.canonicalId, priorClearCount);
-              await this.store.updateTask(task.id, patch);
+              await this.store.updateTask(task.id, patch, UNATTRIBUTED_MUTATION_CONTEXT);
               if (typeof this.store.logEntry === "function") {
                 await Promise.resolve(this.store.logEntry(
                   task.id,
                   TRIAGE_MARKER_CLEARED_REPLAN_LOG_ACTION,
-                  buildInactiveDuplicateClearFeedback(marker.canonicalId),
-                )).catch(() => {});
+                  buildInactiveDuplicateClearFeedback(marker.canonicalId), UNATTRIBUTED_MUTATION_CONTEXT)).catch(() => {});
               }
               resolved += 1;
             }
@@ -15878,7 +15816,7 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               // FNXC:DuplicateIntake 2026-08-09-02:14: preserve a real PROMPT.md for a title-only redirect.
               if (duplicateResolution.source !== "title") rmSync(promptPath, { force: true });
               if (resolveExplicitDuplicateMarker(null, task.title).marker?.canonicalId === marker.canonicalId) {
-                await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${marker.canonicalId}` });
+                await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${marker.canonicalId}` }, UNATTRIBUTED_MUTATION_CONTEXT);
               }
               const priorKeepClears = typeof task.sourceMetadata?.duplicateMarkerClearCount === "number"
                 ? task.sourceMetadata.duplicateMarkerClearCount
@@ -15888,39 +15826,36 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
                 task.id,
                 keepExhausted
                   ? buildMarkerExhaustedFailedTaskPatch(canonicalTask.id, priorKeepClears)
-                  : buildMarkerClearedReplanTaskPatch(canonicalTask.id, priorKeepClears),
-              );
+                  : buildMarkerClearedReplanTaskPatch(canonicalTask.id, priorKeepClears), UNATTRIBUTED_MUTATION_CONTEXT);
               if (typeof this.store.logEntry === "function") {
                 await Promise.resolve(this.store.logEntry(
                   task.id,
                   keepExhausted
                     ? buildDuplicateReplanExhaustedError(canonicalTask.id)
                     : TRIAGE_MARKER_CLEARED_REPLAN_LOG_ACTION,
-                  buildKeepDuplicateClearFeedback(canonicalTask.id),
-                )).catch(() => {});
+                  buildKeepDuplicateClearFeedback(canonicalTask.id), UNATTRIBUTED_MUTATION_CONTEXT)).catch(() => {});
               }
               resolved += 1;
             }
             continue;
           }
           if (resolution === "delete") {
-            await this.store.deleteTask(task.id, { removeLineageReferences: true, auditContext: toRunMutationContext({ agentId: "self-healing", runId: generateSyntheticRunId("self-heal-explicit-duplicate", task.id), callerKind: "engine" as const }) });
+            await this.store.deleteTask(task.id, { removeLineageReferences: true, auditContext: { agentId: "self-healing", runId: generateSyntheticRunId("self-heal-explicit-duplicate", task.id), callerKind: "engine" } }, UNATTRIBUTED_MUTATION_CONTEXT);
           } else if (resolution === "prompt") {
             await flagTriageDuplicate(this.store, task.id, canonicalTask.id);
-            await this.store.updateTask(task.id, { paused: true, pausedReason: "duplicate-decision-required", status: null });
+            await this.store.updateTask(task.id, { paused: true, pausedReason: "duplicate-decision-required", status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
           } else {
             // FNXC:DuplicateIntake 2026-08-09-02:14: title-only redirects must not erase executable prompts.
             if (duplicateResolution.source !== "title") rmSync(promptPath, { force: true });
             if (resolveExplicitDuplicateMarker(null, task.title).marker?.canonicalId === marker.canonicalId) {
-              await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${marker.canonicalId}` });
+              await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${marker.canonicalId}` }, UNATTRIBUTED_MUTATION_CONTEXT);
             }
-            await this.store.updateTask(task.id, buildMarkerClearedReplanTaskPatch(canonicalTask.id));
+            await this.store.updateTask(task.id, buildMarkerClearedReplanTaskPatch(canonicalTask.id), UNATTRIBUTED_MUTATION_CONTEXT);
             if (typeof this.store.logEntry === "function") {
               await Promise.resolve(this.store.logEntry(
                 task.id,
                 TRIAGE_MARKER_CLEARED_REPLAN_LOG_ACTION,
-                buildKeepDuplicateClearFeedback(canonicalTask.id),
-              )).catch(() => {});
+                buildKeepDuplicateClearFeedback(canonicalTask.id), UNATTRIBUTED_MUTATION_CONTEXT)).catch(() => {});
             }
           }
           log.log(`[self-healing] resolved explicit duplicate marker ${task.id} → ${canonicalTask.id}`);
@@ -16006,11 +15941,10 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
             new Date(peer.updatedAt).getTime() > createdAtMs,
           ).length;
 
-          await this.store.updateTask(task.id, { priority: nextPriority });
+          await this.store.updateTask(task.id, { priority: nextPriority }, UNATTRIBUTED_MUTATION_CONTEXT);
           await this.store.logEntry(
             task.id,
-            `Auto-recovered starved refinement triage task: priority ${task.priority ?? "normal"} -> ${nextPriority} (age=${Math.max(0, now - createdAtMs)}ms, peerProgress=${peerProgressCount})`,
-          );
+            `Auto-recovered starved refinement triage task: priority ${task.priority ?? "normal"} -> ${nextPriority} (age=${Math.max(0, now - createdAtMs)}ms, peerProgress=${peerProgressCount})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
 
           try {
             const auditor = createRunAuditor(this.store, {
@@ -16117,12 +16051,12 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               const patch = finalizePlanningSegment(live, endMs);
               applied = patch.planningStartedAt === null;
               return patch;
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
           } else {
             const live = await this.store.getTask(task.id);
             if (live?.planningStartedAt && !planningIds.has(live.id) && !this.options.hasActivePlanningWorkflowSession?.(live.id)) {
               const patch = finalizePlanningSegment(live, endMs);
-              if (patch.planningStartedAt === null) { await this.store.updateTask(task.id, patch); applied = true; }
+              if (patch.planningStartedAt === null) { await this.store.updateTask(task.id, patch, UNATTRIBUTED_MUTATION_CONTEXT); applied = true; }
             }
           }
           if (!applied) continue;
@@ -16231,19 +16165,18 @@ export class SelfHealingManager extends SelfHealingGitEvidence {
               if (!isTaskStillInPlanningStage(live)) return null;
               applied = true;
               return { status: null };
-            });
+            }, UNATTRIBUTED_MUTATION_CONTEXT);
           } else {
             const live = await this.store.getTask(task.id);
             if (live && isTaskStillInPlanningStage(live)) {
-              await this.store.updateTask(task.id, { status: null });
+              await this.store.updateTask(task.id, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
               applied = true;
             }
           }
           if (!applied) continue;
           await this.store.logEntry(
             task.id,
-            "Auto-recovered orphaned planning task — agent session lost, cleared for re-planning",
-          );
+            "Auto-recovered orphaned planning task — agent session lost, cleared for re-planning", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           recovered++;
         } catch (err: unknown) { const errorMessage = err instanceof Error ? err.message : String(err);
           log.error(`Failed to recover orphaned planning task ${task.id}: ${errorMessage}`);

--- a/packages/engine/src/self-healing/archive-ghost-bug.ts
+++ b/packages/engine/src/self-healing/archive-ghost-bug.ts
@@ -3,7 +3,7 @@
  * archiveAsGhostBug peeled from self-healing.ts (U5 / wave19 Slice A).
  */
 import type { TaskStore } from "@fusion/core";
-import { resolveArchiveTargetForTask } from "@fusion/core";
+import { resolveArchiveTargetForTask, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import type { GhostBugDecision } from "../triage-domain/triage-preflight.js";
 
 /**
@@ -21,6 +21,7 @@ export async function archiveAsGhostBug(
     taskId,
     "Auto-archived as ghost bug — cited code construct not present on main",
     JSON.stringify({ reason: decision.reason, findings: decision.findings }, null, 2),
+    UNATTRIBUTED_MUTATION_CONTEXT,
   );
   await store.recordActivity({
     type: "task:auto-archived-ghost-bug",
@@ -32,5 +33,5 @@ export async function archiveAsGhostBug(
       findings: decision.findings.slice(0, 10),
     },
   });
-  await store.moveTask(taskId, await resolveArchiveTargetForTask(store, taskId), { moveSource: "engine", recoveryRehome: true });
+  await store.moveTask(taskId, await resolveArchiveTargetForTask(store, taskId), { moveSource: "engine", recoveryRehome: true }, UNATTRIBUTED_MUTATION_CONTEXT);
 }

--- a/packages/engine/src/self-healing/auto-recover-worktree-session.ts
+++ b/packages/engine/src/self-healing/auto-recover-worktree-session.ts
@@ -8,7 +8,7 @@
  */
 import { resolve } from "node:path";
 import type { Task, TaskStore } from "@fusion/core";
-import { isWorkspaceTask, loadWorkspaceConfig } from "@fusion/core";
+import { isWorkspaceTask, loadWorkspaceConfig, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { hasUsableWorktreeShape } from "../worktree/worktree-pool.js";
 import {
   classifyMissingWorktreeSessionStartFailure,
@@ -74,8 +74,7 @@ export async function autoRecoverWorktreeSessionStartFailure(
   if (nextStaleMetadataClearRecoveryCount !== undefined && nextStaleMetadataClearRecoveryCount > MAX_WORKTREE_SESSION_RETRIES) {
     await store.logEntry(
       task.id,
-      `Auto-recovery exhausted (${MAX_WORKTREE_SESSION_RETRIES}/${MAX_WORKTREE_SESSION_RETRIES}) for merge-active unusable-worktree stale-metadata clears — leaving in-review for human inspection`,
-    );
+      `Auto-recovery exhausted (${MAX_WORKTREE_SESSION_RETRIES}/${MAX_WORKTREE_SESSION_RETRIES}) for merge-active unusable-worktree stale-metadata clears — leaving in-review for human inspection`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await opts.auditor?.database({
       type: "task:auto-recover-worktree-session-exhausted",
       target: task.id,
@@ -92,8 +91,7 @@ export async function autoRecoverWorktreeSessionStartFailure(
   if (!resetRetryBudget && nextCount > MAX_WORKTREE_SESSION_RETRIES) {
     await store.logEntry(
       task.id,
-      `Auto-recovery exhausted (${MAX_WORKTREE_SESSION_RETRIES}/${MAX_WORKTREE_SESSION_RETRIES}) for unusable-worktree session-start failure — leaving in-review for human inspection`,
-    );
+      `Auto-recovery exhausted (${MAX_WORKTREE_SESSION_RETRIES}/${MAX_WORKTREE_SESSION_RETRIES}) for unusable-worktree session-start failure — leaving in-review for human inspection`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await opts.auditor?.database({
       type: "task:auto-recover-worktree-session-exhausted",
       target: task.id,
@@ -153,7 +151,7 @@ export async function autoRecoverWorktreeSessionStartFailure(
       ? {}
       : { branch: nextBranch, branchWriteOrigin: "engine" as const }),
     sessionFile: null,
-  });
+  }, UNATTRIBUTED_MUTATION_CONTEXT);
   await opts.auditor?.database({
     type: "task:auto-recover-worktree-session-metadata",
     target: task.id,
@@ -198,8 +196,7 @@ export async function autoRecoverWorktreeSessionStartFailure(
           staleWorktree && (!missingWorktreePath || resolve(staleWorktree) !== resolve(missingWorktreePath))
             ? `; the recorded task worktree ${staleWorktree} is ${recordedWorktreeStillUsable ? "still present" : "gone too"}`
             : ""
-        } — cleared stale session metadata${clearWorktreeMetadata && !branchIsRederivable ? ` (kept non-canonical branch ${task.branch})` : ""} and retained in ${recoveryColumn} (${attemptLabel}, failure: ${failureExcerpt})`,
-  );
+        } — cleared stale session metadata${clearWorktreeMetadata && !branchIsRederivable ? ` (kept non-canonical branch ${task.branch})` : ""} and retained in ${recoveryColumn} (${attemptLabel}, failure: ${failureExcerpt})`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
   // Legacy outcome name retained for callers; lifecycle recovery itself is in-place.
   return { outcome: "requeue-todo", retries: nextCount, classification };
 }

--- a/packages/engine/src/surfacing-sweeps.ts
+++ b/packages/engine/src/surfacing-sweeps.ts
@@ -29,6 +29,15 @@ parameterized.
 AT-MOST-ONCE is a SAFEGUARD and lives here, outside the policy table: a workflow
 must not be able to author repeated notification of the same signal.
 */
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+Extracted helper of the unattended self-healing / scheduler sweeps, so its store writes carry
+the same MARKER as the sweeps that call it: a timer-driven repair has no session, no request,
+and no acting agent, and the only ids in scope name the SUBJECT of the write rather than its
+author. Counted by `unattributed-actor-census.test.ts`; U13 owns whether these lanes get a real
+system actor.
+*/
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import {
   resolveEffectiveRecovery,
   type ResolvedRecoveryPolicy,
@@ -242,7 +251,7 @@ export async function runSurfacingSweep(spec: SurfacingSpec, deps: SurfacingRunn
 
       await deps.store.logEntry(
         task.id,
-        `${spec.logPrefix} [${signal.code}]: ${spec.describe(task, signal, thresholdMs)}`,
+        `${spec.logPrefix} [${signal.code}]: ${spec.describe(task, signal, thresholdMs)}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT,
       );
       surfaced += 1;
     } catch {

--- a/packages/engine/src/triage.ts
+++ b/packages/engine/src/triage.ts
@@ -56,16 +56,13 @@ import {
   ApprovalRequestStore,
   AWAITING_APPROVAL_PAUSE_REASON,
   isEphemeralAgent,
-  toRunMutationContext,
-  actorContextForAgent,
   resolveEffectiveAgentPermissionPolicy,
   MAX_TASK_LIST_TEXT_CHARS,
   deriveFallbackTaskTitle,
   resolveTaskOutputLanguage,
   parsePlanningPlanMd,
   loadWorkspaceConfig,
-  type NearDuplicateCandidate,
-} from "@fusion/core";
+  type NearDuplicateCandidate, UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 
 
 type TaskListClamp = (lines: string[], opts?: { maxChars?: number }) => string;
@@ -651,8 +648,8 @@ export class TriageProcessor {
         return latest ? { id: latest.id, status: latest.status } : null;
       },
       pauseForApproval: async ({ approvalRequestId, decision }) => {
-        await this.store.pauseTask(taskId, true, toRunMutationContext({ runId, agentId: actorId, source: "triage" }), { pausedByAgentId: actorId, pausedReason: AWAITING_APPROVAL_PAUSE_REASON });
-        await this.store.logEntry(taskId, `Approval required for ${decision.toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`);
+        await this.store.pauseTask(taskId, true, { runId, agentId: actorId, source: "triage" }, { pausedByAgentId: actorId, pausedReason: AWAITING_APPROVAL_PAUSE_REASON }, UNATTRIBUTED_MUTATION_CONTEXT);
+        await this.store.logEntry(taskId, `Approval required for ${decision.toolName}. Request ${approvalRequestId} created; task and agent paused awaiting decision.`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         if (agent && this.options.agentStore) {
           await this.options.agentStore.updateAgentState(agent.id, "paused");
           await this.options.agentStore.updateAgent(agent.id, { pauseReason: "awaiting-approval" });
@@ -721,7 +718,7 @@ export class TriageProcessor {
     let persisted = false;
     await this.store.withPlanningLifecycleLock(task.id, async () => {
       if (this.resetFence.isStale(task.id, planningGeneration)) return;
-      const updated = await this.store.withTaskLock(task.id, () => this.store.updateTaskUnlocked(task.id, { prompt: content }));
+      const updated = await this.store.withTaskLock(task.id, () => this.store.updateTaskUnlocked(task.id, { prompt: content }, UNATTRIBUTED_MUTATION_CONTEXT));
       if (this.store.isBackendMode()) {
         await this.store.reconcileSpecDriftWhilePlanningLocked(updated).catch((error: unknown) => {
           planLog.warn(`[spec-lock] deferred drift reconciliation for ${updated.id}: ${error instanceof Error ? error.message : String(error)}`);
@@ -974,7 +971,7 @@ export class TriageProcessor {
       break the abort.
       */
       if (task.status === "planning") {
-        void Promise.resolve(this.store.updateTask(task.id, { status: null })).catch((err: unknown) => {
+        void Promise.resolve(this.store.updateTask(task.id, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT)).catch((err: unknown) => {
           planLog.warn(`${task.id}: failed to clear planning status after evacuation: ${err instanceof Error ? err.message : String(err)}`);
         });
       }
@@ -1079,11 +1076,10 @@ export class TriageProcessor {
         planLog.warn(
           `Stale 'planning' status on ${t.id} (column=${t.column}, no live planner) — clearing so triage can re-pick it`,
         );
-        await this.store.updateTask(t.id, { status: null });
+        await this.store.updateTask(t.id, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.logEntry(
           t.id,
-          "Auto-recovered: cleared stale planning status left by a planner that never finished",
-        ).catch(() => undefined);
+          "Auto-recovered: cleared stale planning status left by a planner that never finished", undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
       }
     } catch (err) {
       // Never let a housekeeping sweep break the poll.
@@ -1144,7 +1140,7 @@ export class TriageProcessor {
     });
     for (const t of stale) {
       planLog.log(`Startup sweep: clearing stale 'planning' status on ${t.id}`);
-      await this.store.updateTask(t.id, { status: null });
+      await this.store.updateTask(t.id, { status: null }, UNATTRIBUTED_MUTATION_CONTEXT);
     }
     if (stale.length > 0) {
       planLog.log(`Startup sweep: cleared ${stale.length} stale planning task(s)`);
@@ -1665,7 +1661,7 @@ export class TriageProcessor {
       if (parsedSteps.length === 0) {
         const message = "Planning recovery withheld: PROMPT.md has no executable steps and does not declare no commits expected";
         planLog.warn(`${task.id} ${message}`);
-        await this.store.logEntry(task.id, message);
+        await this.store.logEntry(task.id, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         return false;
       }
     }
@@ -1779,7 +1775,7 @@ export class TriageProcessor {
       );
       await this.store.updateTask(task.id, {
         stuckKillCount: (freshTask.stuckKillCount ?? task.stuckKillCount ?? 0) + 1,
-      }).catch((err: unknown) => {
+      }, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to increment stuckKillCount during deferred stuck-detector ${context} cleanup: ${msg}`);
       });
@@ -1831,7 +1827,7 @@ export class TriageProcessor {
       planLog.log(
         `${task.id} killed by stuck detector after planning handoff completed (column=${freshTask.column}, status=${freshTask.status ?? "null"}) — preserving released state (${context})`,
       );
-      await this.store.updateTask(task.id, { stuckKillCount: nextStuckKillCount }).catch((err: unknown) => {
+      await this.store.updateTask(task.id, { stuckKillCount: nextStuckKillCount }, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to increment stuckKillCount after post-handoff stuck-detector ${context} cleanup: ${msg}`);
       });
@@ -1859,7 +1855,7 @@ export class TriageProcessor {
     if (nextStuckKillCount >= maxKills) {
       const exhaustedError = `STUCK_LOOP_EXHAUSTED: triage stuck detector killed ${task.id} ${nextStuckKillCount}/${maxKills} times without planning completion; task paused for manual intervention.`;
       planLog.error(exhaustedError);
-      await this.store.logEntry(task.id, exhaustedError).catch((err: unknown) => {
+      await this.store.logEntry(task.id, exhaustedError, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to log stuck-loop exhaustion: ${msg}`);
       });
@@ -1870,7 +1866,7 @@ export class TriageProcessor {
         paused: true,
         pausedReason: "stuck-loop-exhausted-manual-intervention-required",
         pausedByAgentId: "triage",
-      }).catch((err: unknown) => {
+      }, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to persist stuck-loop exhaustion during stuck-detector ${context} cleanup: ${msg}`);
       });
@@ -1880,14 +1876,14 @@ export class TriageProcessor {
     if (draft) {
       const sourceLabel = draft.source === "prompt" ? "PROMPT.md draft" : "plan task document";
       planLog.log(`${task.id} killed by stuck detector — requeueing to resume existing ${sourceLabel} (${nextStuckKillCount}/${maxKills})`);
-      await this.store.logEntry(task.id, TRIAGE_STUCK_RESUME_LOG_ACTION, TRIAGE_STUCK_RESUME_FEEDBACK).catch((err: unknown) => {
+      await this.store.logEntry(task.id, TRIAGE_STUCK_RESUME_LOG_ACTION, TRIAGE_STUCK_RESUME_FEEDBACK, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to log stuck-resume feedback: ${msg}`);
       });
       await this.store.updateTask(task.id, {
         status: "needs-replan",
         stuckKillCount: nextStuckKillCount,
-      }).catch((err: unknown) => {
+      }, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to restore status to 'needs-replan' during stuck-detector ${context} cleanup: ${msg}`);
       });
@@ -1899,7 +1895,7 @@ export class TriageProcessor {
     await this.store.updateTask(task.id, {
       status: restoreStatus,
       stuckKillCount: nextStuckKillCount,
-    }).catch((err: unknown) => {
+    }, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       planLog.warn(`${task.id}: failed to restore status to '${restoreStatus}' during stuck-detector ${context} cleanup: ${msg}`);
     });
@@ -2246,7 +2242,7 @@ export class TriageProcessor {
     this.fastLanePlanningSkipLogged.add(task.id);
     const message = "Fast mode intentionally skips specification planning";
     planLog.log(`${task.id}: ${message}`);
-    await this.store.logEntry(task.id, message).catch(() => undefined);
+    await this.store.logEntry(task.id, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
   }
 
   private startAdmittedPlanning(task: Task): void {
@@ -2518,7 +2514,7 @@ export class TriageProcessor {
               shared board/API log silent. Mirror genuine live-cap exhaustion onto each queued
               candidate without awaiting it in the poll; the signature prevents poll spam.
               */
-              void Promise.all(eligibleIds.map((taskId) => this.store.logEntry(taskId, capacityReason)))
+              void Promise.all(eligibleIds.map((taskId) => this.store.logEntry(taskId, capacityReason, undefined, UNATTRIBUTED_MUTATION_CONTEXT)))
                 .catch((logErr: unknown) => {
                   planLog.warn(`Failed to write planning capacity reason: ${logErr instanceof Error ? logErr.message : String(logErr)}`);
                 });
@@ -2609,7 +2605,7 @@ export class TriageProcessor {
         return;
       }
       const fallbackTitle = deriveFallbackTaskTitle(current.description || task.description);
-      await this.store.updateTask(task.id, { title: fallbackTitle });
+      await this.store.updateTask(task.id, { title: fallbackTitle }, UNATTRIBUTED_MUTATION_CONTEXT);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       planLog.warn(`${task.id}: failed to backfill blank title after terminal triage failure: ${msg}`);
@@ -2670,12 +2666,11 @@ export class TriageProcessor {
           nearDuplicateScore: canonical.score,
           nearDuplicateSharedTokens: canonical.sharedTokens,
         },
-      } as Parameters<typeof this.store.updateTask>[1]);
+      } as Parameters<typeof this.store.updateTask>[1], UNATTRIBUTED_MUTATION_CONTEXT);
       await this.store.logEntry(
         task.id,
         `Flagged as near-duplicate of ${canonical.id} before planning (imported issue; awaiting user decision)`,
-        `Shared tokens: ${canonical.sharedTokens.join(", ")}`,
-      );
+        `Shared tokens: ${canonical.sharedTokens.join(", ")}`, UNATTRIBUTED_MUTATION_CONTEXT);
       await this.store.recordActivity({
         type: "task:near-duplicate-flagged",
         taskId: task.id,
@@ -2875,14 +2870,14 @@ export class TriageProcessor {
           ? await this.options.agentStore.getAgent(task.assignedAgentId).catch(() => null)
           : null;
 
-        const triageRunContext = toRunMutationContext({
+        const triageRunContext = {
           runId: generateSyntheticRunId("triage", task.id),
           agentId: assignedAgent?.id ?? "triage",
           taskId: task.id,
           taskLineageId: task.lineageId,
           phase: "plan",
           source: "triage",
-        });
+        };
 
         /*
         FNXC:WorkflowAgentRouting 2026-08-07-06:27:
@@ -2943,14 +2938,13 @@ export class TriageProcessor {
               workflowRole: routed.role,
               authorityKind: currentTask.assignedAgentId ? "task-assignee" : null,
             });
-            await this.store.logEntry(task.id, `Planning held: workflow-principal-${routed.reason}:${routed.role}`);
+            await this.store.logEntry(task.id, `Planning held: workflow-principal-${routed.reason}:${routed.role}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.updatePlanningStateIfStillCurrent(task, { status: "needs-replan" });
             return;
           }
           if (routed.status === "routed") {
             assignedAgent = routed.route.agent;
             triageRunContext.agentId = assignedAgent.id;
-            triageRunContext.actor = actorContextForAgent(assignedAgent.id);
             workflowCapacityAttemptId = `${triageRunContext.runId}:${planningNode.id}`;
             workflowCapacityProjectId = this.options.agentStore.workflowProjectId ?? this.rootDir;
             /*
@@ -2969,7 +2963,7 @@ export class TriageProcessor {
               attemptId: workflowCapacityAttemptId,
             });
             if (capacity.status === "held") {
-              await this.store.logEntry(task.id, `Planning held: workflow-principal-${capacity.reason}:triage`);
+              await this.store.logEntry(task.id, `Planning held: workflow-principal-${capacity.reason}:triage`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await this.updatePlanningStateIfStillCurrent(task, { status: "needs-replan" });
               return;
             }
@@ -3065,7 +3059,10 @@ export class TriageProcessor {
           }),
           ...createIdeationTools(this.store),
           ...createGoalRetrievalTools(this.store, {
-            runContext: triageRunContext,
+            runContext: {
+              runId: triageRunContext.runId,
+              agentId: triageRunContext.agentId,
+            },
             taskId: task.id,
           }),
           ...createMemoryTools(this.rootDir, settings, assignedAgent
@@ -3383,7 +3380,7 @@ export class TriageProcessor {
         Engine TUI line `using model` fires on every planning session start and is steady-state — planLog.debug (FUSION_DEBUG=plan). Task activity (logEntry/appendAgentLog) stays so the board still shows which model planned.
         */
         planLog.debug(`${task.id}: using model ${modelDesc}`);
-        await this.store.logEntry(task.id, `Planning using model: ${modelDesc}`);
+        await this.store.logEntry(task.id, `Planning using model: ${modelDesc}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.appendAgentLog(
           task.id,
           `Planning using model: ${modelDesc}`,
@@ -3395,7 +3392,7 @@ export class TriageProcessor {
         // FNXC:TaskTiming 2026-08-01-10:00: triage owns the initial planning lane;
         // first-start wins so a crash between ownership and persistence cannot open a second segment.
         const planningStart = startPlanningSegment(task);
-        if (planningStart.planningStartedAt) await this.store.updateTask(task.id, planningStart);
+        if (planningStart.planningStartedAt) await this.store.updateTask(task.id, planningStart, UNATTRIBUTED_MUTATION_CONTEXT);
         // Register session so the global pause listener can terminate it
         this.activeSessions.set(task.id, session);
 
@@ -3564,8 +3561,7 @@ export class TriageProcessor {
               planLog.warn(`${task.id}: planning turn exceeded ${planningTimeoutMs}ms — disposing session`);
               await this.store.logEntry(
                 task.id,
-                `Planning turn timed out after ${Math.round(planningTimeoutMs / 60_000)} min — aborting session`,
-              ).catch(() => undefined);
+                `Planning turn timed out after ${Math.round(planningTimeoutMs / 60_000)} min — aborting session`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
               try { session.dispose(); } catch { /* best-effort */ }
               // Phrased to match the provider-timeout transient pattern so this routes into the
               // bounded planning retry budget instead of the unclassified-failure park.
@@ -3671,8 +3667,7 @@ export class TriageProcessor {
           if (planPersistence.outcome === "recovered") {
             await this.store.logEntry(
               task.id,
-              "Recovered the plan written inside the task worktree into the project .fusion folder",
-            ).catch(() => undefined);
+              "Recovered the plan written inside the task worktree into the project .fusion folder", undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
           }
 
           let written = await readFile(
@@ -3721,8 +3716,7 @@ export class TriageProcessor {
                 planLog.log(`${task.id}: recovered duplicate verdict ${recoveredMarker.canonicalId} from the planner's reply (no PROMPT.md was written)`);
                 await this.store.logEntry(
                   task.id,
-                  `Recovered duplicate verdict from the planning reply — the planner reported ${recoveredMarker.canonicalId} without writing PROMPT.md`,
-                ).catch(() => undefined);
+                  `Recovered duplicate verdict from the planning reply — the planner reported ${recoveredMarker.canonicalId} without writing PROMPT.md`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
               }
             }
           }
@@ -3754,7 +3748,7 @@ export class TriageProcessor {
             if (decision.shouldRetry) {
               const retryMessage = `${failure} — retry ${decision.nextState.recoveryRetryCount}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)}.`;
               planLog.warn(`${task.id} ${retryMessage}`);
-              await this.store.logEntry(task.id, retryMessage);
+              await this.store.logEntry(task.id, retryMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               await this.updatePlanningStateIfStillCurrent(task, {
                 status: this.restoreStatusAfterInterruptedTriageWork(task),
                 error: null,
@@ -3766,7 +3760,7 @@ export class TriageProcessor {
 
             const failureMessage = `${failure} after ${MAX_RECOVERY_RETRIES} retries. Retry after adjusting the task prompt or model.`;
             planLog.error(`${task.id} clean planning attempt retry budget exhausted`);
-            await this.store.logEntry(task.id, failureMessage);
+            await this.store.logEntry(task.id, failureMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             if (await this.updatePlanningStateIfStillCurrent(task, (live) => {
               const customFields = { ...(live.customFields ?? {}) };
               delete customFields[PLANNING_LIFECYCLE_LOCK_TRANSPORT_FAILURE_KEY];
@@ -3796,7 +3790,7 @@ export class TriageProcessor {
               const retryMessage =
                 `Generated plan failed deterministic validation (${deterministicSpecFailure}) — retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}.`;
               planLog.warn(`${task.id} ${retryMessage}`);
-              await this.store.logEntry(task.id, retryMessage);
+              await this.store.logEntry(task.id, retryMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
               const restoreStatus = this.restoreStatusAfterInterruptedTriageWork(task);
               await this.updatePlanningStateIfStillCurrent(task, {
                 status: restoreStatus,
@@ -3815,8 +3809,7 @@ export class TriageProcessor {
             );
             await this.store.logEntry(
               task.id,
-              failureMessage,
-            );
+              failureMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
             if (await this.updatePlanningStateIfStillCurrent(task, {
               status: "failed",
               error: failureMessage,
@@ -3867,7 +3860,7 @@ export class TriageProcessor {
           const livePlanningTask = await this.store.getTask(task.id);
           if (livePlanningTask) {
             const planningEnd = finalizePlanningSegment(livePlanningTask);
-            if (planningEnd.planningStartedAt === null) await this.store.updateTask(task.id, planningEnd);
+            if (planningEnd.planningStartedAt === null) await this.store.updateTask(task.id, planningEnd, UNATTRIBUTED_MUTATION_CONTEXT);
           }
           session.dispose();
         }
@@ -3877,7 +3870,7 @@ export class TriageProcessor {
         onRetry: (attempt, delayMs, error) => {
           const delaySec = Math.round(delayMs / 1000);
           planLog.warn(`⏳ ${task.id} rate limited — retry ${attempt} in ${delaySec}s: ${error.message}`);
-          this.store.logEntry(task.id, `Rate limited — retry ${attempt} in ${delaySec}s`).catch((err: unknown) => {
+          this.store.logEntry(task.id, `Rate limited — retry ${attempt} in ${delaySec}s`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             planLog.warn(`${task.id}: failed to log rate-limit retry entry: ${msg}`);
           });
@@ -3940,7 +3933,7 @@ export class TriageProcessor {
           const failureMessage =
             `Triage failed: unable to select a usable model after ${err.attempts} attempt${err.attempts === 1 ? "" : "s"}. ${err.message}`;
           planLog.error(`✗ ${task.id} planner model fallback exhausted: ${failureMessage}`);
-          await this.store.logEntry(task.id, failureMessage).catch((logErr: unknown) => {
+          await this.store.logEntry(task.id, failureMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((logErr: unknown) => {
             const msg = logErr instanceof Error ? logErr.message : String(logErr);
             planLog.warn(`${task.id}: failed to log planner fallback exhaustion: ${msg}`);
           });
@@ -3968,7 +3961,7 @@ export class TriageProcessor {
           */
           const failureMessage = `Specification failed: ${errorMessage}`;
           planLog.error(`✗ ${task.id} planning needs operator action: ${errorDetail}`);
-          await this.store.logEntry(task.id, failureMessage, errorStack).catch((logErr: unknown) => {
+          await this.store.logEntry(task.id, failureMessage, errorStack, UNATTRIBUTED_MUTATION_CONTEXT).catch((logErr: unknown) => {
             const msg = logErr instanceof Error ? logErr.message : String(logErr);
             planLog.warn(`${task.id}: failed to persist operator-actionable specification failure: ${msg}`);
           });
@@ -4011,7 +4004,7 @@ export class TriageProcessor {
           if (decision.shouldRetry) {
             const retryMessage = `${failureMessage} — retry ${decision.nextState.recoveryRetryCount}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)}.`;
             planLog.warn(`${task.id} ${retryMessage}`);
-            await this.store.logEntry(task.id, retryMessage).catch(() => undefined);
+            await this.store.logEntry(task.id, retryMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
             await this.updatePlanningStateIfStillCurrent(task, (live) => ({
               ...persistMarker(live),
               status: this.restoreStatusAfterInterruptedTriageWork(task),
@@ -4021,7 +4014,7 @@ export class TriageProcessor {
             }));
             return;
           }
-          await this.store.logEntry(task.id, failureMessage).catch(() => undefined);
+          await this.store.logEntry(task.id, failureMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
           await this.updatePlanningStateIfStillCurrent(task, (live) => {
             const customFields = { ...(live.customFields ?? {}) };
             delete customFields[PLANNING_LIFECYCLE_LOCK_TRANSPORT_FAILURE_KEY];
@@ -4042,7 +4035,7 @@ export class TriageProcessor {
             // Silent transient errors (e.g., "request was aborted") are noisy — skip logging
             if (!isSilentTransientError(errorMessage)) {
               planLog.warn(`⚡ ${task.id} transient error during triage — retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}: ${errorMessage}`);
-              await this.store.logEntry(task.id, `Transient error during specification (retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}): ${errorMessage}`).catch((err: unknown) => {
+              await this.store.logEntry(task.id, `Transient error during specification (retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}): ${errorMessage}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
                 const msg = err instanceof Error ? err.message : String(err);
                 planLog.warn(`${task.id}: failed to log transient-error retry entry: ${msg}`);
               });
@@ -4061,7 +4054,7 @@ export class TriageProcessor {
 
           // Recovery budget exhausted — freeze in triage with error for manual intervention
           planLog.error(`✗ ${task.id} transient error retries exhausted (${MAX_RECOVERY_RETRIES} attempts): ${errorMessage}`);
-          await this.store.logEntry(task.id, `Specification failed after ${MAX_RECOVERY_RETRIES} transient errors: ${errorMessage}`).catch((err: unknown) => {
+          await this.store.logEntry(task.id, `Specification failed after ${MAX_RECOVERY_RETRIES} transient errors: ${errorMessage}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             planLog.warn(`${task.id}: failed to log transient-error retries-exhausted entry: ${msg}`);
           });
@@ -4107,7 +4100,7 @@ export class TriageProcessor {
         });
         planLog.error(`✗ ${task.id} planning failed:`, errorDetail);
         if (errorStack) {
-          await this.store.logEntry(task.id, `Specification failed: ${errorMessage}`, errorStack).catch((logErr: unknown) => {
+          await this.store.logEntry(task.id, `Specification failed: ${errorMessage}`, errorStack, UNATTRIBUTED_MUTATION_CONTEXT).catch((logErr: unknown) => {
             const msg = logErr instanceof Error ? logErr.message : String(logErr);
             planLog.warn(`${task.id}: failed to persist specification-failure stack trace: ${msg}`);
           });
@@ -4119,8 +4112,7 @@ export class TriageProcessor {
           planLog.warn(`⚡ ${task.id} planning failed — retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}: ${errorMessage}`);
           await this.store.logEntry(
             task.id,
-            `Specification failed (retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}): ${errorMessage}`,
-          ).catch((logErr: unknown) => {
+            `Specification failed (retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${delay}): ${errorMessage}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((logErr: unknown) => {
             const msg = logErr instanceof Error ? logErr.message : String(logErr);
             planLog.warn(`${task.id}: failed to log planning-failure retry entry: ${msg}`);
           });
@@ -4146,7 +4138,7 @@ export class TriageProcessor {
         */
         const exhaustedMessage = `PLANNING_FAILED_EXHAUSTED: specification failed ${MAX_RECOVERY_RETRIES} times — last error: ${errorMessage}`;
         planLog.error(`✗ ${task.id} planning retries exhausted (${MAX_RECOVERY_RETRIES} attempts) — parking failed: ${errorMessage}`);
-        await this.store.logEntry(task.id, exhaustedMessage).catch((logErr: unknown) => {
+        await this.store.logEntry(task.id, exhaustedMessage, undefined, UNATTRIBUTED_MUTATION_CONTEXT).catch((logErr: unknown) => {
           const msg = logErr instanceof Error ? logErr.message : String(logErr);
           planLog.warn(`${task.id}: failed to log planning-retries-exhausted entry: ${msg}`);
         });
@@ -4428,7 +4420,7 @@ export class TriageProcessor {
       if (!isTaskStillInPlanningStage(liveTask)) {
         return false;
       }
-      await this.store.updateTask(task.id, typeof patch === "function" ? patch(liveTask) : patch);
+      await this.store.updateTask(task.id, typeof patch === "function" ? patch(liveTask) : patch, UNATTRIBUTED_MUTATION_CONTEXT);
       return true;
     }
 
@@ -4449,7 +4441,7 @@ export class TriageProcessor {
       }
       persisted = true;
       return typeof patch === "function" ? patch(liveTask) : patch;
-    });
+    }, UNATTRIBUTED_MUTATION_CONTEXT);
     return persisted;
   }
 
@@ -4522,7 +4514,7 @@ export class TriageProcessor {
     if (headingNumbers.length > 0 && !headingNumbers.every((heading, index) => heading === index)) {
       const diagnostic = `Step headings must be contiguous 0-based execution indices (observed: ${headingNumbers.join(", ")}). Renumber from Step 0 and update prose cross-references.`;
       planLog.warn(`${taskId}: ${diagnostic}`);
-      await this.store.logEntry(taskId, "Generated plan validation failed: invalid step heading numbering");
+      await this.store.logEntry(taskId, "Generated plan validation failed: invalid step heading numbering", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       return diagnostic;
     }
 
@@ -4533,7 +4525,7 @@ export class TriageProcessor {
     if (danglingRefs.length > 0) {
       const diagnostic = formatDanglingDiagnostic(danglingRefs);
       planLog.warn(`${taskId}: ${diagnostic}`);
-      await this.store.logEntry(taskId, "Generated plan validation failed: dangling task-document references");
+      await this.store.logEntry(taskId, "Generated plan validation failed: dangling task-document references", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       return diagnostic;
     }
 
@@ -4719,7 +4711,7 @@ export class TriageProcessor {
 
     if (decision.shouldRetry) {
       const message = `PROMPT.md disappeared before planning release — retry ${attempt}/${MAX_RECOVERY_RETRIES} in ${formatDelay(decision.delayMs)}.`;
-      await this.store.logEntry(task.id, message);
+      await this.store.logEntry(task.id, message, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       await this.updatePlanningStateIfStillCurrent(task, {
         status: this.restoreStatusAfterInterruptedTriageWork(task),
         error: null,
@@ -4730,7 +4722,7 @@ export class TriageProcessor {
     }
 
     const error = `REQUIRED_ARTIFACT_RECOVERY_EXHAUSTED: PROMPT.md remained missing after ${MAX_RECOVERY_RETRIES} automatic planning retries.`;
-    await this.store.logEntry(task.id, error);
+    await this.store.logEntry(task.id, error, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
     await this.updatePlanningStateIfStillCurrent(task, {
       status: "failed",
       error,
@@ -4772,7 +4764,7 @@ export class TriageProcessor {
       }
       // Same-ID dual-source redirects are one decision; clear both exact sources together.
       if (resolveExplicitDuplicateMarker(null, task.title).marker?.canonicalId === canonicalId) {
-        await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${canonicalId}` });
+        await this.store.updateTask(task.id, { title: `Duplicate redirect cleared: ${canonicalId}` }, UNATTRIBUTED_MUTATION_CONTEXT);
       }
     })) return false;
 
@@ -4780,7 +4772,7 @@ export class TriageProcessor {
     if (options?.exhausted) {
       const error = buildDuplicateReplanExhaustedError(canonicalId);
       try {
-        await Promise.resolve(this.store.logEntry(task.id, error, feedback));
+        await Promise.resolve(this.store.logEntry(task.id, error, feedback, UNATTRIBUTED_MUTATION_CONTEXT));
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         planLog.warn(`${task.id}: failed to log exhausted duplicate replan: ${msg}`);
@@ -4793,7 +4785,7 @@ export class TriageProcessor {
     }
 
     try {
-      await Promise.resolve(this.store.logEntry(task.id, TRIAGE_MARKER_CLEARED_REPLAN_LOG_ACTION, feedback));
+      await Promise.resolve(this.store.logEntry(task.id, TRIAGE_MARKER_CLEARED_REPLAN_LOG_ACTION, feedback, UNATTRIBUTED_MUTATION_CONTEXT));
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       planLog.warn(`${task.id}: failed to log marker-clear replan feedback: ${msg}`);
@@ -4827,7 +4819,7 @@ export class TriageProcessor {
       duplicate decision.
       */
       await this.updatePlanningStateIfStillCurrent(task, { status: "needs-replan", error: null });
-      await this.store.logEntry(task.id, "Duplicate redirect sources conflict", "PROMPT.md and task title name different canonical tasks; correct one exact redirect before planning.");
+      await this.store.logEntry(task.id, "Duplicate redirect sources conflict", "PROMPT.md and task title name different canonical tasks; correct one exact redirect before planning.", UNATTRIBUTED_MUTATION_CONTEXT);
       return;
     }
     // A title-only redirect is authoritative even when there is no prompt file to recover.
@@ -4912,7 +4904,7 @@ export class TriageProcessor {
         const result = await deleteTaskIf.call(this.store, task.id, isTaskStillInPlanningStage, {
           removeLineageReferences: true,
           // FNXC:TaskDeleteAttribution 2026-07-26-14:30: duplicate-resolution delete is engine-driven.
-          auditContext: toRunMutationContext({ agentId: task.assignedAgentId ?? "triage", runId: generateSyntheticRunId("triage-delete", task.id), callerKind: "engine" as const }),
+          auditContext: { agentId: task.assignedAgentId ?? "triage", runId: generateSyntheticRunId("triage-delete", task.id), callerKind: "engine" },
         });
         if (!result.deleted) return;
         await this.store.recordActivity({
@@ -4929,7 +4921,7 @@ export class TriageProcessor {
           sourceMetadataPatch: { nearDuplicateOf: canonicalId, nearDuplicateScore: 1, duplicateSource: "triage-marker", nearDuplicateDismissed: false },
         });
         if (!applied) return;
-        await this.store.logEntry(task.id, "Flagged as triage duplicate", `Duplicate marker points to ${canonicalId}; awaiting operator decision`);
+        await this.store.logEntry(task.id, "Flagged as triage duplicate", `Duplicate marker points to ${canonicalId}; awaiting operator decision`, UNATTRIBUTED_MUTATION_CONTEXT);
         await this.store.recordActivity({ type: "task:auto-archived-duplicate", taskId: task.id, details: "Flagged (not deleted) as triage-marker duplicate", metadata: { canonicalTaskId: canonicalId, source: "triage-marker-flagged" } });
         return;
       }
@@ -5252,8 +5244,7 @@ export class TriageProcessor {
             await this.store.logEntry(
               task.id,
               `Flagged as near-duplicate of ${canonical.id} (awaiting user decision)`,
-              `Shared tokens: ${canonical.sharedTokens.join(", ")}`,
-            );
+              `Shared tokens: ${canonical.sharedTokens.join(", ")}`, UNATTRIBUTED_MUTATION_CONTEXT);
             await this.store.recordActivity({
               type: "task:near-duplicate-flagged",
               taskId: task.id,
@@ -5298,8 +5289,7 @@ export class TriageProcessor {
       if (!await this.updatePlanningStateIfStillCurrent(task, { status: restoreStatus })) return;
       await this.store.logEntry(
         task.id,
-        "Specification approved but task is paused — leaving in triage, will resume on unpause",
-      );
+        "Specification approved but task is paused — leaving in triage, will resume on unpause", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       planLog.log(`${task.id} specified task paused — leaving in triage, will resume on unpause`);
       return;
     }
@@ -5356,8 +5346,7 @@ export class TriageProcessor {
       if (priorFingerprint && priorFingerprint === currentFingerprint) {
         await this.store.logEntry(
           task.id,
-          "Plan unchanged since prior approval — proceeding without re-approval",
-        );
+          "Plan unchanged since prior approval — proceeding without re-approval", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         planLog.log(`${task.id} plan unchanged since prior approval — proceeding without re-approval`);
       } else {
         /*
@@ -5375,8 +5364,7 @@ export class TriageProcessor {
         if (!await this.updatePlanningStateIfStillCurrent(task, approvalUpdates)) return;
         await this.store.logEntry(
           task.id,
-          options.recoveryLogAction ?? "Specification approved by AI — awaiting manual approval",
-        );
+          options.recoveryLogAction ?? "Specification approved by AI — awaiting manual approval", undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         planLog.log(`✓ ${task.id} specified and awaiting manual approval`);
         return;
       }
@@ -5506,28 +5494,28 @@ export class TriageProcessor {
         }
         // Leave needs-replan/failed/awaiting-approval and other durable statuses alone.
         return null;
-      });
+      }, UNATTRIBUTED_MUTATION_CONTEXT);
     } else {
       const live = await Promise.resolve(this.store.getTask(task.id)).catch(() => null);
       if (
         live
         && (live.status === "planning" || live.status === "plan-review-unavailable" || live.status == null)
       ) {
-        await this.store.updateTask(task.id, { status: null, error: null });
+        await this.store.updateTask(task.id, { status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT);
       } else if (!live) {
         // Minimal test stores often omit getTask; still clear the mid-handoff planning stamp.
-        await this.store.updateTask(task.id, { status: null, error: null });
+        await this.store.updateTask(task.id, { status: null, error: null }, UNATTRIBUTED_MUTATION_CONTEXT);
       }
     }
 
     if (options.recoveryLogAction) {
-      await this.store.logEntry(task.id, options.recoveryLogAction);
+      await this.store.logEntry(task.id, options.recoveryLogAction, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
       planLog.log(`✓ ${task.id} recovered and moved to todo`);
       return;
     }
 
     if (options.isReplan) {
-      await this.store.logEntry(task.id, "Spec revised by AI", options.feedback);
+      await this.store.logEntry(task.id, "Spec revised by AI", options.feedback, UNATTRIBUTED_MUTATION_CONTEXT);
       planLog.log(`✓ ${task.id} re-planned and moved to todo`);
     } else {
       planLog.log(`✓ ${task.id} specified and moved to todo`);

--- a/packages/engine/src/workflow-column-boundary-hooks.ts
+++ b/packages/engine/src/workflow-column-boundary-hooks.ts
@@ -15,7 +15,7 @@ exercise the real thing; the Executor now delegates and owns only what is genuin
 
 Behavior is byte-identical to the method it replaces — this is a move, not a rewrite.
 */
-import type { Task, TaskStore, WorkflowWorkItemState } from "@fusion/core";
+import type { RunMutationContext, Task, TaskStore, WorkflowWorkItemState } from "@fusion/core";
 import { ACTIVE_WORKFLOW_WORK_ITEM_STATES } from "@fusion/core";
 
 import { createStoreIrPinPersistence, type WorkflowIrPinStoreSurface } from "./workflows/workflow-column-boundary.js";
@@ -39,6 +39,14 @@ export interface ExecutorColumnBoundaryHooksDeps {
   clearMoveInFlight?: (taskId: string) => void;
   /** Diagnostics sink for the boundary controller's warnings. */
   onWarn?: (message: string, detail: Record<string, unknown>) => void;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+  Required. This factory is the ONE production copy of the boundary wiring, so the durable IR-pin
+  write it builds is attributed exactly once here rather than per hand-rolled harness. The Executor
+  passes its own per-task run context (`getRunContextFor`), which carries a real `runId`/`agentId`
+  and is therefore derived attribution, not a marker.
+  */
+  runContext: RunMutationContext;
 }
 
 /**
@@ -48,15 +56,17 @@ export interface ExecutorColumnBoundaryHooksDeps {
 export function createExecutorColumnBoundaryHooks(
   deps: ExecutorColumnBoundaryHooksDeps,
 ): WorkflowColumnBoundaryHooks {
-  const { store, task, workflowRunId } = deps;
+  const { store, task, workflowRunId, runContext } = deps;
   // KTD-3 (U9b): store-backed durable IR pin. The cast is the same posture as
   // buildBranchPersistence — structural probe of the row surface so a store
   // lacking the pin fields degrades to the inert no-pin seam.
   const pinPersistence = createStoreIrPinPersistence(
     store as unknown as WorkflowIrPinStoreSurface,
     task.id,
+    runContext,
   );
   return {
+    runContext,
     pinNodeEntry: pinPersistence.pinNodeEntry,
     loadPriorPin: pinPersistence.loadPriorPin,
     // KTD-3 drift-park loop fix (PR #2342): detectDrift clears the stale pin
@@ -97,6 +107,8 @@ export function createExecutorColumnBoundaryHooks(
     moveTask: async (toColumn, ctx) => {
       deps.markMoveInFlight?.(task.id);
       try {
+        // FNXC:Identity 2026-08-09-03:04 (U18/KTD2): the graph-owned lifecycle move is attributed
+        // to the run that built these hooks, so a column transition names its author in audit.
         await store.moveTask(task.id, toColumn, {
           moveSource: "engine",
           lifecycleReason: "workflow-graph-node-column",
@@ -104,7 +116,7 @@ export function createExecutorColumnBoundaryHooks(
           bypassGuards: true,
           preserveProgress: true,
           workflowMoveMetadata: { fromColumn: ctx.fromColumn, nodeId: ctx.nodeId },
-        });
+        }, runContext);
       } finally {
         deps.clearMoveInFlight?.(task.id);
       }

--- a/packages/engine/src/workflows/workflow-column-boundary.ts
+++ b/packages/engine/src/workflows/workflow-column-boundary.ts
@@ -31,6 +31,7 @@ in-txn by `moveTaskInternal` is the store-level half of that guarantee.
 */
 
 import {
+  type RunMutationContext,
   type WorkflowIr,
   type WorkflowIrNode,
   type WorkflowIrPin,
@@ -160,6 +161,15 @@ writes — exactly the pre-wiring inert posture, so legacy harnesses are untouch
 /** The minimal task-row surface the pin persistence needs. Structural on purpose
  *  so real stores and test fakes both fit without importing the full TaskStore. */
 export interface WorkflowIrPinStoreSurface {
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+  Hand-declared rather than picked off `TaskStore`, so it does not inherit U18's canonical/deprecated
+  overload pair; at the two-argument arity it would keep writing the pin fields unattributed after
+  the engine sweep and the census would still read clean. The shape mirrors the CANONICAL store
+  arity (required trailing `runContext`), which is also what keeps a real `TaskStore` assignable —
+  the deprecated overload cannot absorb a `RunMutationContext` in a trailing optional slot that the
+  canonical one requires.
+  */
   updateTask?: (
     id: string,
     updates: {
@@ -167,6 +177,7 @@ export interface WorkflowIrPinStoreSurface {
       workflowIrPinNodeId?: string | null;
       workflowIrPinColumnId?: string | null;
     },
+    runContext: RunMutationContext,
   ) => unknown;
   getTask?: (id: string) => Promise<{
     workflowIrPin?: string;
@@ -179,6 +190,13 @@ export interface WorkflowIrPinStoreSurface {
 export function createStoreIrPinPersistence(
   store: WorkflowIrPinStoreSurface,
   taskId: string,
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2):
+  Required and third, so every construction site — production `createExecutorColumnBoundaryHooks`
+  and every harness — has to answer who is writing the pin rather than inheriting an implicit
+  unattributed write from the seam.
+  */
+  runContext: RunMutationContext,
 ): {
   pinNodeEntry: (pin: WorkflowIrPin) => Promise<void>;
   loadPriorPin: () => Promise<WorkflowIrPin | undefined>;
@@ -197,7 +215,7 @@ export function createStoreIrPinPersistence(
         workflowIrPin: pin.irHash,
         workflowIrPinNodeId: pin.nodeId,
         workflowIrPinColumnId: pin.columnId ?? null,
-      });
+      }, runContext);
       lastPin = pin;
     },
     loadPriorPin: async () => {
@@ -227,7 +245,7 @@ export function createStoreIrPinPersistence(
         workflowIrPin: null,
         workflowIrPinNodeId: null,
         workflowIrPinColumnId: null,
-      });
+      }, runContext);
       lastPin = undefined;
     },
   };

--- a/packages/engine/src/workflows/workflow-completion-summary.ts
+++ b/packages/engine/src/workflows/workflow-completion-summary.ts
@@ -1,8 +1,17 @@
-import { resolveTaskOutputLanguage, type ResolvedTaskOutputLanguage, type Settings, type TaskDetail } from "@fusion/core";
+import { resolveTaskOutputLanguage, type ResolvedTaskOutputLanguage, type RunMutationContext, type Settings, type TaskDetail } from "@fusion/core";
+
+/*
+FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+Both members are hand-declared rather than picked off `TaskStore`, so neither inherits U18's
+canonical/deprecated overload pair. At their old arities this summary write — a REAL task mutation
+on the completion boundary — would stay unattributed after the engine call-site sweep, and the
+census would report the package converted. Both now mirror the CANONICAL store arity, which is also
+what keeps a real `TaskStore` structurally assignable here.
+*/
 
 export interface WorkflowCompletionSummaryStore {
-  updateTask?: (taskId: string, updates: { summary: string }) => Promise<unknown> | unknown;
-  logEntry?: (taskId: string, action: string, detail?: string) => Promise<unknown> | unknown;
+  updateTask?: (taskId: string, updates: { summary: string }, runContext: RunMutationContext) => Promise<unknown> | unknown;
+  logEntry?: (taskId: string, action: string, detail: string | undefined, runContext: RunMutationContext) => Promise<unknown> | unknown;
 }
 
 export interface WorkflowCompletionSummaryInput {
@@ -117,6 +126,9 @@ export async function ensureWorkflowCompletionSummary(
   store: WorkflowCompletionSummaryStore,
   task: TaskDetail,
   input: WorkflowCompletionSummaryInput,
+  /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2): required — the completion boundary's caller owns the
+     run, so attribution is answered at each call site rather than defaulted inside the helper. */
+  runContext: RunMutationContext,
 ): Promise<void> {
   if (task.summary?.trim()) return;
   if (!store.updateTask) return;
@@ -131,7 +143,7 @@ export async function ensureWorkflowCompletionSummary(
    * remain authoritative.
    */
   const summary = buildWorkflowCompletionSummary(task, input);
-  await store.updateTask(task.id, { summary });
+  await store.updateTask(task.id, { summary }, runContext);
   await store.logEntry?.(
     task.id,
     "Workflow completion summary recorded",
@@ -140,5 +152,6 @@ export async function ensureWorkflowCompletionSummary(
       workflowId: input.workflowId,
       runId: input.runId,
     }),
+    runContext,
   );
 }

--- a/packages/engine/src/workflows/workflow-graph-executor.ts
+++ b/packages/engine/src/workflows/workflow-graph-executor.ts
@@ -11,7 +11,7 @@ import type {
   WorkflowStepResult,
   WorkflowStepNotRunReason,
 } from "@fusion/core";
-import { BUILTIN_CODING_WORKFLOW_IR, FAST_LANE_SKIP_VALUE, FAST_MODE_BYPASS_ACTOR, PLAN_REVIEW_GROUP_ID, WORKFLOW_STEP_NOT_RUN_REASONS, WorkflowIrError, computeWorkflowIrPin, getWorkflowExtensionRegistry, instanceNodeId, resolveFastLaneRoute, resolveMaxReworkCycles, isExperimentalFeatureEnabled, GRAPH_NATIVE_POST_MERGE_FLAG, isCompletionSummaryNode, classifyReviewLease, isWorkflowOptionalGroupEnabled, isPlanReviewSatisfied, parseNoOpCompletionMarker, requiresContentReviewProof } from "@fusion/core";
+import { BUILTIN_CODING_WORKFLOW_IR, FAST_LANE_SKIP_VALUE, FAST_MODE_BYPASS_ACTOR, PLAN_REVIEW_GROUP_ID, WORKFLOW_STEP_NOT_RUN_REASONS, WorkflowIrError, computeWorkflowIrPin, getWorkflowExtensionRegistry, instanceNodeId, resolveFastLaneRoute, resolveMaxReworkCycles, isExperimentalFeatureEnabled, GRAPH_NATIVE_POST_MERGE_FLAG, isCompletionSummaryNode, classifyReviewLease, isWorkflowOptionalGroupEnabled, isPlanReviewSatisfied, parseNoOpCompletionMarker, requiresContentReviewProof, isPermissionDeniedError, PERMISSION_DENIED_ERROR_CODE } from "@fusion/core";
 import { isNonPlanDefectPlanReviewFailure } from "../errors/transient-error-detector.js";
 import { isSessionContentionError } from "../errors/transient-error-patterns.js";
 import { isRequiredArtifactReadFailedValue, parseRequiredArtifactMissingValue } from "../execution/required-workflow-artifacts.js";
@@ -166,6 +166,30 @@ export const WORKFLOW_OPTIONAL_GROUP_CONTEXT_KEY = "workflow:optionalGroupActive
 /** Explicit parent marker for template execution; never inferred from template labels or output. */
 export const WORKFLOW_REVIEW_KIND_CONTEXT_KEY = "workflow:reviewKind";
 export const WORKFLOW_NODE_ENGINE_PAUSE_ABORT_KIND: WorkflowNodeAbortKind = "engine-pause";
+
+/*
+FNXC:Authorization 2026-08-09-03:04:
+A node handler's thrown error does NOT survive as an Error object: every throw sink below
+flattens it to `error.message` and stores that string under `node:<id>:error`. Everything past
+this boundary — including the executor's terminal park — only ever sees prose, which is why a
+permission denial was indistinguishable from any other exception downstream.
+Carry the `code` discriminant across the flattening in its own context key so the receiver can
+recognise a denial WITHOUT matching on message text. This is the minimum plumbing that makes the
+typed error useful outside the throwing frame; widening the whole contextPatch channel to carry
+structured errors is a larger change than the one denial case justifies.
+*/
+export const WORKFLOW_NODE_ERROR_CODE_CONTEXT_KEY_SUFFIX = ":errorCode";
+
+export function workflowNodeErrorCodeContextKey(nodeId: string): string {
+  return `node:${nodeId}${WORKFLOW_NODE_ERROR_CODE_CONTEXT_KEY_SUFFIX}`;
+}
+
+/** Context patch carrying the typed error code, or empty when the error is untyped. */
+function nodeErrorCodeContextPatch(nodeId: string, error: unknown): Record<string, unknown> {
+  return isPermissionDeniedError(error)
+    ? { [workflowNodeErrorCodeContextKey(nodeId)]: PERMISSION_DENIED_ERROR_CODE }
+    : {};
+}
 
 export interface WorkflowNodeResult {
   outcome: WorkflowNodeOutcome;
@@ -2048,6 +2072,7 @@ export class WorkflowGraphExecutor {
           contextPatch: {
             [`node:${node.id}:error`]: error instanceof Error ? error.message : String(error),
             [`node:${node.id}:extensionId`]: extensionId,
+            ...nodeErrorCodeContextPatch(node.id, error),
           },
         };
       }
@@ -2287,6 +2312,7 @@ export class WorkflowGraphExecutor {
         : isSessionContentionError(lastErrorText) ? SESSION_CONTENTION_HOLD_VALUE : "exception",
       contextPatch: {
         [`node:${node.id}:error`]: lastErrorText,
+        ...nodeErrorCodeContextPatch(node.id, lastError),
       },
     };
     if (recordProgress && this.shouldRecordNodeProgress(node)) {

--- a/packages/engine/src/workflows/workflow-graph-task-runner.ts
+++ b/packages/engine/src/workflows/workflow-graph-task-runner.ts
@@ -1,4 +1,12 @@
-import type { Settings, TaskDetail, TaskStep, WorkflowDefinition, WorkflowIr } from "@fusion/core";
+import type {
+  RunMutationContext,
+  Settings,
+  TaskDetail,
+  TaskStep,
+  WorkflowDefinition,
+  WorkflowIr,
+  WorkflowStepResult,
+} from "@fusion/core";
 import {
   getBuiltinWorkflow,
   isBuiltinWorkflowId,
@@ -180,6 +188,18 @@ export interface WorkflowGraphTaskRunnerDeps {
 /** Task/workflow-independent hooks the runner needs to build a column-boundary
  *  controller. The runner supplies taskId/workflowId/ir/initialColumn per run. */
 export interface WorkflowColumnBoundaryHooks {
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+  `moveTask` here is a narrow, hand-declared move hook rather than the store's own method, so it
+  inherits neither of U18's `TaskStore` overloads and cannot itself carry the required parameter —
+  the boundary controller invoking it knows a column and a node, never an actor. The requirement is
+  therefore restated on the BUNDLE: a hooks provider cannot be assembled without naming the run its
+  moves are written under, and the single production provider
+  (`createExecutorColumnBoundaryHooks`) threads that same context into `store.moveTask` and into the
+  durable IR pin. Without this field a hand-rolled bundle would silently reopen the hole the engine
+  sweep just closed.
+  */
+  runContext: RunMutationContext;
   moveTask?: WorkflowColumnMove;
   emitAudit?: (event: WorkflowColumnBoundaryAuditEvent) => void | Promise<void>;
   pinNodeEntry?: (pin: WorkflowIrPin) => void | Promise<void>;

--- a/packages/engine/src/workflows/workflow-task-runtime.ts
+++ b/packages/engine/src/workflows/workflow-task-runtime.ts
@@ -1,4 +1,5 @@
-import type { Settings, TaskDetail, WorkflowIr, WorkflowIrArtifact, WorkflowIrNode, WorkflowWorkItem, WorkflowWorkItemState } from "@fusion/core";
+import type { RunMutationContext, Settings, TaskDetail, WorkflowIr, WorkflowIrArtifact, WorkflowIrNode, WorkflowWorkItem, WorkflowWorkItemState } from "@fusion/core";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import {
   getBuiltinWorkflow,
   resolveTaskOutputLanguage,
@@ -40,8 +41,15 @@ export interface WorkflowTaskRuntimeDeps extends Omit<WorkflowGraphExecutorDeps,
   store: WorkflowIrResolverStore & {
     getTask?: (taskId: string) => Promise<TaskDetail>;
     getTaskDocument?: (taskId: string, key: string) => Promise<unknown | null>;
-    updateTask?: (taskId: string, updates: { summary: string }) => Promise<unknown> | unknown;
-    logEntry?: (taskId: string, action: string, detail?: string) => Promise<unknown> | unknown;
+    /*
+    FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+    Hand-declared, so it inherits neither of U18's `TaskStore` overloads; at the old arity the
+    completion-summary write reached the store unattributed no matter what the call-site sweep did.
+    Mirrors the CANONICAL store arity, which also keeps a real `TaskStore` assignable and keeps this
+    surface interchangeable with `WorkflowCompletionSummaryStore`.
+    */
+    updateTask?: (taskId: string, updates: { summary: string }, runContext: RunMutationContext) => Promise<unknown> | unknown;
+    logEntry?: (taskId: string, action: string, detail: string | undefined, runContext: RunMutationContext) => Promise<unknown> | unknown;
     transitionWorkflowWorkItem?: (
       id: string,
       state: WorkflowWorkItemState,
@@ -152,6 +160,9 @@ export class WorkflowTaskRuntime {
         };
       }
       const latestTask = await this.deps.store.getTask?.(task.id).catch(() => undefined);
+      /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2): marker — the runtime carries a run id but no
+         actor and no agent id, and the summary is written by the graph itself rather than by
+         whoever ran the node. U13 owns giving unattended graph writes a real system actor. */
       await ensureWorkflowCompletionSummary(this.deps.store, latestTask ?? task, {
         reason: "workflow-runtime-completed",
         workflowId: target.workflowId,
@@ -159,7 +170,7 @@ export class WorkflowTaskRuntime {
         settings,
         originalInput: task.description,
         outputLanguage,
-      }).catch(() => undefined);
+      }, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     }
 
     const disposition: WorkflowTaskRuntimeDisposition = result.outcome === "success" ? "completed" : "failed";
@@ -225,6 +236,7 @@ export class WorkflowTaskRuntime {
     }
 
     if (fencedWorkItem.kind === "merge" || workItem.kind === "manual-hold") {
+      // FNXC:Identity 2026-08-09-03:04 (U18/KTD2): marker — same reason as above.
       await ensureWorkflowCompletionSummary(this.deps.store, task, {
         reason: `workflow-work-item:${workItem.kind}`,
         workflowId: target.workflowId,
@@ -232,7 +244,7 @@ export class WorkflowTaskRuntime {
         settings,
         originalInput: task.description,
         outputLanguage,
-      }).catch(() => undefined);
+      }, UNATTRIBUTED_MUTATION_CONTEXT).catch(() => undefined);
     }
 
     const invoked: string[] = [];

--- a/packages/engine/src/workflows/workflow-work-processor.ts
+++ b/packages/engine/src/workflows/workflow-work-processor.ts
@@ -1,4 +1,5 @@
 import type { Settings, WorkflowWorkItem, WorkflowWorkItemKind, WorkflowWorkItemState } from "@fusion/core";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { claimDueWorkflowWorkItem, type WorkflowWorkSchedulerStore } from "./workflow-work-scheduler.js";
 import { WorkflowTaskRuntime, type WorkflowTaskRuntimeResult } from "./workflow-task-runtime.js";
 
@@ -51,7 +52,10 @@ export async function processDueWorkflowWorkItem(
       void store.renewSymbolLocks!(dispatch.symbolLocks!, dispatch.taskId, 10 * 60_000)
         .then(async (result) => {
           if (result.lost.length > 0) {
-            await store.logEntry?.(dispatch.taskId, `workflow symbol-lock renewal lost: ${result.lost.join(", ")}`);
+            /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2): marker — a lease-renewal loss is written by
+               a timer with no run and no acting agent; `dispatch.runId` names the claim, not an
+               author. U13 owns whether unattended sweeps get a real system actor. */
+            await store.logEntry?.(dispatch.taskId, `workflow symbol-lock renewal lost: ${result.lost.join(", ")}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           }
         })
         .catch(() => undefined);

--- a/packages/engine/src/workflows/workflow-work-scheduler.ts
+++ b/packages/engine/src/workflows/workflow-work-scheduler.ts
@@ -1,4 +1,5 @@
-import type { AsyncMissionStore, MissionStore, Task, WorkflowWorkItem, WorkflowWorkItemDueFilter, WorkflowWorkItemKind } from "@fusion/core";
+import type { AsyncMissionStore, MissionStore, RunMutationContext, Task, WorkflowWorkItem, WorkflowWorkItemDueFilter, WorkflowWorkItemKind } from "@fusion/core";
+import { UNATTRIBUTED_MUTATION_CONTEXT } from "@fusion/core";
 import { decideMissionSymbolAdmission } from "../missions/mission-symbol-admission.js";
 
 const WORKFLOW_SYMBOL_LOCK_LEASE_MS = 10 * 60_000;
@@ -21,7 +22,14 @@ export interface WorkflowWorkSchedulerStore {
   ): Promise<{ acquired: true; conflicts: [] } | { acquired: false; conflicts: Array<{ symbolKey: string; ownerTaskId: string }> }>;
   releaseSymbolLocks?(symbols: readonly string[], ownerTaskId: string): Promise<unknown>;
   renewSymbolLocks?(symbols: readonly string[], ownerTaskId: string, leaseMs: number): Promise<{ renewed: string[]; lost: string[] }>;
-  logEntry?(taskId: string, message: string): Promise<unknown>;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 — the seam restates the required context):
+  Hand-declared, so it does not inherit U18's canonical/deprecated overload pair on `TaskStore`.
+  Left at the two-argument arity it would keep absorbing unattributed writes after the engine sweep,
+  and the census would report the package converted while this admission path stayed open. The shape
+  below mirrors the CANONICAL store arity, which is also what keeps a real `TaskStore` assignable.
+  */
+  logEntry?(taskId: string, message: string, outcome: string | undefined, runContext: RunMutationContext): Promise<unknown>;
 }
 
 export interface WorkflowWorkDispatch {
@@ -67,7 +75,11 @@ export async function claimDueWorkflowWorkItem(
         planApprovalRequired: settings?.planApprovalMode === "require-all",
       });
       if (admission.kind === "lineage-blocked") {
-        await store.logEntry?.(task.id, `workflow work not claimed — mission lineage blocked: ${admission.reason}`);
+        /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2): marker, not derived — `leaseOwner` names the
+           WORKER that would have taken the claim, not an actor that authored this refusal, and the
+           refusal is written before any run exists. Deriving from it would attribute a system
+           admission decision to a lease holder that never acted. */
+        await store.logEntry?.(task.id, `workflow work not claimed — mission lineage blocked: ${admission.reason}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
         continue;
       }
       if (admission.kind === "symbol-lock") {
@@ -78,7 +90,7 @@ export async function claimDueWorkflowWorkItem(
         );
         if (!result.acquired) {
           const conflict = result.conflicts[0];
-          await store.logEntry?.(task.id, `workflow work not claimed — symbol contention: symbol=${conflict?.symbolKey ?? "unknown"} holder=${conflict?.ownerTaskId ?? "unknown"}`);
+          await store.logEntry?.(task.id, `workflow work not claimed — symbol contention: symbol=${conflict?.symbolKey ?? "unknown"} holder=${conflict?.ownerTaskId ?? "unknown"}`, undefined, UNATTRIBUTED_MUTATION_CONTEXT);
           continue;
         }
         lockedSymbols = admission.symbols;

--- a/packages/engine/src/worktree/worktree-acquisition.ts
+++ b/packages/engine/src/worktree/worktree-acquisition.ts
@@ -75,7 +75,16 @@ export interface AcquireTaskWorktreeOptions {
   settings: Partial<Settings>;
   logger?: { log: (m: string) => void; warn: (m: string) => void; debug?: (m: string) => void; error?: (m: string) => void };
   audit?: Pick<RunAuditor, "git" | "filesystem">;
-  runContext?: RunMutationContext;
+  /*
+  FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage C — required, not optional):
+  Stage B left this optional and resolved a single unattributed marker inside `acquireTaskWorktree`,
+  because `executor.ts` was the one caller that could not supply a context. Stage C threaded the
+  executor's run carrier, so every caller can — and the option is now REQUIRED. That is the whole
+  point of the staging: an optional context turns ~45 downstream writes in this file into writes an
+  unwired caller can silently leave unattributed, and only a required parameter makes that a compile
+  error instead.
+  */
+  runContext: RunMutationContext;
   runInitCommand?: boolean;
   secretsStore?: Pick<SecretsStore, "listEnvExportable">;
   createWorktree?: (
@@ -269,7 +278,8 @@ async function maybeWarnForeignTaskStartPoint(
     taskId: string;
     logger?: { warn: (m: string) => void };
     store: TaskStore;
-    runContext?: RunMutationContext;
+    /** FNXC:Identity 2026-08-09-03:04 (U18 Stage B): required — the only caller resolves it first. */
+    runContext: RunMutationContext;
   },
 ): Promise<void> {
   const { baseBranch, rootDir, worktreePath, taskId, logger, store, runContext } = input;
@@ -357,6 +367,12 @@ async function ensureWorkspaceGroupOwnership(
 }
 
 export async function acquireTaskWorktree(opts: AcquireTaskWorktreeOptions): Promise<AcquireTaskWorktreeResult> {
+  /*
+  FNXC:Identity 2026-08-15-22:52 (U18/KTD2 Stage C):
+  This file already threaded `runContext` end to end; what U18 changed is that the store now REFUSES
+  an absent one, and what Stage C changed is that the caller can no longer omit it. The ~45
+  downstream writes take the caller's context directly — there is no local fallback left to resolve.
+  */
   const { task, rootDir, store, settings, logger, audit, runContext, createWorktree, runConfiguredCommand, runInitCommand, taskEnv, secretsStore, workspaceContext } = opts;
   const ensureDependencyReadiness = opts.ensureDependencyReadiness ?? ensureWorktreeDependencies;
   /*
@@ -384,12 +400,12 @@ export async function acquireTaskWorktree(opts: AcquireTaskWorktreeOptions): Pro
           branchWriteOrigin: patch.branchWriteOrigin ?? branchWriteOriginFor(patch.branch),
         };
     if (!opts.suppressSingularWorktreePersist) {
-      await store.updateTask(task.id, provenancePatch);
+      await store.updateTask(task.id, provenancePatch, runContext);
       return;
     }
     const { worktree: _worktree, branch: _branch, branchWriteOrigin: _origin, ...nonSingularPatch } = provenancePatch;
     if (Object.keys(nonSingularPatch).length > 0) {
-      await store.updateTask(task.id, nonSingularPatch);
+      await store.updateTask(task.id, nonSingularPatch, runContext);
     }
   };
   const renameWorktreeDirectory = opts.renameWorktreeDirectory ?? rename;
@@ -421,7 +437,7 @@ export async function acquireTaskWorktree(opts: AcquireTaskWorktreeOptions): Pro
     const refreshSettings = settings.worktrunk?.enabled === true
       ? { ...settings, worktrunk: { ...settings.worktrunk, enabled: false } }
       : settings;
-    const refresh = await refreshReusedWorktreeBase({ task, rootDir, worktreePath: path, store, settings: refreshSettings, audit, logger });
+    const refresh = await refreshReusedWorktreeBase({ task, rootDir, worktreePath: path, store, settings: refreshSettings, audit, logger, runContext });
     /*
     FNXC:WorktreeBaseRefresh 2026-08-09-23:49:
     A declined refresh is an unremarkable outcome, not an execution failure: the checkout is intact and the
@@ -1111,7 +1127,7 @@ export async function acquireTaskWorktree(opts: AcquireTaskWorktreeOptions): Pro
         }
       }
       // The removed worktree's session cannot resume into a fresh checkout — clear it so the executor starts clean.
-      await store.updateTask(task.id, { sessionFile: null });
+      await store.updateTask(task.id, { sessionFile: null }, runContext);
     }
 
       const created = await createWorktreeImpl(branchName, pinnedPath, task.id, freshStartPoint, allowSiblingBranchRename, true, workingBranch.origin);
@@ -1205,7 +1221,8 @@ async function verifyResumeBranchNotMisbound(input: {
   store: TaskStore;
   audit?: Pick<RunAuditor, "git" | "filesystem">;
   logger?: { log?: (msg: string) => void; warn?: (msg: string) => void };
-  runContext: RunMutationContext | undefined;
+  /** FNXC:Identity 2026-08-09-03:04 (U18 Stage B): required — both callers sit below the single resolution point above. */
+  runContext: RunMutationContext;
 }): Promise<void> {
   const { worktreePath, branchName, taskId, rootDir, store, audit, logger, runContext } = input;
 
@@ -1277,7 +1294,10 @@ export interface AcquireWorkspaceTaskWorktreesOptions {
   logger?: AcquireWorkspaceRepoWorktreeOptions["logger"];
   secretsStore?: AcquireWorkspaceRepoWorktreeOptions["secretsStore"];
   audit?: AcquireWorkspaceRepoWorktreeOptions["audit"];
-  runContext?: RunMutationContext;
+  /* FNXC:Identity 2026-08-23-06:40: REQUIRED — the workspace acquisition path forwards this straight
+     into per-repo writes that demand a carrier, so an optional field here just relocates the
+     failure to a call site that cannot supply one. */
+  runContext: RunMutationContext;
   registry?: ActiveSessionRegistry;
   runConfiguredCommand?: AcquireTaskWorktreeOptions["runConfiguredCommand"];
   ensureDependencyReadiness?: AcquireTaskWorktreeOptions["ensureDependencyReadiness"];
@@ -1297,7 +1317,10 @@ export interface AcquireWorkspaceRepoWorktreeOptions {
   logger?: { log: (m: string) => void; warn: (m: string) => void; error?: (m: string) => void };
   secretsStore?: Pick<SecretsStore, "listEnvExportable">;
   audit?: Pick<RunAuditor, "git" | "filesystem">;
-  runContext?: RunMutationContext;
+  /* FNXC:Identity 2026-08-09-03:04 (U18/KTD2 Stage C): required for the same reason as
+     `AcquireTaskWorktreeOptions.runContext` — the sole context-less caller was
+     `fn_acquire_repo_worktree`, built by `executor.ts`, which now carries a run context. */
+  runContext: RunMutationContext;
   /** Test seam: inject the path-keyed exclusivity registry (defaults to the process singleton). */
   registry?: ActiveSessionRegistry;
   /**

--- a/packages/engine/src/worktree/worktrunk-failure-handler.ts
+++ b/packages/engine/src/worktree/worktrunk-failure-handler.ts
@@ -31,7 +31,8 @@ export interface HandleFailureParams {
   task: Task;
   settings: WorktrunkSettings;
   store: Pick<TaskStore, "pauseTask" | "updateTask">;
-  runContext?: RunMutationContext;
+  /** FNXC:Identity 2026-08-09-03:04 (U18 Stage B): required — worktree acquisition resolves one before calling. */
+  runContext: RunMutationContext;
   runAudit?: Pick<RunAuditor, "git">;
   notify: (event: WorktrunkFailureNotification) => Promise<void> | void;
   nativeFallback?: () => Promise<WorktreeOperationResult>;


### PR DESCRIPTION
**Stack 3/5** — 54 files. Base: `identity/2-engine-executor`.

Completes the atomic engine-source conversion started in 2/5: heartbeat, agent tools, scheduling, healing, merge, missions, workflows, and the shared `util/run-audit` helpers. **Engine typecheck goes green here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)