### PR TITLE
fix: normalize subscribe for callback-only runtime sessions

### DIFF
--- a/.changeset/runtime-session-subscribe-compat.md
+++ b/.changeset/runtime-session-subscribe-compat.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Make workflow steps compatible with callback-only plugin runtimes.
+category: fix
+dev: Adds the missing `AgentSession.subscribe` compatibility at the shared runtime boundary, preserves native subscriptions, and relays events across deferred cross-runtime swaps.

--- a/packages/engine/src/__tests__/agent-session-helpers.test.ts
+++ b/packages/engine/src/__tests__/agent-session-helpers.test.ts
@@ -693,6 +693,111 @@ describe("createResolvedAgentSession", () => {
     );
   });
 
+  /*
+  FNXC:RuntimeSubscribeCompat 2026-08-22-02:36:
+  Workflow steps subscribe unconditionally, so the shared runtime boundary must
+  adapt callback-only plugin sessions instead of requiring every bundled and
+  vendored runtime to duplicate the same event bridge.
+  */
+  it("adds isolated subscribe delivery to callback-only plugin sessions", async () => {
+    const callbackSession = { dispose: vi.fn() } as any;
+    const createSessionMock = vi.fn().mockResolvedValue({ session: callbackSession });
+    const runtimePrompt = vi.fn(async () => {
+      const runtimeOptions = createSessionMock.mock.calls[0][0];
+      runtimeOptions.onText?.("answer");
+      runtimeOptions.onThinking?.("reasoning");
+      runtimeOptions.onToolStart?.("read_file", { path: "README.md" });
+      runtimeOptions.onToolEnd?.("read_file", false, { text: "ok" });
+    });
+    resolveRuntimeMock.mockResolvedValue({
+      runtime: {
+        id: "hermes",
+        name: "Hermes Runtime",
+        createSession: createSessionMock,
+        promptWithFallback: runtimePrompt,
+        describeModel: vi.fn(() => "hermes/test"),
+      },
+      runtimeId: "hermes",
+      wasConfigured: true,
+    });
+    const onText = vi.fn();
+    const onThinking = vi.fn();
+    const onToolStart = vi.fn();
+    const onToolEnd = vi.fn();
+
+    const { session } = await createResolvedAgentSession({
+      sessionPurpose: "executor",
+      cwd: "/tmp/project",
+      systemPrompt: "system",
+      onText,
+      onThinking,
+      onToolStart,
+      onToolEnd,
+    });
+    const events: unknown[] = [];
+    const unsubscribeThrowing = session.subscribe(() => {
+      throw new Error("broken subscriber");
+    });
+    const unsubscribe = session.subscribe((event) => events.push(event));
+
+    await (session as any).promptWithFallback("review");
+
+    expect(onText).toHaveBeenCalledWith("answer");
+    expect(onThinking).toHaveBeenCalledWith("reasoning");
+    expect(onToolStart).toHaveBeenCalledWith("read_file", { path: "README.md" });
+    expect(onToolEnd).toHaveBeenCalledWith("read_file", false, { text: "ok" });
+    expect(events).toEqual([
+      {
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "answer" },
+      },
+      {
+        type: "message_update",
+        assistantMessageEvent: { type: "thinking_delta", contentIndex: 1, delta: "reasoning" },
+      },
+      { type: "tool_execution_start", toolName: "read_file", args: { path: "README.md" } },
+      { type: "tool_execution_end", toolName: "read_file", isError: false, result: { text: "ok" } },
+    ]);
+
+    unsubscribeThrowing();
+    unsubscribe();
+    await (session as any).promptWithFallback("second review");
+    expect(events).toHaveLength(4);
+  });
+
+  it("preserves native subscription delivery on non-pi plugin sessions", async () => {
+    const nativeUnsubscribe = vi.fn();
+    const nativeSubscribe = vi.fn(() => nativeUnsubscribe);
+    const nativeSession = { subscribe: nativeSubscribe, dispose: vi.fn() } as any;
+    const createSessionMock = vi.fn().mockResolvedValue({ session: nativeSession });
+    resolveRuntimeMock.mockResolvedValue({
+      runtime: {
+        id: "acp",
+        name: "ACP Runtime",
+        createSession: createSessionMock,
+        promptWithFallback: vi.fn(),
+        describeModel: vi.fn(() => "acp/test"),
+      },
+      runtimeId: "acp",
+      wasConfigured: true,
+    });
+    const onText = vi.fn();
+
+    const { session } = await createResolvedAgentSession({
+      sessionPurpose: "executor",
+      cwd: "/tmp/project",
+      systemPrompt: "system",
+      onText,
+    });
+    const handler = vi.fn();
+
+    expect(session.subscribe).toBe(nativeSubscribe);
+    expect(session.subscribe(handler)).toBe(nativeUnsubscribe);
+    createSessionMock.mock.calls[0][0].onText?.("native answer");
+    expect(onText).toHaveBeenCalledWith("native answer");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("forwards plugin skill names and body paths to runtime session factory", async () => {
     const createSessionMock = vi.fn().mockResolvedValue({
       session: { prompt: vi.fn() },

--- a/packages/engine/src/__tests__/cross-runtime-fallback.test.ts
+++ b/packages/engine/src/__tests__/cross-runtime-fallback.test.ts
@@ -11,6 +11,7 @@ import {
   captureTransferableConversationContext,
   TRANSFERABLE_CONVERSATION_LIMITS,
 } from "../agents/cross-runtime-fallback.js";
+import type { AgentRuntimeOptions } from "../agents/agent-runtime.js";
 
 const primaryError = new Error("rate limit exceeded");
 
@@ -68,6 +69,68 @@ describe("cross-runtime fallback", () => {
     expect(fallbackPrompt.mock.calls[1]?.[1]).toBe("later request");
     await session.dispose();
     expect(fallbackSession.dispose).toHaveBeenCalledOnce();
+  });
+
+  /*
+  FNXC:RuntimeSubscribeCompat 2026-08-22-03:07:
+  Subscribers stay attached to the caller-held primary session across a deferred
+  runtime swap, so fallback callbacks must relay through that stable boundary.
+  */
+  it("relays fallback callbacks to subscribers on the primary session", async () => {
+    let fallbackOptions: AgentRuntimeOptions | undefined;
+    const fallbackSession = { dispose: vi.fn() };
+    const fallbackPrompt = vi.fn(async () => {
+      fallbackOptions?.onText?.("answer");
+      fallbackOptions?.onThinking?.("reasoning");
+      fallbackOptions?.onToolStart?.("read_file", { path: "README.md" });
+      fallbackOptions?.onToolEnd?.("read_file", false, { text: "ok" });
+    });
+    resolveRuntime.mockResolvedValue({
+      runtimeId: "cursor",
+      runtime: {
+        createSession: vi.fn(async (options: AgentRuntimeOptions) => {
+          fallbackOptions = options;
+          return { session: fallbackSession };
+        }),
+        promptWithFallback: fallbackPrompt,
+      },
+    });
+    const primaryListeners = new Set<(event: unknown) => void>();
+    const session = {
+      ...createSession(),
+      subscribe: (listener: (event: unknown) => void) => {
+        primaryListeners.add(listener);
+        return () => primaryListeners.delete(listener);
+      },
+    };
+    arm(session);
+    const events: unknown[] = [];
+    const unsubscribeThrowing = session.subscribe(() => {
+      throw new Error("broken subscriber");
+    });
+    const unsubscribe = session.subscribe((event) => events.push(event));
+
+    await expect(
+      (session.promptWithFallback as (prompt: string) => Promise<unknown>)("hello"),
+    ).resolves.toBeUndefined();
+
+    expect(events).toEqual([
+      {
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "answer" },
+      },
+      {
+        type: "message_update",
+        assistantMessageEvent: { type: "thinking_delta", contentIndex: 1, delta: "reasoning" },
+      },
+      { type: "tool_execution_start", toolName: "read_file", args: { path: "README.md" } },
+      { type: "tool_execution_end", toolName: "read_file", isError: false, result: { text: "ok" } },
+    ]);
+
+    unsubscribeThrowing();
+    unsubscribe();
+    await (session.promptWithFallback as (prompt: string) => Promise<unknown>)("again");
+    expect(events).toHaveLength(4);
   });
 
   it.each([

--- a/packages/engine/src/agents/agent-session-helpers.ts
+++ b/packages/engine/src/agents/agent-session-helpers.ts
@@ -64,6 +64,7 @@ import {
   armDeferredCrossRuntimeFallback,
   deferCrossRuntimeCliFallback,
   type DeferredCrossRuntimeFallback,
+  withRuntimeEventCallbacks,
 } from "./cross-runtime-fallback.js";
 
 /** Logger for agent session helpers */
@@ -141,6 +142,49 @@ function wrapPluginRuntimeToolOptions(
 
 function shouldWrapCustomToolsForRuntime(runtimeId: string): boolean {
   return !RUNTIMES_WITH_INTERNAL_TOOL_GATING.has(runtimeId);
+}
+
+/*
+FNXC:RuntimeSubscribeCompat 2026-08-22-02:36:
+Workflow steps consume the pi AgentSession contract and subscribe unconditionally,
+while callback-only plugin runtimes use local structural session types. Normalize
+that mismatch once at the shared runtime boundary so bundled and vendored runtimes
+do not each need a duplicate event bridge.
+*/
+function createPluginSessionSubscribeCompatibility(options: AgentRuntimeOptions): {
+  options: AgentRuntimeOptions;
+  attach: (session: AgentSession) => void;
+} {
+  const subscribers = new Set<(event: unknown) => void>();
+  let enabled = false;
+  const emit = (event: Record<string, unknown>): void => {
+    if (!enabled) return;
+    for (const handler of subscribers) {
+      try {
+        handler(event);
+      } catch {
+        // FNXC:RuntimeSubscribeCompat 2026-08-22-02:36: one faulty consumer cannot break runtime streaming.
+      }
+    }
+  };
+
+  return {
+    options: withRuntimeEventCallbacks(options, emit),
+    attach: (session) => {
+      const compatible = session as unknown as {
+        subscribe?: (handler: (event: unknown) => void) => () => void;
+      };
+      if (typeof compatible.subscribe === "function") return;
+
+      enabled = true;
+      compatible.subscribe = (handler) => {
+        subscribers.add(handler);
+        return () => {
+          subscribers.delete(handler);
+        };
+      };
+    },
+  };
 }
 
 function extractSkillNamesFromSelection(skillSelection: SkillSelectionContext | undefined): string[] {
@@ -995,7 +1039,13 @@ export async function createResolvedAgentSession(
           ...baseSessionCreateOptions,
           sessionPurpose,
         };
-  const result = await resolved.runtime.createSession(sessionCreateOptions);
+  const subscribeCompatibility = resolved.runtimeId === "pi"
+    ? undefined
+    : createPluginSessionSubscribeCompatibility(sessionCreateOptions);
+  const result = await resolved.runtime.createSession(
+    subscribeCompatibility?.options ?? sessionCreateOptions,
+  );
+  subscribeCompatibility?.attach(result.session);
 
   const noModelResolved = !mockProviderActive && !testModeActive && (!runtimeOptions.defaultProvider || !runtimeOptions.defaultModelId);
   const runtimeBuiltInFallbackModel = noModelResolved ? resolved.runtime.describeModel(result.session) : undefined;

--- a/packages/engine/src/agents/cross-runtime-fallback.ts
+++ b/packages/engine/src/agents/cross-runtime-fallback.ts
@@ -9,6 +9,42 @@ import { getCliProviderRouting, stripCliProviderPrefix } from "./cli-provider-ro
 
 const fallbackLog = createLogger("cross-runtime-fallback");
 
+/*
+FNXC:RuntimeSubscribeCompat 2026-08-22-03:07:
+Callback-only runtime events use one pi-shaped bridge whether the session is
+created initially or by a deferred cross-runtime fallback.
+*/
+export function withRuntimeEventCallbacks(
+  options: AgentRuntimeOptions,
+  emit: (event: Record<string, unknown>) => void,
+): AgentRuntimeOptions {
+  return {
+    ...options,
+    onText: (delta) => {
+      emit({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta },
+      });
+      options.onText?.(delta);
+    },
+    onThinking: (delta) => {
+      emit({
+        type: "message_update",
+        assistantMessageEvent: { type: "thinking_delta", contentIndex: 1, delta },
+      });
+      options.onThinking?.(delta);
+    },
+    onToolStart: (toolName, args) => {
+      emit({ type: "tool_execution_start", toolName, args });
+      options.onToolStart?.(toolName, args);
+    },
+    onToolEnd: (toolName, isError, result) => {
+      emit({ type: "tool_execution_end", toolName, isError, result });
+      options.onToolEnd?.(toolName, isError, result);
+    },
+  };
+}
+
 export interface DeferredCrossRuntimeFallback {
   providerId: string;
   runtimeId: string;
@@ -182,6 +218,30 @@ export function armDeferredCrossRuntimeFallback(args: {
 }): void {
   const { session, sessionPurpose, pluginRunner, runAuditor, deferred, createOptions, primaryProvider, primaryModelId, onFallbackModelUsed, taskId, taskTitle, auditEventType, preserveConversationContext } = args;
   const original = session.promptWithFallback as (prompt: string, options?: unknown) => Promise<unknown>;
+  const fallbackSubscribers = new Set<(event: unknown) => void>();
+  const subscribable = session as unknown as {
+    subscribe?: (handler: (event: unknown) => void) => () => void;
+  };
+  if (typeof subscribable.subscribe === "function") {
+    const subscribe = subscribable.subscribe.bind(session);
+    subscribable.subscribe = (handler) => {
+      fallbackSubscribers.add(handler);
+      const unsubscribe = subscribe(handler);
+      return () => {
+        fallbackSubscribers.delete(handler);
+        unsubscribe();
+      };
+    };
+  }
+  const fallbackCreateOptions = withRuntimeEventCallbacks(createOptions, (event) => {
+    for (const handler of fallbackSubscribers) {
+      try {
+        handler(event);
+      } catch {
+        // FNXC:RuntimeSubscribeCompat 2026-08-22-03:07: fallback observers are isolated like primary observers.
+      }
+    }
+  });
   const primaryDescription = `${primaryProvider ?? "unknown"}/${primaryModelId ?? "unknown"}`;
   const fallbackDescription = `${deferred.providerId}/${deferred.modelId ?? "unknown"}`;
   type Swap = {
@@ -214,7 +274,7 @@ export function armDeferredCrossRuntimeFallback(args: {
         const attempt = (async (): Promise<Swap> => {
           const resolved = await resolveRuntime(buildRuntimeResolutionContext(sessionPurpose, pluginRunner, deferred.runtimeId));
           if (resolved.runtimeId !== deferred.runtimeId) throw new Error(`${deferred.runtimeId} runtime unavailable at swap time`);
-          const fallbackSession = (await resolved.runtime.createSession(createOptions)).session;
+          const fallbackSession = (await resolved.runtime.createSession(fallbackCreateOptions)).session;
           const transferredContext = preserveConversationContext
             ? captureTransferableConversationContext(session)
             : undefined;

--- a/plugins/fusion-plugin-acp-runtime/src/__tests__/fixtures/echo-agent.mjs
+++ b/plugins/fusion-plugin-acp-runtime/src/__tests__/fixtures/echo-agent.mjs
@@ -83,14 +83,28 @@ class EchoAgent {
         sessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: "Working on it." },
+          content: { type: "text", text: "Working on " },
+        },
+      });
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "it." },
         },
       });
       await this.connection.sessionUpdate({
         sessionId,
         update: {
           sessionUpdate: "agent_thought_chunk",
-          content: { type: "text", text: "Let me think about this." },
+          content: { type: "text", text: "Let me think " },
+        },
+      });
+      await this.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "about this." },
         },
       });
       await this.connection.sessionUpdate({

--- a/plugins/fusion-plugin-acp-runtime/src/__tests__/runtime-adapter.test.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/__tests__/runtime-adapter.test.ts
@@ -124,10 +124,13 @@ describe("AcpRuntimeAdapter (U3)", () => {
   it("exposes session.subscribe and replays streamed updates as pi-shaped events", async () => {
     const adapter = makeAdapter({ acpEnvAllowList: ["ACP_FIXTURE_RICH_PROMPT"] });
     const { session } = await adapter.createSession(
-      makeOptions({ taskEnv: { ACP_FIXTURE_RICH_PROMPT: "1" } } as never),
+      makeOptions({ taskEnv: { ACP_FIXTURE_RICH_PROMPT: "1" } }),
     );
     const events: Array<{ type: string; assistantMessageEvent?: { type: string; delta: string; contentIndex?: number }; toolName?: string }> = [];
     const retained: Array<{ type: string }> = [];
+    const throwingUnsub = session.subscribe(() => {
+      throw new Error("broken subscriber");
+    });
     const unsubscribe = session.subscribe((event: unknown) => events.push(event as { type: string }));
     const retainedUnsub = session.subscribe((event: unknown) => retained.push(event as { type: string }));
     try {
@@ -135,20 +138,19 @@ describe("AcpRuntimeAdapter (U3)", () => {
         adapter.promptWithFallback(session, "rich turn"),
       ).resolves.toEqual({ stopReason: "end_turn" });
 
-      const textDelta = events.find(
+      const textDeltas = events.filter(
         (e) => e.type === "message_update" && e.assistantMessageEvent?.type === "text_delta",
       );
-      expect(textDelta?.assistantMessageEvent?.delta).toContain("Working on it");
+      expect(textDeltas).toHaveLength(2);
+      expect(textDeltas.map((e) => e.assistantMessageEvent?.delta).join("")).toContain("Working on it");
       // FNXC:AcpSubscribeCompat 2026-08-21-20:24: contentIndex is per block, not per delta.
-      expect(textDelta?.assistantMessageEvent?.contentIndex).toBe(0);
-      expect(events.filter((e) => e.assistantMessageEvent?.type === "text_delta").every((e) => e.assistantMessageEvent?.contentIndex === 0)).toBe(true);
+      expect(textDeltas.map((e) => e.assistantMessageEvent?.contentIndex)).toEqual([0, 0]);
 
-      const thinkingDelta = events.find(
+      const thinkingDeltas = events.filter(
         (e) => e.type === "message_update" && e.assistantMessageEvent?.type === "thinking_delta",
       );
-      expect(thinkingDelta).toBeDefined();
-      expect(thinkingDelta?.assistantMessageEvent?.contentIndex).toBe(1);
-      expect(events.filter((e) => e.assistantMessageEvent?.type === "thinking_delta").every((e) => e.assistantMessageEvent?.contentIndex === 1)).toBe(true);
+      expect(thinkingDeltas.length).toBeGreaterThan(1);
+      expect(new Set(thinkingDeltas.map((e) => e.assistantMessageEvent?.contentIndex))).toEqual(new Set([1]));
 
       const toolStart = events.find((e) => e.type === "tool_execution_start");
       expect(toolStart?.toolName).toBeTruthy();
@@ -168,6 +170,7 @@ describe("AcpRuntimeAdapter (U3)", () => {
       expect(events.length).toBe(countAfterFirst);
       expect(retained.length).toBeGreaterThan(retainedBeforeSecond);
     } finally {
+      throwingUnsub();
       retainedUnsub();
       await adapter.dispose(session);
     }
@@ -186,7 +189,7 @@ describe("AcpRuntimeAdapter (U3)", () => {
         onToolStart: (n: string, a?: unknown) => toolStarts.push({ name: n, args: a }),
         onToolEnd: (n: string, e: boolean) => toolEnds.push({ name: n, isError: e }),
         taskEnv: { ACP_FIXTURE_RICH_PROMPT: "1" },
-      } as never),
+      }),
     );
     const seenText: string[] = [];
     const seenThinking: string[] = [];

--- a/plugins/fusion-plugin-acp-runtime/src/runtime-adapter.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/runtime-adapter.ts
@@ -142,15 +142,13 @@ export class AcpRuntimeAdapter implements AgentRuntime {
       env: buildSpawnEnv(this.settings.envAllowList, {
         required: this.settings.requiredEnv,
         /*
-        FNXC:AcpSubscribeCompat 2026-08-21-18:40:
+        FNXC:AcpTaskEnv 2026-08-21-18:40:
         `taskEnv` is the engine's contract for task-scoped subprocess env
-        (AgentRuntimeOptions.taskEnv). Merge it AFTER the allow-list so task
-        values win, but only for keys the allow-list already admits — the
-        allow-list stays the trust boundary (KTD6b).
+        (AgentRuntimeOptions.taskEnv). Overlay it before filtering so task values
+        win, while only keys admitted by the allow-list reach the subprocess —
+        the allow-list stays the trust boundary (KTD6b).
         */
-        sourceEnv: options.taskEnv
-          ? { ...process.env, ...options.taskEnv }
-          : process.env,
+        sourceEnv: { ...process.env, ...options.taskEnv },
       }),
       advertiseFs: { read: this.settings.fsRead, write: this.settings.fsWrite },
       clientHandler,

--- a/plugins/fusion-plugin-acp-runtime/src/types.ts
+++ b/plugins/fusion-plugin-acp-runtime/src/types.ts
@@ -117,7 +117,7 @@ export interface AgentRuntimeOptions {
   systemPrompt: string;
   tools?: "coding" | "readonly";
   /**
-   * FNXC:AcpSubscribeCompat 2026-08-21-19:12:
+   * FNXC:AcpTaskEnv 2026-08-21-19:12:
    * Task-scoped subprocess environment (engine contract); allow-list still gates forwarding.
    */
   taskEnv?: NodeJS.ProcessEnv;
@@ -187,7 +187,7 @@ export interface AcpSession {
    * call sites call it unconditionally (execute-workflow-step.ts, pi.ts).
    * ACP sessions stream through the bridging client handler onto `callbacks`
    * instead, so this adapter replays each forwarded event to every handler.
-   * Returns a no-op unsubscribe for interface compatibility.
+   * Returns an unsubscribe function that removes only the registered handler.
    */
   subscribe(handler: (event: unknown) => void): () => void;
 }


### PR DESCRIPTION
## Summary

- normalize callback-only plugin sessions at the shared runtime boundary
- preserve runtime-native subscriptions and isolate subscriber failures
- strengthen ACP multi-delta, unsubscribe, and callback-delivery coverage
- correct the task environment and unsubscribe contracts

## Why

PR #3501 fixed the generic ACP adapter, but workflow steps still call `session.subscribe()` unconditionally. Bundled callback-only runtimes such as Hermes and the vendored Grok/Claude/OMP ACP clients can still return sessions without that method. Handling the compatibility once in `createResolvedAgentSession` closes every current runtime surface without copying the bridge into each adapter.

## Testing

- `packages/engine`: `agent-session-helpers.test.ts` — 61 passed
- `fusion-plugin-acp-runtime`: `runtime-adapter.test.ts` — 14 passed
- `fusion-plugin-acp-runtime`: `process-manager.test.ts` — 15 passed
- engine typecheck passed
- ACP runtime typecheck passed
- changeset format, FNXC date check, ESLint, and `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with callback-based runtime sessions.
  - Added reliable subscriptions for text, thinking, and tool activity updates.
  - Preserved native subscription behavior where available.
  - Prevented subscriber errors from interrupting event delivery.
  - Improved unsubscribe behavior for removed handlers.
  - Improved event delivery during deferred runtime fallback.
  - Corrected task environment values passed to runtime subprocesses.

- **Tests**
  - Expanded coverage for streaming updates, fallback handling, cleanup, and subscriber isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->