### PR TITLE
fix(paperclip): reconcile terminal heartbeat-run records

### DIFF
--- a/.changeset/paperclip-terminal-run-record.md
+++ b/.changeset/paperclip-terminal-run-record.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Complete Paperclip runs from their terminal heartbeat-run record.
+category: fix
+dev: Polls the run record when event polling has not reported a terminal status.

--- a/plugins/fusion-plugin-paperclip-runtime/src/__tests__/paperclip-client.test.ts
+++ b/plugins/fusion-plugin-paperclip-runtime/src/__tests__/paperclip-client.test.ts
@@ -7,6 +7,7 @@ import {
   getIssue,
   getIssueComments,
   getIssueViaCli,
+  getRun,
   getRunEvents,
   listCompaniesViaCli,
   listCompanyAgents,
@@ -202,8 +203,28 @@ describe("wakeAgent", () => {
 });
 
 // ---------------------------------------------------------------------------
-// getRunEvents
+// getRun / getRunEvents
 // ---------------------------------------------------------------------------
+
+describe("getRun", () => {
+  it("fetches the heartbeat-run record with bearer auth", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ id: "RUN-1", status: "succeeded" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getRun("http://localhost:3100/", "secret", "RUN-1");
+
+    expect(result).toEqual({ id: "RUN-1", status: "succeeded" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3100/api/heartbeat-runs/RUN-1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer secret" }),
+      }),
+    );
+  });
+});
 
 describe("getRunEvents", () => {
   it("uses afterSeq + limit query params", async () => {

--- a/plugins/fusion-plugin-paperclip-runtime/src/__tests__/runtime-adapter.test.ts
+++ b/plugins/fusion-plugin-paperclip-runtime/src/__tests__/runtime-adapter.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetIssue,
   mockGetIssueViaCli,
   mockGetIssueComments,
+  mockGetRun,
   mockGetRunEvents,
   mockWakeAgent,
   mockResolveConfig,
@@ -23,6 +24,7 @@ const {
   mockGetIssue: vi.fn(),
   mockGetIssueViaCli: vi.fn(),
   mockGetIssueComments: vi.fn(),
+  mockGetRun: vi.fn(),
   mockGetRunEvents: vi.fn(),
   mockWakeAgent: vi.fn(),
   mockResolveConfig: vi.fn((settings?: Record<string, unknown>) => ({
@@ -50,6 +52,7 @@ vi.mock("../paperclip-client.js", () => ({
   getIssue: mockGetIssue,
   getIssueViaCli: mockGetIssueViaCli,
   getIssueComments: mockGetIssueComments,
+  getRun: mockGetRun,
   getRunEvents: mockGetRunEvents,
   wakeAgent: mockWakeAgent,
   resolvePaperclipConfig: mockResolveConfig,
@@ -60,10 +63,13 @@ const baseSessionOpts = {
   systemPrompt: "be helpful",
 };
 
-function makeAdapter(config: Record<string, unknown> = {}) {
+function makeAdapter(
+  config: Record<string, unknown> = {},
+  warn: (message: string) => void = () => undefined,
+) {
   return new PaperclipRuntimeAdapter(config, {
     info: () => undefined,
-    warn: () => undefined,
+    warn,
     error: () => undefined,
   });
 }
@@ -82,6 +88,7 @@ beforeEach(() => {
     { seq: 2, type: "heartbeat.run.status", payload: { status: "succeeded" } },
   ];
   mockGetRunEvents.mockResolvedValue(defaultEvents);
+  mockGetRun.mockResolvedValue({ id: "RUN-1", status: "running" });
   mockWakeAgent.mockResolvedValue({ id: "RUN-1", status: "queued" });
   mockCreateIssue.mockResolvedValue({ id: "ISS-1", status: "todo" });
   mockGetIssue.mockResolvedValue({ id: "ISS-1", status: "done" });
@@ -235,10 +242,157 @@ describe("PaperclipRuntimeAdapter — terminal statuses", () => {
     );
   });
 
+  it("empty events + terminal run record returns the exact final response", async () => {
+    mockGetRunEvents.mockResolvedValueOnce([]);
+    mockGetRun.mockResolvedValueOnce({ id: "RUN-1", status: "succeeded" });
+    mockGetIssueComments.mockResolvedValueOnce([
+      { id: "C-1", body: "RICHARD_CANARY_EXACT_RESPONSE" },
+    ]);
+    const adapter = makeAdapter({ agentId: "AG-1", companyId: "CO-1" });
+    const onText = vi.fn();
+    const onToolEnd = vi.fn();
+    const { session } = await adapter.createSession({
+      ...baseSessionOpts,
+      onText,
+      onToolEnd,
+    });
+
+    await adapter.promptWithFallback(session, "p");
+
+    expect(onText).toHaveBeenCalledTimes(1);
+    expect(onText).toHaveBeenCalledWith("RICHARD_CANARY_EXACT_RESPONSE");
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "paperclip.run",
+      false,
+      expect.objectContaining({ runStatus: "succeeded" }),
+    );
+  });
+
+  it("polls the run record until running becomes succeeded", async () => {
+    mockGetRunEvents.mockResolvedValue([]);
+    mockGetRun
+      .mockResolvedValueOnce({ id: "RUN-1", status: "running" })
+      .mockResolvedValueOnce({ id: "RUN-1", status: "succeeded" });
+    const adapter = makeAdapter({ agentId: "AG-1", companyId: "CO-1" });
+    const onToolEnd = vi.fn();
+    const { session } = await adapter.createSession({ ...baseSessionOpts, onToolEnd });
+
+    await adapter.promptWithFallback(session, "p");
+
+    expect(mockGetRun).toHaveBeenCalledTimes(2);
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "paperclip.run",
+      false,
+      expect.objectContaining({ runStatus: "succeeded" }),
+    );
+  });
+
+  it.each(["failed", "cancelled", "interrupted", "timed_out"])(
+    "%s from the run record → onToolEnd isError=true",
+    async (status) => {
+      mockGetRunEvents.mockResolvedValueOnce([]);
+      mockGetRun.mockResolvedValueOnce({ id: "RUN-1", status });
+      const adapter = makeAdapter({ agentId: "AG-1", companyId: "CO-1" });
+      const onToolEnd = vi.fn();
+      const { session } = await adapter.createSession({ ...baseSessionOpts, onToolEnd });
+
+      await adapter.promptWithFallback(session, "p");
+
+      expect(onToolEnd).toHaveBeenCalledWith(
+        "paperclip.run",
+        true,
+        expect.objectContaining({ runStatus: status }),
+      );
+    },
+  );
+
+  it("treats interrupted from the run record as terminal without a local timeout", async () => {
+    mockGetRunEvents.mockResolvedValue([]);
+    mockGetRun.mockResolvedValue({ id: "RUN-1", status: "interrupted" });
+    const adapter = makeAdapter({
+      agentId: "AG-1",
+      companyId: "CO-1",
+      runTimeoutMs: 1,
+      pollIntervalMs: 1,
+      pollIntervalMaxMs: 1,
+    });
+    const onToolEnd = vi.fn();
+    const { session } = await adapter.createSession({ ...baseSessionOpts, onToolEnd });
+
+    await adapter.promptWithFallback(session, "p");
+
+    expect(mockGetRunEvents).toHaveBeenCalledTimes(1);
+    expect(mockGetRun).toHaveBeenCalledTimes(1);
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "paperclip.run",
+      true,
+      expect.objectContaining({
+        runStatus: "interrupted",
+        timedOutLocally: false,
+      }),
+    );
+  });
+
+  it("preserves polling after a transient run-record failure", async () => {
+    mockGetRunEvents.mockResolvedValue([]);
+    mockGetRun
+      .mockRejectedValueOnce(new Error("temporary network error"))
+      .mockResolvedValueOnce({ id: "RUN-1", status: "succeeded" });
+    const warn = vi.fn();
+    const adapter = makeAdapter({ agentId: "AG-1", companyId: "CO-1" }, warn);
+    const onToolEnd = vi.fn();
+    const { session } = await adapter.createSession({ ...baseSessionOpts, onToolEnd });
+
+    await adapter.promptWithFallback(session, "p");
+
+    expect(mockGetRun).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("temporary network error"),
+    );
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "paperclip.run",
+      false,
+      expect.objectContaining({ runStatus: "succeeded" }),
+    );
+  });
+
+  it("ignores a malformed run-record status and keeps polling", async () => {
+    mockGetRunEvents.mockResolvedValue([]);
+    mockGetRun
+      .mockResolvedValueOnce({ id: "RUN-1", status: 123 })
+      .mockResolvedValueOnce({ id: "RUN-1", status: "succeeded" });
+    const warn = vi.fn();
+    const adapter = makeAdapter({ agentId: "AG-1", companyId: "CO-1" }, warn);
+    const onToolEnd = vi.fn();
+    const { session } = await adapter.createSession({ ...baseSessionOpts, onToolEnd });
+
+    await adapter.promptWithFallback(session, "p");
+
+    expect(mockGetRun).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("missing or empty status"),
+    );
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "paperclip.run",
+      false,
+      expect.objectContaining({ runStatus: "succeeded" }),
+    );
+  });
+
+  it("does not fetch the run record when an event is already terminal", async () => {
+    const adapter = makeAdapter({ agentId: "AG-1", companyId: "CO-1" });
+    const { session } = await adapter.createSession({ ...baseSessionOpts });
+
+    await adapter.promptWithFallback(session, "p");
+
+    expect(mockGetRun).not.toHaveBeenCalled();
+  });
+
   it("local timeout → exits with timedOutLocally=true, no throw", async () => {
     mockGetRunEvents.mockResolvedValue([
       { seq: 1, type: "heartbeat.run.status", payload: { status: "running" } },
     ]);
+    mockGetRun.mockResolvedValue({ id: "RUN-1", status: "running" });
     const adapter = makeAdapter({
       agentId: "AG-1",
       companyId: "CO-1",

--- a/plugins/fusion-plugin-paperclip-runtime/src/paperclip-client.ts
+++ b/plugins/fusion-plugin-paperclip-runtime/src/paperclip-client.ts
@@ -89,6 +89,13 @@ export interface RunEvent {
   createdAt?: string;
 }
 
+/** A heartbeat-run record returned by GET /api/heartbeat-runs/{runId}. */
+export interface HeartbeatRunRecord {
+  id?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -507,6 +514,20 @@ export async function getRunEvents(
   const r = result as Record<string, unknown>;
   if (Array.isArray(r.events)) return r.events as RunEvent[];
   return [];
+}
+
+/**
+ * Fetches the current heartbeat-run record.
+ *
+ * This is the authoritative terminal-state fallback when the incremental
+ * events endpoint has no new status event.
+ */
+export async function getRun(
+  apiUrl: string,
+  apiKey: string | undefined,
+  runId: string,
+): Promise<HeartbeatRunRecord> {
+  return request<HeartbeatRunRecord>(apiUrl, `/heartbeat-runs/${runId}`, { apiKey });
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/fusion-plugin-paperclip-runtime/src/runtime-adapter.ts
+++ b/plugins/fusion-plugin-paperclip-runtime/src/runtime-adapter.ts
@@ -8,6 +8,7 @@ import {
   getIssue,
   getIssueComments,
   getIssueViaCli,
+  getRun,
   getRunEvents,
   resolvePaperclipConfig,
   wakeAgent,
@@ -28,6 +29,7 @@ const TERMINAL_RUN_STATUSES = new Set<string>([
   "succeeded",
   "failed",
   "cancelled",
+  "interrupted",
   "timed_out",
 ]);
 
@@ -296,7 +298,11 @@ export class PaperclipRuntimeAdapter implements AgentRuntime {
     if (finalText) session.onText?.(finalText);
     if (stream.thinking) session.onThinking?.(stream.thinking);
 
-    const isError = stream.runStatus === "failed" || stream.runStatus === "timed_out";
+    const isError =
+      stream.runStatus === "failed" ||
+      stream.runStatus === "cancelled" ||
+      stream.runStatus === "interrupted" ||
+      stream.runStatus === "timed_out";
     session.onToolEnd?.("paperclip.run", isError || stream.timedOutLocally, {
       runId,
       runStatus: stream.runStatus,
@@ -400,6 +406,25 @@ export class PaperclipRuntimeAdapter implements AgentRuntime {
           }
         }
         // Other event types (adapter.invoke, tool calls) are ignored for v1.
+      }
+
+      if (TERMINAL_RUN_STATUSES.has(runStatus)) break;
+
+      try {
+        const run = await getRun(session.apiUrl, session.apiKey, runId);
+        const recordStatus = asString(run.status)?.trim();
+        if (recordStatus) {
+          runStatus = recordStatus;
+        } else {
+          this.logger.warn(
+            `Paperclip getRun returned a missing or empty status for run ${runId}; preserving the event/timeout polling path.`,
+          );
+        }
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Paperclip getRun failed for run ${runId}: ${reason}; preserving the event/timeout polling path.`,
+        );
       }
 
       if (TERMINAL_RUN_STATUSES.has(runStatus)) break;


### PR DESCRIPTION
## Summary

- add an authoritative heartbeat-run record lookup to the Paperclip client
- reconcile terminal run state when the events endpoint omits the final status event
- preserve event streaming, local timeout behavior, and transient-error fallback
- classify cancelled and interrupted terminal runs as errors

## Why

Paperclip can mark a heartbeat run terminal while its events endpoint returns no terminal status event. Fusion then keeps the local run in running state until its timeout and never returns the worker comment/result. The run record endpoint is the authoritative fallback.

## Verification

- focused Paperclip runtime tests: 75 passed
- plugin typecheck: passed
- plugin build: passed
- changeset validation: passed
- git diff check: passed

The change includes a patch changeset and regression coverage for empty-event terminal records, delayed terminal records, failure states, malformed or transient record responses, terminal-event fast paths, and the existing timeout path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved run completion tracking by checking the latest heartbeat-run status when event updates are incomplete.
  * Added support for recognizing interrupted, cancelled, and timed-out runs as terminal outcomes.

* **Bug Fixes**
  * Preserved existing event and timeout handling when run-status checks are unavailable, empty, malformed, or unsuccessful.
  * Improved error reporting for failed terminal runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->