### PR TITLE
fix: preserve dirty orphan worktrees

### DIFF
--- a/.changeset/preserve-dirty-orphan-worktrees.md
+++ b/.changeset/preserve-dirty-orphan-worktrees.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Preserve worktree content during automatic cleanup.
+category: fix
+dev: Registered idle and pool-prune cleanup revalidates and preserves tracked, untracked, and ignored content without force. Native non-defensive removals retain their legacy forced default; Worktrunk receives force only from explicit caller intent. Missing registrations are pruned; unregistered cleanup removes only empty residue after Fusion-owned secret cleanup; a concurrently missing managed env clears its fingerprint.

--- a/packages/engine/src/__tests__/reliability-interactions/secrets-env-materialization.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/secrets-env-materialization.test.ts
@@ -113,11 +113,42 @@ describe("reliability interactions: secrets env materialization", () => {
     mkdirSync(orphan, { recursive: true });
     // `.git` link file present, but the admin entry it points at was pruned away: leak residue.
     writeFileSync(join(orphan, ".git"), `gitdir: ${join(root, ".git", "worktrees", "ghost")}\n`);
-    writeFileSync(join(orphan, ".env"), "A=1\n");
-    writeFileSync(join(orphan, ".fusion-secrets-env.fingerprint"), "abc\n.env\n");
+    const body = "A=1\n";
+    writeFileSync(join(orphan, ".env"), body);
+    writeFileSync(join(orphan, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(body).digest("hex")}\n.env\n`);
 
     const removed = await reapOrphanWorktrees(root);
     expect(removed).toBe(1);
     expect(existsSync(orphan)).toBe(false);
+  });
+
+  it("reclaims a dangling worktree pointer after removing only its fingerprint-owned env", async () => {
+    const root = tmpRepo();
+    const orphan = join(root, ".worktrees", "dangling-generated-env");
+    mkdirSync(orphan, { recursive: true });
+    const body = "A=1\n";
+    writeFileSync(join(orphan, ".git"), "gitdir: /missing-worktree-admin\n");
+    writeFileSync(join(orphan, ".env"), body);
+    writeFileSync(join(orphan, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(body).digest("hex")}\n.env\n`);
+
+    const removed = await reapOrphanWorktrees(root);
+
+    expect(removed).toBe(1);
+    expect(existsSync(orphan)).toBe(false);
+  });
+
+  it("preserves a dangling worktree pointer with an unowned env", async () => {
+    const root = tmpRepo();
+    const orphan = join(root, ".worktrees", "dangling-user-env");
+    mkdirSync(orphan, { recursive: true });
+    const body = "USER_AUTHORED=1\n";
+    writeFileSync(join(orphan, ".git"), "gitdir: /missing-worktree-admin\n");
+    writeFileSync(join(orphan, ".env"), body);
+
+    const removed = await reapOrphanWorktrees(root);
+
+    expect(removed).toBe(0);
+    expect(existsSync(orphan)).toBe(true);
+    expect(readFileSync(join(orphan, ".env"), "utf8")).toBe(body);
   });
 });

--- a/packages/engine/src/__tests__/reliability-interactions/worktree-pool-orphan-reap-race.real-fs.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktree-pool-orphan-reap-race.real-fs.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    rmdirSync: vi.fn((path: unknown) => {
+      const worktreePath = String(path);
+      if (worktreePath.endsWith("/race-orphan")) {
+        actual.writeFileSync(`${worktreePath}/created-after-scan.txt`, "user-authored\n");
+      }
+      if (worktreePath.endsWith("/restore-fails-orphan") || worktreePath.endsWith("/concurrent-wins-orphan")) {
+        actual.writeFileSync(`${worktreePath}/user-file.txt`, "user-authored\n");
+      }
+      return actual.rmdirSync(worktreePath);
+    }),
+    // Pointer recreation through writeFileSync(wx) must never be the restore path:
+    // force it to fail, so a regression back to recreate-based restoration is caught.
+    writeFileSync: vi.fn((path: unknown, data: unknown, options?: unknown) => {
+      const opts = options as { flag?: string } | undefined;
+      if (String(path).endsWith("/race-orphan/.git") && opts?.flag === "wx") {
+        throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+      }
+      return actual.writeFileSync(String(path), String(data), options as never);
+    }),
+    // Force the restore link to fail with a NON-EEXIST error (EPERM): the stash
+    // must be restored via the copy fallback rather than abandoned, and a
+    // regression to a warn-only catch (orphaned stash + lost pointer) is caught.
+    linkSync: vi.fn((src: unknown, dest: unknown) => {
+      if (String(dest).endsWith("/restore-fails-orphan/.git") || String(dest).endsWith("/concurrent-wins-orphan/.git")) {
+        throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+      }
+      return actual.linkSync(String(src), String(dest));
+    }),
+    // Simulate a concurrent process creating an authoritative .git between the
+    // link failure and the copy fallback: the copy must fail EEXIST and the
+    // concurrent pointer must win, never being overwritten by the stash.
+    copyFileSync: vi.fn((src: unknown, dest: unknown, mode?: unknown) => {
+      if (String(dest).endsWith("/concurrent-wins-orphan/.git")) {
+        actual.writeFileSync(String(dest), "gitdir: /concurrent/authoritative.git\n");
+        throw Object.assign(new Error("EEXIST: file already exists"), { code: "EEXIST" });
+      }
+      return actual.copyFileSync(String(src), String(dest), mode as never);
+    }),
+  };
+});
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { reapOrphanWorktrees } from "../../worktree/worktree-pool.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("reapOrphanWorktrees real filesystem race", () => {
+  it("restores dangling .git metadata when content appears before rmdir, even if pointer recreation would fail", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pool-orphan-race-"));
+    roots.push(root);
+    const orphan = join(root, ".worktrees", "race-orphan");
+    const dotGit = join(orphan, ".git");
+    const createdAfterScan = join(orphan, "created-after-scan.txt");
+    const pointer = `gitdir: ${join(root, ".git", "worktrees", "race-orphan")}\n`;
+    const mode = 0o640;
+
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(dotGit, pointer, { mode });
+
+    const removed = await reapOrphanWorktrees(root);
+
+    expect(removed).toBe(0);
+    expect(existsSync(orphan)).toBe(true);
+    expect(existsSync(createdAfterScan)).toBe(true);
+    expect(readFileSync(dotGit, "utf8")).toBe(pointer);
+    expect(statSync(dotGit).mode & 0o777).toBe(mode);
+  });
+
+  it("restores the dangling .git pointer via the copy fallback when restore-link fails with a non-EEXIST error (no orphaned stash)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pool-orphan-restore-fail-"));
+    roots.push(root);
+    const orphan = join(root, ".worktrees", "restore-fails-orphan");
+    const dotGit = join(orphan, ".git");
+    const userFile = join(orphan, "user-file.txt");
+    const pointer = `gitdir: ${join(root, ".git", "worktrees", "restore-fails-orphan")}\n`;
+    const mode = 0o640;
+
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(dotGit, pointer, { mode });
+
+    const removed = await reapOrphanWorktrees(root);
+
+    expect(removed).toBe(0);
+    expect(existsSync(orphan)).toBe(true);
+    expect(existsSync(userFile)).toBe(true);
+    // Pointer restored from the stash (rename-back preserves content and mode),
+    // never lost to a warn-only catch.
+    expect(readFileSync(dotGit, "utf8")).toBe(pointer);
+    expect(statSync(dotGit).mode & 0o777).toBe(mode);
+    // No stash left abandoned next to the orphan.
+    const stashFiles = readdirSync(join(root, ".worktrees")).filter((entry) => entry.includes(".git-reap-stash-"));
+    expect(stashFiles).toEqual([]);
+  });
+
+  it("never overwrites a concurrent .git pointer during the copy-fallback restore (concurrent pointer wins)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pool-orphan-concurrent-wins-"));
+    roots.push(root);
+    const orphan = join(root, ".worktrees", "concurrent-wins-orphan");
+    const dotGit = join(orphan, ".git");
+    const userFile = join(orphan, "user-file.txt");
+    const pointer = `gitdir: ${join(root, ".git", "worktrees", "concurrent-wins-orphan")}\n`;
+    const mode = 0o640;
+
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(dotGit, pointer, { mode });
+
+    const removed = await reapOrphanWorktrees(root);
+
+    expect(removed).toBe(0);
+    expect(existsSync(orphan)).toBe(true);
+    expect(existsSync(userFile)).toBe(true);
+    // The concurrent authoritative pointer wins; the stashed dangling pointer
+    // must never replace it (COPYFILE_EXCL refuses and the stash is dropped).
+    expect(readFileSync(dotGit, "utf8")).toBe("gitdir: /concurrent/authoritative.git\n");
+    const stashFiles = readdirSync(join(root, ".worktrees")).filter((entry) => entry.includes(".git-reap-stash-"));
+    expect(stashFiles).toEqual([]);
+  });
+});

--- a/packages/engine/src/__tests__/reliability-interactions/worktree-remove-non-empty-recovery.real-git.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktree-remove-non-empty-recovery.real-git.test.ts
@@ -1,9 +1,11 @@
-import { access, chmod, mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdtemp, mkdir, readdir, realpath, rm, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { NativeWorktreeBackend, RemovalReason, removeWorktree } from "../../worktree/worktree-backend.js";
+import { cleanupOrphanedWorktrees } from "../../worktree/worktree-pool.js";
 import { git, hasGit } from "./_helpers.js";
 
 async function pathExists(path: string): Promise<boolean> {
@@ -102,6 +104,105 @@ describe.skipIf(!hasGit)("reliability interactions: worktree remove non-empty re
     expect(events).toContain("worktree:remove-fallback");
     expect(events).toContain("worktree:admin-entry-pruned");
     expect(events).toContain("worktree:remove");
+  });
+
+  it("preserves ignored content during an idle-sweep removal", async () => {
+    const root = await setupRepo();
+    await writeFile(join(root, ".gitignore"), ".env\n", "utf-8");
+    git(root, "git add .gitignore");
+    git(root, 'git commit -m "ignore env"');
+    const worktreePath = await createWorktree(root, "fn-ignored", "fusion/fn-ignored");
+    await writeFile(join(worktreePath, ".env"), "RECOVERABLE=1\n", "utf-8");
+
+    await expect(removeWorktree({
+      rootDir: root,
+      worktreePath,
+      settings: {},
+      reason: RemovalReason.SelfHealingIdleSweep,
+    })).rejects.toThrow(/dirty worktree/);
+
+    expect(await pathExists(join(worktreePath, ".env"))).toBe(true);
+  });
+
+  it("removes an idle worktree containing only generated ignored residue after ownership cleanup", async () => {
+    const root = await setupRepo();
+    await writeFile(join(root, ".gitignore"), ".env\nnode_modules/\ndist/\n", "utf-8");
+    git(root, "git add .gitignore");
+    git(root, 'git commit -m "ignore generated residue"');
+    const worktreePath = await createWorktree(root, "fn-generated-clean", "fusion/fn-generated-clean");
+    await mkdir(join(worktreePath, "node_modules", "pkg"), { recursive: true });
+    await writeFile(join(worktreePath, "node_modules", "pkg", "index.js"), "generated\n", "utf-8");
+    await mkdir(join(worktreePath, "dist"), { recursive: true });
+    await writeFile(join(worktreePath, "dist", "bundle.js"), "generated\n", "utf-8");
+    const env = "SECRET=1\n";
+    await writeFile(join(worktreePath, ".env"), env, "utf-8");
+    await writeFile(join(worktreePath, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(env).digest("hex")}\n.env\n`, "utf-8");
+
+    await cleanupOrphanedWorktrees(root, { listTasks: async () => [] } as any);
+
+    await expectWorktreeRemoved(root, worktreePath);
+  });
+
+  it("preserves a registered worktree whose checkout root is no longer probeable", async () => {
+    const root = await setupRepo();
+    const worktreePath = await createWorktree(root, "fn-corrupt", "fusion/fn-corrupt");
+    // User-authored content that must survive the corrupt-root removal intact.
+    await writeFile(join(worktreePath, "draft.md"), "user note\n", "utf-8");
+    await rm(join(worktreePath, ".git"));
+
+    await removeWorktree({
+      rootDir: root,
+      worktreePath,
+      settings: {},
+      reason: RemovalReason.PoolPrune,
+    });
+
+    // The checkout root is no longer registered/removed from the worktree list...
+    await expectWorktreeRemoved(root, worktreePath);
+    // ...but its contents are preserved (renamed into the contained recovery area),
+    // never recursively deleted.
+    const recoveryWorktrees = join(root, ".fusion", "recovery", "worktrees");
+    const entries = await readdir(recoveryWorktrees);
+    const corrupt = entries.find((entry) => entry.startsWith("corrupt-"));
+    expect(corrupt).toBeDefined();
+    expect(await pathExists(join(recoveryWorktrees, corrupt as string, "draft.md"))).toBe(true);
+  });
+
+  it("rejects user-authored ignored artifacts under generated-looking paths during an idle-sweep removal", async () => {
+    const root = await setupRepo();
+    await writeFile(join(root, ".gitignore"), "dist/\n", "utf-8");
+    git(root, "git add .gitignore");
+    git(root, 'git commit -m "ignore generated directory"');
+    const worktreePath = await createWorktree(root, "fn-generated", "fusion/fn-generated");
+    const manualPath = join(worktreePath, "dist", "manual.txt");
+    await mkdir(dirname(manualPath), { recursive: true });
+    await writeFile(manualPath, "user-authored\n", "utf-8");
+
+    await expect(removeWorktree({
+      rootDir: root,
+      worktreePath,
+      settings: {},
+      reason: RemovalReason.SelfHealingIdleSweep,
+    })).rejects.toThrow(/dirty worktree/);
+
+    expect(await pathExists(manualPath)).toBe(true);
+    expect(await pathExists(worktreePath)).toBe(true);
+  });
+
+  it("prunes a missing worktree registration during defensive cleanup", async () => {
+    const root = await setupRepo();
+    const worktreePath = await createWorktree(root, "fn-missing-pool", "fusion/fn-missing-pool");
+    const resolvedWorktreePath = await realpath(worktreePath);
+    await rm(worktreePath, { recursive: true, force: true });
+
+    await removeWorktree({
+      rootDir: root,
+      worktreePath,
+      settings: {},
+      reason: RemovalReason.PoolPrune,
+    });
+
+    await expectWorktreeRemoved(root, resolvedWorktreePath);
   });
 
   it("removes and prunes a worktree with nested-git content when native removal falls back", async () => {

--- a/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktrunk-worktree-removal.test.ts
@@ -14,7 +14,20 @@ const { execSpy, existsSpy, readdirSpy, readFileSpy } = vi.hoisted(() => ({
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
-  return { ...actual, exec: execSpy };
+  const { promisify } = await import("node:util");
+  const execFileSpy: any = vi.fn((file: string, args: string[] | undefined, opts: any, cb: any) => {
+    const callback = typeof opts === "function" ? opts : cb;
+    const options = typeof opts === "function" ? {} : (opts ?? {});
+    execSpy([file, ...(Array.isArray(args) ? args : [])].join(" "), options, (err: unknown, stdout: string, stderr: string) => callback(err, stdout, stderr));
+  });
+  execFileSpy[promisify.custom] = (file: string, args?: string[], opts?: unknown) =>
+    new Promise((resolve, reject) => {
+      execFileSpy(file, args, opts, (err: unknown, stdout: string, stderr: string) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    });
+  return { ...actual, exec: execSpy, execFile: execFileSpy };
 });
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -92,6 +105,10 @@ describe("reliability interactions: worktrunk worktree removal routing", () => {
     execSpy.mockImplementation((cmd: string, _opts: unknown, cb: (err: unknown, stdout: string, stderr: string) => void) => {
       if (cmd.includes("git worktree list --porcelain")) {
         cb(null, "worktree /repo/.worktrees/fn-1\n", "");
+        return;
+      }
+      if (cmd.includes("rev-parse --show-toplevel")) {
+        cb(null, "/repo/.worktrees/fn-1\n", "");
         return;
       }
       cb(null, "", "");

--- a/packages/engine/src/__tests__/secrets-env-writer.test.ts
+++ b/packages/engine/src/__tests__/secrets-env-writer.test.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, statSync, symlinkSync, writeFileSync, existsSync, rmSync, renameSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, statSync, symlinkSync, writeFileSync, existsSync, rmSync, renameSync, promises as fsPromises } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { cleanupSecretsEnvFile, reconcileSecretsEnvFingerprint, writeSecretsEnvFile } from "../worktree/secrets-env-writer.js";
+import { cleanupSecretsEnvFile, FINGERPRINT_FILE, isOwnedEnvQuarantineArtifactPath, reconcileSecretsEnvFingerprint, writeSecretsEnvFile } from "../worktree/secrets-env-writer.js";
 
 const dirs: string[] = [];
 
@@ -33,6 +33,26 @@ describe("secrets-env-writer", () => {
     });
     expect(result).toEqual({ outcome: "skipped", filename: ".env", reason: "disabled" });
     expect(filesystem).not.toHaveBeenCalled();
+  });
+
+  it("owns a quarantine artifact only when its content matches the recorded fingerprint (Issue 1)", async () => {
+    const dir = tmpWorktree();
+    const body = "# Managed by Fusion — do not edit by hand.\nKEY=value\n";
+    const fingerprint = createHash("sha256").update(body, "utf8").digest("hex");
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    writeFileSync(join(dir, ".git", FINGERPRINT_FILE), `${fingerprint}\n.env\n`, "utf8");
+    // Fusion's own parked cleanup inode: quarantine-shaped name, matching content.
+    const ownedName = ".env.fusion-cleanup-4567-aaaa-bbbb.deleting";
+    writeFileSync(join(dir, ownedName), body, "utf8");
+    // User-authored ignored file that merely borrows the predictable quarantine name
+    // (the Greptile P1 "Quarantine name bypasses dirty check" case).
+    const userFile = ".env.fusion-cleanup-4567-eeee-ffff";
+    writeFileSync(join(dir, userFile), "anything-else", "utf8");
+
+    await expect(isOwnedEnvQuarantineArtifactPath(dir, ownedName)).resolves.toBe(true);
+    await expect(isOwnedEnvQuarantineArtifactPath(dir, userFile)).resolves.toBe(false);
+    // A non-quarantine path is never considered owned.
+    await expect(isOwnedEnvQuarantineArtifactPath(dir, "USER-NOTES.txt")).resolves.toBe(false);
   });
 
   it("skips when no store", async () => {
@@ -427,6 +447,7 @@ describe("secrets-env-writer", () => {
     writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), "broken\n.env\n");
     await expect(cleanupSecretsEnvFile({ worktreePath: dir, taskId: "FN-1", expectedFingerprint: null, filename: ".env" })).resolves.toMatchObject({ outcome: "cleaned" });
     expect(existsSync(join(dir, ".env"))).toBe(false);
+    expect(existsSync(join(dir, ".git", ".fusion-secrets-env.fingerprint"))).toBe(false);
     expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
   });
 
@@ -439,6 +460,77 @@ describe("secrets-env-writer", () => {
     writeFileSync(join(dir, ".git"), "gitdir: /missing-private-git-dir\n");
 
     await expect(cleanupSecretsEnvFile({ worktreePath: dir, taskId: "FN-1", expectedFingerprint: null, filename: ".env" })).resolves.toEqual({ outcome: "skipped", reason: "invalid-record" });
+    expect(existsSync(join(dir, ".env"))).toBe(true);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
+  });
+
+  it("refuses legacy cleanup when a dangling pointer was repaired before authorization (tracked env preserved)", async () => {
+    const dir = tmpWorktree();
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    const body = "A=1\n";
+    writeFileSync(join(dir, ".env"), body);
+    execFileSync("git", ["add", ".env"], { cwd: dir });
+    execFileSync("git", ["commit", "-qm", "track env"], { cwd: dir });
+    // The pointer is dangling, so private-dir resolution fails (legacy-only path),
+    // but the orphan reaper's stale verdict is revalidated at authorization time:
+    // the admin target was recreated meanwhile, so the tracked env must survive.
+    renameSync(join(dir, ".git"), join(dir, ".git-away"));
+    writeFileSync(join(dir, ".git"), "gitdir: /missing-private-git-dir\n");
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(body).digest("hex")}\n.env\n`);
+
+    await expect(cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "FN-1",
+      expectedFingerprint: null,
+      filename: ".env",
+      allowLegacyCleanupForDanglingGitdir: true,
+      isDanglingGitdir: () => false,
+    })).resolves.toEqual({ outcome: "skipped", reason: "invalid-record" });
+    expect(existsSync(join(dir, ".env"))).toBe(true);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
+  });
+
+  it("legacy-cleans a dangling orphan only while the pointer is still dangling at authorization", async () => {
+    const dir = tmpWorktree();
+    const body = "A=1\n";
+    writeFileSync(join(dir, ".env"), body);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(body).digest("hex")}\n.env\n`);
+    renameSync(join(dir, ".git"), join(dir, ".git-away"));
+    writeFileSync(join(dir, ".git"), "gitdir: /missing-private-git-dir\n");
+
+    await expect(cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "FN-1",
+      expectedFingerprint: null,
+      filename: ".env",
+      allowLegacyCleanupForDanglingGitdir: true,
+      isDanglingGitdir: () => true,
+    })).resolves.toMatchObject({ outcome: "cleaned" });
+    expect(existsSync(join(dir, ".env"))).toBe(false);
+  });
+
+  it("revalidates legacy cleanup after awaited reads before deleting a repaired env", async () => {
+    const dir = tmpWorktree();
+    const body = "A=1\n";
+    writeFileSync(join(dir, ".env"), body);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(body).digest("hex")}\n.env\n`);
+    renameSync(join(dir, ".git"), join(dir, ".git-away"));
+    writeFileSync(join(dir, ".git"), "gitdir: /missing-private-git-dir\n");
+    let dangling = true;
+
+    await expect(cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "FN-1",
+      expectedFingerprint: null,
+      filename: ".env",
+      allowLegacyCleanupForDanglingGitdir: true,
+      isDanglingGitdir: () => dangling,
+      readFileImpl: async (...args) => {
+        dangling = false;
+        return fsPromises.readFile(...args);
+      },
+    })).resolves.toEqual({ outcome: "skipped", reason: "invalid-record" });
     expect(existsSync(join(dir, ".env"))).toBe(true);
     expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
   });
@@ -462,10 +554,44 @@ describe("secrets-env-writer", () => {
     expect(existsSync(join(orphan, ".fusion-secrets-env.fingerprint"))).toBe(false);
   });
 
+  it("removes metadata when the managed env disappears before unlink", async () => {
+    const dir = tmpWorktree();
+    const secretsStore = { listEnvExportable: vi.fn().mockResolvedValue([{ id: "1", key: "A", exportKey: "ALPHA", scope: "project", plaintextValue: "v" }]) } as any;
+    await writeSecretsEnvFile({ rootDir: dir, worktreePath: dir, taskId: "FN-1", settings: { secretsEnv: { enabled: true, requireGitignored: false } }, worktreeSource: "fresh", secretsStore });
+    const envPath = join(dir, ".env");
+    const unlinkSpy = vi.spyOn(fsPromises, "unlink").mockImplementationOnce(async () => {
+      rmSync(envPath);
+      throw Object.assign(new Error("already removed"), { code: "ENOENT" });
+    });
+
+    try {
+      await expect(cleanupSecretsEnvFile({ worktreePath: dir, taskId: "FN-1", expectedFingerprint: null, filename: ".env" })).resolves.toEqual({ outcome: "cleaned", reason: "fingerprint-match" });
+      expect(existsSync(join(dir, ".git", ".fusion-secrets-env.fingerprint"))).toBe(false);
+    } finally {
+      unlinkSpy.mockRestore();
+    }
+  });
+
+  it("preserves metadata when managed env removal fails", async () => {
+    const dir = tmpWorktree();
+    const secretsStore = { listEnvExportable: vi.fn().mockResolvedValue([{ id: "1", key: "A", exportKey: "ALPHA", scope: "project", plaintextValue: "v" }]) } as any;
+    await writeSecretsEnvFile({ rootDir: dir, worktreePath: dir, taskId: "FN-1", settings: { secretsEnv: { enabled: true, requireGitignored: false } }, worktreeSource: "fresh", secretsStore });
+    const unlinkSpy = vi.spyOn(fsPromises, "unlink").mockRejectedValueOnce(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+
+    try {
+      await expect(cleanupSecretsEnvFile({ worktreePath: dir, taskId: "FN-1", expectedFingerprint: null, filename: ".env" })).resolves.toEqual({ outcome: "skipped", reason: "record-remove-failed" });
+      expect(existsSync(join(dir, ".git", ".fusion-secrets-env.fingerprint"))).toBe(true);
+    } finally {
+      unlinkSpy.mockRestore();
+    }
+  });
+
   it("does not report cleanup success when private metadata removal fails", async () => {
     const dir = tmpWorktree();
     const secretsStore = { listEnvExportable: vi.fn().mockResolvedValue([{ id: "1", key: "A", exportKey: "ALPHA", scope: "project", plaintextValue: "v" }]) } as any;
     await writeSecretsEnvFile({ rootDir: dir, worktreePath: dir, taskId: "FN-1", settings: { secretsEnv: { enabled: true, requireGitignored: false } }, worktreeSource: "fresh", secretsStore });
+    // Route through the fingerprint-mismatch path, which still removes bookkeeping.
+    writeFileSync(join(dir, ".env"), "MUTATED=1\n");
     const privateRecord = join(dir, ".git", ".fusion-secrets-env.fingerprint");
     // FNXC:SecretsEnvMaterialization 2026-08-08-03:30: A failed bookkeeping removal is retryable but must never be published as successful cleanup.
     await expect(cleanupSecretsEnvFile({
@@ -501,7 +627,7 @@ describe("secrets-env-writer", () => {
       filename: ".env",
       audit: { filesystem },
     });
-    expect(cleaned.outcome).toBe("cleaned");
+    expect(cleaned).toMatchObject({ outcome: "cleaned", reason: "fingerprint-match" });
     expect(existsSync(join(dir, ".env"))).toBe(false);
     expect(existsSync(join(dir, ".git", ".fusion-secrets-env.fingerprint"))).toBe(false);
 
@@ -524,6 +650,292 @@ describe("secrets-env-writer", () => {
     expect(skipped.reason).toBe("fingerprint-mismatch");
     expect(existsSync(join(dir, ".env"))).toBe(true);
     expect(existsSync(join(dir, ".git", ".fusion-secrets-env.fingerprint"))).toBe(false);
+  });
+
+  it("removes the verified inode while preserving a replacement that lands during quarantine", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-race-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    const original = "MANAGED=1\n";
+    const replacement = "USER_REPLACEMENT=1\n";
+    writeFileSync(envPath, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(original).digest("hex")}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "orphan",
+      expectedFingerprint: null,
+      filename: ".env",
+      renameFileImpl: async (from, to) => {
+        await fsPromises.rename(from, to);
+        const replacementPath = `${envPath}.replacement`;
+        writeFileSync(replacementPath, replacement);
+        await fsPromises.rename(replacementPath, envPath);
+      },
+    });
+
+    expect(result).toEqual({ outcome: "cleaned", reason: "fingerprint-match" });
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
+    expect(readFileSync(envPath, "utf8")).toBe(replacement);
+  });
+
+  it("restores unverified content moved into quarantine instead of deleting it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-race-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    const original = "MANAGED=1\n";
+    const replacement = "USER_REPLACEMENT=1\n";
+    writeFileSync(envPath, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(original).digest("hex")}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "orphan",
+      expectedFingerprint: null,
+      filename: ".env",
+      renameFileImpl: async (from, to) => {
+        await fsPromises.rename(from, to);
+        writeFileSync(to, replacement);
+      },
+    });
+
+    expect(result).toEqual({ outcome: "skipped", reason: "fingerprint-mismatch" });
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
+    expect(readFileSync(envPath, "utf8")).toBe(replacement);
+  });
+
+  it("preserves an unverified quarantine when a replacement wins the restore path", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-race-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    const original = "MANAGED=1\n";
+    const replacement = "USER_REPLACEMENT=1\n";
+    writeFileSync(envPath, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(original).digest("hex")}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "orphan",
+      expectedFingerprint: null,
+      filename: ".env",
+      readFileImpl: async (filePath, encoding) => {
+        if (String(filePath).includes(".fusion-cleanup-")) return replacement;
+        return fsPromises.readFile(filePath, encoding);
+      },
+      renameFileImpl: async (from, to) => {
+        await fsPromises.rename(from, to);
+        writeFileSync(envPath, replacement);
+      },
+    });
+
+    expect(result).toEqual({ outcome: "skipped", reason: "file-retained" });
+    expect(readFileSync(envPath, "utf8")).toBe(replacement);
+    const quarantined = readdirSync(dir).filter((entry) => entry.startsWith(".env.fusion-cleanup-"));
+    expect(quarantined).toHaveLength(1);
+    expect(readFileSync(join(dir, quarantined[0]), "utf8")).toBe(original);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
+  });
+
+  it("preserves the quarantined inode as a recovery copy when the restore link fails with a non-EEXIST error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-race-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    const original = "MANAGED=1\n";
+    const replacement = "USER_REPLACEMENT=1\n";
+    writeFileSync(envPath, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(original).digest("hex")}\n.env\n`);
+    const warn = vi.fn();
+
+    // The quarantine holds the only surviving copy of the unverified content and
+    // the restore link fails for a reason other than EEXIST (e.g. EACCES/ENOSPC).
+    // restoreQuarantine must NOT unlink the quarantine: the inode is preserved as
+    // a recovery file next to the pathname instead of being deleted.
+    const linkSpy = vi.spyOn(fsPromises, "link").mockRejectedValueOnce(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+    try {
+      const result = await cleanupSecretsEnvFile({
+        worktreePath: dir,
+        taskId: "orphan",
+        expectedFingerprint: null,
+        filename: ".env",
+        logger: { log: vi.fn(), warn },
+        renameFileImpl: async (from, to) => {
+          await fsPromises.rename(from, to);
+          writeFileSync(to, replacement);
+        },
+      });
+
+      expect(result).toEqual({ outcome: "skipped", reason: "file-retained" });
+      // The pathname was never restored, so both recovery content and ownership metadata survive.
+      expect(existsSync(envPath)).toBe(false);
+      const quarantined = readdirSync(dir).filter((entry) => entry.startsWith(".env.fusion-cleanup-"));
+      expect(quarantined).toHaveLength(1);
+      expect(readFileSync(join(dir, quarantined[0]), "utf8")).toBe(replacement);
+      expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("quarantine"));
+    } finally {
+      linkSpy.mockRestore();
+    }
+  });
+
+  it("restores a quarantined recovery file to the env path and finishes cleanup on retry", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-retry-"));
+    dirs.push(dir);
+    const original = "MANAGED=1\n";
+    const fingerprint = createHash("sha256").update(original).digest("hex");
+    const quarantine = join(dir, `.env.fusion-cleanup-${process.pid}-recovery`);
+    writeFileSync(quarantine, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${fingerprint}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "retry",
+      expectedFingerprint: null,
+      filename: ".env",
+    });
+
+    // A previous cleanup crashed after quarantining the managed inode; the retry
+    // must put the content back at the env path (exclusive link, never clobbering)
+    // and then complete the removal instead of stranding it under the recovery prefix.
+    expect(result).toEqual({ outcome: "cleaned", reason: "fingerprint-match" });
+    expect(existsSync(join(dir, ".env"))).toBe(false);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
+    expect(readdirSync(dir).filter((entry) => entry.startsWith(".env.fusion-cleanup-"))).toHaveLength(0);
+  });
+
+  it("restores unverified quarantined content to the env path and drops only the stale record on retry", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-retry-"));
+    dirs.push(dir);
+    const original = "MANAGED=1\n";
+    const replacement = "USER_REPLACEMENT=1\n";
+    const fingerprint = createHash("sha256").update(original).digest("hex");
+    const quarantine = join(dir, `.env.fusion-cleanup-${process.pid}-recovery`);
+    writeFileSync(quarantine, replacement);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${fingerprint}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "retry",
+      expectedFingerprint: null,
+      filename: ".env",
+    });
+
+    // The quarantined inode is unverified (concurrent replacement): restore it to
+    // the env path as user content, never delete it, and retire only the stale record.
+    expect(result).toEqual({ outcome: "skipped", reason: "fingerprint-mismatch" });
+    expect(readFileSync(join(dir, ".env"), "utf8")).toBe(replacement);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
+    expect(readdirSync(dir).filter((entry) => entry.startsWith(".env.fusion-cleanup-"))).toHaveLength(0);
+  });
+
+  it("reconciles multiple identical quarantine artifacts without stranding recovery", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-retry-"));
+    dirs.push(dir);
+    const original = "MANAGED=1\n";
+    const fingerprint = createHash("sha256").update(original).digest("hex");
+    writeFileSync(join(dir, `.env.fusion-cleanup-${process.pid}-a`), original);
+    writeFileSync(join(dir, `.env.fusion-cleanup-${process.pid}-b`), original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${fingerprint}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({ worktreePath: dir, taskId: "retry", expectedFingerprint: null, filename: ".env" });
+
+    expect(result).toEqual({ outcome: "cleaned", reason: "fingerprint-match" });
+    expect(existsSync(join(dir, ".env"))).toBe(false);
+    expect(readdirSync(dir).filter((entry) => entry.startsWith(".env.fusion-cleanup-")).sort()).toHaveLength(0);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
+  });
+
+  it("reclaims an owned cleanup artifact without treating a user-authored similarly named file as owned", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-owned-recovery-"));
+    dirs.push(dir);
+    const original = "MANAGED=1\n";
+    const fingerprint = createHash("sha256").update(original).digest("hex");
+    writeFileSync(join(dir, ".env"), "USER=1\n");
+    writeFileSync(join(dir, `.env.fusion-cleanup-${process.pid}-recovery`), original);
+    writeFileSync(join(dir, ".env.fusion-cleanup-user-notes"), "KEEP=1\n");
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${fingerprint}\n.env\n`);
+
+    const result = await cleanupSecretsEnvFile({ worktreePath: dir, taskId: "retry", expectedFingerprint: null, filename: ".env" });
+
+    expect(result).toEqual({ outcome: "skipped", reason: "fingerprint-mismatch" });
+    expect(existsSync(join(dir, `.env.fusion-cleanup-${process.pid}-recovery`))).toBe(false);
+    expect(readFileSync(join(dir, ".env.fusion-cleanup-user-notes"), "utf8")).toBe("KEEP=1\n");
+    expect(readFileSync(join(dir, ".env"), "utf8")).toBe("USER=1\n");
+  });
+
+  it("restores a quarantined recovery file stranded under .deleting and converges on retry", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-deleting-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    const original = "MANAGED=1\n";
+    writeFileSync(envPath, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(original).digest("hex")}\n.env\n`);
+
+    // Deletion-shaped flows: the quarantine rename to the .deleting pathname
+    // SUCCEEDS, but the final unlink of that moved inode fails (EACCES). The
+    // failure must not strand the content under .deleting while restoreQuarantine
+    // keeps reading the old quarantinePath (now gone) — the restore must follow
+    // the inode to its moved .deleting pathname and put it back at the env path.
+    const originalRename = fsPromises.rename.bind(fsPromises);
+    const originalUnlink = fsPromises.unlink.bind(fsPromises);
+    const renameSpy = vi.spyOn(fsPromises, "rename");
+    let deletingRenameCount = 0;
+    renameSpy.mockImplementation(async (from: any, to: any) => {
+      if (String(to).endsWith(".deleting")) {
+        deletingRenameCount++;
+      }
+      return originalRename(from, to);
+    });
+    let failedDeletingUnlink = false;
+    const unlinkSpy = vi.spyOn(fsPromises, "unlink").mockImplementation(async (p: any) => {
+      const s = String(p);
+      // Fail the FIRST unlink of the moved .deleting inode; later restores pass.
+      if (s.endsWith(".deleting") && deletingRenameCount >= 1 && !failedDeletingUnlink) {
+        failedDeletingUnlink = true;
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+      }
+      return originalUnlink(p);
+    });
+
+    try {
+      const result = await cleanupSecretsEnvFile({ worktreePath: dir, taskId: "orphan", expectedFingerprint: null, filename: ".env" });
+      // Fails closed: content and ownership metadata survive under the recovery copy.
+      expect(result).toEqual({ outcome: "skipped", reason: "record-remove-failed" });
+      expect(readFileSync(envPath, "utf8")).toBe(original);
+      expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
+
+      // A retry converges: the recovered content is deleted and the record drops.
+      const again = await cleanupSecretsEnvFile({ worktreePath: dir, taskId: "orphan", expectedFingerprint: null, filename: ".env" });
+      expect(again).toEqual({ outcome: "cleaned", reason: "fingerprint-match" });
+      expect(existsSync(envPath)).toBe(false);
+      expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(false);
+      expect(readdirSync(dir).filter((entry) => entry.startsWith(".env.fusion-cleanup-"))).toHaveLength(0);
+    } finally {
+      unlinkSpy.mockRestore();
+      renameSpy.mockRestore();
+    }
+  });
+
+  it("revalidates dangling authorization after the deletion inode lstat", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "secrets-env-late-repair-"));
+    dirs.push(dir);
+    const envPath = join(dir, ".env");
+    const original = "MANAGED=1\n";
+    writeFileSync(envPath, original);
+    writeFileSync(join(dir, ".fusion-secrets-env.fingerprint"), `${createHash("sha256").update(original).digest("hex")}\n.env\n`);
+    let danglingChecks = 0;
+
+    const result = await cleanupSecretsEnvFile({
+      worktreePath: dir,
+      taskId: "late-repair",
+      expectedFingerprint: null,
+      filename: ".env",
+      allowLegacyCleanupForDanglingGitdir: true,
+      isDanglingGitdir: () => ++danglingChecks < 2,
+    });
+
+    expect(result).toEqual({ outcome: "skipped", reason: "invalid-record" });
+    expect(readFileSync(envPath, "utf8")).toBe(original);
+    expect(existsSync(join(dir, ".fusion-secrets-env.fingerprint"))).toBe(true);
   });
 
   it("never deletes a tracked env even when its fingerprint matches", async () => {

--- a/packages/engine/src/__tests__/self-healing-tempdir-sweep.test.ts
+++ b/packages/engine/src/__tests__/self-healing-tempdir-sweep.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -198,7 +198,10 @@ describe("SelfHealingManager worktrees-dir sweeps", () => {
     expect(existsSync(aiMergeContainer)).toBe(true);
     expect(existsSync(recoveryContainer)).toBe(true);
     expect(existsSync(orphan)).toBe(false);
-    expect(fsState.rmCalls).toContain(orphan);
+    const preserved = readdirSync(join(projectRoot, ".fusion", "recovery", "worktrees"));
+    expect(preserved).toHaveLength(1);
+    expect(existsSync(join(projectRoot, ".fusion", "recovery", "worktrees", preserved[0]))).toBe(true);
+    expect(fsState.rmCalls).not.toContain(orphan);
     expect(fsState.rmCalls).not.toContain(aiMergeContainer);
     expect(fsState.rmCalls).not.toContain(recoveryContainer);
   });
@@ -220,7 +223,38 @@ describe("SelfHealingManager worktrees-dir sweeps", () => {
     expect(existsSync(recoveryContainer)).toBe(true);
     expect(childState.execCalls.some((command) => command.includes(".ai-merge"))).toBe(false);
     expect(childState.execCalls.some((command) => command.includes(".fusion-recovery"))).toBe(false);
-    expect(childState.execCalls.some((command) => command.includes("idle-wt"))).toBe(true);
+  });
+
+  it("preserves unregistered orphan content in contained recovery", async () => {
+    const worktreesDir = join(projectRoot, ".worktrees");
+    const orphan = join(worktreesDir, "user-content");
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(join(orphan, "notes.txt"), "keep me\n");
+    const { manager } = makeManager({ recycleWorktrees: true });
+
+    await expect((manager as any).reapUnregisteredOrphans()).resolves.toBe(1);
+
+    expect(existsSync(join(orphan, "notes.txt"))).toBe(false);
+    const recovery = readdirSync(join(projectRoot, ".fusion", "recovery", "worktrees"));
+    expect(recovery).toHaveLength(1);
+    expect(readFileSync(join(projectRoot, ".fusion", "recovery", "worktrees", recovery[0], "notes.txt"), "utf8")).toBe("keep me\n");
+    expect(fsState.rmCalls).not.toContain(orphan);
+  });
+
+  it("prepares generated residue before cap enforcement and restores it when the worktree survives a refused removal", async () => {
+    const worktreesDir = join(projectRoot, ".worktrees");
+    const idle = join(worktreesDir, "idle-wt");
+    const nodeModules = join(idle, "node_modules");
+    mkdirSync(nodeModules, { recursive: true });
+    childState.execStdout = gitWorktreeList(["idle-wt"]);
+    const { manager } = makeManager({ maxWorktrees: 0 });
+
+    await expect((manager as any).enforceWorktreeCap()).resolves.toBeUndefined();
+
+    // The removal leaves the idle dir in place (no real git registration to prune), so the
+    // generated residue must be put back for the surviving worktree — never stranded in recovery.
+    expect(existsSync(nodeModules)).toBe(true);
+    expect(readdirSync(join(projectRoot, ".fusion", "recovery", "worktrees"))).toHaveLength(0);
   });
 });
 

--- a/packages/engine/src/__tests__/worktree-acquisition.test.ts
+++ b/packages/engine/src/__tests__/worktree-acquisition.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { execSync } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { randomUUID, createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -489,6 +489,117 @@ describe("acquireTaskWorktree", () => {
     );
   });
 
+  it("preserves a dirty task-pinned worktree checked out on a foreign branch", async () => {
+    const rootDir = makeRepo();
+    const pinnedPath = join(rootDir, ".worktrees", "fn-1");
+    git(rootDir, `git worktree add -b fusion/fn-foreign ${JSON.stringify(pinnedPath)} main`);
+    writeFileSync(join(pinnedPath, "recoverable.txt"), "keep me\n", "utf-8");
+    const createWorktree = vi.fn().mockResolvedValue({ path: pinnedPath, branch: "fusion/fn-1" });
+
+    await expect(acquireTaskWorktree({
+      task: { ...task, worktree: pinnedPath, branch: "fusion/fn-1" },
+      rootDir,
+      store,
+      settings: { worktreeNaming: "task-id", recycleWorktrees: false },
+      createWorktree,
+    })).rejects.toThrow(/dirty worktree/);
+
+    expect(readFileSync(join(pinnedPath, "recoverable.txt"), "utf-8")).toBe("keep me\n");
+    expect(createWorktree).not.toHaveBeenCalled();
+  });
+
+  it("reclaims a task-pinned worktree holding only generated residue (node_modules, dist, fingerprint-owned .env)", async () => {
+    const rootDir = makeRepo();
+    writeFileSync(join(rootDir, ".gitignore"), "node_modules/\ndist/\n.env\n", "utf-8");
+    git(rootDir, "git add .gitignore");
+    git(rootDir, 'git commit -m "ignore generated residue"');
+    const pinnedPath = join(rootDir, ".worktrees", "fn-1");
+    git(rootDir, `git worktree add -b fusion/fn-foreign ${JSON.stringify(pinnedPath)} main`);
+    // Generated residue only: node_modules + dist + fingerprint-owned .env. No user content.
+    mkdirSync(join(pinnedPath, "node_modules", "pkg"), { recursive: true });
+    writeFileSync(join(pinnedPath, "node_modules", "pkg", "index.js"), "generated\n", "utf-8");
+    mkdirSync(join(pinnedPath, "dist"));
+    writeFileSync(join(pinnedPath, "dist", "bundle.js"), "generated\n", "utf-8");
+    const envBody = "SECRET=1\n";
+    const fingerprint = createHash("sha256").update(envBody).digest("hex");
+    writeFileSync(join(pinnedPath, ".env"), envBody, "utf-8");
+    writeFileSync(join(pinnedPath, ".fusion-secrets-env.fingerprint"), `${fingerprint}\n.env\n`, "utf-8");
+
+    const result = await acquireTaskWorktree({
+      task: { ...task, worktree: pinnedPath, branch: "fusion/fn-1" },
+      rootDir,
+      store,
+      settings: { worktreeNaming: "task-id", recycleWorktrees: false },
+    });
+
+    expect(result).toMatchObject({
+      worktreePath: pinnedPath,
+      branch: "fusion/fn-1",
+      source: "fresh",
+      isResume: false,
+    });
+    expect(existsSync(join(pinnedPath, ".git"))).toBe(true);
+    expect(git(rootDir, "git worktree list --porcelain")).toContain(pinnedPath);
+    expect(existsSync(join(pinnedPath, "node_modules"))).toBe(false);
+    expect(existsSync(join(pinnedPath, ".env"))).toBe(false);
+  });
+
+  it("preserves tracked user content committed inside an ignored generated dir during pinned reclaim", async () => {
+    const rootDir = makeRepo();
+    writeFileSync(join(rootDir, ".gitignore"), "node_modules/\ndist/\n.env\n", "utf-8");
+    git(rootDir, "git add .gitignore");
+    git(rootDir, 'git commit -m "ignore generated residue"');
+    const pinnedPath = join(rootDir, ".worktrees", "fn-1");
+    git(rootDir, `git worktree add -b fusion/fn-foreign ${JSON.stringify(pinnedPath)} main`);
+    // Some repos commit build output under dist/ despite the ignore rule; that is
+    // user content and must never be swept by reclaim residue cleanup.
+    mkdirSync(join(pinnedPath, "dist"), { recursive: true });
+    writeFileSync(join(pinnedPath, "dist", "shipped.txt"), "user content\n", "utf-8");
+    git(rootDir, `git -C ${JSON.stringify(pinnedPath)} add -f dist/shipped.txt`);
+    git(rootDir, `git -C ${JSON.stringify(pinnedPath)} commit -m "ship dist artifact"`);
+    // An untracked non-ignored file forces the removal probe to refuse; the
+    // tracked dist content must survive that refused reclaim.
+    writeFileSync(join(pinnedPath, "recoverable.txt"), "keep me\n", "utf-8");
+
+    await expect(acquireTaskWorktree({
+      task: { ...task, worktree: pinnedPath, branch: "fusion/fn-1" },
+      rootDir,
+      store,
+      settings: { worktreeNaming: "task-id", recycleWorktrees: false },
+    })).rejects.toThrow(/dirty worktree/);
+
+    expect(readFileSync(join(pinnedPath, "dist", "shipped.txt"), "utf-8")).toBe("user content\n");
+    expect(readFileSync(join(pinnedPath, "recoverable.txt"), "utf-8")).toBe("keep me\n");
+  });
+
+  it("preserves user-authored files under ignored generated dirs during pinned reclaim", async () => {
+    const rootDir = makeRepo();
+    writeFileSync(join(rootDir, ".gitignore"), "node_modules/\ndist/\n.env\n", "utf-8");
+    git(rootDir, "git add .gitignore");
+    git(rootDir, 'git commit -m "ignore generated residue"');
+    const pinnedPath = join(rootDir, ".worktrees", "fn-1");
+    git(rootDir, `git worktree add -b fusion/fn-foreign ${JSON.stringify(pinnedPath)} main`);
+    // User-authored file under an ignored dir: untracked and git-ignored, so the
+    // reclaim probe cannot see it once residue cleanup deletes the directory.
+    mkdirSync(join(pinnedPath, "dist"), { recursive: true });
+    writeFileSync(join(pinnedPath, "dist", "user-notes.txt"), "precious\n", "utf-8");
+
+    const result = await acquireTaskWorktree({
+      task: { ...task, worktree: pinnedPath, branch: "fusion/fn-1" },
+      rootDir,
+      store,
+      settings: { worktreeNaming: "task-id", recycleWorktrees: false },
+    });
+
+    // Reclaim proceeds (the path is freed) but the user file survives in the
+    // worktree recovery area instead of being silently deleted.
+    expect(result).toMatchObject({ worktreePath: pinnedPath, source: "fresh" });
+    const recoveryRoot = join(rootDir, ".fusion", "recovery", "worktrees");
+    const preserved = readdirSync(recoveryRoot).filter((name) => name.startsWith("residue-"));
+    expect(preserved).toHaveLength(1);
+    expect(readFileSync(join(recoveryRoot, preserved[0], "user-notes.txt"), "utf-8")).toBe("precious\n");
+  });
+
   it("preserves an orphan beside an external worktree root when project recovery is cross-device", async () => {
     const rootDir = makeRepo();
     const externalWorktrees = track(mkdtempSync(join(tmpdir(), "fn-external-worktrees-")));
@@ -520,7 +631,7 @@ describe("acquireTaskWorktree", () => {
     expect(renameWorktreeDirectory).toHaveBeenCalledTimes(2);
   });
 
-  it("retains only the newest ten generated orphan directories in the primary recovery root", async () => {
+  it("retains every preserved orphan directory in the primary recovery root (no pruning of older user content)", async () => {
     const rootDir = makeRepo();
     const pinnedPath = join(rootDir, ".worktrees", "fn-1");
     const recoveryRoot = join(rootDir, ".fusion", "recovery", "worktrees");
@@ -554,14 +665,15 @@ describe("acquireTaskWorktree", () => {
       .filter((entry) => entry.isDirectory() && /^fn-\d+-[0-9a-f-]{36}$/.test(entry.name))
       .map((entry) => entry.name);
     expect(result.worktreePath).toBe(pinnedPath);
-    expect(generatedDirectories).toHaveLength(11);
+    expect(generatedDirectories).toHaveLength(12);
     expect(generatedDirectories).toContain(seeded[0]);
-    expect(generatedDirectories).not.toContain(seeded[1]);
+    expect(generatedDirectories).toContain(seeded[1]);
+    expect(readFileSync(join(recoveryRoot, seeded[1], "artifact"), "utf-8")).toBe("1\n");
     expect(existsSync(unknownPath)).toBe(true);
     expect(existsSync(generatedSymlink)).toBe(true);
   });
 
-  it("retains only the newest ten generated orphan directories in the EXDEV fallback root", async () => {
+  it("retains every preserved orphan directory in the EXDEV fallback root (no pruning of older user content)", async () => {
     const rootDir = makeRepo();
     const externalWorktrees = track(mkdtempSync(join(tmpdir(), "fn-external-retention-worktrees-")));
     const pinnedPath = join(externalWorktrees, "fn-1");
@@ -598,9 +710,10 @@ describe("acquireTaskWorktree", () => {
       .filter((entry) => entry.isDirectory() && /^fn-\d+-[0-9a-f-]{36}$/.test(entry.name))
       .map((entry) => entry.name);
     expect(result.worktreePath).toBe(pinnedPath);
-    expect(generatedDirectories).toHaveLength(11);
+    expect(generatedDirectories).toHaveLength(12);
     expect(generatedDirectories).toContain(seeded[0]);
-    expect(generatedDirectories).not.toContain(seeded[1]);
+    expect(generatedDirectories).toContain(seeded[1]);
+    expect(readFileSync(join(recoveryRoot, seeded[1], "artifact"), "utf-8")).toBe("1\n");
     expect(existsSync(unknownPath)).toBe(true);
   });
 

--- a/packages/engine/src/__tests__/worktree-backend.test.ts
+++ b/packages/engine/src/__tests__/worktree-backend.test.ts
@@ -193,6 +193,27 @@ describe("NativeWorktreeBackend", () => {
     expect(pruneWorktreeAdminEntriesMock).not.toHaveBeenCalled();
   });
 
+  it("prunes a missing path when non-force removal fails", async () => {
+    const error = { message: "fatal: is not a working tree", stderr: "fatal: is not a working tree" };
+    existsSyncMock.mockReturnValue(false);
+    execMock.mockRejectedValueOnce(error);
+
+    await new NativeWorktreeBackend().remove({
+      rootDir: "/repo",
+      worktreePath: "/repo/.worktrees/fn-missing",
+      force: false,
+    });
+
+    expect(rmMock).not.toHaveBeenCalled();
+    expect(pruneWorktreeAdminEntriesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootDir: "/repo",
+        reason: "remove-missing-fallback",
+        target: "/repo/.worktrees/fn-missing",
+      }),
+    );
+  });
+
   it("falls back to filesystem removal and prunes admin entries when native remove leaves a non-empty directory", async () => {
     const audit = { git: vi.fn().mockResolvedValue(undefined) };
     execMock.mockRejectedValueOnce({
@@ -1136,6 +1157,22 @@ describe("removeWorktree", () => {
     expect(audit.git).toHaveBeenCalledWith({ type: "worktree:worktrunk-remove", target: "/repo/.worktrees/fn-1" });
   });
 
+  it("does not force Worktrunk removal unless the caller opts in", async () => {
+    execMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+    await removeWorktree({
+      rootDir: "/repo",
+      worktreePath: "/repo/.worktrees/fn-1",
+      settings: { worktrunk: { enabled: true, binaryPath: "worktrunk", onFailure: "fail" } as any },
+      reason: RemovalReason.SelfHealingReclaim,
+    });
+
+    expect(execMock).toHaveBeenCalledWith(
+      '"worktrunk" "remove" "--foreground" "/repo/.worktrees/fn-1"',
+      expect.objectContaining({ cwd: "/repo", timeout: 60000 }),
+    );
+  });
+
   it("falls back to native when worktrunk remove fails and onFailure=fallback-native", async () => {
     execMock
       .mockRejectedValueOnce(new WorktrunkOperationError({ operation: "remove", code: "worktrunk_operation_failed", stderr: "boom", exitCode: 1 }))
@@ -1154,6 +1191,30 @@ describe("removeWorktree", () => {
       expect.objectContaining({ type: "worktree:worktrunk-fallback", target: "/repo/.worktrees/fn-1" }),
     );
     expect(audit.git).toHaveBeenCalledWith({ type: "worktree:remove", target: "/repo/.worktrees/fn-1" });
+  });
+
+  it("preserves Native's implicit force on non-defensive Worktrunk fallback", async () => {
+    execMock
+      .mockRejectedValueOnce(new WorktrunkOperationError({ operation: "remove", code: "worktrunk_operation_failed", stderr: "boom", exitCode: 1 }))
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    await removeWorktree({
+      rootDir: "/repo",
+      worktreePath: "/repo/.worktrees/fn-1",
+      settings: { worktrunk: { enabled: true, binaryPath: "worktrunk", onFailure: "fallback-native" } as any },
+      reason: RemovalReason.MergerCleanup,
+    });
+
+    expect(execMock).toHaveBeenNthCalledWith(
+      1,
+      '"worktrunk" "remove" "--foreground" "/repo/.worktrees/fn-1"',
+      expect.objectContaining({ cwd: "/repo", timeout: 60000 }),
+    );
+    expect(execMock).toHaveBeenNthCalledWith(
+      2,
+      'git worktree remove --force "/repo/.worktrees/fn-1"',
+      expect.objectContaining({ cwd: "/repo", timeout: 60000 }),
+    );
   });
 
   it("rethrows worktrunk remove failure when onFailure=fail", async () => {

--- a/packages/engine/src/__tests__/worktree-pool-reap-replacement-race.test.ts
+++ b/packages/engine/src/__tests__/worktree-pool-reap-replacement-race.test.ts
@@ -1,0 +1,89 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/*
+FNXC:WorktreeCleanup 2026-08-17: replacement-pointer boundary regression.
+`reapOrphanWorktrees` stashes an orphan's dangling `.git` pointer, revalidates its
+inode, then removes the pathname. Between the inode revalidation and the unlink, a
+concurrent repair can REPLACE the `.git` pathname with a pointer to a DIFFERENT, live
+admin directory. The cleanup's own `targetPath` is derived from the STASHED original,
+so it stays stale and cannot see the replacement — naive `unlinkSync(dotGit)` then
+deletes the live replacement pointer and `rmdir` destroys the live directory.
+
+This test drives the real filesystem (only the deletion boundary is wrapped) and
+asserts fail-closed preservation: the replacement pointer and the directory it points
+into must survive, and no reap residue may be left behind.
+*/
+
+// Hostile-repair injection switch. When production's fuse `renameSync` removes the
+// occupant of this exact path, the wrapper first swaps in a fresh pointer to a
+// DIFFERENT live admin before delegating the real move, guaranteeing a new inode.
+let injectReplacementAt: string | null = null;
+let replacementGitdirContent = "";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    renameSync: vi.fn((src: unknown, dest: unknown) => {
+      const s = String(src);
+      if (s === injectReplacementAt) {
+        // Hostile repair lands at the deletion boundary: unlink the dangling original
+        // and write a NEW `.git` pointer to a different, live admin in its place, then
+        // let production move whichever inode now occupies the pathname aside.
+        actual.unlinkSync(s);
+        actual.writeFileSync(s, replacementGitdirContent);
+      }
+      return actual.renameSync(s, String(dest));
+    }),
+  };
+});
+
+const dirs: string[] = [];
+function tmpRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "reap-repl-race-"));
+  dirs.push(root);
+  return root;
+}
+afterEach(async () => {
+  injectReplacementAt = null;
+  replacementGitdirContent = "";
+  await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
+});
+
+describe("reapOrphanWorktrees replacement-pointer boundary", () => {
+  it("preserves an orphan whose .git pointer is replaced with a LIVE pointer to a different admin at the deletion boundary", async () => {
+    const root = tmpRoot();
+    const worktrees = join(root, ".worktrees");
+    const orphanDir = join(worktrees, "leaked-wt");
+    const orphanDotGit = join(orphanDir, ".git");
+    const admins = join(root, ".git", "worktrees");
+    const liveOtherAdmin = join(admins, "other-live");
+    const deadOwnAdmin = join(admins, "leaked-wt");
+    mkdirSync(orphanDir, { recursive: true });
+    mkdirSync(liveOtherAdmin, { recursive: true });
+    // The orphan's `.git` is dangling: it points at its OWN admin entry which no longer exists.
+    writeFileSync(orphanDotGit, `gitdir: ${deadOwnAdmin}\n`);
+
+    // Arm the hostile repair for the orphan's `.git` path.
+    injectReplacementAt = orphanDotGit;
+    replacementGitdirContent = `gitdir: ${liveOtherAdmin}\n`;
+
+    const mod = await import("../worktree/worktree-pool.js");
+    const removed = await mod.reapOrphanWorktrees(root);
+
+    expect(injectReplacementAt).not.toBeNull(); // defensive: the injection must have run
+    // Fail closed: the repair must win. Nothing is removed, no residue, the live pointer
+    // and the different live admin it targets survive.
+    expect(removed).toBe(0);
+    expect(existsSync(orphanDir)).toBe(true);
+    expect(existsSync(orphanDotGit)).toBe(true);
+    expect(readFileSync(orphanDotGit, "utf8")).toBe(`gitdir: ${liveOtherAdmin}\n`);
+    expect(existsSync(liveOtherAdmin)).toBe(true);
+    const reapResidue = readdirSync(worktrees).filter((n) => n.includes(".git-reap-"));
+    expect(reapResidue).toEqual([]);
+  });
+});

--- a/packages/engine/src/__tests__/worktree-pool-secrets-env-cleanup.test.ts
+++ b/packages/engine/src/__tests__/worktree-pool-secrets-env-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -38,7 +38,10 @@ afterEach(async () => {
 
 describe("worktree-pool secrets cleanup hooks", () => {
   it("reapOrphanWorktrees invokes cleanup before removal", async () => {
-    cleanupSecretsEnvFile.mockResolvedValue({ outcome: "cleaned", reason: "fingerprint-match" });
+    cleanupSecretsEnvFile.mockImplementationOnce(async ({ worktreePath }) => {
+      rmSync(join(worktreePath, ".env"));
+      return { outcome: "cleaned", reason: "fingerprint-match" };
+    });
     const root = tmpRoot();
     const worktrees = join(root, ".worktrees");
     const orphan = join(worktrees, "orphan-1");

--- a/packages/engine/src/__tests__/worktree-pool.test.ts
+++ b/packages/engine/src/__tests__/worktree-pool.test.ts
@@ -12,7 +12,9 @@ vi.mock("node:child_process", async () => {
     const options = typeof opts === "function" ? {} : (opts ?? {});
     try {
       const out = execSyncFn(cmd, { ...options, stdio: ["pipe", "pipe", "pipe"] });
-      const stdout = out === undefined ? "" : out.toString();
+      const stdout = out === undefined || (Buffer.isBuffer(out) && out.length === 0)
+        ? (cmd.includes("rev-parse --show-toplevel") ? (cmd.match(/-C (\S+)/)?.[1] ?? "") + "\n" : "")
+        : out.toString();
       if (typeof callback === "function") callback(null, stdout, "");
     } catch (err) {
       if (typeof callback === "function") {
@@ -56,11 +58,21 @@ vi.mock("../worktree/worktree-paths.js", () => ({
 }));
 
 vi.mock("node:fs", () => ({
+  chmodSync: vi.fn(),
+  cpSync: vi.fn(),
+  copyFileSync: vi.fn(),
   existsSync: vi.fn().mockReturnValue(true),
+  linkSync: vi.fn(),
   lstatSync: vi.fn().mockReturnValue({ isDirectory: () => true, isSymbolicLink: () => false }),
+  mkdirSync: vi.fn(),
   readdirSync: vi.fn().mockReturnValue([]),
   readFileSync: vi.fn().mockReturnValue(""),
+  renameSync: vi.fn(),
   rmSync: vi.fn(),
+  rmdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  constants: { COPYFILE_EXCL: 1 },
   realpathSync: vi.fn((path: string) => path),
 }));
 
@@ -68,8 +80,13 @@ vi.mock("../worktree/worktree-prune.js", () => ({
   pruneWorktreeAdminEntries: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../worktree/worktree-generated-residue.js", () => ({
+  preserveGeneratedResidue: vi.fn(),
+}));
+
 import * as desktopArtifacts from "../worktree/worktree-desktop-artifacts.js";
 import * as worktreePrune from "../worktree/worktree-prune.js";
+import * as generatedResidue from "../worktree/worktree-generated-residue.js";
 import {
   WorktreePool,
   detectGitRepository,
@@ -83,7 +100,7 @@ import {
 import { BranchConflictError } from "../execution/branch-conflicts.js";
 import * as branchConflictModule from "../execution/branch-conflicts.js";
 import { execSync } from "node:child_process";
-import { existsSync, lstatSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, existsSync, linkSync, lstatSync, readdirSync, readFileSync, renameSync, rmdirSync, unlinkSync, mkdirSync, copyFileSync, rmSync } from "node:fs";
 import type { Task, Column } from "@fusion/core";
 
 const mockedExecSync = vi.mocked(execSync);
@@ -91,8 +108,16 @@ const mockedExistsSync = vi.mocked(existsSync);
 const mockedLstatSync = vi.mocked(lstatSync);
 const mockedReaddirSync = vi.mocked(readdirSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedRmdirSync = vi.mocked(rmdirSync);
+const mockedRenameSync = vi.mocked(renameSync);
+const mockedLinkSync = vi.mocked(linkSync);
+const mockedUnlinkSync = vi.mocked(unlinkSync);
+const mockedMkdirSync = vi.mocked(mkdirSync);
+const mockedCopyFileSync = vi.mocked(copyFileSync);
+const mockedCpSync = vi.mocked(cpSync);
 const mockedRmSync = vi.mocked(rmSync);
 const mockedPruneWorktreeAdminEntries = vi.mocked(worktreePrune.pruneWorktreeAdminEntries);
+const mockedPreserveGeneratedResidue = vi.mocked(generatedResidue.preserveGeneratedResidue);
 const TEST_TASK_ID = "FN-test";
 
 let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -1006,6 +1031,7 @@ describe("cleanupOrphanedWorktrees", () => {
     mockedExistsSync.mockReturnValue(true);
     mockRegisteredWorktrees("/root", []);
     mockedPruneWorktreeAdminEntries.mockResolvedValue(undefined);
+    mockedPreserveGeneratedResidue.mockResolvedValue(async () => {});
   });
 
   it("removes worktrees not assigned to any active task", async () => {
@@ -1026,6 +1052,160 @@ describe("cleanupOrphanedWorktrees", () => {
     expect(removeCalls).toHaveLength(2);
     expect(removeCalls[0][0]).toContain("/root/.worktrees/orphan-1");
     expect(removeCalls[1][0]).toContain("/root/.worktrees/orphan-2");
+  });
+
+  it("removes registered orphaned worktrees when status probe reports only Fusion's own env quarantine artifact", async () => {
+    mockedReaddirSync.mockReturnValue([
+      makeDirEntry("owned-q-wt"),
+    ] as any);
+    mockedExecSync.mockImplementation((cmd: any) => {
+      if (String(cmd) === "git worktree list --porcelain") {
+        return [
+          "worktree /root",
+          "HEAD abc123",
+          "branch refs/heads/main",
+          "",
+          "worktree /root/.worktrees/owned-q-wt",
+          "HEAD def456",
+          "branch refs/heads/fusion/owned-q-wt",
+          "",
+        ].join("\n") as any;
+      }
+      if (String(cmd).includes("status --porcelain")) {
+        // FNXC:WorktreeCleanup 2026-08-19-15:09: a fingerprint-owned .env parked
+        // mid-cleanup under `.env.fusion-cleanup-*.deleting` is Fusion's own
+        // internal quarantine inode (Greptile: \"Quarantine blocks generated-only
+        // reclaim\"), not user dirt — the dirty probe must ignore it so reclaiming a
+        // generated-only pinned worktree converges instead of refusing forever.
+        return "?? .env.fusion-cleanup-4242-00000000-0000-4000-8000-000000000000.deleting\n" as any;
+      }
+      return Buffer.from("");
+    });
+
+    const store = createMockStore([]);
+
+    const cleaned = await cleanupOrphanedWorktrees("/root", store);
+
+    expect(cleaned).toBe(1);
+    const removeCalls = mockedExecSync.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("worktree remove"),
+    );
+    expect(removeCalls).toHaveLength(1);
+    expect(removeCalls[0][0]).toContain("/root/.worktrees/owned-q-wt");
+  });
+
+  it("preserves registered orphaned worktrees that have uncommitted changes", async () => {
+    mockedReaddirSync.mockReturnValue([
+      makeDirEntry("dirty-wt"),
+    ] as any);
+    mockedExecSync.mockImplementation((cmd: any) => {
+      if (String(cmd) === "git worktree list --porcelain") {
+        return [
+          "worktree /root",
+          "HEAD abc123",
+          "branch refs/heads/main",
+          "",
+          "worktree /root/.worktrees/dirty-wt",
+          "HEAD def456",
+          "branch refs/heads/fusion/dirty-wt",
+          "",
+        ].join("\n") as any;
+      }
+      if (String(cmd).includes("status --porcelain")) {
+        return " M src/file.ts\n" as any;
+      }
+      return Buffer.from("");
+    });
+
+    const store = createMockStore([]);
+
+    const cleaned = await cleanupOrphanedWorktrees("/root", store);
+
+    expect(cleaned).toBe(0);
+    const removeCalls = mockedExecSync.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("worktree remove"),
+    );
+    expect(removeCalls).toHaveLength(0);
+  });
+
+  it("does not mask the removal failure when generated-residue restoration itself fails", async () => {
+    mockedReaddirSync.mockReturnValue([
+      makeDirEntry("dirty-wt"),
+    ] as any);
+    mockRegisteredWorktrees("/root", ["dirty-wt"]);
+    mockedExecSync.mockImplementation((cmd: any) => {
+      if (String(cmd) === "git worktree list --porcelain") {
+        return [
+          "worktree /root",
+          "HEAD abc123",
+          "branch refs/heads/main",
+          "",
+          "worktree /root/.worktrees/dirty-wt",
+          "HEAD def456",
+          "branch refs/heads/fusion/dirty-wt",
+          "",
+        ].join("\n") as any;
+      }
+      if (String(cmd).includes("status --porcelain")) {
+        return " M src/file.ts\n" as any;
+      }
+      return Buffer.from("");
+    });
+    mockedPreserveGeneratedResidue.mockResolvedValue(async () => {
+      throw new Error("restore exploded");
+    });
+
+    const store = createMockStore([]);
+
+    const cleaned = await cleanupOrphanedWorktrees("/root", store);
+
+    expect(cleaned).toBe(0);
+    // The original removal refusal is the failure reported — a restore error
+    // must never replace it in the removal log (masking).
+    const removalLog = errorSpy.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .find((m: string) => m.includes("Failed to remove orphaned worktree /root/.worktrees/dirty-wt"));
+    expect(removalLog).toBeDefined();
+    expect(removalLog).toContain("refusing to remove dirty worktree");
+    expect(removalLog).not.toContain("restore exploded");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("generated-residue restore failed for registered orphan /root/.worktrees/dirty-wt: restore exploded"),
+    );
+  });
+
+  it("removes registered orphaned worktrees when status probe is clean", async () => {
+    mockedReaddirSync.mockReturnValue([
+      makeDirEntry("clean-wt"),
+    ] as any);
+    mockedExecSync.mockImplementation((cmd: any) => {
+      if (String(cmd) === "git worktree list --porcelain") {
+        return [
+          "worktree /root",
+          "HEAD abc123",
+          "branch refs/heads/main",
+          "",
+          "worktree /root/.worktrees/clean-wt",
+          "HEAD def456",
+          "branch refs/heads/fusion/clean-wt",
+          "",
+        ].join("\n") as any;
+      }
+      if (String(cmd) === "git status --porcelain") {
+        return Buffer.from("");
+      }
+      return Buffer.from("");
+    });
+
+    const store = createMockStore([]);
+
+    const cleaned = await cleanupOrphanedWorktrees("/root", store);
+
+    expect(cleaned).toBe(1);
+    const removeCalls = mockedExecSync.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("worktree remove"),
+    );
+    expect(removeCalls).toHaveLength(1);
+    expect(removeCalls[0][0]).toContain("/root/.worktrees/clean-wt");
   });
 
   it("preserves worktrees assigned to in-progress/in-review tasks", async () => {
@@ -1116,7 +1296,7 @@ describe("cleanupOrphanedWorktrees", () => {
 
     expect(cleaned).toBe(0);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[worktree-pool] Failed to read .worktrees/ directory for cleanup: cleanup permission denied"),
+      expect.stringContaining("[worktree-pool] reapOrphanWorktrees: failed to read .worktrees/ — cleanup permission denied"),
     );
   });
 
@@ -1147,18 +1327,16 @@ describe("cleanupOrphanedWorktrees", () => {
       makeDirEntry("broken-wt"),
     ] as any);
     mockRegisteredWorktrees("/root", []);
+    mockedExistsSync.mockImplementation((path) => !String(path).endsWith("/.git"));
 
     const store = createMockStore([]);
 
     const cleaned = await cleanupOrphanedWorktrees("/root", store);
 
     expect(cleaned).toBe(1);
-    expect(mockedRmSync).toHaveBeenCalledWith("/root/.worktrees/broken-wt", {
-      recursive: true,
-      force: true,
-    });
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/.ai-merge", expect.anything());
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/.fusion-recovery", expect.anything());
+    expect(mockedRmdirSync).toHaveBeenCalledWith("/root/.worktrees/broken-wt");
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/.ai-merge");
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/.fusion-recovery");
   });
 
   it("removes unregistered directories even when stale active task metadata references them", async () => {
@@ -1166,6 +1344,7 @@ describe("cleanupOrphanedWorktrees", () => {
       makeDirEntry("broken-wt"),
     ] as any);
     mockRegisteredWorktrees("/root", []);
+    mockedExistsSync.mockImplementation((path) => !String(path).endsWith("/.git"));
 
     const store = createMockStore([
       makeTask("FN-001", "in-progress", "/root/.worktrees/broken-wt"),
@@ -1174,12 +1353,9 @@ describe("cleanupOrphanedWorktrees", () => {
     const cleaned = await cleanupOrphanedWorktrees("/root", store);
 
     expect(cleaned).toBe(1);
-    expect(mockedRmSync).toHaveBeenCalledWith("/root/.worktrees/broken-wt", {
-      recursive: true,
-      force: true,
-    });
+    expect(mockedRmdirSync).toHaveBeenCalledWith("/root/.worktrees/broken-wt");
     expect(mockedPruneWorktreeAdminEntries).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "pool-cleanup-orphan", target: "/root/.worktrees/broken-wt" }),
+      expect.objectContaining({ reason: "pool-reap-orphan", target: "/root/.worktrees/broken-wt" }),
     );
   });
 });
@@ -1188,23 +1364,47 @@ describe("reapOrphanWorktrees", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRegisteredWorktrees("/root", []);
-    mockedExistsSync.mockImplementation((path) => String(path) === "/root/.worktrees");
+    mockedExistsSync.mockImplementation((path) => {
+      const value = String(path);
+      return value === "/root/.worktrees" || (value.startsWith("/root/.worktrees/") && !value.endsWith("/.git"));
+    });
     mockedLstatSync.mockReturnValue({ isDirectory: () => true, isSymbolicLink: () => false } as any);
   });
 
-  it("excludes containers and unproven half-initialized directories", async () => {
-    mockedReaddirSync.mockReturnValue([
-      makeDirEntry(".ai-merge"),
-      makeDirEntry(".fusion-recovery"),
-      makeDirEntry("half-built"),
-    ] as any);
+  // FNXC:WorktreeMerge KB-001 2026-08-22-04:30:
+  // Dual-semantics test resolution: this branch's reaper uses rmdirSync (never
+  // recursive rmSync) and preserves dirty half-initialized dirs; main's variant
+  // asserted containers/unproven dirs are never recursively removed. The merged
+  // implementation keeps the branch removal path gated by main's
+  // isReclaimableWorktreeCandidate, so both sides' invariants are asserted here:
+  // container exclusion + no recursive rmSync (main) and dirty preservation via
+  // ENOTEMPTY without admin prune (branch).
+  it("excludes internal containers while removing half-initialized task worktrees", async () => {
+    mockedReaddirSync.mockImplementation((path: any) =>
+      String(path) === "/root/.worktrees"
+        ? [makeDirEntry(".ai-merge"), makeDirEntry(".fusion-recovery"), makeDirEntry("half-built")] as any
+        : [] as any,
+    );
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(1);
+    expect(mockedRmdirSync).toHaveBeenCalledWith("/root/.worktrees/half-built");
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/.ai-merge");
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/.fusion-recovery");
+    // Main-side invariant: the reaper never recursively force-removes candidates.
+    expect(mockedRmSync).not.toHaveBeenCalled();
+  });
+
+  it("preserves a dirty half-initialized worktree", async () => {
+    mockedReaddirSync.mockReturnValue([makeDirEntry("dirty-half-built")] as any);
+    mockedRmdirSync.mockImplementationOnce(() => {
+      throw new Error("ENOTEMPTY");
+    });
 
     const removed = await reapOrphanWorktrees("/root");
 
     expect(removed).toBe(0);
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/half-built", expect.anything());
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/.ai-merge", expect.anything());
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/.fusion-recovery", expect.anything());
+    expect(mockedPruneWorktreeAdminEntries).not.toHaveBeenCalled();
   });
 
   // FN-6782 follow-up: a directory whose `.git` points to a missing admin entry is leak
@@ -1212,7 +1412,12 @@ describe("reapOrphanWorktrees", () => {
   // must be reaped — otherwise it collides with freshly generated worktree names and
   // breaks `execute`. Previously the reaper skipped on mere `.git` presence.
   it("reaps a dir with a dangling .git pointer (admin gitdir missing)", async () => {
-    mockedReaddirSync.mockReturnValue([makeDirEntry("leaked-wt")] as any);
+    mockedReaddirSync.mockImplementation((path: any) =>
+      String(path) === "/root/.worktrees"
+        ? [makeDirEntry("leaked-wt")] as any
+        : [".git"] as any,
+    );
+
     // `.git` is a link FILE (not a dir); the worktree dir itself is a dir.
     mockedLstatSync.mockImplementation((p: any) =>
       (String(p).endsWith("/.git")
@@ -1229,7 +1434,44 @@ describe("reapOrphanWorktrees", () => {
     const removed = await reapOrphanWorktrees("/root");
 
     expect(removed).toBe(1);
-    expect(mockedRmSync).toHaveBeenCalledWith("/root/.worktrees/leaked-wt", { recursive: true, force: true });
+    // Production stashes the dangling pointer with a hard link (linkSync) so a
+    // concurrent repair's pathname is never overwritten; the old renameSync mock
+    // is stale for that current primitive.
+    expect(mockedLinkSync).toHaveBeenCalledWith(
+      "/root/.worktrees/leaked-wt/.git",
+      expect.stringMatching(/^\/root\/\.worktrees\/\.leaked-wt\.git-reap-stash-\d+-[a-z0-9]+$/),
+    );
+    // The occupant of the `.git` pathname is moved to a private deletion path before the
+    // captured inode is removed, so a live replacement that wins the pathname is never the
+    // unlink target.
+    const deletePath = expect.stringMatching(/^\/root\/\.worktrees\/\.leaked-wt\.git-reap-del-\d+-[a-z0-9]+$/);
+    expect(mockedRenameSync).toHaveBeenCalledWith("/root/.worktrees/leaked-wt/.git", deletePath);
+    expect(mockedUnlinkSync).toHaveBeenCalledWith(deletePath);
+    expect(mockedRmdirSync).toHaveBeenCalledWith("/root/.worktrees/leaked-wt");
+  });
+
+  it("preserves a dangling .git pointer when the orphan contains user files", async () => {
+    mockedReaddirSync.mockImplementation((path: any) =>
+      String(path) === "/root/.worktrees"
+        ? [makeDirEntry("dirty-leaked-wt")] as any
+        : [".git", "notes.txt"] as any,
+    );
+    mockedLstatSync.mockImplementation((p: any) =>
+      (String(p).endsWith("/.git")
+        ? { isDirectory: () => false, isSymbolicLink: () => false }
+        : { isDirectory: () => true, isSymbolicLink: () => false }) as any,
+    );
+    mockedReadFileSync.mockReturnValue("gitdir: /root/.git/worktrees/dirty-leaked-wt\n" as any);
+    mockedExistsSync.mockImplementation((p) => {
+      const value = String(p);
+      return value === "/root/.worktrees" || value === "/root/.worktrees/dirty-leaked-wt/.git";
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    expect(mockedUnlinkSync).not.toHaveBeenCalled();
+    expect(mockedRmdirSync).not.toHaveBeenCalled();
   });
 
   it("skips a dir with a valid .git pointer (admin gitdir exists)", async () => {
@@ -1249,7 +1491,7 @@ describe("reapOrphanWorktrees", () => {
     const removed = await reapOrphanWorktrees("/root");
 
     expect(removed).toBe(0);
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/live-wt", expect.anything());
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/live-wt");
   });
 
   it("does NOT reap a dir whose .git is unparseable (conservative — only confirmed-dangling pointers)", async () => {
@@ -1270,7 +1512,340 @@ describe("reapOrphanWorktrees", () => {
     const removed = await reapOrphanWorktrees("/root");
 
     expect(removed).toBe(0);
-    expect(mockedRmSync).not.toHaveBeenCalledWith("/root/.worktrees/maybe-wt", expect.anything());
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/maybe-wt");
   });
+
+
+  // Greptile (find: failed pointer restore accepted): when the removed orphan's admin
+  // target is repaired in the removal window, the reaper recreates the directory and
+  // restores the stashed .git pointer. If BOTH restore methods fail with a non-EEXIST
+  // filesystem error, restoreStashedDotGit returns false — the previous code silently
+  // continued, leaving the recreated checkout without a canonical .git pointer. It must
+  // fail closed: keep the stash for manual recovery and surface it.
+  it("fails closed when the stashed pointer cannot be restored to the repaired checkout", async () => {
+    mockedReaddirSync.mockImplementation((p: any) =>
+      String(p) === "/root/.worktrees" ? [makeDirEntry("failclose-wt")] as any : [".git"] as any,
+    );
+    mockedLstatSync.mockImplementation((p: any) => {
+      const s = String(p);
+      return {
+        dev: 11,
+        ino: s.endsWith("/.git") || s.includes(".git-reap-stash") || s.includes(".git-reap-del") ? 22 : 11,
+        isDirectory: () => !s.endsWith("/.git"),
+        isSymbolicLink: () => false,
+      } as any;
+    });
+    mockedReadFileSync.mockReturnValue("gitdir: /root/.git/worktrees/failclose-wt\n" as any);
+    // Admin target exists in the post-removal window (repaired before probe #6) so the
+    // "repaired during removal" restore path is taken; but the restore fails.
+    let probe = 0;
+    mockedExistsSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s !== "/root/.git/worktrees/failclose-wt") {
+        return s === "/root/.worktrees" || s === "/root/.worktrees/failclose-wt/.git";
+      }
+      probe++;
+      if (probe >= 6) return true;
+      return false;
+    });
+    // Force both restoration methods to fail with a non-EEXIST code.
+    mockedMkdirSync.mockImplementation(() => undefined);
+    mockedLinkSync.mockImplementation((src: any, dest: any) => {
+      if (String(src).includes(".git-reap-stash")) {
+        const err: NodeJS.ErrnoException = new Error("fake EPERM");
+        err.code = "EPERM";
+        throw err;
+      }
+    });
+    mockedCopyFileSync.mockImplementation(() => {
+      const err: NodeJS.ErrnoException = new Error("fake EPERM");
+      err.code = "EPERM";
+      throw err;
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    // Fail closed: the stash is retained for manual recovery (kept, not unlinked).
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("admin target repaired during removal but .git pointer restore failed"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("keeping stash for manual recovery"),
+    );
+  });
+
+  // Greptile (find: concurrent pointer overwrite): restoreReplacedDotGit's last-resort
+  // restore path checks `existsSync(dotGit)` and then `renameSync(dotGitDelete, dotGit)`.
+  // renameSync ALWAYS overwrites the destination, so an authoritative `.git` pointer
+  // created between the existsSync check and the rename is silently destroyed while the
+  // captured (stale) pointer wins. The restore must be atomic and non-overwriting:
+  // never call renameSync to place a captured pointer back over dotGit; fail closed and
+  // keep the captured pointer for manual recovery when link/copy-EXCL both error.
+  it("does NOT overwrite an authoritative .git pointer via renameSync in the replacement-restore fallback", async () => {
+    mockedReaddirSync.mockImplementation((p: any) =>
+      String(p) === "/root/.worktrees" ? [makeDirEntry("concurrent-win")] as any : [".git"] as any,
+    );
+    // Real flow: after capture the occupant is renamed to the private delete path, so the
+    // canonical `.git` pathname is absent again — exactly the window where a concurrent
+    // authoritative pointer can be recreated and then clobbered by a rename fallback.
+    let dotGitMoved = false;
+    mockedRenameSync.mockImplementation((src: any, dest: any) => {
+      if (String(src) === "/root/.worktrees/concurrent-win/.git" && String(dest).includes(".git-reap-del")) {
+        dotGitMoved = true;
+      }
+    });
+    mockedLstatSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s.includes(".git-reap-del-")) return { dev: 11, ino: 33, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      if (s.endsWith("/.git") || s.includes(".git-reap-stash-")) return { dev: 11, ino: 22, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      return { dev: 11, ino: 11, isDirectory: () => true, isSymbolicLink: () => false } as any;
+    });
+    mockedReadFileSync.mockReturnValue("gitdir: /root/.git/worktrees/concurrent-win\n" as any);
+    mockedExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s === "/root/.worktrees/concurrent-win/.git") return !dotGitMoved;
+      return s === "/root/.worktrees";
+    });
+    // Force both atomic non-overwriting restores to fail with a non-EEXIST code so the
+    // buggy renameSync fallback is the only path left open.
+    mockedLinkSync.mockImplementation((src: any) => {
+      if (String(src).includes(".git-reap-del-")) {
+        const err: NodeJS.ErrnoException = new Error("fake EPERM");
+        err.code = "EPERM";
+        throw err;
+      }
+    });
+    mockedCopyFileSync.mockImplementation(() => {
+      const err: NodeJS.ErrnoException = new Error("fake EPERM");
+      err.code = "EPERM";
+      throw err;
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    // The captured replacement pointer must never be renameSync'd back over dotGit:
+    // renameSync cannot be made non-overwriting and would clobber a concurrent winner.
+    expect(mockedRenameSync).not.toHaveBeenCalledWith(
+      expect.stringMatching(/\.git-reap-del-/),
+      "/root/.worktrees/concurrent-win/.git",
+    );
+    // Fail closed: keep the captured pointer as a manual-recovery copy instead of
+    // dropping it after a failed non-overwriting restore.
+    expect(mockedUnlinkSync).not.toHaveBeenCalledWith(
+      expect.stringMatching(/\.git-reap-del-/),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to restore replacement .git"),
+    );
+  });
+
+  // Greptile (find: concurrent metadata copy corrupts repair): the directory restore
+  // must be an ATOMIC non-overwriting move, not a recursive copy. cpSync into dotGit
+  // let a concurrent repair that recreates `.git` mid-copy receive PARTIAL stale
+  // metadata before errorOnExist threw — mixed/unusable Git metadata in the
+  // authoritative directory. renameSync of the captured directory refuses a non-empty
+  // destination (ENOTEMPTY), so a concurrently recreated authoritative `.git` always
+  // wins untouched and the captured copy is moved to contained recovery instead.
+  it("restores a concurrently captured .git directory with an atomic non-overwriting rename", async () => {
+    mockedReaddirSync.mockImplementation((p: any) =>
+      String(p) === "/root/.worktrees" ? [makeDirEntry("directory-win")] as any : [".git"] as any,
+    );
+    let dotGitMoved = false;
+    mockedRenameSync.mockImplementation((src: any, dest: any) => {
+      if (String(src) === "/root/.worktrees/directory-win/.git" && String(dest).includes(".git-reap-del")) {
+        dotGitMoved = true;
+      }
+    });
+    mockedLstatSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s.includes(".git-reap-del-")) return { dev: 11, ino: 33, isDirectory: () => true, isSymbolicLink: () => false } as any;
+      if (s.endsWith("/.git") || s.includes(".git-reap-stash-")) return { dev: 11, ino: 22, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      return { dev: 11, ino: 11, isDirectory: () => true, isSymbolicLink: () => false } as any;
+    });
+    mockedReadFileSync.mockReturnValue("gitdir: /root/.git/worktrees/directory-win\n" as any);
+    mockedExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s === "/root/.worktrees/directory-win/.git") return !dotGitMoved;
+      return s === "/root/.worktrees";
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    // The captured directory is moved back atomically — never copied into place.
+    expect(mockedRenameSync).toHaveBeenCalledWith(
+      expect.stringMatching(/\.git-reap-del-/),
+      "/root/.worktrees/directory-win/.git",
+    );
+    expect(mockedCpSync).not.toHaveBeenCalled();
+    // A directory restore is a rename, never a recursive delete of the capture.
+    expect(mockedRmSync).not.toHaveBeenCalledWith(expect.stringMatching(/\.git-reap-del-/), { recursive: true });
+    expect(mockedCopyFileSync).not.toHaveBeenCalled();
+  });
+
+  // Greptile (find: stale target after re-registration): `targetPath` is derived once from
+  // the STASHED original dangling pointer. A concurrent repair can RE-REGISTER the orphan,
+  // recreating `.git` to point at a DIFFERENT, live admin while the original target stays
+  // missing. The reaper must re-read the CURRENT `.git` pointer before its destructive
+  // rmdir and preserve on the freshly-resolved live target — otherwise it deletes a live
+  // worktree it reclassified against a stale path.
+  it("preserves an orphan re-registered to a different live admin target (re-reads current .git pointer)", async () => {
+    mockedReaddirSync.mockImplementation((p: any) =>
+      String(p) === "/root/.worktrees" ? [makeDirEntry("rereg-wt")] as any : [".git"] as any,
+    );
+    // The re-registration lands right after the reaper renames the dangling `.git` aside:
+    // the canonical `.git` path is recreated to point at a DIFFERENT live admin target.
+    let pointerReplaced = false;
+    mockedRenameSync.mockImplementation((src: any, dest: any) => {
+      if (String(src) === "/root/.worktrees/rereg-wt/.git" && String(dest).includes(".git-reap-del")) {
+        pointerReplaced = true;
+      }
+    });
+    // stash, captured occupant, and the `.git` pathname all share the dangling original's
+    // inode until the re-registration replaces the pointer's CONTENT (readFileSync flip).
+    mockedLstatSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s.endsWith("/.git") || s.includes(".git-reap-stash-") || s.includes(".git-reap-del-")) {
+        return { dev: 11, ino: 22, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      }
+      return { dev: 11, ino: 11, isDirectory: () => true, isSymbolicLink: () => false } as any;
+    });
+    const ORIGINAL = "gitdir: /root/.git/worktrees/rereg-wt\n";
+    const RE_REGISTERED = "gitdir: /root/.git/worktrees/reregistered\n";
+    mockedReadFileSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s.includes(".git-reap-stash-")) return ORIGINAL as any; // stash always holds the dangling original
+      if (pointerReplaced && s.endsWith("/.git")) return RE_REGISTERED as any;
+      if (s.endsWith("/.git")) return ORIGINAL as any;
+      return "" as any;
+    });
+    mockedExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      // Re-registered admin (B) is live; the original dangling admin (A) is gone.
+      if (s === "/root/.git/worktrees/reregistered") return true;
+      if (s === "/root/.git/worktrees/rereg-wt") return false;
+      return s === "/root/.worktrees" || s === "/root/.worktrees/rereg-wt/.git" || s === "/root/.worktrees/rereg-wt";
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    // The live re-registered worktree must NOT be destroyed:
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/rereg-wt");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Preserving orphan worktree"),
+    );
+  });
+
+  // Greptile (find: replacement Git directory stays unrecognized): after the dangling
+  // pointer is moved aside, a concurrent repair can install a REAL `.git` DIRECTORY at
+  // the canonical pathname. `resolveCurrentAdminTarget` returns no pointer for a directory,
+  // so without an explicit guard the reaper fell back to the stale missing `targetPath` and
+  // `rmdirSync`'d a populated, repaired checkout. A present `.git` directory is authoritative
+  // and live — the orphan must be preserved, never reaped.
+  it("preserves an orphan whose .git is replaced by a real directory during removal", async () => {
+    mockedReaddirSync.mockImplementation((p: any) =>
+      String(p) === "/root/.worktrees" ? [makeDirEntry("dir-repair")] as any : [".git"] as any,
+    );
+    // The dangling pointer is a FILE until a concurrent repair replaces the canonical `.git`
+    // with a real DIRECTORY after the reaper moved the original aside.
+    let dotGitReplaced = false;
+    mockedRenameSync.mockImplementation((src: any, dest: any) => {
+      if (String(src) === "/root/.worktrees/dir-repair/.git" && String(dest).includes(".git-reap-del")) {
+        dotGitReplaced = true;
+      }
+    });
+    mockedLstatSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s.endsWith("/.git") && dotGitReplaced) return { dev: 11, ino: 44, isDirectory: () => true, isSymbolicLink: () => false } as any;
+      if (s.includes(".git-reap-del-")) return { dev: 11, ino: 22, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      if (s.endsWith("/.git") || s.includes(".git-reap-stash-")) return { dev: 11, ino: 22, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      return { dev: 11, ino: 11, isDirectory: () => true, isSymbolicLink: () => false } as any;
+    });
+    mockedReadFileSync.mockReturnValue("gitdir: /root/.git/worktrees/dir-repair\n" as any);
+    mockedExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s === "/root/.git/worktrees/dir-repair") return false;
+      return s === "/root/.worktrees" || s === "/root/.worktrees/dir-repair" || s === "/root/.worktrees/dir-repair/.git";
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    // The repaired checkout with a real `.git` directory is never rmdir'd:
+    expect(mockedRmdirSync).not.toHaveBeenCalledWith("/root/.worktrees/dir-repair");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Preserving orphan worktree"),
+    );
+  });
+
+  // Greptile (find: recovery directory remains scannable): when a concurrently
+  // captured `.git` directory cannot be restored back to the canonical path, the
+  // previous branch left the captured recovery copy directly under the worktrees
+  // directory. The next orphan scan then treated it as an ordinary orphan
+  // candidate, repeatedly reaping (and never completing) the only metadata copy of
+  // a preserved checkout. The reaper must move a failed directory restore into the
+  // contained `.fusion-recovery/worktrees` namespace that orphan scans skip.
+  it("moves a failed replacement-directory restore into contained recovery so it is not re-scanned as an orphan", async () => {
+    mockedReaddirSync.mockImplementation((p: any) =>
+      String(p) === "/root/.worktrees" ? [makeDirEntry("dir-fail-move")] as any : [".git"] as any,
+    );
+    let dotGitMoved = false;
+    mockedRenameSync.mockImplementation((src: any, dest: any) => {
+      if (String(src) === "/root/.worktrees/dir-fail-move/.git" && String(dest).includes(".git-reap-del")) {
+        dotGitMoved = true;
+        return;
+      }
+      // Greptile (find: concurrent metadata copy corrupts repair): the restore is an
+      // atomic non-overwriting rename; a concurrent repair that recreates `.git` as a
+      // non-empty directory makes it fail with ENOTEMPTY. The captured directory must
+      // then go to contained recovery — never be partially copied into the winner.
+      if (String(src).includes(".git-reap-del") && String(dest).endsWith("/.git")) {
+        const err: NodeJS.ErrnoException = new Error("fake ENOTEMPTY");
+        err.code = "ENOTEMPTY";
+        throw err;
+      }
+    });
+    mockedLstatSync.mockImplementation((p: any) => {
+      const s = String(p);
+      if (s.includes(".git-reap-del-")) return { dev: 11, ino: 33, isDirectory: () => true, isSymbolicLink: () => false } as any;
+      if (s.endsWith("/.git") || s.includes(".git-reap-stash-")) return { dev: 11, ino: 22, isDirectory: () => false, isSymbolicLink: () => false } as any;
+      return { dev: 11, ino: 11, isDirectory: () => true, isSymbolicLink: () => false } as any;
+    });
+    mockedReadFileSync.mockReturnValue("gitdir: /root/.git/worktrees/dir-fail-move\n" as any);
+    mockedExistsSync.mockImplementation((p) => {
+      const s = String(p);
+      if (s === "/root/.worktrees/dir-fail-move/.git") return !dotGitMoved;
+      return s === "/root/.worktrees" || s === "/root/.worktrees/dir-fail-move";
+    });
+    // The atomic restore rename fails with ENOTEMPTY (a concurrent repair recreated
+    // `.git` as a non-empty directory), so the reaper takes the contained-recovery
+    // branch instead of consuming the capture in place.
+    mockedCpSync.mockImplementation(() => {
+      const err: NodeJS.ErrnoException = new Error("should not be used for directory restore");
+      err.code = "EINVAL";
+      throw err;
+    });
+
+    const removed = await reapOrphanWorktrees("/root");
+
+    expect(removed).toBe(0);
+    // The captured directory is staged into the contained recovery namespace that
+    // orphan scans skip, never left directly scannable under the worktrees root.
+    expect(mockedMkdirSync).toHaveBeenCalledWith(
+      "/root/.worktrees/.fusion-recovery/worktrees",
+      { recursive: true },
+    );
+    expect(mockedRenameSync).toHaveBeenCalledWith(
+      expect.stringContaining(".git-reap-del-"),
+      expect.stringContaining("/root/.worktrees/.fusion-recovery/worktrees/replaced-dir-fail-move-"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("moved captured directory to contained recovery"),
+    );
+  });
+
 });
 

--- a/packages/engine/src/self-healing.ts
+++ b/packages/engine/src/self-healing.ts
@@ -58,6 +58,8 @@ import {
 } from "./duplicate-marker-clear.js";
 import { mergeEffectiveSettings } from "./project/effective-settings.js";
 import { RemovalReason, classifyTaskWorktree, getRegisteredWorktreeBranchMap, getRegisteredWorktreePaths, isUsableTaskWorktree, relocateReclaimableWorktreeIntoRoot, removeWorktree, resolveWorktreeBackend, scanIdleWorktrees, scanOrphanedBranches } from "./worktree/worktree-pool.js";
+import { cleanupSecretsEnvFile } from "./worktree/secrets-env-writer.js";
+import { preserveCorruptRegisteredRoot, preserveGeneratedResidue } from "./worktree/worktree-generated-residue.js";
 import {
   isMissingWorktreeSessionStartFailure,
   isMergeActiveMissingWorktreeSessionStartFailure,
@@ -16532,6 +16534,27 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
           log.debug(`[self-healing] deferring idle-sweep for ${worktreePath}: resume-eligible CLI session present`);
           continue;
         }
+        // FNXC:WorktreeCleanup 2026-08-17: the removal probe includes --ignored, so
+        // fingerprint-owned .env and generated residue (node_modules/dist) must leave
+        // the path first — cleaned/preserved, never deleted, mirroring the pool path.
+        try {
+          await cleanupSecretsEnvFile({
+            worktreePath,
+            taskId: `orphan:${basename(worktreePath)}`,
+            expectedFingerprint: null,
+            filename: ".env",
+            audit: undefined,
+            logger: log,
+          });
+        } catch (error) {
+          log.warn(`[self-healing] secrets-env cleanup failed for idle worktree ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        let restoreGeneratedResidue: ((removedSuccessfully?: boolean) => Promise<void>) | undefined;
+        try {
+          restoreGeneratedResidue = await preserveGeneratedResidue(worktreePath, this.options.rootDir, log);
+        } catch (error) {
+          log.warn(`[self-healing] generated-residue preservation failed for idle worktree ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`);
+        }
         try {
           await removeWorktree({
             rootDir: this.options.rootDir,
@@ -16539,8 +16562,21 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
             settings,
             reason: RemovalReason.SelfHealingIdleSweep,
           });
+          await restoreGeneratedResidue?.(true);
           cleaned++;
         } catch (err: unknown) {
+          try {
+            await restoreGeneratedResidue?.();
+          } catch (restoreError) {
+            // Greptile (restore fail-closed): a refused removal PLUS a residue restore
+            // failure leaves the SURVIVING checkout missing node_modules/dist. This must
+            // never be swallowed as a benign non-fatal skip — escalate so supervision
+            // records the worktree as broken (its residue stays recoverable in the
+            // contained recovery area) instead of pretending the checkout is valid.
+            log.error(`[self-healing] generated-residue restore failed for idle worktree ${worktreePath}; surviving checkout is missing preserved generated dirs: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`);
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            throw new Error(`generated-residue restore failed for ${worktreePath}: ${errorMessage}; ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`);
+          }
           const errorMessage = err instanceof Error ? err.message : String(err);
           log.warn(`Failed to remove orphaned worktree ${worktreePath}: ${errorMessage} — non-fatal`);
           // Individual failure is non-fatal
@@ -16617,11 +16653,12 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
         continue;
       }
       try {
-        rmSync(path, { recursive: true, force: true });
-        log.log(`Cleaned unregistered worktree dir: ${path}`);
+        const preservedPath = await preserveCorruptRegisteredRoot(path, this.options.rootDir);
+        await execAsync("git worktree prune", { cwd: this.options.rootDir, timeout: 30_000 });
+        log.log(`Preserved unregistered worktree dir: ${path} -> ${preservedPath}`);
         cleaned++;
       } catch (err: unknown) {
-        log.warn(`Failed to remove unregistered worktree dir ${path}: ${err instanceof Error ? err.message : String(err)}`);
+        log.warn(`Failed to preserve unregistered worktree dir ${path}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 
@@ -16958,6 +16995,26 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
           log.debug(`[self-healing] cap-enforcement skipping ${worktreePath}: resume-eligible CLI session present`);
           continue;
         }
+        // FNXC:WorktreeCleanup 2026-08-17: cap enforcement shares the idle-sweep
+        // preparation so owned secrets and generated residue do not veto reclaim.
+        try {
+          await cleanupSecretsEnvFile({
+            worktreePath,
+            taskId: `orphan:${basename(worktreePath)}`,
+            expectedFingerprint: null,
+            filename: ".env",
+            audit: undefined,
+            logger: log,
+          });
+        } catch (error) {
+          log.warn(`[self-healing] secrets-env cleanup failed for idle worktree ${worktreePath} during cap enforcement: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        let restoreGeneratedResidue: ((removedSuccessfully?: boolean) => Promise<void>) | undefined;
+        try {
+          restoreGeneratedResidue = await preserveGeneratedResidue(worktreePath, this.options.rootDir, log);
+        } catch (error) {
+          log.warn(`[self-healing] generated-residue preservation failed for idle worktree ${worktreePath} during cap enforcement: ${error instanceof Error ? error.message : String(error)}`);
+        }
         try {
           await removeWorktree({
             rootDir: this.options.rootDir,
@@ -16965,8 +17022,18 @@ const movedTask = await this.store.moveTask(task.id, completeLane);
             settings,
             reason: RemovalReason.SelfHealingIdleSweep,
           });
+          await restoreGeneratedResidue?.(true);
           removed++;
         } catch (err: unknown) {
+          try {
+            await restoreGeneratedResidue?.();
+          } catch (restoreError) {
+            // Greptile (restore fail-closed): escalate rather than leave the surviving
+            // checkout missing its preserved generated dirs; residue stays recoverable.
+            log.error(`[self-healing] generated-residue restore failed for cap worktree ${worktreePath}; surviving checkout is missing preserved generated dirs: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`);
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            throw new Error(`generated-residue restore failed for ${worktreePath}: ${errorMessage}; ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`);
+          }
           const errorMessage = err instanceof Error ? err.message : String(err);
           log.warn(`Failed to remove idle worktree ${worktreePath} during cap enforcement: ${errorMessage} — non-fatal`);
           // Individual failure is non-fatal

--- a/packages/engine/src/util/run-audit.ts
+++ b/packages/engine/src/util/run-audit.ts
@@ -176,6 +176,8 @@ export type GitMutationType =
    * ```
    */
   | "worktree:admin-entry-pruned"
+  | "worktree:corrupt-registered-preserved"
+  | "worktree:corrupt-preserve-failed"
   | "worktree:removal-refused-active-session"
   | "worktree:removal-forced-over-active-session"
   | "worktree:active-session-reconciled"

--- a/packages/engine/src/worktree/__tests__/worktree-generated-residue.test.ts
+++ b/packages/engine/src/worktree/__tests__/worktree-generated-residue.test.ts
@@ -1,0 +1,314 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { preserveCorruptRegisteredRoot, preserveGeneratedResidue } from "../worktree-generated-residue.js";
+
+// Genuinely-generated fixtures: node_modules carries a package-manager marker
+// and dist carries a sourcemap, so they are provably generated output rather
+// than a merely generated-looking dir holding user content (Greptile: residue
+// provenance).
+function makeGeneratedNodeModules(worktree: string): void {
+  // A real install leaves a root package-lock.json listing installed packages;
+  // the residue classifier requires it to prove node_modules was installed
+  // (Greptile 4/5: a hand-assembled package.json + .js is not install proof).
+  writeFileSync(
+    join(worktree, "package-lock.json"),
+    JSON.stringify({ name: "fixture", lockfileVersion: 3, packages: { "node_modules/pkg": { version: "1.0.0" } } }),
+  );
+  mkdirSync(join(worktree, "node_modules"));
+  writeFileSync(join(worktree, "node_modules", ".package-lock.json"), "{}");
+  mkdirSync(join(worktree, "node_modules", "pkg"));
+  writeFileSync(join(worktree, "node_modules", "pkg", "package.json"), "{}");
+}
+
+function makeGeneratedDist(worktree: string): void {
+  mkdirSync(join(worktree, "dist"));
+  writeFileSync(join(worktree, "dist", "bundle.js.map"), "{}");
+}
+
+function gitInit(worktree: string, gitignore: string): void {
+  execFileSync("git", ["init", "-q", worktree]);
+  writeFileSync(join(worktree, ".gitignore"), gitignore);
+}
+
+describe("preserveGeneratedResidue", () => {
+  it("restores generated directories when removal is refused", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\ndist/\n");
+    makeGeneratedNodeModules(worktree);
+    makeGeneratedDist(worktree);
+    writeFileSync(join(worktree, "node_modules", "pkg", "bundle.js"), "deps");
+    writeFileSync(join(worktree, "dist", "bundle.js"), "build");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+    expect(existsSync(join(worktree, "node_modules"))).toBe(false);
+    expect(existsSync(join(worktree, "dist"))).toBe(false);
+
+    await restore();
+    expect(readFileSync(join(worktree, "node_modules", "pkg", "bundle.js"), "utf8")).toBe("deps");
+    expect(readFileSync(join(worktree, "dist", "bundle.js"), "utf8")).toBe("build");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile (residue provenance): a git-ignored sibling must NOT be moved ahead
+  // of the dirty probe merely because it carries a generated-looking name. Only
+  // PROVABLY generated output is moved; anything ambiguous stays in the checkout
+  // so the removal's dirty probe fails closed and the checkout keeps its content.
+  it("does not move a generated-looking but not provably generated ignored dir", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\ndist/\n");
+    // Hand-authored ignored content under generated-looking names, no install/build
+    // provenance markers.
+    mkdirSync(join(worktree, "node_modules"));
+    writeFileSync(join(worktree, "node_modules", "user-notes.txt"), "keep me");
+    mkdirSync(join(worktree, "dist"));
+    writeFileSync(join(worktree, "dist", "user-notes.txt"), "keep me");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    // Neither ambiguous dir was moved — the checkout stays valid for restore.
+    expect(existsSync(join(worktree, "node_modules"))).toBe(true);
+    expect(existsSync(join(worktree, "dist"))).toBe(true);
+    expect(readFileSync(join(worktree, "node_modules", "user-notes.txt"), "utf8")).toBe("keep me");
+    expect(readFileSync(join(worktree, "dist", "user-notes.txt"), "utf8")).toBe("keep me");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile (Issue 2, mixed residue): ONE recognized package-manager/build marker
+  // beside user-authored ignored content must NOT let the whole node_modules/dist be
+  // moved ahead of the dirty probe. Every entry must look generated; a mixed
+  // directory stays in place so removal fails closed and the user's file survives.
+  it("keeps a mixed node_modules/dist (marker + user file) in place", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\ndist/\n");
+    mkdirSync(join(worktree, "node_modules"));
+    writeFileSync(join(worktree, "node_modules", ".package-lock.json"), "{}");
+    writeFileSync(join(worktree, "node_modules", "user-notes.txt"), "keep me");
+    mkdirSync(join(worktree, "dist"));
+    writeFileSync(join(worktree, "dist", "bundle.js.map"), "{}");
+    writeFileSync(join(worktree, "dist", "user-notes.txt"), "keep me");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    // Neither mixed directory is provably generated, so neither is moved and the
+    // user-authored files survive the removal's dirty probe.
+    expect(existsSync(join(worktree, "node_modules"))).toBe(true);
+    expect(existsSync(join(worktree, "dist"))).toBe(true);
+    expect(readFileSync(join(worktree, "node_modules", "user-notes.txt"), "utf8")).toBe("keep me");
+    expect(readFileSync(join(worktree, "dist", "user-notes.txt"), "utf8")).toBe("keep me");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile (4/5, nested residue): a PACKAGE-shaped child of node_modules is
+  // accepted on its package.json alone; a user-authored ignored file nested
+  // INSIDE that package (e.g. node_modules/pkg/user-notes.txt) would then be
+  // moved before the dirty probe and lost on successful reclaim. Deep-inspect
+  // the package and fail closed when any nested entry is not package output.
+  it("keeps node_modules in place when a nested package holds user content", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\n");
+    // Package-shaped child with a real package.json (install provenance) PLUS a
+    // user-authored file nested inside the package directory.
+    mkdirSync(join(worktree, "node_modules"));
+    writeFileSync(join(worktree, "node_modules", ".package-lock.json"), "{}");
+    mkdirSync(join(worktree, "node_modules", "pkg"));
+    writeFileSync(join(worktree, "node_modules", "pkg", "package.json"), "{}");
+    writeFileSync(join(worktree, "node_modules", "pkg", "user-notes.txt"), "keep me");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    expect(existsSync(join(worktree, "node_modules"))).toBe(true);
+    expect(readFileSync(join(worktree, "node_modules", "pkg", "user-notes.txt"), "utf8")).toBe("keep me");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile (4/5, "generated-looking extensions"): a sourcemap beside an
+  // extension-allowed file is not proof. In dist, an executable without its own
+  // .map companion (e.g. a hand-authored `user-tool.js` next to `bundle.js.map`)
+  // fails the whole directory closed so it is never moved ahead of the probe.
+  it("keeps dist in place when an executable has no sourcemap companion", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "dist/\n");
+    mkdirSync(join(worktree, "dist"));
+    writeFileSync(join(worktree, "dist", "bundle.js.map"), "{}");
+    writeFileSync(join(worktree, "dist", "user-tool.js"), "user authored");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    expect(existsSync(join(worktree, "dist"))).toBe(true);
+    expect(readFileSync(join(worktree, "dist", "user-tool.js"), "utf8")).toBe("user authored");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile (4/5): dist JSON that is not a build manifest (e.g. a hand-authored
+  // `data.json` beside one sourcemap) is not provably generated.
+  it("keeps dist in place when a bare json is not a build manifest", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "dist/\n");
+    mkdirSync(join(worktree, "dist"));
+    writeFileSync(join(worktree, "dist", "bundle.js.map"), "{}");
+    writeFileSync(join(worktree, "dist", "data.json"), "{\"user\": true}");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    expect(existsSync(join(worktree, "dist"))).toBe(true);
+    expect(readFileSync(join(worktree, "dist", "data.json"), "utf8")).toBe("{\"user\": true}");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile (4/5): a package-shaped node_modules child with a package.json but
+  // no root lockfile, or not listed in it, is not provably installed — a user
+  // can hand-assemble it with .js/.json content. Stay in place, fail closed.
+  it("keeps node_modules in place when no root lockfile proves the install", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\n");
+    mkdirSync(join(worktree, "node_modules"));
+    writeFileSync(join(worktree, "node_modules", ".package-lock.json"), "{}");
+    mkdirSync(join(worktree, "node_modules", "pkg"));
+    writeFileSync(join(worktree, "node_modules", "pkg", "package.json"), "{}");
+    writeFileSync(join(worktree, "node_modules", "pkg", "index.js"), "hand made");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    expect(existsSync(join(worktree, "node_modules"))).toBe(true);
+    expect(readFileSync(join(worktree, "node_modules", "pkg", "index.js"), "utf8")).toBe("hand made");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("keeps node_modules in place when a package is not listed in the lockfile", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\n");
+    // Lockfile lists a DIFFERENT package; `handmade` is not installed.
+    writeFileSync(
+      join(worktree, "package-lock.json"),
+      JSON.stringify({ name: "fixture", lockfileVersion: 3, packages: { "node_modules/other": { version: "1.0.0" } } }),
+    );
+    mkdirSync(join(worktree, "node_modules"));
+    writeFileSync(join(worktree, "node_modules", ".package-lock.json"), "{}");
+    mkdirSync(join(worktree, "node_modules", "handmade"));
+    writeFileSync(join(worktree, "node_modules", "handmade", "package.json"), "{}");
+    writeFileSync(join(worktree, "node_modules", "handmade", "index.js"), "hand made");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+
+    expect(existsSync(join(worktree, "node_modules"))).toBe(true);
+    expect(readFileSync(join(worktree, "node_modules", "handmade", "index.js"), "utf8")).toBe("hand made");
+    await restore();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("keeps preserved generated directories in contained recovery after successful removal", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\n");
+    makeGeneratedNodeModules(worktree);
+    writeFileSync(join(worktree, "node_modules", "pkg", "marker.js"), "deps");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+    await restore(true);
+
+    // Greptile: residue moved ahead of the dirty probe may hold user-authored ignored
+    // content, so it is NEVER recursively deleted on success — it stays in the contained
+    // recovery area for manual recovery instead of being discarded.
+    const recoveryRoot = join(root, ".fusion", "recovery", "worktrees");
+    const preserved = await readdir(recoveryRoot);
+    expect(preserved).toHaveLength(1);
+    expect(readFileSync(join(recoveryRoot, preserved[0], "pkg", "marker.js"), "utf8")).toBe("deps");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("fails restoration when removal recreates a source and preserves both copies", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\n");
+    makeGeneratedNodeModules(worktree);
+    writeFileSync(join(worktree, "node_modules", "pkg", "marker.js"), "deps");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+    mkdirSync(join(worktree, "node_modules"));
+    writeFileSync(join(worktree, "node_modules", "new-marker"), "recreated");
+
+    await expect(restore()).rejects.toThrow(/Failed to restore generated residue/);
+    expect(readFileSync(join(worktree, "node_modules", "new-marker"), "utf8")).toBe("recreated");
+    const recoveryRoot = join(root, ".fusion", "recovery", "worktrees");
+    const preserved = await readdir(recoveryRoot);
+    expect(preserved).toHaveLength(1);
+    expect(readFileSync(join(recoveryRoot, preserved[0], "pkg", "marker.js"), "utf8")).toBe("deps");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  // Greptile: the restore loop threw on the FIRST conflicting/recreated source and
+  // skipped the remaining moved entries, leaving the surviving worktree without its
+  // other generated directory while it stayed stranded in recovery. Restoration must
+  // attempt every moved entry and throw an aggregate error only after all are tried.
+  it("restores the remaining generated dir even when one source was recreated", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-residue-"));
+    const worktree = join(root, "worktree");
+    mkdirSync(worktree);
+    gitInit(worktree, "node_modules/\ndist/\n");
+    makeGeneratedNodeModules(worktree);
+    makeGeneratedDist(worktree);
+    writeFileSync(join(worktree, "node_modules", "pkg", "marker.js"), "deps");
+    writeFileSync(join(worktree, "dist", "bundle.js"), "build");
+
+    const restore = await preserveGeneratedResidue(worktree, root);
+    // dist is restored first (reverse order); recreate its source so it conflicts,
+    // proving the conflict must not prevent node_modules from being restored too.
+    mkdirSync(join(worktree, "dist"));
+    writeFileSync(join(worktree, "dist", "recreated"), "new-build");
+
+    await expect(restore()).rejects.toThrow(/Failed to restore generated residue/);
+    // The recreated source is preserved in place...
+    expect(readFileSync(join(worktree, "dist", "recreated"), "utf8")).toBe("new-build");
+    // ...and the OTHER moved dir was still restored despite the conflict.
+    expect(readFileSync(join(worktree, "node_modules", "pkg", "marker.js"), "utf8")).toBe("deps");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("falls back beside the worktrees root when project recovery is cross-device", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-corrupt-"));
+    const worktrees = await mkdtemp(join(tmpdir(), "fusion-worktrees-"));
+    const worktree = join(worktrees, "broken");
+    mkdirSync(worktree);
+    writeFileSync(join(worktree, "marker"), "keep");
+    const actualRename = (await import("node:fs/promises")).rename;
+    const renameFile = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error("cross-device"), { code: "EXDEV" }))
+      .mockImplementation(actualRename);
+
+    const preserved = await preserveCorruptRegisteredRoot(worktree, root, worktrees, renameFile);
+
+    expect(preserved).toContain(join(worktrees, ".fusion-recovery", "worktrees"));
+    expect(readFileSync(join(preserved, "marker"), "utf8")).toBe("keep");
+    expect(renameFile).toHaveBeenCalledTimes(2);
+    await rm(root, { recursive: true, force: true });
+    await rm(worktrees, { recursive: true, force: true });
+  });
+});

--- a/packages/engine/src/worktree/secrets-env-writer.ts
+++ b/packages/engine/src/worktree/secrets-env-writer.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -13,7 +13,7 @@ const VALID_FINGERPRINT = /^[0-9a-f]{64}$/;
 const execFileAsync = promisify(execFile);
 
 export type WriteSkipReason = "disabled" | "no-secrets" | "not-gitignored" | "skip-existing" | "invalid-filename" | "no-store" | "list-failed" | "record-reconciliation-failed";
-export type CleanupSkipReason = "fingerprint-mismatch" | "file-missing" | "no-record" | "disabled" | "stat-failed" | "ambiguous-record" | "invalid-record" | "tracked-file" | "record-remove-failed";
+export type CleanupSkipReason = "fingerprint-mismatch" | "file-missing" | "file-retained" | "no-record" | "disabled" | "stat-failed" | "ambiguous-record" | "invalid-record" | "tracked-file" | "record-remove-failed";
 export type FingerprintReconciliationOutcome = "clean" | "adopted-legacy" | "removed-legacy" | "recovered-private" | "conflict" | "invalid-record" | "tracked-record" | "git-dir-unavailable" | "private-record-write-failed" | "legacy-remove-failed";
 
 export interface WriteSecretsEnvFileOptions {
@@ -41,10 +41,25 @@ export interface CleanupSecretsEnvFileOptions {
   taskId: string;
   expectedFingerprint: string | null;
   filename: string;
+  /** Allow legacy cleanup only after the orphan reaper has positively proven a dangling gitdir. */
+  allowLegacyCleanupForDanglingGitdir?: boolean;
+  /**
+   * Current-state revalidation for legacy orphan cleanup: called at the authorization
+   * boundary (after the awaited private-dir resolution) so the orphan reaper's earlier
+   * dangling verdict cannot authorize deleting a tracked .env from a worktree that a
+   * concurrent repair made live again.
+   */
+  isDanglingGitdir?: () => boolean;
   audit?: Pick<RunAuditor, "filesystem">;
   logger?: { log: (m: string) => void; warn: (m: string) => void };
   /** Test seam for proving cleanup never converts metadata-removal failures into success. */
   removeRecordPaths?: (recordPaths: string[]) => Promise<void>;
+  /** Test seam for proving ownership is revalidated at the deletion boundary. */
+  readFileImpl?: typeof fs.readFile;
+  /** Test seam for proving the pathname is atomically quarantined before removal. */
+  renameFileImpl?: typeof fs.rename;
+  /** Run the destructive worktree removal while the managed inode is quarantined. */
+  onVerifiedBeforeDelete?: () => Promise<void>;
 }
 
 export interface CleanupSecretsEnvFileResult {
@@ -129,6 +144,49 @@ async function resolvePrivateRecordPath(worktreePath: string): Promise<string> {
   const gitDir = stdout.trim();
   if (!gitDir) throw new Error("git-dir-empty");
   return path.join(path.isAbsolute(gitDir) ? gitDir : path.resolve(worktreePath, gitDir), FINGERPRINT_FILE);
+}
+
+function isOwnedQuarantineArtifact(name: string, filename: string): boolean {
+  return name.startsWith(`${filename}.fusion-cleanup-`) && /^.+\.fusion-cleanup-\d+-(?:[0-9a-f-]+(?:\.deleting)?|recovery)$/u.test(name);
+}
+
+/**
+ * True when a worktree-relative porcelain path refers to a Fusion-owned env
+ * quarantine artifact (`.env.fusion-cleanup-<pid>-<uuid>[.deleting]`). The
+ * dirty probe uses this so removal never treats its own verified, parked
+ * cleanup inode as user content.
+ *
+ * Ownership is NOT inferred from the predictable basename: a user-authored
+ * ignored file could carry that quarantine-shaped name. The parked inode's
+ * on-disk content must match the recorded fingerprint for the managed `.env`
+ * (private git-dir record, falling back to the legacy root sidecar). Any
+ * quarantine-named file that is not fingerprint-proven stays dirty (fail
+ * closed) so a defensive removal refuses instead of deleting user content.
+ */
+export async function isOwnedEnvQuarantineArtifactPath(
+  worktreePath: string,
+  relativePath: string,
+): Promise<boolean> {
+  const unquoted = relativePath.trim().replace(/^"(.*)"$/u, "$1");
+  if (!isOwnedQuarantineArtifact(path.basename(unquoted), ".env")) return false;
+  if (path.isAbsolute(unquoted)) return false;
+  let body: string;
+  try {
+    body = await fs.readFile(path.join(worktreePath, unquoted), "utf8");
+  } catch {
+    return false;
+  }
+  const candidate = sha256(body);
+  const recordPaths: Array<[string, RecordFormat]> = [[path.join(worktreePath, FINGERPRINT_FILE), "legacy"]];
+  const privatePath = await resolvePrivateRecordPath(worktreePath).catch(() => undefined);
+  if (privatePath) recordPaths.unshift([privatePath, "private"]);
+  for (const [recordPath, format] of recordPaths) {
+    const state = await readRecord(recordPath, format);
+    if (state.kind === "valid" && state.record.filename === ".env" && state.record.fingerprint === candidate) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function recordsMatch(left: FingerprintRecord, right: FingerprintRecord): boolean {
@@ -407,6 +465,8 @@ export async function writeSecretsEnvFile(opts: WriteSecretsEnvFileOptions): Pro
 
 export async function cleanupSecretsEnvFile(opts: CleanupSecretsEnvFileOptions): Promise<CleanupSecretsEnvFileResult> {
   const removeRecords = opts.removeRecordPaths ?? removeRecordPaths;
+  const readFile = opts.readFileImpl ?? fs.readFile;
+  const renameFile = opts.renameFileImpl ?? fs.rename;
   try { await fs.access(opts.worktreePath); } catch { return { outcome: "cleaned", reason: "directory-missing" }; }
   const legacyPath = path.join(opts.worktreePath, FINGERPRINT_FILE);
   let privatePath: string | undefined;
@@ -414,16 +474,22 @@ export async function cleanupSecretsEnvFile(opts: CleanupSecretsEnvFileOptions):
     privatePath = await resolvePrivateRecordPath(opts.worktreePath);
   } catch {
     /*
-     * FNXC:SecretsEnvMaterialization 2026-08-08-03:23:
-     * A Git worktree whose private-dir lookup fails is not an orphan. Fail closed rather than treating its
-     * root record as orphan metadata, because that fallback could delete a tracked project file on a transient
-     * Git failure. Only a path with no .git entry can use legacy orphan cleanup.
+     * FNXC:SecretsEnvMaterialization 2026-08-17-16:45:
+     * The orphan reaper's dangling verdict predates this awaited git/private-dir
+     * resolution, which gave a concurrent repair time to recreate the admin entry
+     * the pointer references. Legacy cleanup is authorized only while the pointer
+     * is STILL positively dangling at this instant: a repaired worktree is live
+     * again and its tracked .env must never be deleted on a stale verdict (the
+     * tracked-file guard below runs only when a private path resolved).
      */
-    try {
-      await fs.lstat(path.join(opts.worktreePath, ".git"));
-      return { outcome: "skipped", reason: "invalid-record" };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return { outcome: "skipped", reason: "invalid-record" };
+    const stillDangling = opts.allowLegacyCleanupForDanglingGitdir && (opts.isDanglingGitdir?.() ?? false);
+    if (!stillDangling) {
+      try {
+        await fs.lstat(path.join(opts.worktreePath, ".git"));
+        return { outcome: "skipped", reason: "invalid-record" };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") return { outcome: "skipped", reason: "invalid-record" };
+      }
     }
   }
   if (privatePath) {
@@ -442,15 +508,66 @@ export async function cleanupSecretsEnvFile(opts: CleanupSecretsEnvFileOptions):
   if (!record) return { outcome: "skipped", reason: "no-record" };
   const recordPaths = [privateState, legacyState].flatMap((state) => state.kind === "valid" && recordsMatch(state.record, record) ? [state.record.path] : []);
   let body: string;
-  try { body = await fs.readFile(path.join(opts.worktreePath, record.filename), "utf8"); } catch {
+  try { body = await readFile(path.join(opts.worktreePath, record.filename), "utf8"); } catch {
+    // The managed pathname is missing. A previous cleanup may have quarantined
+    // the inode (rename) before crashing; restore it to the pathname via an
+    // exclusive link so the content is never stranded under the recovery prefix.
+    // With no quarantine the managed file is simply gone and the record can drop.
+    const quarantineEntries = (await fs.readdir(opts.worktreePath)).filter((name) => isOwnedQuarantineArtifact(name, record.filename));
+    if (quarantineEntries.length === 0) {
+      try {
+        await removeRecords(recordPaths);
+      } catch {
+        return { outcome: "skipped", reason: "record-remove-failed" };
+      }
+      return { outcome: "skipped", reason: "file-missing" };
+    }
+    const quarantinePaths = quarantineEntries.map((name) => path.join(opts.worktreePath, name));
+    let recoveredBody: string;
     try {
-      await removeRecords(recordPaths);
+      recoveredBody = await readFile(quarantinePaths[0], "utf8");
+      const recoveredBodies = await Promise.all(quarantinePaths.map((quarantinePath) => readFile(quarantinePath, "utf8")));
+      if (recoveredBodies.some((candidate) => sha256(candidate) !== sha256(recoveredBody))) {
+        return { outcome: "skipped", reason: "file-retained" };
+      }
+    } catch {
+      return { outcome: "skipped", reason: "file-retained" };
+    }
+    try {
+      await fs.link(quarantinePaths[0], path.join(opts.worktreePath, record.filename));
+    } catch {
+      // The pathname is occupied or the link failed: keep the recovery copy and
+      // ownership record so a later retry can converge.
+      return { outcome: "skipped", reason: "file-retained" };
+    }
+    // FNXC:SecretsEnvMaterialization 2026-08-18-19: Duplicate owned recovery copies may be left by interrupted cleanup. Reconcile only identical copies, then consume the recovery set after restoring one inode.
+    await Promise.all(quarantinePaths.map((quarantinePath) => fs.unlink(quarantinePath).catch(() => undefined)));
+    try {
+      body = await readFile(path.join(opts.worktreePath, record.filename), "utf8");
     } catch {
       return { outcome: "skipped", reason: "record-remove-failed" };
     }
-    return { outcome: "skipped", reason: "file-missing" };
   }
   if (sha256(body) !== record.fingerprint) {
+    try {
+      const quarantineEntries = (await fs.readdir(opts.worktreePath)).filter((name) => isOwnedQuarantineArtifact(name, record.filename));
+      for (const name of quarantineEntries) {
+        const quarantinePath = path.join(opts.worktreePath, name);
+        try {
+          if (sha256(await readFile(quarantinePath, "utf8")) === record.fingerprint) {
+            await fs.unlink(quarantinePath);
+          } else {
+            return { outcome: "skipped", reason: "file-retained" };
+          }
+        } catch {
+          return { outcome: "skipped", reason: "file-retained" };
+        }
+      }
+    } catch {
+      // Preserve ownership metadata when quarantine state cannot be inspected.
+      return { outcome: "skipped", reason: "file-retained" };
+    }
+
     try {
       await removeRecords(recordPaths);
     } catch {
@@ -466,7 +583,96 @@ export async function cleanupSecretsEnvFile(opts: CleanupSecretsEnvFileOptions):
     // Cleanup cannot prove ownership when Git cannot answer; preserve both content and record for retry.
     return { outcome: "skipped", reason: "tracked-file" };
   }
-  await fs.unlink(path.join(opts.worktreePath, record.filename));
+  // A pathname cannot be unlinked conditionally by Node: comparing it and then
+  // unlinking it would be TOCTOU-unsafe. Rename the pathname into a private
+  // quarantine name (atomic), re-verify the moved inode's content, then unlink
+  // the quarantine. A concurrent replacement either lands at the freed pathname
+  // (preserved) or is moved into quarantine and restored on mismatch; only the
+  // verified managed inode is ever removed.
+  const envPath = path.join(opts.worktreePath, record.filename);
+  const quarantinePath = `${envPath}.fusion-cleanup-${process.pid}-${randomUUID()}`;
+  // Follows the verified inode across its own quarantine rename so a recovery
+  // restore after the deletion-shaped move still finds the content (the original
+  // quarantinePath name is gone once quarantined under the .deleting pathname).
+  let activeQuarantinePath = quarantinePath;
+  try {
+    await renameFile(envPath, quarantinePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      return { outcome: "skipped", reason: "record-remove-failed" };
+    }
+    try {
+      await removeRecords(recordPaths);
+    } catch {
+      return { outcome: "skipped", reason: "record-remove-failed" };
+    }
+    return { outcome: "skipped", reason: "file-missing" };
+  }
+  // Put the quarantined inode back at envPath without ever clobbering a newer
+  // occupant (link fails with EEXIST); if the occupant already won, the
+  // quarantined file is dropped. Returns false when the restore link failed for
+  // a reason other than EEXIST: the quarantine is then the only surviving copy
+  // of this content and must be preserved as a recovery file, never unlinked.
+  const restoreQuarantine = async (): Promise<boolean> => {
+    try {
+      await fs.link(activeQuarantinePath, envPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        opts.logger?.warn(`secrets-env: restore link failed for quarantined ${record.filename}; preserved recovery copy at ${activeQuarantinePath}`);
+        return false;
+      }
+      // The pathname is occupied, but the quarantined inode is unverified.
+      // Keep it as recovery evidence; EEXIST is not proof it is safe to delete.
+      return false;
+    }
+    await fs.unlink(activeQuarantinePath).catch(() => undefined);
+    return true;
+  };
+  try {
+    if (sha256(await readFile(quarantinePath, "utf8")) !== record.fingerprint) {
+      // A concurrent replacement was moved into quarantine: restore it and drop
+      // the stale bookkeeping (the managed content is already gone).
+      if (!await restoreQuarantine()) return { outcome: "skipped", reason: "file-retained" };
+      try {
+        await removeRecords(recordPaths);
+      } catch {
+        return { outcome: "skipped", reason: "record-remove-failed" };
+      }
+      return { outcome: "skipped", reason: "fingerprint-mismatch" };
+    }
+  } catch {
+    // The quarantined inode cannot be read (permissions): restore it and fail closed.
+    await restoreQuarantine();
+    return { outcome: "skipped", reason: "record-remove-failed" };
+  }
+  const quarantinedStat = await fs.lstat(quarantinePath);
+  // ponytail: rename the verified inode away before unlink; the old pathname cannot be swapped under us.
+  if (!privatePath && opts.allowLegacyCleanupForDanglingGitdir && !(opts.isDanglingGitdir?.() ?? false)) {
+    await restoreQuarantine();
+    return { outcome: "skipped", reason: "invalid-record" };
+  }
+  const deletionPath = `${quarantinePath}.deleting`;
+  try {
+    await fs.rename(quarantinePath, deletionPath);
+    activeQuarantinePath = deletionPath;
+    const deletionStat = await fs.lstat(deletionPath);
+    if (deletionStat.dev !== quarantinedStat.dev || deletionStat.ino !== quarantinedStat.ino) {
+      return { outcome: "skipped", reason: "file-retained" };
+    }
+    // FNXC:SecretsEnvMaterialization 2026-08-18-15: Revalidate after every awaited
+    // boundary so a repaired dangling worktree cannot lose its managed inode.
+    if (!privatePath && opts.allowLegacyCleanupForDanglingGitdir && !(opts.isDanglingGitdir?.() ?? false)) {
+      await restoreQuarantine();
+      return { outcome: "skipped", reason: "invalid-record" };
+    }
+    await opts.onVerifiedBeforeDelete?.();
+    await fs.unlink(deletionPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      try { await restoreQuarantine(); } catch { /* retain recovery copy */ }
+      return { outcome: "skipped", reason: "record-remove-failed" };
+    }
+  }
   try {
     await removeRecords(recordPaths);
   } catch {

--- a/packages/engine/src/worktree/worktree-acquisition.ts
+++ b/packages/engine/src/worktree/worktree-acquisition.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
 import { exec } from "node:child_process";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -40,8 +40,9 @@ import {
 } from "./worktrunk-failure-handler.js";
 import { resolveWorkspaceReviewRemediationRepository } from "../executor/workspace-review-remediation.js";
 import type { RunAuditor } from "../util/run-audit.js";
-import { reconcileSecretsEnvFingerprint, writeSecretsEnvFile } from "./secrets-env-writer.js";
+import { cleanupSecretsEnvFile, reconcileSecretsEnvFingerprint, writeSecretsEnvFile } from "./secrets-env-writer.js";
 import { removeDesktopBuildArtifacts } from "./worktree-desktop-artifacts.js";
+import { ensureContainedDirectory, preserveGeneratedResidue } from "./worktree-generated-residue.js";
 import { installTaskWorktreeIdentityGuard } from "./worktree-hooks.js";
 import { copyConfiguredWorktreeFiles, type WorktreeCopyFileResult } from "./worktree-copy-files.js";
 import { resolveCapturedBaseCommitSha } from "../execution/base-commit-capture.js";
@@ -53,8 +54,6 @@ import { normalizeWorkspaceTaskRouting } from "../executor/workspace-config-reso
 
 const execAsync = promisify(exec);
 const WORKTREE_BACKEND_MARKER = "fusion-worktree-backend-kind";
-const PRESERVED_ORPHAN_RETENTION_COUNT = 10;
-const PRESERVED_ORPHAN_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 async function resolveWorktreeBackendMarkerPath(worktreePath: string): Promise<string> {
   const { stdout } = await execAsync(`git rev-parse --git-path ${JSON.stringify(WORKTREE_BACKEND_MARKER)}`, {
@@ -175,80 +174,6 @@ export class RepoRootWorktreeError extends Error {
 }
 
 const INIT_OUTCOME_MAX_CHARS = 2_000;
-
-async function ensureContainedDirectory(parentCanonicalPath: string, name: string): Promise<string> {
-  const candidate = join(parentCanonicalPath, name);
-  try {
-    await mkdir(candidate);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-  }
-  const canonicalCandidate = await realpath(candidate);
-  const candidateRelative = relative(parentCanonicalPath, canonicalCandidate);
-  if (candidateRelative === "" || candidateRelative.startsWith("..") || isAbsolute(candidateRelative)) {
-    throw new Error(`Refusing to use recovery directory outside ${parentCanonicalPath}: ${canonicalCandidate}`);
-  }
-  if (!(await stat(canonicalCandidate)).isDirectory()) {
-    throw new Error(`Refusing to use non-directory recovery path: ${canonicalCandidate}`);
-  }
-  return canonicalCandidate;
-}
-
-interface PreservedOrphanCandidate {
-  path: string;
-  canonicalPath: string;
-  mtimeMs: number;
-}
-
-async function inspectPreservedOrphanCandidate(
-  canonicalRecoveryRoot: string,
-  name: string,
-): Promise<PreservedOrphanCandidate | null> {
-  if (!PRESERVED_ORPHAN_NAME_PATTERN.test(name)) return null;
-  const path = join(canonicalRecoveryRoot, name);
-  try {
-    const pathStat = await lstat(path);
-    if (!pathStat.isDirectory() || pathStat.isSymbolicLink()) return null;
-    const canonicalPath = await realpath(path);
-    const candidateRelative = relative(canonicalRecoveryRoot, canonicalPath);
-    if (candidateRelative !== name || candidateRelative.includes("/") || candidateRelative.includes("\\") || isAbsolute(candidateRelative)) {
-      return null;
-    }
-    return { path, canonicalPath, mtimeMs: pathStat.mtimeMs };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * FNXC:TaskPinnedWorktrees 2026-08-10-01:12:
- * Each actual orphan-recovery root retains its newest ten generated task-id-plus-UUID directories. Pruning is fail-soft and removes only direct canonical non-symlink directories after an immediate active-session check; unknown, unstatable, or active entries are preserved.
- */
-async function prunePreservedOrphanDirectories(
-  canonicalRecoveryRoot: string,
-  logger?: { warn: (message: string) => void },
-): Promise<void> {
-  try {
-    const entries = await readdir(canonicalRecoveryRoot, { withFileTypes: true });
-    const candidates = (await Promise.all(entries.map((entry) =>
-      inspectPreservedOrphanCandidate(canonicalRecoveryRoot, entry.name))))
-      .filter((candidate): candidate is PreservedOrphanCandidate => candidate !== null)
-      .sort((left, right) => right.mtimeMs - left.mtimeMs || right.path.localeCompare(left.path));
-
-    for (const candidate of candidates.slice(PRESERVED_ORPHAN_RETENTION_COUNT)) {
-      try {
-        const current = await inspectPreservedOrphanCandidate(canonicalRecoveryRoot, candidate.path.slice(canonicalRecoveryRoot.length + 1));
-        if (!current || current.canonicalPath !== candidate.canonicalPath) continue;
-        if (activeSessionRegistry.isPathActive(current.path) || activeSessionRegistry.isPathActive(current.canonicalPath)) continue;
-        await rm(current.path, { recursive: true, force: true });
-      } catch (error) {
-        logger?.warn(`Failed to prune preserved orphan directory ${candidate.path}: ${formatError(error).message}`);
-      }
-    }
-  } catch (error) {
-    logger?.warn(`Failed to inspect preserved orphan retention root ${canonicalRecoveryRoot}: ${formatError(error).message}`);
-  }
-}
 
 function configuredCommandErrorMessage(result: { spawnError?: string | Error; timedOut?: boolean; exitCode?: number | null }): string {
   if (result.spawnError) return `Failed to start command: ${result.spawnError}`;
@@ -1025,16 +950,36 @@ export async function acquireTaskWorktree(opts: AcquireTaskWorktreeOptions): Pro
             } catch (error) {
               logger?.warn(`${task.id}: failed to log preserved orphan ${preservedPath}: ${formatError(error).message}`);
             }
-            await prunePreservedOrphanDirectories(actualRecoveryRoot, logger);
           } else {
-            await removeWorktree({
+            const restoreGeneratedResidue = await preserveGeneratedResidue(pinnedPath, rootDir, logger);
+            const removeStalePinnedWorktree = () => removeWorktree({
               rootDir,
               worktreePath: pinnedPath,
               settings,
               reason: RemovalReason.PoolPrune,
               taskId: task.id,
               audit: undefined,
+            }).then(() => undefined);
+            const cleanupResult = await cleanupSecretsEnvFile({
+              worktreePath: pinnedPath,
+              taskId: task.id,
+              expectedFingerprint: null,
+              filename: ".env",
+              audit: undefined,
+              logger,
+              onVerifiedBeforeDelete: removeStalePinnedWorktree,
             });
+            if (cleanupResult.outcome === "cleaned") {
+              await restoreGeneratedResidue(true);
+            } else {
+              try {
+                await removeStalePinnedWorktree();
+              } catch (error) {
+                await restoreGeneratedResidue();
+                throw error;
+              }
+              await restoreGeneratedResidue(true);
+            }
           }
         } catch (removeErr) {
           /*

--- a/packages/engine/src/worktree/worktree-backend.ts
+++ b/packages/engine/src/worktree/worktree-backend.ts
@@ -1,5 +1,5 @@
-import { exec } from "node:child_process";
-import { existsSync } from "node:fs";
+import { exec, execFile } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
 import { access, rm } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -11,10 +11,12 @@ import {
   type ProcessActiveProbe,
 } from "../agents/active-session-registry.js";
 import type { RunAuditor } from "../util/run-audit.js";
-import { resolveTaskWorktreePath } from "./worktree-paths.js";
+import { resolveTaskWorktreePath, resolveWorktreesDir } from "./worktree-paths.js";
 import { inspectBareBranchCollision, inspectBranchConflict } from "../execution/branch-conflicts.js";
 import { resolveIntegrationBranch } from "../merge/integration-branch.js";
 import { formatError } from "../logger.js";
+import { preserveCorruptRegisteredRoot } from "./worktree-generated-residue.js";
+import { isOwnedEnvQuarantineArtifactPath } from "./secrets-env-writer.js";
 import { installTaskWorktreeIdentityGuard } from "./worktree-hooks.js";
 import { pruneWorktreeAdminEntries } from "./worktree-prune.js";
 import { isRetryableRemovalError, removeDirectoryWithRetry } from "./worktree-removal-retry.js";
@@ -27,13 +29,21 @@ import {
 import { parseStaleRegistrationPath, recoverStaleRegistration } from "./worktree-stale-registration.js";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const NATIVE_TIMEOUT_MS = 120_000;
 const REMOVE_TIMEOUT_MS = 60_000;
 const MAX_BUFFER = 10 * 1024 * 1024;
 
+function canonicalWorktreePath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
 
 export type WorktreeRemoveOutcome =
-  | { removed: true; classification: "removed" }
+  | { removed: true; classification: "removed"; preservedPath?: string }
   | {
       removed: false;
       harmless: true;
@@ -216,6 +226,7 @@ export interface WorktreeRemoveInput {
   worktreePath: string;
   branch?: string;
   taskId?: string;
+  force?: boolean;
 }
 
 export interface WorktreeSyncInput {
@@ -678,8 +689,11 @@ export class NativeWorktreeBackend implements WorktreeBackend {
   }
 
   async remove(input: WorktreeRemoveInput): Promise<void> {
+    // FNXC:WorktreeCleanup 2026-08-15-13:45: explicit false lets Git revalidate
+    // cleanliness; omission preserves the backend's legacy forced removal.
+    const force = input.force !== false;
     try {
-      await execAsync(`git worktree remove --force ${quoteShellArg(input.worktreePath)}`, {
+      await execAsync(`git worktree remove${force ? " --force" : ""} ${quoteShellArg(input.worktreePath)}`, {
         cwd: input.rootDir,
         encoding: "utf-8",
         timeout: REMOVE_TIMEOUT_MS,
@@ -687,6 +701,20 @@ export class NativeWorktreeBackend implements WorktreeBackend {
       });
       return;
     } catch (error) {
+      if (!force) {
+        const missingPathError = /is not a working tree|no such file or directory|does not exist/i.test(getErrorMessageWithStderr(error));
+        if (!existsSync(input.worktreePath) && missingPathError) {
+          await pruneWorktreeAdminEntries({
+            rootDir: input.rootDir,
+            auditor: this.deps.audit,
+            reason: "remove-missing-fallback",
+            target: input.worktreePath,
+            logger: this.deps.logger,
+          });
+          return;
+        }
+        throw error;
+      }
       if (!isRecoverableNativeWorktreeRemoveError(error)) {
         throw error;
       }
@@ -950,8 +978,9 @@ export class WorktrunkWorktreeBackend implements WorktreeBackend {
 
   async remove(input: WorktreeRemoveInput): Promise<void> {
     const target = input.branch ?? input.worktreePath;
+    const args = ["remove", "--foreground", ...(input.force ? ["--force"] : []), target];
     try {
-      await this.runWorktrunk(["remove", "--foreground", target], {
+      await this.runWorktrunk(args, {
         cwd: input.rootDir,
         operation: "remove",
       });
@@ -1165,11 +1194,130 @@ export async function removeWorktree(input: {
   }
 
   const backend = resolveWorktreeBackend(input.settings, { logger, audit: input.audit });
+  const requiresDirtyRevalidation = input.reason === RemovalReason.SelfHealingIdleSweep || input.reason === RemovalReason.PoolPrune;
+  let allowCorruptRegisteredRemoval = false;
+  if (requiresDirtyRevalidation) {
+    let rootOutput = "";
+    try {
+      ({ stdout: rootOutput } = await execFileAsync("git", ["-C", input.worktreePath, "rev-parse", "--show-toplevel"], {
+        cwd: input.rootDir,
+        timeout: 15_000,
+        maxBuffer: MAX_BUFFER,
+      }));
+    } catch {
+      if (existsSync(input.worktreePath)) {
+        // A registered checkout can lose its `.git` metadata after an interrupted
+        // cleanup. The root probe is then impossible, but the registration still
+        // scopes the removal; let the backend prune the corrupt directory.
+        let registered = false;
+        try {
+          const { stdout } = await execAsync("git worktree list --porcelain", {
+            cwd: input.rootDir,
+            encoding: "utf-8",
+            timeout: 15_000,
+            maxBuffer: MAX_BUFFER,
+          });
+          registered = porcelainContainsWorktree(String(stdout), input.worktreePath);
+        } catch {
+          // Fail closed when registration itself cannot be verified.
+        }
+        if (!registered) {
+          throw new Error(`refusing to remove worktree with unverifiable root: ${input.worktreePath}`);
+        }
+        allowCorruptRegisteredRemoval = true;
+      }
+    }
+    if (rootOutput && canonicalWorktreePath(rootOutput.trim()) !== canonicalWorktreePath(input.worktreePath)) {
+      let registered = false;
+      try {
+        const { stdout } = await execAsync("git worktree list --porcelain", {
+          cwd: input.rootDir,
+          encoding: "utf-8",
+          timeout: 15_000,
+          maxBuffer: MAX_BUFFER,
+        });
+        registered = porcelainContainsWorktree(String(stdout), input.worktreePath);
+      } catch {
+        // Fail closed when registration itself cannot be verified.
+      }
+      if (!registered) {
+        throw new Error(`refusing to remove worktree with unverifiable root: ${input.worktreePath}`);
+      }
+      allowCorruptRegisteredRemoval = true;
+      rootOutput = "";
+    }
+    if (rootOutput) {
+      const { stdout: statusOutput } = await execFileAsync("git", ["-C", input.worktreePath, "status", "--porcelain", "--untracked-files=all", "--ignored"], {
+        cwd: input.rootDir,
+        timeout: 15_000,
+        maxBuffer: MAX_BUFFER,
+      });
+      // FNXC:WorktreeCleanup 2026-08-19-15:09: a fingerprint-owned managed .env
+      // parked mid-cleanup under `.env.fusion-cleanup-<pid>-<uuid>.deleting` is
+      // Fusion's own quarantine inode, not user content. The pinned-reclaim flow
+      // runs this probe from cleanupSecretsEnvFile's onVerifiedBeforeDelete while
+      // the verified inode still carries the quarantine name; counting it as dirty
+      // makes a generated-only reclaim refuse forever (Greptile P1: "Quarantine
+      // blocks generated-only reclaim"). Ownership must be fingerprint/content
+      // verified (not guessed from the predictable basename): a user-authored
+      // ignored file that merely carries a quarantine-shaped name stays dirty so
+      // removal refuses (Greptile P1: "Quarantine name bypasses dirty check"). All
+      // other porcelain lines (tracked edits, untracked files, ignored residue)
+      // still refuse as before.
+      const unsafeStatusLines: string[] = [];
+      for (const line of statusOutput.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        // porcelain v1 line: "XY <path>" — strip the two status chars + space.
+        const relativePath = trimmed.length > 3 ? trimmed.slice(3) : trimmed;
+        if (await isOwnedEnvQuarantineArtifactPath(input.worktreePath, relativePath)) continue;
+        unsafeStatusLines.push(line);
+      }
+      const hasUnsafeStatus = unsafeStatusLines.length > 0;
+      if (hasUnsafeStatus) {
+        throw new Error(`refusing to remove dirty worktree: ${input.worktreePath}`);
+      }
+    }
+  }
+
+  const nativeForce = input.force === true || (input.force !== false && !requiresDirtyRevalidation);
   const removeInput: WorktreeRemoveInput = {
     rootDir: input.rootDir,
     worktreePath: input.worktreePath,
     taskId: input.taskId,
+    force: backend.kind === "native" ? nativeForce || allowCorruptRegisteredRemoval : input.force,
   };
+
+  if (allowCorruptRegisteredRemoval && backend.kind === "native") {
+    let preservedPath: string;
+    try {
+      preservedPath = await preserveCorruptRegisteredRoot(
+        input.worktreePath,
+        input.rootDir,
+        resolveWorktreesDir(input.rootDir, input.settings),
+      );
+    } catch (error) {
+      await input.audit?.git({
+        type: "worktree:corrupt-preserve-failed",
+        target: input.worktreePath,
+        metadata: { reason: input.reason, error: previewError(error) },
+      });
+      throw error;
+    }
+    await input.audit?.git({
+      type: "worktree:corrupt-registered-preserved",
+      target: input.worktreePath,
+      metadata: { reason: input.reason, preservedPath },
+    });
+    await pruneWorktreeAdminEntries({
+      rootDir: input.rootDir,
+      auditor: input.audit,
+      reason: "remove-corrupt-registered-worktree",
+      target: input.worktreePath,
+      logger,
+    });
+    return { removed: true, classification: "removed", preservedPath };
+  }
 
   if (input.force === false || typeof input.timeout === "number") {
     // Backwards-compatible helper signature for callers that carried raw git flags/timeouts.
@@ -1207,7 +1355,7 @@ export async function removeWorktree(input: {
 
     const native = new NativeWorktreeBackend({ logger, settings: input.settings });
     try {
-      await native.remove(removeInput);
+      await native.remove({ ...removeInput, force: nativeForce });
       await input.audit?.git({ type: "worktree:remove", target: input.worktreePath });
       return { removed: true, classification: "removed" };
     } catch (nativeError) {

--- a/packages/engine/src/worktree/worktree-generated-residue.ts
+++ b/packages/engine/src/worktree/worktree-generated-residue.ts
@@ -1,0 +1,353 @@
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, readdir, realpath, rename, stat } from "node:fs/promises";
+import { exec } from "node:child_process";
+import { isAbsolute, join, relative } from "node:path";
+import { promisify } from "node:util";
+import { formatError } from "../logger.js";
+import { WORKTREE_RECOVERY_DIRNAME } from "./worktree-paths.js";
+
+const execAsync = promisify(exec);
+
+const PACKAGE_MANAGER_MARKERS = [".package-lock.json", ".yarn-integrity", ".modules.yaml", ".pnpm"] as const;
+
+// Recognized names/extensions inside an installed package directory. Anything
+// else (notes.txt, custom.env, settings.config, an extensionless file that is
+// not a license/readme, a stray .yaml/.log) fails the whole directory closed,
+// because a user can drop a hand-authored ignored file inside node_modules.
+const GENERATED_PACKAGE_FILES = new Set([
+  "package.json",
+  "package-lock.json",
+  "README.md", "README.txt", "README",
+  "LICENSE", "LICENSE.md", "LICENSE.txt",
+  "CHANGELOG.md", "CHANGELOG",
+  "NOTICE",
+  "index.js", "index.mjs", "index.cjs", "index.d.ts",
+]);
+
+const GENERATED_PACKAGE_EXTENSIONS = [
+  ".js", ".mjs", ".cjs", ".d.ts", ".tsbuildinfo",
+  ".json", ".node", ".wasm", ".map",
+  ".css", ".html", ".svg", ".png", ".jpg", ".jpeg",
+  ".gif", ".webp", ".ico", ".woff", ".woff2", ".ttf", ".eot",
+] as const;
+
+function isGeneratedPackageEntry(entry: string): boolean {
+  if (GENERATED_PACKAGE_FILES.has(entry)) return true;
+  return GENERATED_PACKAGE_EXTENSIONS.some((ext) => entry.endsWith(ext));
+}
+
+/**
+ * Walk an installed package directory (depth-limited) and return false as soon
+ * as any entry is not provably package-manager output. This is what makes the
+ * nested case fail closed: a `node_modules/pkg/user-notes.txt` (or any file
+ * that is not a build artifact, manifest, readme, or license) stops the whole
+ * node_modules directory from being moved ahead of the dirty probe.
+ */
+async function packageDirIsGenerated(packageDir: string, depth: number): Promise<boolean> {
+  let entries: string[];
+  try {
+    entries = await readdir(packageDir);
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (isGeneratedPackageEntry(entry)) continue;
+    let subEntries: string[];
+    try {
+      subEntries = await readdir(join(packageDir, entry));
+    } catch {
+      // A file that is not a recognized package artifact (e.g. user-notes.txt,
+      // custom.env, settings.config, extensionless): user content, fail closed.
+      return false;
+    }
+    if (depth <= 0 || !subEntries.length) {
+      // Dir we cannot prove generated at this depth is fail-closed, except the
+      // common package subdir shapes that are always generated.
+      if (GENERATED_PACKAGE_FILES.has(entry) || GENERATED_PACKAGE_EXTENSIONS.some((ext) => entry.endsWith(ext))) continue;
+      return false;
+    }
+    if (!(await packageDirIsGenerated(join(packageDir, entry), depth - 1))) return false;
+  }
+  return true;
+}
+
+// Recognized build-output shapes for dist/. A sourcemap alone does NOT prove
+// the whole directory is generated — every executable file must carry its own
+// .map companion (build tools emit bundle.js + bundle.js.map together), and a
+// lone .json/.svg/.xml may be hand-authored, so it only passes when emitted by
+// an accompanying sourcemap. Anything else fails the whole directory closed.
+const DIST_EXECUTABLE_EXTENSIONS = [".js", ".mjs", ".cjs", ".css", ".html"] as const;
+
+/**
+ * A git-ignored sibling (node_modules, dist) only counts as generated residue
+ * worth moving ahead of the dirty probe when its contents are PROVABLY
+ * generated output. A directory that merely carries a generated-looking name
+ * (Greptile: residue provenance) may hold user-authored ignored content, so it
+ * must NOT be moved: leaving it in place makes the removal's dirty probe fail
+ * closed and the checkout stays valid. Returns true only for structure that
+ * cannot be hand-authored in any realistic sense.
+ *
+ * A SINGLE recognized marker must not classify a MIXED directory as generated
+ * (Greptile: "Mixed residue bypasses validation"). When a marker sits next to
+ * user-authored ignored content, EVERY entry must still look generated, or the
+ * directory is left in place so the dirty probe refuses the removal.
+ *
+ * Greptile (4/5, "generated-looking extensions"): filename extensions are not
+ * proof. A `dist` with one sourcemap plus arbitrary `.js`/`.json` files, or a
+ * `node_modules` package with a manifest plus hand-placed JS/JSON, would move
+ * user-authored content. Proof is therefore per-file:
+ *   - dist: every executable file MUST have its own `.map` companion in the
+ *     same directory (bundlers emit bundle.js + bundle.js.map together); the
+ *     only bare JSON allowed is a build manifest (package.json / manifest.json
+ *     / tsconfig.tsbuildinfo).
+ *   - node_modules: a package is only accepted when the worktree's root
+ *     package-lock.json actually lists it (`node_modules/<name>` under
+ *     "packages"), i.e. the package manager installed it. No lockfile or
+ *     unknown package -> fail closed, keep in place.
+ */
+async function looksGeneratedResidue(worktreePath: string, name: string): Promise<boolean> {
+  const dir = join(worktreePath, name);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return false;
+  }
+  if (name === "node_modules") {
+    // A real dependency install always carries a package-manager marker or at
+    // least one installed package subdir with its own manifest. Require EVERY
+    // top-level entry to be a known marker or a package dir; any stray plain
+    // file or unknown directory next to a marker fails closed. Package dirs
+    // are also inspected recursively (depth-limited) so a nested user-authored
+    // file (e.g. `node_modules/pkg/user-notes.txt`) fails the whole directory.
+    // Installed packages must be listed in the root package-lock.json; a
+    // hand-assembled package.json + user .js/.json is not install proof.
+    let installedNames: Set<string> | null = null;
+    try {
+      const lock = JSON.parse(await readFile(join(worktreePath, "package-lock.json"), "utf8"));
+      const names = new Set<string>();
+      for (const key of Object.keys(lock.packages ?? {})) {
+        if (key.startsWith("node_modules/")) names.add(key.slice("node_modules/".length));
+      }
+      for (const dep of Object.keys(lock.dependencies ?? {})) names.add(dep);
+      installedNames = names;
+    } catch {
+      installedNames = null;
+    }
+    let sawInstallEvidence = false;
+    for (const entry of entries) {
+      if ((PACKAGE_MANAGER_MARKERS as readonly string[]).includes(entry)) {
+        sawInstallEvidence = true;
+        continue;
+      }
+      let sub: string[];
+      try {
+        sub = await readdir(join(dir, entry));
+      } catch {
+        // A top-level plain file (not a marker) is user content: fail closed.
+        return false;
+      }
+      if (sub.includes("package.json")) {
+        sawInstallEvidence = true;
+        // Greptile (4/5): a package manifest plus .js/.json inside it is not
+        // proof of an install — the lockfile must list this package. Without
+        // the lockfile or without this entry, fail closed.
+        if (installedNames === null || !installedNames.has(entry)) return false;
+        // Inspect nested package contents: any user-authored file inside the
+        // package (notes.txt, custom.env, settings.config, extensionless)
+        // fails the whole node_modules directory closed.
+        if (!(await packageDirIsGenerated(join(dir, entry), 3))) return false;
+        continue;
+      }
+      // Scoped package dirs (@scope/pkg) hold package.json one level deeper.
+      if (entry.startsWith("@")) {
+        let scoped = false;
+        for (const scopeEntry of sub) {
+          try {
+            const scopeSub = await readdir(join(dir, entry, scopeEntry));
+            if (scopeSub.includes("package.json")) {
+              scoped = true;
+              if (installedNames === null || !installedNames.has(`${entry}/${scopeEntry}`)) return false;
+              if (!(await packageDirIsGenerated(join(dir, entry, scopeEntry), 3))) return false;
+              break;
+            }
+          } catch {
+            // ignore unreadable scope entries; fall through
+          }
+        }
+        if (scoped) {
+          sawInstallEvidence = true;
+          continue;
+        }
+      }
+      // A directory that is neither a marker nor a package dir may be
+      // user-authored ignored content: fail closed.
+      return false;
+    }
+    return sawInstallEvidence && entries.length > 0;
+  }
+  if (name === "dist") {
+    // Build output requires proof per file: every executable entry must carry
+    // its own sourcemap companion (bundle.js + bundle.js.map). `.map`, `.d.ts`
+    // and `.tsbuildinfo` are build metadata. The only bare JSON accepted is a
+    // build manifest (package.json / manifest.json). A lonely `.js`/`.json`/
+    // asset without its own `.map` may be user-authored (Greptile 4/5) and
+    // fails the whole directory closed.
+    const isBuildMetadata = (e: string) =>
+      e.endsWith(".map") || e.endsWith(".d.ts") || e.endsWith(".tsbuildinfo") ||
+      e === "package.json" || e === "manifest.json";
+    const hasMapCompanion = (e: string) => entries.includes(`${e}.map`);
+    let sawSourcemap = false;
+    for (const entry of entries) {
+      if (isBuildMetadata(entry)) {
+        if (entry.endsWith(".map")) sawSourcemap = true;
+        continue;
+      }
+      if (DIST_EXECUTABLE_EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+        if (!hasMapCompanion(entry)) return false;
+        sawSourcemap = true;
+        continue;
+      }
+      // A file that is neither metadata nor an executables-with-map pair is
+      // user-authored ignored content (e.g. `data.json`, `user.png`).
+      return false;
+    }
+    return sawSourcemap && entries.length > 0;
+  }
+  return false;
+}
+
+/**
+ * Create (or resolve) a direct child directory of a canonical parent, refusing
+ * to follow symlinked ancestors or escape the parent. Recovery/containment
+ * paths that cross into unowned locations must fail closed before any
+ * preserve/rename moves orphan contents.
+ */
+export async function ensureContainedDirectory(parentCanonicalPath: string, name: string): Promise<string> {
+  const candidate = join(parentCanonicalPath, name);
+  try {
+    await mkdir(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+  const canonicalCandidate = await realpath(candidate);
+  const candidateRelative = relative(parentCanonicalPath, canonicalCandidate);
+  if (candidateRelative === "" || candidateRelative.startsWith("..") || isAbsolute(candidateRelative)) {
+    throw new Error(`Refusing to use recovery directory outside ${parentCanonicalPath}: ${canonicalCandidate}`);
+  }
+  if (!(await stat(canonicalCandidate)).isDirectory()) {
+    throw new Error(`Refusing to use non-directory recovery path: ${canonicalCandidate}`);
+  }
+  return canonicalCandidate;
+}
+
+/**
+ * Preserve git-ignored generated residue (node_modules, dist) of a worktree
+ * being reclaimed, by moving it into the Fusion recovery area instead of
+ * deleting it. Removal probes include `--ignored`, so any ignored content
+ * would otherwise refuse the reclaim and strand the worktree forever — yet the
+ * directory may still hold user-authored files, so nothing is ever deleted.
+ *
+ * Tracked or otherwise non-ignored content is user content: it is preserved in
+ * place and the caller's dirty probe fails closed below. Any failure preserves
+ * in place too.
+ */
+export async function preserveGeneratedResidue(
+  worktreePath: string,
+  rootDir: string,
+  logger?: { warn: (m: string) => void },
+): Promise<(removedSuccessfully?: boolean) => Promise<void>> {
+  const moved: Array<{ source: string; preserved: string }> = [];
+  for (const name of ["node_modules", "dist"] as const) {
+    const path = join(worktreePath, name);
+    if (!existsSync(path)) continue;
+    try {
+      await execAsync(`git check-ignore -q -- ${JSON.stringify(name)}`, { cwd: worktreePath });
+    } catch {
+      // Tracked or otherwise non-ignored content is user content: preserve it in
+      // place and let removeWorktree's dirty probe fail closed below.
+      continue;
+    }
+    // Greptile (residue provenance): a git-ignored sibling only earns moving
+    // ahead of the dirty probe when it is PROVABLY generated output. A merely
+    // generated-looking dir may hold user-authored ignored files; leaving it
+    // in place fails the removal cleanly and keeps the checkout valid.
+    if (!(await looksGeneratedResidue(worktreePath, name))) continue;
+    try {
+      const canonicalRoot = await realpath(rootDir);
+      const fusionRoot = await ensureContainedDirectory(canonicalRoot, ".fusion");
+      const recoveryRoot = await ensureContainedDirectory(fusionRoot, "recovery");
+      const worktreesRecovery = await ensureContainedDirectory(recoveryRoot, "worktrees");
+      const preservedPath = join(worktreesRecovery, `residue-${randomUUID()}`);
+      await rename(path, preservedPath);
+      moved.push({ source: path, preserved: preservedPath });
+    } catch (error) {
+      // Preserve in place on any failure; removeWorktree's dirty probe fails closed.
+      logger?.warn(`Failed to preserve generated residue at ${path}: ${formatError(error).message}`);
+    }
+  }
+  return async (removedSuccessfully = false) => {
+    if (removedSuccessfully) {
+      // Greptile (find: residue discarded on success): the preserved directory may hold
+      // user-authored ignored files beneath node_modules/dist. It is moved to the
+      // CONTAINED recovery area (never deleted) so a reclaim proceeds without destroying
+      // those recoverable files. On successful removal there is no source to restore
+      // into, so the residue simply remains in recovery for manual recovery rather than
+      // being recursively discarded.
+      return;
+    }
+    const failures: string[] = [];
+    // Greptile: attempt EVERY moved entry so a conflicted/recreating source does not
+    // strand its sibling dirs in recovery; report all failures after the loop.
+    for (const { source, preserved } of moved.reverse()) {
+      if (!existsSync(preserved)) continue;
+      if (existsSync(source)) {
+        failures.push(`Failed to restore generated residue at ${source}: source was recreated`);
+        continue;
+      }
+      try {
+        await rename(preserved, source);
+      } catch (error) {
+        failures.push(`Failed to restore generated residue at ${source}: ${formatError(error).message}`);
+      }
+    }
+    if (failures.length > 0) {
+      throw new Error(failures.join("\n"));
+    }
+  };
+}
+
+/**
+ * Preserve a registered worktree whose checkout ROOT can no longer be probed
+ * (e.g. its `.git` pointer was lost after an interrupted cleanup). Because the
+ * directory's dirty state cannot be assessed, it is never deleted: the whole
+ * root is renamed into the contained recovery area and the caller prunes only
+ * the admin registration entry. Fails closed — any failure throws rather than
+ * falling through to deletion.
+ */
+export async function preserveCorruptRegisteredRoot(
+  worktreePath: string,
+  rootDir: string,
+  worktreesRoot?: string,
+  renameDirectory: typeof rename = rename,
+): Promise<string> {
+  const canonicalRoot = await realpath(rootDir);
+  const fusionRoot = await ensureContainedDirectory(canonicalRoot, ".fusion");
+  const recoveryRoot = await ensureContainedDirectory(fusionRoot, "recovery");
+  const worktreesRecovery = await ensureContainedDirectory(recoveryRoot, "worktrees");
+  let preservedPath = join(worktreesRecovery, `corrupt-${randomUUID()}`);
+  try {
+    await renameDirectory(worktreePath, preservedPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EXDEV" || !worktreesRoot) {
+      throw new Error(`Failed to preserve corrupt registered worktree ${worktreePath} in ${preservedPath}: ${formatError(error).message}`);
+    }
+    const canonicalWorktreesRoot = await realpath(worktreesRoot);
+    const localRecoveryRoot = await ensureContainedDirectory(canonicalWorktreesRoot, WORKTREE_RECOVERY_DIRNAME);
+    const localRecoveryWorktrees = await ensureContainedDirectory(localRecoveryRoot, "worktrees");
+    preservedPath = join(localRecoveryWorktrees, `corrupt-${randomUUID()}`);
+    await renameDirectory(worktreePath, preservedPath);
+  }
+  return preservedPath;
+}

--- a/packages/engine/src/worktree/worktree-pool.ts
+++ b/packages/engine/src/worktree/worktree-pool.ts
@@ -1,6 +1,6 @@
 import { exec, execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, realpathSync } from "node:fs";
+import { constants, copyFileSync, existsSync, linkSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, rmdirSync, unlinkSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, isAbsolute } from "node:path";
 import type { SecretsStore, Settings, TaskStore, WorktrunkSettings, WorkspaceWorktreeContext } from "@fusion/core";
@@ -8,7 +8,7 @@ import { assertCleanBranchAtBase, inspectBranchConflict } from "../execution/bra
 import { worktreePoolLog } from "../logger.js";
 /*
 */
-import { isInsideConfiguredWorktreesDir, isReclaimableWorktreeCandidate, isWorktreeContainerDir, resolveWorktreesDir } from "./worktree-paths.js";
+import { isInsideConfiguredWorktreesDir, isReclaimableWorktreeCandidate, isWorktreeContainerDir, WORKTREE_RECOVERY_DIRNAME, resolveWorktreesDir } from "./worktree-paths.js";
 import { canonicalFusionBranchName } from "./worktree-names.js";
 import {
   resolveWorktrunkBinary,
@@ -20,6 +20,7 @@ import {
 } from "./worktree-backend.js";
 import { cleanupSecretsEnvFile } from "./secrets-env-writer.js";
 import { removeDesktopBuildArtifacts } from "./worktree-desktop-artifacts.js";
+import { preserveGeneratedResidue } from "./worktree-generated-residue.js";
 import { resolveIntegrationBranch } from "../merge/integration-branch.js";
 import type { RunAuditor } from "../util/run-audit.js";
 import { pruneWorktreeAdminEntries } from "./worktree-prune.js";
@@ -976,9 +977,8 @@ export async function scanIdleWorktrees(
 /**
  * Clean up orphaned worktrees left behind from previous engine runs.
  *
- * Removes worktree directories under `<rootDir>/.worktrees/` that are NOT
- * assigned to any non-done task. Used on startup when `recycleWorktrees`
- * is false to avoid disk waste.
+ * Removes registered worktrees not assigned to unfinished tasks and empty
+ * unregistered residue. Used on startup when `recycleWorktrees` is false.
  *
  * Failures on individual worktree removals are logged but not fatal.
  *
@@ -1003,6 +1003,14 @@ export async function cleanupOrphanedWorktrees(
   const orphaned = await scanIdleWorktrees(rootDir, store, settings);
   const registeredWorktrees = await getRegisteredWorktreePaths(rootDir);
 
+  // FNXC:WorktreeMerge KB-001 2026-08-22-04:20:
+  // Dual-semantics merge resolution: main's newer sweep added a directory scan
+  // that also collects UNREGISTERED but reclaimable worktree candidates via
+  // isReclaimableWorktreeCandidate, while this branch's dirty-orphan preservation
+  // governs how every candidate is removed. Keep both: the scan block from main,
+  // and the branch's removal path (secrets-env cleanup + preserveGeneratedResidue
+  // before any probe/removal, restore on failure) now applied to the combined
+  // candidate list instead of only recorded orphans.
   let dirs: string[] = [];
   if (existsSync(worktreesDir)) {
     try {
@@ -1026,6 +1034,15 @@ export async function cleanupOrphanedWorktrees(
   for (const worktreePath of candidates) {
     try {
       if (registeredWorktrees.has(resolve(worktreePath))) {
+        // FNXC:WorktreeCleanup 2026-08-15-19:00:
+        // Never probe a missing directory; prune its stale admin entry instead.
+        // The shared removal path revalidates tracked, untracked, and ignored content
+        // after cleaning only fingerprint-owned Fusion secrets.
+        if (!existsSync(worktreePath)) {
+          await pruneWorktreeAdminEntries({ rootDir, reason: "pool-cleanup-missing-orphan", target: worktreePath, logger: worktreePoolLog }).catch(() => undefined);
+          cleaned++;
+          continue;
+        }
         const orphanTaskId = `orphan:${basename(worktreePath)}`;
         try {
           await cleanupSecretsEnvFile({
@@ -1041,18 +1058,65 @@ export async function cleanupOrphanedWorktrees(
             `secrets-env cleanup failed for registered orphan ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
+        // FNXC:WorktreeCleanup 2026-08-17: the removal probe includes --ignored, so
+        // generated residue (node_modules/dist) must leave the path before the probe
+        // runs — preserved, never deleted, mirroring the pinned-reclaim residue policy.
+        let restoreGeneratedResidue: (() => Promise<void>) | undefined;
+        try {
+          restoreGeneratedResidue = await preserveGeneratedResidue(worktreePath, rootDir, worktreePoolLog);
+        } catch (error) {
+          worktreePoolLog.warn(
+            `generated-residue preservation failed for registered orphan ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
 
-        await removeWorktreeViaBackend({
-          rootDir,
-          worktreePath,
-          settings: settings ?? {},
-          reason: RemovalReason.PoolPrune,
-        });
+        try {
+          await removeWorktreeViaBackend({
+            rootDir,
+            worktreePath,
+            settings: settings ?? {},
+            reason: RemovalReason.PoolPrune,
+          });
+        } catch (error) {
+          try {
+            await restoreGeneratedResidue?.();
+          } catch (restoreError) {
+            worktreePoolLog.warn(
+              `generated-residue restore failed for registered orphan ${worktreePath}: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`,
+            );
+          }
+          throw error;
+        }
       } else {
+        // FNXC:WorktreeMerge KB-001 2026-08-22-04:20:
+        // Ported main's unregistered-candidate removal onto the branch's
+        // preservation discipline: generated residue leaves the path before the
+        // rmSync probe (so --ignored-style content checks never delete user data)
+        // and is restored if the removal fails. Main's containment guard
+        // (isInsideWorktreesDir) is kept verbatim.
         if (!isInsideWorktreesDir(rootDir, worktreePath, settings)) {
           throw new Error(`Refusing to remove path outside .worktrees: ${worktreePath}`);
         }
-        rmSync(worktreePath, { recursive: true, force: true });
+        let restoreUnregisteredResidue: (() => Promise<void>) | undefined;
+        try {
+          restoreUnregisteredResidue = await preserveGeneratedResidue(worktreePath, rootDir, worktreePoolLog);
+        } catch (error) {
+          worktreePoolLog.warn(
+            `generated-residue preservation failed for unregistered orphan ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        try {
+          rmSync(worktreePath, { recursive: true, force: true });
+        } catch (error) {
+          try {
+            await restoreUnregisteredResidue?.();
+          } catch (restoreError) {
+            worktreePoolLog.warn(
+              `generated-residue restore failed for unregistered orphan ${worktreePath}: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`,
+            );
+          }
+          throw error;
+        }
         await pruneWorktreeAdminEntries({
           rootDir,
           reason: "pool-cleanup-orphan",
@@ -1068,7 +1132,7 @@ export async function cleanupOrphanedWorktrees(
     }
   }
 
-  return cleaned;
+  return cleaned + await reapOrphanWorktrees(rootDir, settings);
 }
 
 /**
@@ -1117,6 +1181,141 @@ function dotGitPointerIsDangling(dotGitPath: string): boolean {
     return !existsSync(resolved);
   } catch {
     return false;
+  }
+}
+
+/**
+ * Re-resolve the CURRENT `.git` pointer's admin target. A concurrent repair can have
+ * RE-REGISTERED the worktree after `targetPath` was derived from the STASHED original,
+ * pointing `.git` at a different, live admin while the stash-derived target stays dead.
+ * The reaper must re-read the current pointer fresh before a destructive step instead of
+ * acting on the stale path. Returns `undefined` when there is no readable live pointer
+ * (absent path, a `.git` directory, or an unparseable/corrupt pointer).
+ */
+function resolveCurrentAdminTarget(dotGit: string): string | undefined {
+  try {
+    if (!existsSync(dotGit) || lstatSync(dotGit).isDirectory()) return undefined;
+    const match = /^gitdir:\s*(.+)$/.exec(readFileSync(dotGit, "utf8").trim());
+    if (!match) return undefined;
+    const target = match[1].trim();
+    return isAbsolute(target) ? target : resolve(dirname(dotGit), target);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when the orphan's admin target is live at the moment of the check. A present
+ * current pointer is authoritative: preserve iff its freshly-resolved target exists
+ * (fail closed on re-registration to a different live admin). Only when no current
+ * pointer exists do we fall back to the stash-derived `targetPath` (in-place repair of
+ * the original admin without recreating the `.git` pointer).
+ */
+function adminTargetIsLive(targetPath: string | undefined, dotGit: string): boolean {
+  // Greptile (find: replacement Git directory stays unrecognized): a concurrent repair can
+  // install a REAL `.git` DIRECTORY after the dangling pointer was moved aside. That is a
+  // populated, authoritative checkout — never reap it via the stale `targetPath` fallback.
+  // A present real `.git` directory is live regardless of any admin-target pointer.
+  if (existsSync(dotGit) && lstatSync(dotGit).isDirectory()) return true;
+  const current = resolveCurrentAdminTarget(dotGit);
+  if (current !== undefined) return existsSync(current);
+  return targetPath !== undefined && existsSync(targetPath);
+}
+
+/**
+ * Restore a stashed `.git` pointer at its original pathname, preserving the
+ * stash as a manual-recovery copy when every restore attempt fails for a
+ * reason other than a concurrent pointer (which is authoritative and wins).
+ * Returns `true` when the stash was consumed (restored or superseded by a
+ * concurrent pointer); `false` when the stash was kept for manual recovery.
+ */
+function restoreStashedDotGit(dotGit: string, dotGitStash: string, name: string): boolean {
+  try {
+    linkSync(dotGitStash, dotGit);
+    unlinkSync(dotGitStash);
+    return true;
+  } catch (restoreError) {
+    const restoreCode = restoreError instanceof Error && "code" in restoreError ? (restoreError as { code?: unknown }).code : undefined;
+    if (restoreCode === "EEXIST") {
+      unlinkSync(dotGitStash);
+      return true;
+    }
+    // linkSync failed for a reason other than a concurrent .git
+    // (EPERM/ENOSPC/...): the pointer exists only in the stash. Fail
+    // closed — COPYFILE_EXCL restores it without ever overwriting a
+    // .git that appears concurrently; if one does, EEXIST keeps the
+    // authoritative pointer and drops the stash.
+    try {
+      copyFileSync(dotGitStash, dotGit, constants.COPYFILE_EXCL);
+      unlinkSync(dotGitStash);
+      return true;
+    } catch (fallbackError) {
+      const fallbackCode = fallbackError instanceof Error && "code" in fallbackError ? (fallbackError as { code?: unknown }).code : undefined;
+      if (fallbackCode === "EEXIST") {
+        unlinkSync(dotGitStash);
+        return true;
+      }
+      worktreePoolLog.warn(
+        `reapOrphanWorktrees: failed to restore .git for ${name} — ${restoreError instanceof Error ? restoreError.message : String(restoreError)}; keeping stash for manual recovery: ${dotGitStash}`,
+      );
+      return false;
+    }
+  }
+}
+
+/** Restore a captured replacement pointer without overwriting a concurrent winner. */
+function restoreReplacedDotGit(dotGit: string, dotGitDelete: string, dotGitStash: string | undefined, name: string): boolean {
+  try {
+    if (lstatSync(dotGitDelete).isDirectory()) {
+      // FNXC:WorktreeCleanup 2026-08-19-15:34: A concurrent repair can replace the dangling pointer with a real .git directory.
+      // Restore it with an ATOMIC non-overwriting rename (POSIX refuses a non-empty directory destination with ENOTEMPTY), so a
+      // concurrently recreated authoritative .git always wins untouched. The previous cpSync approach could copy PART of the
+      // captured stale metadata into the authoritative directory before errorOnExist threw (Greptile P1: "Concurrent metadata
+      // copy corrupts repair"); renameSync never leaves partial or mixed metadata behind.
+      renameSync(dotGitDelete, dotGit);
+      return true;
+    }
+  } catch (directoryRestoreError) {
+    const recoveryRoot = join(dirname(dotGitDelete), WORKTREE_RECOVERY_DIRNAME, "worktrees");
+    const recoveryPath = join(recoveryRoot, `replaced-${name}-${process.pid}-${Date.now().toString(36)}`);
+    try {
+      mkdirSync(recoveryRoot, { recursive: true });
+      renameSync(dotGitDelete, recoveryPath);
+      worktreePoolLog.warn(`reapOrphanWorktrees: failed to restore replacement .git directory for ${name} — ${directoryRestoreError instanceof Error ? directoryRestoreError.message : String(directoryRestoreError)}; moved captured directory to contained recovery: ${recoveryPath}`);
+    } catch (recoveryError) {
+      worktreePoolLog.warn(`reapOrphanWorktrees: failed to restore replacement .git directory for ${name} — ${directoryRestoreError instanceof Error ? directoryRestoreError.message : String(directoryRestoreError)}; keeping captured directory for manual recovery: ${dotGitDelete}; recovery move failed: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`);
+    }
+    return false;
+  }
+  try {
+    linkSync(dotGitDelete, dotGit);
+    unlinkSync(dotGitDelete);
+    return true;
+  } catch (restoreError) {
+    const code = restoreError instanceof Error && "code" in restoreError ? (restoreError as { code?: unknown }).code : undefined;
+    if (code === "EEXIST") {
+      unlinkSync(dotGitDelete);
+      return true;
+    }
+    try {
+      copyFileSync(dotGitDelete, dotGit, constants.COPYFILE_EXCL);
+      unlinkSync(dotGitDelete);
+      return true;
+    } catch (fallbackError) {
+      const fallbackCode = fallbackError instanceof Error && "code" in fallbackError ? (fallbackError as { code?: unknown }).code : undefined;
+      if (fallbackCode === "EEXIST") {
+        unlinkSync(dotGitDelete);
+        return true;
+      }
+      // Both atomic non-overwriting restores (link, then copy EXCL) failed with a
+      // non-EEXIST error. The previous fallback checked existsSync(dotGit) and then
+      // renameSync(dotGitDelete, dotGit) — but renameSync ALWAYS overwrites its
+      // destination, so an authoritative `.git` pointer created between the existsSync
+      // check and the rename would be silently destroyed. Node has no non-overwriting
+      // rename; fail closed instead, keeping the captured pointer for manual recovery.
+      worktreePoolLog.warn(`reapOrphanWorktrees: failed to restore replacement .git for ${name} — ${restoreError instanceof Error ? restoreError.message : String(restoreError)}; keeping captured pointer for manual recovery: ${dotGitDelete}`);
+      return false;
+    }
   }
 }
 
@@ -1191,38 +1390,202 @@ export async function reapOrphanWorktrees(
     // git never registered). Only skip when the gitdir target actually exists; reap
     // dangling pointers like any other half-initialized orphan.
     const dotGit = join(resolvedFull, ".git");
+    const danglingDotGit = existsSync(dotGit) && dotGitPointerIsDangling(dotGit);
     if (existsSync(dotGit)) {
-      if (!dotGitPointerIsDangling(dotGit)) {
+      if (!danglingDotGit) {
         // Valid registration, a real .git dir, or a pointer we couldn't positively classify as
         // dangling — leave it; assertValidWorktreeSession handles it on the next agent start.
         worktreePoolLog.debug(`reapOrphanWorktrees: skipping ${name} (has .git entry but not in registered list — may be partially registered)`);
         continue;
       }
       worktreePoolLog.debug(`reapOrphanWorktrees: ${name} has a dangling .git pointer (admin entry missing) — treating as orphan`);
-      // fall through to removal
     }
 
-    // This directory is on disk but has no valid .git entry and is not a registered
-    // worktree — it is a half-initialized / leaked orphan.  Remove it.
+    // FNXC:WorktreeCleanup 2026-08-15-20:40: clean Fusion-owned secret residue before removing an empty orphan.
     try {
+      let dotGitStash: string | undefined;
+      let targetPath: string | undefined;
       try {
         await cleanupSecretsEnvFile({
           worktreePath: resolvedFull,
           taskId: `orphan:${name}`,
           expectedFingerprint: null,
           filename: ".env",
+          allowLegacyCleanupForDanglingGitdir: danglingDotGit,
+          // FNXC:SecretsEnvMaterialization 2026-08-17-16:45: the boolean verdict
+          // predates this awaited cleanup; revalidate the pointer's CURRENT state
+          // at the authorization boundary so a repaired worktree's tracked .env
+          // is never cleaned on the stale flag.
+          isDanglingGitdir: () => dotGitPointerIsDangling(dotGit),
           logger: worktreePoolLog,
         });
       } catch (error) {
         worktreePoolLog.warn(`secrets-env cleanup failed for orphan ${name}: ${error instanceof Error ? error.message : String(error)}`);
       }
-      rmSync(resolvedFull, { recursive: true, force: true });
-      await pruneWorktreeAdminEntries({
-        rootDir: projectRoot,
-        reason: "pool-reap-orphan",
-        target: resolvedFull,
-        logger: worktreePoolLog,
-      }).catch(() => undefined);
+      if (danglingDotGit) {
+        const remainingEntries = readdirSync(resolvedFull);
+        if (remainingEntries.some((entry) => entry !== ".git")) {
+          worktreePoolLog.warn(`Preserving orphan worktree with uncommitted content: ${resolvedFull}`);
+          continue;
+        }
+        /*
+         * FNXC:WorktreeCleanup 2026-08-16-21:30:
+         * The dangling verdict above predates the awaited secrets-env cleanup, which gave a
+         * concurrent repair time to recreate the admin entry the pointer references. Revalidate
+         * the pointer immediately before stashing it: a pointer that is no longer positively
+         * dangling (target recreated, .git replaced by a real directory, or the file vanished)
+         * must be preserved — stashing/removing it would delete a repaired worktree.
+         */
+        if (!dotGitPointerIsDangling(dotGit)) {
+          worktreePoolLog.warn(`Preserving orphan worktree whose .git pointer is no longer dangling: ${resolvedFull}`);
+          continue;
+        }
+        // Hard-link the pointer aside, then revalidate its inode before unlinking
+        // the pathname. Unlike rename, this never overwrites a repair that wins
+        // while the stash is being made.
+        dotGitStash = join(dirname(resolvedFull), `.${name}.git-reap-stash-${process.pid}-${Date.now().toString(36)}`);
+        linkSync(dotGit, dotGitStash);
+        const pointerStat = lstatSync(dotGit);
+        const stashStat = lstatSync(dotGitStash);
+        if (pointerStat.dev !== stashStat.dev || pointerStat.ino !== stashStat.ino || !dotGitPointerIsDangling(dotGit)) {
+          unlinkSync(dotGitStash);
+          dotGitStash = undefined;
+          worktreePoolLog.warn(`Preserving orphan worktree whose .git pointer was repaired during stash: ${resolvedFull}`);
+          continue;
+        }
+        // The stash holds the pointer's original content; derive the admin target
+        // once and reuse it for every pre/post-removal liveness revalidation.
+        const stashedTarget = /^gitdir:\s*(.+)$/m.exec(readFileSync(dotGitStash, "utf8").trim())?.[1]?.trim();
+        targetPath = stashedTarget
+          ? (isAbsolute(stashedTarget) ? stashedTarget : resolve(dirname(dotGit), stashedTarget))
+          : undefined;
+        // The dangling verdict + inode check above predate this removal; a repair can
+        // REPLACE the `.git` PATHNAME with a pointer to a DIFFERENT, live admin between the
+        // inode check and the unlink. Unlinking the pathname would then delete the live
+        // replacement while `targetPath` (derived from the STASHED original) stays stale,
+        // and the later rmdir destroys the directory the live replacement references. Close
+        // the boundary by atomically renaming WHATEVER currently occupies the pathname to a
+        // private deletion path, then unlinking only the captured occupant. A repair that
+        // wins the freed pathname after this rename creates a fresh `.git` we never touch.
+        const dotGitDelete = join(dirname(resolvedFull), `.${name}.git-reap-del-${process.pid}-${Date.now().toString(36)}`);
+        renameSync(dotGit, dotGitDelete);
+        const capturedStat = lstatSync(dotGitDelete);
+        if (capturedStat.dev !== stashStat.dev || capturedStat.ino !== stashStat.ino) {
+          // The replacement pointer is authoritative; restore it without overwriting a
+          // concurrent winner, and keep the original stash if every restore path fails.
+          if (restoreReplacedDotGit(dotGit, dotGitDelete, dotGitStash, name)) {
+            const staleStash = dotGitStash;
+            dotGitStash = undefined;
+            if (staleStash) {
+              try { unlinkSync(staleStash); } catch { /* best-effort recovery-copy cleanup */ }
+            }
+          }
+          worktreePoolLog.warn(`Preserving orphan worktree whose .git pointer was replaced by a live pointer during deletion: ${resolvedFull}`);
+          continue;
+        }
+        // Captured occupant is our dangling original — remove it. A repair that later wins
+        // the freed pathname is protected by the ENOTEMPTY + authoritative-pointer recovery
+        // in the removal/restore paths below; its live admin target is never our rmdir victim.
+        unlinkSync(dotGitDelete);
+        // A repair can win in the removal window itself. Preserve the worktree before
+        // the later rmdir/prune can delete its live admin target. Re-read the CURRENT
+        // pointer (re-registration may point at a different live admin than the stash).
+        if (adminTargetIsLive(targetPath, dotGit)) {
+          if (restoreStashedDotGit(dotGit, dotGitStash, name)) {
+            dotGitStash = undefined;
+          }
+          worktreePoolLog.warn(`Preserving orphan worktree whose admin target was repaired during unlink: ${resolvedFull}`);
+          continue;
+        }
+      }
+      if (danglingDotGit && dotGitStash && adminTargetIsLive(targetPath, dotGit)) {
+        if (restoreStashedDotGit(dotGit, dotGitStash, name)) {
+          dotGitStash = undefined;
+        }
+        worktreePoolLog.warn(`Preserving orphan worktree whose admin target was repaired before removal: ${resolvedFull}`);
+        continue;
+      }
+      try {
+        rmdirSync(resolvedFull);
+      } catch (removeError) {
+        if (dotGitStash) {
+          restoreStashedDotGit(dotGit, dotGitStash, name);
+        }
+        throw removeError;
+      }
+      /*
+       * FNXC:WorktreeCleanup 2026-08-17-10:30:
+       * The final admin-target check above ran before rmdir; a repair can still land
+       * in the rmdir window, leaving a live `.git/worktrees/<name>` entry that
+       * references the directory just removed. Restore the directory and the stashed
+       * pointer so the repaired worktree survives instead of being destroyed. No
+       * shared lock exists with the repair side (external git / assertValidWorktreeSession),
+       * so this post-removal recovery is the smallest race-safe closing of the window.
+       */
+      if (dotGitStash && adminTargetIsLive(targetPath, dotGit)) {
+        try {
+          mkdirSync(resolvedFull);
+        } catch {
+          // EEXIST: a concurrent repair already recreated the directory — keep it.
+        }
+        // Greptile(find: failed pointer restore accepted): if restoring the stashed
+        // .git pointer fails for a non-EEXIST reason (EPERM/ENOSPC), do NOT treat the
+        // recreated checkout as cleanly preserved — it has no canonical .git while its
+        // only metadata copy is stranded. Fail closed: keep the stash for manual
+        // recovery and surface it explicitly instead of silently continuing.
+        if (restoreStashedDotGit(dotGit, dotGitStash, name)) {
+          dotGitStash = undefined;
+          worktreePoolLog.warn(`Preserving orphan worktree whose admin target was repaired during removal: ${resolvedFull}`);
+        } else {
+          worktreePoolLog.warn(
+            `reapOrphanWorktrees: orphan ${name} admin target repaired during removal but .git pointer restore failed; checkout preserved without canonical .git — keeping stash for manual recovery: ${dotGitStash}`,
+          );
+        }
+        continue;
+      }
+      if (dotGitStash) {
+        const stashDelete = `${dotGitStash}.deleting`;
+        try {
+          renameSync(dotGitStash, stashDelete);
+        } catch (stashMoveError) {
+          worktreePoolLog.warn(`reapOrphanWorktrees: orphan ${name} stash quarantine failed — ${stashMoveError instanceof Error ? stashMoveError.message : String(stashMoveError)}`);
+          continue;
+        }
+        if (adminTargetIsLive(targetPath, dotGit)) {
+          try {
+            mkdirSync(resolvedFull);
+          } catch {
+            // EEXIST: a concurrent repair already recreated the directory — keep it.
+          }
+          if (restoreStashedDotGit(dotGit, stashDelete, name)) {
+            dotGitStash = undefined;
+            worktreePoolLog.warn(`Preserving orphan worktree whose admin target was repaired during stash cleanup: ${resolvedFull}`);
+          } else {
+            worktreePoolLog.warn(
+              `reapOrphanWorktrees: orphan ${name} admin target repaired during stash cleanup but .git pointer restore failed; keeping stash for manual recovery: ${stashDelete}`,
+            );
+          }
+          continue;
+        }
+        try {
+          unlinkSync(stashDelete);
+          dotGitStash = undefined;
+        } catch (stashError) {
+          worktreePoolLog.warn(`reapOrphanWorktrees: orphan ${name} removed but .git stash cleanup failed — ${stashError instanceof Error ? stashError.message : String(stashError)}`);
+        }
+      }
+      // A dangling pointer was removed above, so there is no stale admin entry
+      // to prune. Skipping the separate `git worktree prune` closes the last
+      // window where another process can recreate the admin target after the
+      // final existence check and have Git delete it again.
+      if (!danglingDotGit) {
+        await pruneWorktreeAdminEntries({
+          rootDir: projectRoot,
+          reason: "pool-reap-orphan",
+          target: resolvedFull,
+          logger: worktreePoolLog,
+        }).catch(() => undefined);
+      }
       worktreePoolLog.log(`reapOrphanWorktrees: removed half-initialized orphan ${name}`);
       removed++;
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- Fail closed when a registered worktree root or status cannot be verified — tracked, untracked, and recognized generated content are preserved, never deleted.
- Preserve ignored content during defensive cleanup, including user-authored files beneath generated-looking paths.
- Preserve backend-specific removal semantics: Native keeps its legacy forced default outside defensive cleanup; Worktrunk is forced only by explicit caller intent.
- Require every pool-prune path to reject dirty content instead of forcing removal.
- Prepare owned-secrets and generated residue before idle-sweep and cap-enforcement removal so legitimately generated files do not veto reclaim.
- Move corrupt registered worktree roots into a contained recovery area (never recursively delete) and prune only the admin entry, failing closed on any preservation error.
- Prune already-missing registrations without recursive deletion; reap only empty unregistered residue after fingerprint-verified secrets cleanup, including positively identified dangling git dirs.
- Preserve dangling Git metadata when user content remains; keep quarantine recovery content and ownership metadata when restoration fails or a production file is replaced concurrently.

## Greptile Review Requirements (addressed)

Each line summarizes a rule raised by the `greptile-apps[bot]` reviews throughout this PR and how the code satisfies it.

1. Regression tests must exercise the real runtime paths (reapOrphanWorktrees/self-healing), not only direct cleanupOrphanedWorktrees calls.
2. Periodic cleanup (idle-sweep/cap-enforcement) must apply the same defensive dirty validation as pool prune.
3. A failing root probe (rev-parse/status) must preserve the checkout, never turn the failure into deletion.
4. Dangling/half-initialized worktrees with recoverable content must be preserved (probes fail closed).
5. PoolPrune with a failing root probe must not continue with an empty root — it must fail closed.
6. Fusion-owned `.env`/fingerprint residue must be recognized as generated, not mistaken for user content.
7. Reclaiming a task-pinned worktree on a foreign branch with edits must preserve the edits, never discard them.
8. User-authored ignored files under dist/build/node_modules must be preserved.
9. Git metadata must not be lost during removal: captured up front, restored with non-overwriting, fail-closed semantics.
10. A concurrent `.git` pointer must not be overwritten (atomic non-overwriting rename).
11. A concurrently replaced managed `.env` must not be deleted (quarantine rename-verify-delete plus inode/authorization revalidation).
12. Cleanup retry with a quarantine artifact must restore/preserve recoverable content.
13. A failed quarantine restore must keep ownership metadata and recoverable content.
14. Late repair (after the final dangling check) must not lose the env file or the pointer stash.
15. Recovery copies are retained indefinitely (user decision) — no destructive pruning.
16. A corrupt registered root goes to contained recovery; only the admin entry is pruned.
17. Failed residue restoration must attempt ALL moved directories and report aggregate errors.
18. A restoration failure must not abort the self-healing sweep.
19. A recovery directory from a failed restore must not remain scannable as an orphan.
20. A refused reclaim must not delete the environment file (revalidate before deleting).
21. A concurrently replaced `.git` directory must not corrupt metadata (atomic rename, no partial cpSync).
22. An owned quarantine artifact must not veto reclaim of a generated-only worktree.
23. Quarantine ownership must not be proven by filename alone — content fingerprint is required.
24. Mixed residue (marker + user-authored file) is not moved: EVERY entry must be generated.
25. User-authored content nested inside a generated package/directory is not moved (recursive inspection).
26. "Generated-looking" extensions do not prove generation: dist requires a per-file `.map` companion; node_modules requires a root lockfile listing the package.
27. Late gitdir repair must not lose the worktree (final-state revalidation before unlink).
28. A failed pointer restore must not leave the checkout without canonical metadata (fail closed).
29. Multiple quarantine artifacts must converge, not block cleanup forever.## Verification

- Focused pool/backend/acquisition/self-healing/recovery tests pass.
- Engine typecheck passes.
- diff check passes.

## Scope

Worktree cleanup and data-integrity behavior only.
