### PR TITLE
fix(ci): correct future FNXC stamps

### DIFF
--- a/packages/cli/src/__tests__/staged-plugin-core-imports.test.ts
+++ b/packages/cli/src/__tests__/staged-plugin-core-imports.test.ts
@@ -16,7 +16,7 @@ export interface CoreImportInspection {
 }
 
 /**
- * FNXC:BundledPlugins 2026-08-16-00:00:
+ * FNXC:BundledPlugins 2026-08-15-22:55:
  * Staged plugins reach core through the CLI shim in package mode, but fast builds resolve their
  * declared workspace dependency directly. Parse every legal core reference and fail closed instead
  * of regexing named imports: aliases, namespaces, dynamic calls, re-exports, and subpaths otherwise

--- a/packages/engine/src/__tests__/workspace-merger-lease.test.ts
+++ b/packages/engine/src/__tests__/workspace-merger-lease.test.ts
@@ -336,7 +336,7 @@ describeIfGit("landWorkspaceTask — per-repo land lease (Phase C U3, KTD4)", ()
     fx.git("repo-a", `git push --force-with-lease=${dispatchRef}:${staleDispatchSha} origin ${successorDispatchSha}:${dispatchRef}`);
 
     /*
-    FNXC:WorkspaceMergeDispatch 2026-08-19-00:00:
+    FNXC:WorkspaceMergeDispatch 2026-08-15-22:55:
     A dispatch lease renewal may never run while a merge body is suspended. The resource must
     reject its atomic ref advance after a successor republishes the task fence, even when main
     still equals the predecessor's observed tip.

--- a/packages/engine/src/merge/merger-ai.ts
+++ b/packages/engine/src/merge/merger-ai.ts
@@ -852,7 +852,7 @@ export interface LandRepoContext {
   noCommitsExpected?: boolean;
   /** FNXC:Workspace 2026-08-15-08:36: Present only for workspace sub-repos; it fences the durable intent and remote ref advance. */
   workspaceLand?: { handle: WorkspaceLeaseHandle; repoRelPath: string; remote: string };
-  /** FNXC:WorkspaceMergeDispatch 2026-08-19-00:00: Task-level pin that fences every merge-body ref advance. */
+  /** FNXC:WorkspaceMergeDispatch 2026-08-15-22:55: Task-level pin that fences every merge-body ref advance. */
   workspaceDispatchFence?: { fenceRefName: string; fenceRefSha: string };
   store: TaskStore;
 }
@@ -1105,7 +1105,7 @@ export async function landOneRepo(
       }
 
       /*
-       * FNXC:AIMerge 2026-08-19-00:00:
+       * FNXC:AIMerge 2026-08-15-22:55:
        * This is the sole production pre-land seam: the reviewer approved the
        * clean-room squash but the integration ref has not advanced, so scope and
        * shrinkage violations can still leave every integration branch untouched.

--- a/packages/engine/src/merge/merger-diff-volume-gate.ts
+++ b/packages/engine/src/merge/merger-diff-volume-gate.ts
@@ -93,7 +93,7 @@ export async function checkDiffVolume({
     if (branchNet <= minLines) continue;
 
     /*
-     * FNXC:AIMerge 2026-08-19-00:00:
+     * FNXC:AIMerge 2026-08-15-22:55:
      * The unified land has an approved commit, not staged changes; preserve the
      * legacy index read unless its clean-room range is supplied.
      */

--- a/packages/engine/src/merge/merger-file-scope.ts
+++ b/packages/engine/src/merge/merger-file-scope.ts
@@ -142,7 +142,7 @@ export class FileScopeViolationError extends Error {
 export type StagedFilesReader = (cwd: string) => Promise<string[]>;
 
 /**
- * FNXC:AIMerge 2026-08-19-00:00:
+ * FNXC:AIMerge 2026-08-15-22:55:
  * Unified AI merges approve a committed clean-room squash, so their file list
  * must be read from the approved commit range rather than the empty index.
  */

--- a/packages/engine/src/project-engine.ts
+++ b/packages/engine/src/project-engine.ts
@@ -4554,7 +4554,7 @@ export class ProjectEngine {
                   {
                     ...mergerOptions,
                     allowDirtyLocalCheckoutSync: settings.merger?.allowDirtyLocalCheckoutSync === true,
-                    // FNXC:WorkspaceMergeDispatch 2026-08-19-00:00:
+                    // FNXC:WorkspaceMergeDispatch 2026-08-15-22:55:
                     // Admission is not a licence to write: the per-task dispatch pin travels to
                     // every workspace ref advance so git rejects an expired predecessor even if
                     // renewal never ran and the target tip has not moved.

--- a/scripts/lib/fnxc-future-dates-baseline.json
+++ b/scripts/lib/fnxc-future-dates-baseline.json
@@ -1,14 +1,1 @@
-{
-  "packages/core/src/async-stores/async-chat-store.ts": 4,
-  "packages/core/src/async-stores/async-mission-store.ts": 1,
-  "packages/core/src/chat/chat-store.ts": 1,
-  "packages/core/src/postgres/migrations/0036_chat_session_tags.sql": 2,
-  "packages/dashboard/app/App.tsx": 1,
-  "packages/dashboard/app/components/AgentDetailView.css": 1,
-  "packages/dashboard/app/components/ChatView.css": 2,
-  "packages/dashboard/app/components/TaskDetailModal.css": 1,
-  "packages/dashboard/vitest.config.ts": 1,
-  "packages/engine/src/project-engine.ts": 1,
-  "packages/engine/src/triage.ts": 2,
-  "docs/workflow-steps.md": 1
-}
+{}


### PR DESCRIPTION
## Summary
- replaces newly added future-dated FNXC metadata with the actual UTC change time
- tightens the FNXC future-date baseline to zero known exceptions

## Test plan
- `pnpm check:fnxc-future-dates`
- `pnpm check:lifecycle-columns`
- `pnpm check:changesets`
- `pnpm --filter @runfusion/fusion exec vitest run src/__tests__/staged-plugin-core-imports.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/engine typecheck`
- `pnpm lint`
