### PR TITLE
fix(dashboard): remove stale taskStuck aliases

### DIFF
--- a/.changeset/remove-stuck-task-aliases.md
+++ b/.changeset/remove-stuck-task-aliases.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Remove stale taskStuck package exports and build/test aliases after deleting the dashboard helper.
+category: fix
+dev: "Cleans dashboard and dependency-graph configuration so no published export, Vite/Vitest alias, or TypeScript path points at the removed app/utils/taskStuck module."

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -31,10 +31,6 @@
       "types": "./app/components/ViewHeader.tsx",
       "import": "./app/components/ViewHeader.tsx"
     },
-    "./app/utils/taskStuck": {
-      "types": "./app/utils/taskStuck.ts",
-      "import": "./app/utils/taskStuck.ts"
-    },
     "./app/utils/copyToClipboard": {
       "types": "./app/utils/copyToClipboard.ts",
       "import": "./app/utils/copyToClipboard.ts"

--- a/packages/dashboard/tsconfig.app.json
+++ b/packages/dashboard/tsconfig.app.json
@@ -22,8 +22,7 @@
       "@fusion/dashboard/app/components/ViewHeader": ["./app/components/ViewHeader.tsx"],
       "@fusion/dashboard/app/api/tasks/task-content": ["./app/api/tasks/task-content.ts"],
       "@fusion/dashboard/app/plugins/types": ["./app/plugins/types.ts"],
-      "@fusion/dashboard/app/utils/projectStorage": ["./app/utils/projectStorage.ts"],
-      "@fusion/dashboard/app/utils/taskStuck": ["./app/utils/taskStuck.ts"]
+      "@fusion/dashboard/app/utils/projectStorage": ["./app/utils/projectStorage.ts"]
     }
   },
   "include": ["app/**/*"],

--- a/packages/dashboard/tsconfig.test-check.json
+++ b/packages/dashboard/tsconfig.test-check.json
@@ -13,8 +13,7 @@
       "@fusion/dashboard/app/components/TaskCard": ["./app/components/TaskCard.tsx"],
       "@fusion/dashboard/app/components/ViewHeader": ["./app/components/ViewHeader.tsx"],
       "@fusion/dashboard/app/plugins/types": ["./app/plugins/types.ts"],
-      "@fusion/dashboard/app/utils/projectStorage": ["./app/utils/projectStorage.ts"],
-      "@fusion/dashboard/app/utils/taskStuck": ["./app/utils/taskStuck.ts"]
+      "@fusion/dashboard/app/utils/projectStorage": ["./app/utils/projectStorage.ts"]
     }
   },
   "include": ["app/**/*"]

--- a/packages/dashboard/vite.config.ts
+++ b/packages/dashboard/vite.config.ts
@@ -151,7 +151,6 @@ export default defineConfig({
       "@fusion/dashboard/app/api/tasks/task-content": resolve(__dirname, "app/api/tasks/task-content.ts"),
       "@fusion/dashboard/app/plugins/types": resolve(__dirname, "app/plugins/types.ts"),
       "@fusion/dashboard/app/utils/projectStorage": resolve(__dirname, "app/utils/projectStorage.ts"),
-      "@fusion/dashboard/app/utils/taskStuck": resolve(__dirname, "app/utils/taskStuck.ts"),
       "@fusion-plugin-examples/compound-engineering/dashboard-view": resolve(
         __dirname,
         "../../plugins/fusion-plugin-compound-engineering/src/dashboard-view.tsx",

--- a/packages/dashboard/vitest.config.ts
+++ b/packages/dashboard/vitest.config.ts
@@ -545,7 +545,6 @@ export default defineConfig({
       "@fusion/dashboard/app/api/tasks/task-content": resolve(__dirname, "app/api/tasks/task-content.ts"),
       "@fusion/dashboard/app/plugins/types": resolve(__dirname, "app/plugins/types.ts"),
       "@fusion/dashboard/app/utils/projectStorage": resolve(__dirname, "app/utils/projectStorage.ts"),
-      "@fusion/dashboard/app/utils/taskStuck": resolve(__dirname, "app/utils/taskStuck.ts"),
       "@fusion-plugin-examples/droid-runtime/probe": resolve(
         __dirname,
         "../../plugins/fusion-plugin-droid-runtime/src/probe.ts",

--- a/scripts/__tests__/dashboard-stuck-task-removal.test.mjs
+++ b/scripts/__tests__/dashboard-stuck-task-removal.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { URL } from "node:url";
+
+const staleModule = "@fusion/dashboard/app/utils/taskStuck";
+const files = [
+  "packages/dashboard/package.json",
+  "packages/dashboard/vite.config.ts",
+  "packages/dashboard/vitest.config.ts",
+  "packages/dashboard/tsconfig.app.json",
+  "packages/dashboard/tsconfig.test-check.json",
+  "plugins/fusion-plugin-dependency-graph/tsconfig.json",
+];
+
+test("removed taskStuck module has no package, build, test, or plugin aliases", () => {
+  for (const file of files) {
+    const source = readFileSync(new URL(`../../${file}`, import.meta.url), "utf8");
+    assert.equal(source.includes(staleModule), false, `${file} still references ${staleModule}`);
+  }
+});


### PR DESCRIPTION
## Summary
- removes the deleted taskStuck helper from dashboard package exports and local build/test aliases
- removes the dependency-graph plugin TypeScript path for the deleted dashboard module
- adds a script regression so the removed module cannot be reintroduced as a stale alias

## Test Plan
- pnpm test:scripts -- scripts/__tests__/dashboard-stuck-task-removal.test.mjs
- pnpm check:changesets
- pnpm exec eslint scripts/__tests__/dashboard-stuck-task-removal.test.mjs packages/dashboard/vite.config.ts packages/dashboard/vitest.config.ts
- pnpm --filter @fusion/dashboard typecheck
- pnpm --filter @fusion-plugin-examples/dependency-graph build
- pnpm --filter @fusion/dashboard build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale stuck-task references from dashboard package and build configurations.
  * Prevented unavailable task-stuck utilities from being exposed or resolved.

* **Tests**
  * Added validation to ensure removed task-stuck references do not reappear in dashboard or plugin configuration.

* **Documentation**
  * Recorded the cleanup in the project’s release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->