### PR TITLE
feat: Fusion Cloud Mode A thin client (fn cloud)

### DIFF
--- a/.changeset/cloud-link-mode-a.md
+++ b/.changeset/cloud-link-mode-a.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": minor
+---
+
+summary: Add Fusion Cloud Mode A client — pair, heartbeat, and cloudTicket remote-login.
+category: feature
+dev: New `fn cloud` CLI (`pair-start`, `pair-complete`, `heartbeat`, `status`, `unlink`) and `@fusion/core` cloud-link HTTP client. `/remote-login?cloudTicket=` redeems against the Fusion Cloud control plane then issues a short-lived `rt` (or daemon token). Device state in `~/.fusion/cloud-link.json`.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -140,6 +140,13 @@ async function loadCommandHandlers() {
   const { runGoalsList, runGoalsCreate, runGoalsArchive, runGoalsCitations } = await import("./commands/goals.js");
   const { runProjectList, runProjectAdd, runProjectRemove, runProjectShow, runProjectInfo, runProjectSetDefault, runProjectDetect } = await import("./commands/project.js");
   const { runNodeList, runNodeConnect, runNodeDisconnect, runNodeShow, runNodeHealth, runMeshStatus } = await import("./commands/node.js");
+  const {
+    runCloudPairStart,
+    runCloudPairComplete,
+    runCloudHeartbeat,
+    runCloudStatus,
+    runCloudUnlink,
+  } = await import("./commands/cloud.js");
   const { runInit } = await import("./commands/init.js");
   const { runOnboard } = await import("./commands/onboard.js");
   const { runAgentStop, runAgentStart } = await import("./commands/agent.js");
@@ -413,6 +420,14 @@ PR:
   fn node show | info [name] [--json] Show node details
   fn node health <name>               Health check a node
   fn mesh status [--json]              Show full mesh state
+  fn cloud pair-start [--http <url>] [--name <name>]
+                                      Start Fusion Cloud pairing (prints code)
+  fn cloud pair-complete --code <code> --pending-secret <secret> [--http <url>]
+                                      Finish pairing after console claim
+  fn cloud heartbeat [--url <origin>] [--port <n>] [--loop]
+                                      Publish reachability candidates to cloud
+  fn cloud status [--json]             Show local cloud-link state
+  fn cloud unlink                      Clear ~/.fusion/cloud-link.json
   fn settings                          Show current Fusion configuration
   fn settings set <key> <value>        Update a configuration setting
   fn settings set defaultNodeId <node-id>
@@ -1148,6 +1163,62 @@ async function main() {
           default:
             console.error(`Unknown subcommand: mesh ${subcommand || ""}`);
             console.log("Try: fn mesh status");
+            process.exit(1);
+        }
+        break;
+      }
+
+      case "cloud": {
+        /*
+        FNXC:CloudLink 2026-08-17-23:45:
+        Thin client for Runfusion/fusion-cloud Mode A pairing and presence.
+        */
+        const subcommand = args[1];
+        switch (subcommand) {
+          case "pair-start": {
+            await runCloudPairStart({
+              http: getFlagValue(args, "--http"),
+              name: getFlagValue(args, "--name"),
+            });
+            break;
+          }
+          case "pair-complete": {
+            const code = getFlagValue(args, "--code");
+            const pendingSecret = getFlagValue(args, "--pending-secret");
+            if (!code || !pendingSecret) {
+              console.error(
+                "Usage: fn cloud pair-complete --code <code> --pending-secret <secret> [--http <url>]",
+              );
+              process.exit(1);
+            }
+            await runCloudPairComplete({
+              http: getFlagValue(args, "--http"),
+              code,
+              pendingSecret,
+            });
+            break;
+          }
+          case "heartbeat": {
+            await runCloudHeartbeat({
+              url: getFlagValue(args, "--url"),
+              port: getFlagValueNumber(args, "--port"),
+              loop: args.includes("--loop"),
+            });
+            break;
+          }
+          case "status": {
+            await runCloudStatus({ json: args.includes("--json") });
+            break;
+          }
+          case "unlink": {
+            await runCloudUnlink();
+            break;
+          }
+          default:
+            console.error(`Unknown subcommand: cloud ${subcommand || ""}`);
+            console.log(
+              "Try: fn cloud pair-start | pair-complete | heartbeat | status | unlink",
+            );
             process.exit(1);
         }
         break;

--- a/packages/cli/src/commands/cloud.ts
+++ b/packages/cli/src/commands/cloud.ts
@@ -1,0 +1,168 @@
+/**
+ * FNXC:CloudLink 2026-08-17-23:45:
+ * CLI for Fusion Cloud Mode A — pair / complete / heartbeat / status / unlink.
+ * Control plane lives in Runfusion/fusion-cloud; this is the thin engine client.
+ */
+import {
+  clearCloudLinkState,
+  cloudHeartbeat,
+  cloudPairComplete,
+  cloudPairStart,
+  loadCloudLinkState,
+  saveCloudLinkState,
+  type CloudReachabilityCandidate,
+} from "@fusion/core";
+import { networkInterfaces } from "node:os";
+
+function resolveHttpBase(explicit?: string): string {
+  const fromEnv = process.env.FUSION_CLOUD_HTTP_URL?.trim();
+  const base = (explicit || fromEnv || "").replace(/\/$/, "");
+  if (!base) {
+    throw new Error(
+      "Missing cloud HTTP URL. Pass --http <url> or set FUSION_CLOUD_HTTP_URL (Convex .convex.site).",
+    );
+  }
+  return base;
+}
+
+function lanCandidate(port: number): CloudReachabilityCandidate | null {
+  const nets = networkInterfaces();
+  for (const entries of Object.values(nets)) {
+    for (const entry of entries ?? []) {
+      if (entry.internal || entry.family !== "IPv4") continue;
+      return {
+        kind: "lan",
+        url: `http://${entry.address}:${port}`,
+        priority: 10,
+        tls: false,
+      };
+    }
+  }
+  return null;
+}
+
+export async function runCloudPairStart(opts: {
+  http?: string;
+  name?: string;
+}): Promise<void> {
+  const http = resolveHttpBase(opts.http);
+  const started = await cloudPairStart(http, { engineName: opts.name });
+  // Stash pending in state file under a temporary shape until complete
+  saveCloudLinkState({
+    httpBaseUrl: http,
+    engineId: "",
+    deviceSecret: "",
+    name: opts.name,
+    linkedAt: new Date().toISOString(),
+  });
+  // Write pending alongside via env-like sidecar fields in a dedicated pending file is overkill;
+  // print secrets for complete step.
+  console.log(`Pairing code: ${started.code}`);
+  console.log("Claim this code in Fusion Cloud console (/pair), then run:");
+  console.log(
+    `  fn cloud pair-complete --http ${http} --code ${started.code} --pending-secret ${started.pendingSecret}`,
+  );
+  if (started.expiresAt) {
+    console.log(`Expires: ${started.expiresAt}`);
+  }
+}
+
+export async function runCloudPairComplete(opts: {
+  http?: string;
+  code: string;
+  pendingSecret: string;
+}): Promise<void> {
+  const http = resolveHttpBase(opts.http);
+  const completed = await cloudPairComplete(http, {
+    code: opts.code,
+    pendingSecret: opts.pendingSecret,
+  });
+  saveCloudLinkState({
+    httpBaseUrl: http,
+    engineId: completed.engineId,
+    deviceSecret: completed.deviceSecret,
+    name: completed.name,
+    linkedAt: new Date().toISOString(),
+  });
+  console.log(`Linked engineId: ${completed.engineId}`);
+  console.log(`Name: ${completed.name}`);
+  console.log("Credentials saved to ~/.fusion/cloud-link.json");
+  console.log("Next: fn cloud heartbeat --url <public-or-lan-url> [--loop]");
+}
+
+export async function runCloudHeartbeat(opts: {
+  url?: string;
+  port?: number;
+  loop?: boolean;
+}): Promise<void> {
+  const state = loadCloudLinkState();
+  if (!state?.engineId || !state.deviceSecret) {
+    throw new Error("Not linked. Run fn cloud pair-start / pair-complete first.");
+  }
+  const candidates: CloudReachabilityCandidate[] = [];
+  if (opts.url) {
+    const u = new URL(opts.url);
+    candidates.push({
+      kind: u.hostname.startsWith("100.") ? "tailscale" : u.protocol === "https:" ? "public" : "lan",
+      url: u.origin,
+      priority: 20,
+      tls: u.protocol === "https:",
+    });
+  }
+  const lan = lanCandidate(opts.port ?? 4040);
+  if (lan) candidates.push(lan);
+  if (candidates.length === 0) {
+    throw new Error("Provide --url <engine-origin> or ensure a LAN IPv4 is available.");
+  }
+
+  const once = async () => {
+    const result = await cloudHeartbeat(state.httpBaseUrl, {
+      engineId: state.engineId,
+      deviceSecret: state.deviceSecret,
+      candidates,
+      capabilities: { headless: true, dashboard: true },
+    });
+    console.log(new Date().toISOString(), "heartbeat", result.status);
+  };
+
+  if (opts.loop) {
+    for (;;) {
+      await once();
+      await new Promise((r) => setTimeout(r, 20_000));
+    }
+  } else {
+    await once();
+  }
+}
+
+export async function runCloudStatus(opts: { json?: boolean } = {}): Promise<void> {
+  const state = loadCloudLinkState();
+  if (!state) {
+    if (opts.json) {
+      console.log(JSON.stringify({ linked: false }));
+    } else {
+      console.log("Not linked to Fusion Cloud.");
+    }
+    return;
+  }
+  const payload = {
+    linked: Boolean(state.engineId && state.deviceSecret),
+    engineId: state.engineId || null,
+    name: state.name ?? null,
+    httpBaseUrl: state.httpBaseUrl,
+    linkedAt: state.linkedAt,
+  };
+  if (opts.json) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.log(`Linked: ${payload.linked}`);
+    console.log(`Engine: ${payload.engineId ?? "-"} (${payload.name ?? "unnamed"})`);
+    console.log(`Cloud:  ${payload.httpBaseUrl}`);
+    console.log(`Since:  ${payload.linkedAt}`);
+  }
+}
+
+export async function runCloudUnlink(): Promise<void> {
+  clearCloudLinkState();
+  console.log("Cleared ~/.fusion/cloud-link.json");
+}

--- a/packages/core/src/cloud-link/__tests__/client.test.ts
+++ b/packages/core/src/cloud-link/__tests__/client.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { buildCloudLoginHandoffUrl, cloudRedeemTicket } from "../client.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("buildCloudLoginHandoffUrl", () => {
+  it("appends cloudTicket on /remote-login", () => {
+    expect(buildCloudLoginHandoffUrl("https://eng.example:4040", "jti.sec")).toBe(
+      "https://eng.example:4040/remote-login?cloudTicket=jti.sec",
+    );
+  });
+});
+
+describe("cloudRedeemTicket", () => {
+  it("POSTs ticket to /v1/tickets/redeem", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          engineId: "eng_1",
+          userId: "user_1",
+          localSessionToken: "sess",
+          candidates: [],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await cloudRedeemTicket("https://cloud.example.convex.site", {
+      ticket: "a.b",
+      engineId: "eng_1",
+    });
+    expect(result.localSessionToken).toBe("sess");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.example.convex.site/v1/tickets/redeem",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/packages/core/src/cloud-link/client.ts
+++ b/packages/core/src/cloud-link/client.ts
@@ -1,0 +1,154 @@
+/**
+ * FNXC:CloudLink 2026-08-17-23:45:
+ * HTTP client for Fusion Cloud control plane (.convex.site /v1/*).
+ */
+import {
+  FUSION_CLOUD_LINK_PROTOCOL,
+  FUSION_CLOUD_LINK_VERSION,
+  type CloudEngineCapabilities,
+  type CloudPairCompleteResult,
+  type CloudPairStartResult,
+  type CloudReachabilityCandidate,
+  type CloudRedeemResult,
+} from "./types.js";
+
+export class CloudLinkHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = "CloudLinkHttpError";
+  }
+}
+
+function normalizeBase(httpBaseUrl: string): string {
+  return httpBaseUrl.trim().replace(/\/$/, "");
+}
+
+async function postJson<T>(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!res.ok) {
+    const msg =
+      typeof json.message === "string"
+        ? json.message
+        : typeof json.error === "string"
+          ? json.error
+          : `HTTP ${res.status}`;
+    throw new CloudLinkHttpError(msg, res.status, json);
+  }
+  return json as T;
+}
+
+export async function cloudPairStart(
+  httpBaseUrl: string,
+  opts: { engineName?: string } = {},
+): Promise<CloudPairStartResult> {
+  const base = normalizeBase(httpBaseUrl);
+  const result = await postJson<{
+    code: string;
+    pendingSecret: string;
+    expiresAt?: string;
+  }>(`${base}/v1/pair/start`, {
+    engineName: opts.engineName ?? "fusion-engine",
+  });
+  return {
+    code: result.code,
+    pendingSecret: result.pendingSecret,
+    expiresAt: result.expiresAt,
+  };
+}
+
+export async function cloudPairComplete(
+  httpBaseUrl: string,
+  opts: { code: string; pendingSecret: string },
+): Promise<CloudPairCompleteResult> {
+  const base = normalizeBase(httpBaseUrl);
+  const result = await postJson<{
+    engineId: string;
+    deviceSecret: string;
+    name: string;
+  }>(`${base}/v1/pair/complete`, {
+    code: opts.code,
+    pendingSecret: opts.pendingSecret,
+  });
+  return {
+    engineId: result.engineId,
+    deviceSecret: result.deviceSecret,
+    name: result.name,
+  };
+}
+
+export async function cloudHeartbeat(
+  httpBaseUrl: string,
+  opts: {
+    engineId: string;
+    deviceSecret: string;
+    candidates: CloudReachabilityCandidate[];
+    capabilities?: Partial<CloudEngineCapabilities>;
+  },
+): Promise<{ status: string }> {
+  const base = normalizeBase(httpBaseUrl);
+  const capabilities: CloudEngineCapabilities = {
+    headless: opts.capabilities?.headless ?? true,
+    dashboard: opts.capabilities?.dashboard ?? true,
+    sharedPostgres: opts.capabilities?.sharedPostgres ?? false,
+    meshMembership: opts.capabilities?.meshMembership ?? false,
+    protocolVersion: opts.capabilities?.protocolVersion ?? FUSION_CLOUD_LINK_VERSION,
+    fusionVersion: opts.capabilities?.fusionVersion,
+  };
+  const result = await postJson<{ status: string }>(
+    `${base}/v1/engine/heartbeat`,
+    {
+      protocol: FUSION_CLOUD_LINK_PROTOCOL,
+      version: FUSION_CLOUD_LINK_VERSION,
+      engineId: opts.engineId,
+      candidates: opts.candidates,
+      capabilities,
+    },
+    { Authorization: `Bearer ${opts.deviceSecret}` },
+  );
+  return { status: result.status };
+}
+
+export async function cloudRedeemTicket(
+  httpBaseUrl: string,
+  opts: { ticket: string; engineId?: string },
+): Promise<CloudRedeemResult> {
+  const base = normalizeBase(httpBaseUrl);
+  const result = await postJson<{
+    engineId: string;
+    userId: string;
+    localSessionToken: string;
+    candidates?: CloudReachabilityCandidate[];
+  }>(`${base}/v1/tickets/redeem`, {
+    ticket: opts.ticket,
+    engineId: opts.engineId,
+  });
+  return {
+    engineId: result.engineId,
+    userId: result.userId,
+    localSessionToken: result.localSessionToken,
+    candidates: result.candidates ?? [],
+  };
+}
+
+export function buildCloudLoginHandoffUrl(
+  engineOrigin: string,
+  ticket: string,
+): string {
+  const origin = new URL(engineOrigin);
+  const path = new URL("/remote-login", origin.origin);
+  path.searchParams.set("cloudTicket", ticket);
+  return path.toString();
+}

--- a/packages/core/src/cloud-link/index.ts
+++ b/packages/core/src/cloud-link/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./client.js";
+export * from "./store.js";

--- a/packages/core/src/cloud-link/store.ts
+++ b/packages/core/src/cloud-link/store.ts
@@ -1,0 +1,39 @@
+/**
+ * FNXC:CloudLink 2026-08-17-23:45:
+ * Persist cloud-link device credentials under ~/.fusion/cloud-link.json (global, not project).
+ */
+import { mkdirSync, readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { CloudLinkDeviceState } from "./types.js";
+
+export function defaultCloudLinkStatePath(): string {
+  return join(homedir(), ".fusion", "cloud-link.json");
+}
+
+export function loadCloudLinkState(
+  path: string = defaultCloudLinkStatePath(),
+): CloudLinkDeviceState | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as CloudLinkDeviceState;
+    if (!raw.httpBaseUrl || !raw.engineId || !raw.deviceSecret) return null;
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCloudLinkState(
+  state: CloudLinkDeviceState,
+  path: string = defaultCloudLinkStatePath(),
+): void {
+  mkdirSync(join(homedir(), ".fusion"), { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
+}
+
+export function clearCloudLinkState(
+  path: string = defaultCloudLinkStatePath(),
+): void {
+  if (existsSync(path)) unlinkSync(path);
+}

--- a/packages/core/src/cloud-link/types.ts
+++ b/packages/core/src/cloud-link/types.ts
@@ -1,0 +1,60 @@
+/**
+ * FNXC:CloudLink 2026-08-17-23:45:
+ * Fusion Cloud Mode A client types. Control plane is Runfusion/fusion-cloud (Convex).
+ * Engines pair/heartbeat/redeem; boards stay local. Aligns with fusion-cloud docs/PROTOCOL.md.
+ */
+
+export const FUSION_CLOUD_LINK_PROTOCOL = "fusion.cloud-link" as const;
+export const FUSION_CLOUD_LINK_VERSION = "0.1.0" as const;
+export const CLOUD_TICKET_QUERY = "cloudTicket" as const;
+
+export type CloudCandidateKind =
+  | "lan"
+  | "tailscale"
+  | "cloudflare"
+  | "public"
+  | "other";
+
+export interface CloudReachabilityCandidate {
+  kind: CloudCandidateKind;
+  url: string;
+  priority: number;
+  expiresAt?: string;
+  tls: boolean;
+}
+
+export interface CloudEngineCapabilities {
+  headless: boolean;
+  dashboard: boolean;
+  sharedPostgres: boolean;
+  meshMembership: boolean;
+  protocolVersion: string;
+  fusionVersion?: string;
+}
+
+export interface CloudLinkDeviceState {
+  httpBaseUrl: string;
+  engineId: string;
+  deviceSecret: string;
+  name?: string;
+  linkedAt: string;
+}
+
+export interface CloudPairStartResult {
+  code: string;
+  pendingSecret: string;
+  expiresAt?: string;
+}
+
+export interface CloudPairCompleteResult {
+  engineId: string;
+  deviceSecret: string;
+  name: string;
+}
+
+export interface CloudRedeemResult {
+  engineId: string;
+  userId: string;
+  localSessionToken: string;
+  candidates: CloudReachabilityCandidate[];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2878,3 +2878,4 @@ export * from "./memory/recall-capture.js";
  * filesystem-dependent spawn factory remains available only at @fusion/core/mcp-builtin-servers.
  */
 export * from "./config/mcp-builtin-descriptor.js";
+export * from "./cloud-link/index.js";

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -20,7 +20,16 @@ import type {
   AgentLogEntry,
   RunAuditEvent,
 } from "@fusion/core";
-import { AgentStore, ChatStore, queryRunAuditEvents, resolveGlobalDir, resolveReboundTargetForTask, setRunningAgentCountSource } from "@fusion/core";
+import {
+  AgentStore,
+  ChatStore,
+  cloudRedeemTicket,
+  loadCloudLinkState,
+  queryRunAuditEvents,
+  resolveGlobalDir,
+  resolveReboundTargetForTask,
+  setRunningAgentCountSource,
+} from "@fusion/core";
 import type { AuthStorageLike, ModelRegistryLike } from "./routes.js";
 import { createApiRoutes } from "./routes.js";
 import { createSSE, disconnectSSEClient, markSSEClientAlive } from "./sse.js";
@@ -74,7 +83,7 @@ import { setupCliSessionWebSocket } from "./cli-session-ws.js";
 import { createCliSessionsRouter } from "./routes/cli-sessions.js";
 import { getProjectIdFromRequest, resolveStoreForProjectId } from "./routes/context.js";
 import type { CliRelaunchRegistry } from "./cli-session-transport.js";
-import { validateRemoteAuthToken } from "./remote-auth.js";
+import { issueRemoteAuthToken, validateRemoteAuthToken } from "./remote-auth.js";
 import { getCliPackageVersion, isUnresolvedCliPackageVersion } from "./cli-package-version.js";
 import { performUpdateCheck } from "./update-check.js";
 import { buildAutoUpdateDeps, startAutoUpdateWatcher } from "./auto-update.js";
@@ -2155,6 +2164,14 @@ export function createServer(store: TaskStore, options?: ServerOptions): ReturnT
 
   app.get("/remote-login", async (req, res) => {
     const remoteToken = typeof req.query.rt === "string" ? req.query.rt : undefined;
+    /*
+    FNXC:CloudLink 2026-08-17-23:45:
+    Mode A handoff from Fusion Cloud console uses cloudTicket=jti.secret.
+    Redeem against the control plane, then issue a short-lived local remote token (rt)
+    and redirect through the existing remote-login path so daemon auth still works.
+    */
+    const cloudTicket =
+      typeof req.query.cloudTicket === "string" ? req.query.cloudTicket : undefined;
 
     let settings: Awaited<ReturnType<typeof store.getSettings>>;
     try {
@@ -2168,6 +2185,50 @@ export function createServer(store: TaskStore, options?: ServerOptions): ReturnT
     if (!remoteAccess) {
       res.status(401).json({ error: "Unauthorized", code: "remote_token_invalid" });
       return;
+    }
+
+    if (cloudTicket) {
+      try {
+        const linked = loadCloudLinkState();
+        const httpBase =
+          linked?.httpBaseUrl ||
+          process.env.FUSION_CLOUD_HTTP_URL?.trim() ||
+          "";
+        if (!httpBase) {
+          res.status(401).json({
+            error: "Unauthorized",
+            code: "cloud_ticket_cloud_url_missing",
+          });
+          return;
+        }
+        await cloudRedeemTicket(httpBase, {
+          ticket: cloudTicket,
+          engineId: linked?.engineId,
+        });
+        if (!remoteAccess.tokenStrategy.shortLived.enabled) {
+          const daemonTokenForRedirect = getDaemonToken(options);
+          if (daemonTokenForRedirect) {
+            const redirectUrl = new URL("/", `${req.protocol}://${req.get("host")}`);
+            redirectUrl.searchParams.set("token", daemonTokenForRedirect);
+            res.redirect(302, redirectUrl.pathname + redirectUrl.search);
+            return;
+          }
+          res.redirect(302, "/");
+          return;
+        }
+        const issued = issueRemoteAuthToken("short-lived", remoteAccess);
+        const redirectUrl = new URL("/remote-login", `${req.protocol}://${req.get("host")}`);
+        redirectUrl.searchParams.set("rt", issued.token);
+        res.redirect(302, redirectUrl.pathname + redirectUrl.search);
+        return;
+      } catch (err) {
+        res.status(401).json({
+          error: "Unauthorized",
+          code: "cloud_ticket_invalid",
+          message: err instanceof Error ? err.message : "redeem failed",
+        });
+        return;
+      }
     }
 
     const result = validateRemoteAuthToken(remoteToken, remoteAccess);


### PR DESCRIPTION
## Summary

Thin Fusion client for the private **Runfusion/fusion-cloud** control plane (Mode A):

- `@fusion/core` cloud-link HTTP client (pair / heartbeat / redeem)
- Device credentials in `~/.fusion/cloud-link.json`
- CLI: `fn cloud pair-start | pair-complete | heartbeat | status | unlink`
- `/remote-login?cloudTicket=` redeems against cloud then issues short-lived `rt` (or daemon token)

Boards stay on the engine; cloud remains signaling/discovery only.

## Test plan

- [x] `pnpm --filter @fusion/core exec vitest run src/cloud-link/__tests__/client.test.ts`
- [ ] Manual: pair against live fusion-cloud, heartbeat, Connect from console, open `cloudTicket` URL
- [ ] Confirm existing `/remote-login?rt=` path unchanged

Companion cloud UI: https://github.com/Runfusion/fusion-cloud/pull/2 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud pairing and device linking through the CLI.
  * Added heartbeat, connection status, and unlink commands with human-readable or JSON output.
  * Added remote login using cloud tickets, including short-lived authentication tokens.
  * Added automatic persistence and secure handling of cloud-link credentials.
  * Added support for discovering device network reachability during linking.
* **Documentation**
  * Documented the Fusion Cloud Mode A release and available cloud-link workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->