### PR TITLE
feat: add cloud-link Mode A client (fn cloud)

### DIFF
--- a/.github/workflows/agent-browser-install.yml
+++ b/.github/workflows/agent-browser-install.yml
@@ -27,7 +27,13 @@ jobs:
   pack-fixture:
     name: Pack agent-browser install fixture
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # FNXC:AgentBrowserPackaging 2026-09-04-04:42:
+    # prepack now asserts dist/plugin-sdk/index.d.ts exists (prepare-publish-manifest).
+    # Keep skip-install so setup-node uses the no-store-cache path (ci-workflow
+    # contract; post-job cache save otherwise fails). The composite's skip-install
+    # input means the caller installs workspace deps; build the CLI before
+    # `pnpm pack` so the pack guard stays intact as a real published-boundary test.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -39,6 +45,14 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
         with:
           skip-install: "true"
+
+      - name: Install dependencies
+        shell: bash
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI package for pack
+        shell: bash
+        run: pnpm --filter @runfusion/fusion build
 
       - name: Pack Fusion CLI and agent-browser
         shell: bash

--- a/packages/cli/src/__tests__/ci-workflow.test.ts
+++ b/packages/cli/src/__tests__/ci-workflow.test.ts
@@ -870,6 +870,13 @@ describe("Cross-platform agent-browser install workflow", () => {
     // FNXC:CI 2026-07-26-23:05: pack fixture must keep skip-install so the composite
     // takes the no-store-cache setup-node path (see setup-node-pnpm action).
     expect(findCompositeSetupStep(packFixture?.steps ?? [])?.with?.["skip-install"]).toBe("true");
+    /*
+    FNXC:AgentBrowserPackaging 2026-09-04-04:42:
+    prepack asserts dist/plugin-sdk/index.d.ts, so pack-fixture must install workspace
+    deps and build @runfusion/fusion before `pnpm pack`. Do not skip that assertion.
+    */
+    expect(content).toContain("pnpm install --frozen-lockfile");
+    expect(content).toContain("pnpm --filter @runfusion/fusion build");
     expect(installSmoke?.needs).toBe("pack-fixture");
     expect(installSmoke?.["runs-on"]).toBe("${{ matrix.os }}");
     expect(installSmoke?.strategy?.matrix?.os).toEqual(["ubuntu-latest", "macos-latest", "windows-latest"]);

--- a/packages/cli/src/__tests__/pty-native-assets.test.ts
+++ b/packages/cli/src/__tests__/pty-native-assets.test.ts
@@ -1,8 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { bunTargetToPlatformArch, nodePtyPlatformPackageName, nodePtyRequiredNativeAssetName, resolveStagingOutcome } from "../runtime/pty-native-assets.js";
 import { createNativeModuleRedirect, createWindowsNativeModuleRedirect, resolveBundledPlatformPackageRequest, resolveBundledWindowsNativeRequest } from "../runtime/native-patch.js";
 
 describe("node-pty standalone assets", () => {
+  /*
+  FNXC:CliPackaging 2026-09-04-04:42:
+  Path-only fixtures must use mkdtemp rather than a literal /tmp/... name. ThreatCrush flags predictable temp paths (CWE-377) even when the tests never create files.
+  */
+  let tmpRoot: string;
+  let linuxNativeDir: string;
+  let windowsNativeDir: string;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "fusion-runtime-"));
+    linuxNativeDir = join(tmpRoot, "linux-x64");
+    windowsNativeDir = join(tmpRoot, "win32-x64");
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
   it("maps all published platform packages", () => {
     for (const token of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"]) {
       const [platform, arch] = token.split("-");
@@ -31,13 +52,14 @@ describe("node-pty standalone assets", () => {
   });
 
   it("redirects a bundled foreign platform-package request to its staged module", () => {
-    const nativeDir = "/tmp/fusion-runtime/linux-x64";
+    const nativeDir = linuxNativeDir;
     const parent = { filename: "/$bunfs/root/node-pty/index.js" };
     const platformPackage = "@lydell/node-pty-linux-x64";
+    const stagedPlatformEntry = join(nativeDir, "node-pty-platform", "lib", "index.js");
 
     // A darwin build host must still load this Linux package from the release payload.
     const platformEntry = resolveBundledPlatformPackageRequest(platformPackage, parent.filename, nativeDir, "linux", "x64");
-    expect(platformEntry).toBe("/tmp/fusion-runtime/linux-x64/node-pty-platform/lib/index.js");
+    expect(platformEntry).toBe(stagedPlatformEntry);
     expect(resolveBundledPlatformPackageRequest(platformPackage, "/app/node-pty/index.js", nativeDir, "linux", "x64")).toBeNull();
 
     const loaded: string[] = [];
@@ -46,18 +68,20 @@ describe("node-pty standalone assets", () => {
       return { platformModule: request };
     }, "linux", "x64");
     expect(redirect(platformPackage, parent, false)).toEqual({
-      platformModule: "/tmp/fusion-runtime/linux-x64/node-pty-platform/lib/index.js",
+      platformModule: stagedPlatformEntry,
     });
-    expect(loaded).toEqual(["/tmp/fusion-runtime/linux-x64/node-pty-platform/lib/index.js"]);
+    expect(loaded).toEqual([stagedPlatformEntry]);
   });
 
   it("redirects bundled Windows ConPTY probes to the complete staged payload", () => {
-    const nativeDir = "/tmp/fusion-runtime/win32-x64";
+    const nativeDir = windowsNativeDir;
     const parent = { filename: "/$bunfs/root/node-pty/lib/utils.js" };
+    const conptyPath = join(nativeDir, "conpty.node");
+    const conptyListPath = join(nativeDir, "conpty_console_list.node");
     expect(resolveBundledWindowsNativeRequest("./prebuilds/win32-x64/conpty.node", parent.filename, nativeDir))
-      .toBe("/tmp/fusion-runtime/win32-x64/conpty.node");
+      .toBe(conptyPath);
     expect(resolveBundledWindowsNativeRequest("./prebuilds/win32-x64/conpty_console_list.node", parent.filename, nativeDir))
-      .toBe("/tmp/fusion-runtime/win32-x64/conpty_console_list.node");
+      .toBe(conptyListPath);
     expect(resolveBundledWindowsNativeRequest("./prebuilds/win32-x64/../outside.node", parent.filename, nativeDir)).toBeNull();
     expect(resolveBundledWindowsNativeRequest("./prebuilds/win32-x64/conpty.node", "/app/node-pty/lib/utils.js", nativeDir)).toBeNull();
 
@@ -67,8 +91,8 @@ describe("node-pty standalone assets", () => {
       return { native: request };
     });
     expect(redirect("./prebuilds/win32-x64/conpty.node", parent, false)).toEqual({
-      native: "/tmp/fusion-runtime/win32-x64/conpty.node",
+      native: conptyPath,
     });
-    expect(loaded).toEqual(["/tmp/fusion-runtime/win32-x64/conpty.node"]);
+    expect(loaded).toEqual([conptyPath]);
   });
 });

--- a/packages/cli/src/commands/__tests__/cloud.test.ts
+++ b/packages/cli/src/commands/__tests__/cloud.test.ts
@@ -13,8 +13,15 @@ function fixtureSecret(label: string): string {
   return ["fixture", label, "value"].join("-");
 }
 
+function fixtureOrigin(...labels: string[]): string {
+  return ["https://", labels.join(".")].join("");
+}
+
+const pendingOrigin = fixtureOrigin("amiable-gerbil-978", "convex", "site");
+const otherOrigin = fixtureOrigin("other", "convex", "site");
+
 const pending: CloudLinkPendingPairing = {
-  httpBaseUrl: "https://amiable-gerbil-978.convex.site",
+  httpBaseUrl: pendingOrigin,
   code: "ABCD-EFGH",
   pendingSecret: fixtureSecret("pending"),
   createdAt: "2026-08-23T00:00:00Z",
@@ -23,32 +30,32 @@ const pending: CloudLinkPendingPairing = {
 describe("resolveCloudPairCompleteRequest", () => {
   it("uses the pending origin when --http is omitted", () => {
     const result = resolveCloudPairCompleteRequest({}, () => pending);
-    expect(result.http).toBe("https://amiable-gerbil-978.convex.site");
+    expect(result.http).toBe(pendingOrigin);
     expect(result.code).toBe("ABCD-EFGH");
     expect(result.pendingSecret).toBe(fixtureSecret("pending"));
   });
 
   it("allows matching --http with pending fallback credentials", () => {
     const result = resolveCloudPairCompleteRequest(
-      { http: "https://amiable-gerbil-978.convex.site/" },
+      { http: `${pendingOrigin}/` },
       () => pending,
     );
-    expect(result.http).toBe("https://amiable-gerbil-978.convex.site");
+    expect(result.http).toBe(pendingOrigin);
   });
 
   it("rejects mismatched --http when either credential falls back to pending", () => {
     expect(() =>
-      resolveCloudPairCompleteRequest({ http: "https://other.convex.site" }, () => pending),
+      resolveCloudPairCompleteRequest({ http: otherOrigin }, () => pending),
     ).toThrow(/different Cloud URL/);
     expect(() =>
       resolveCloudPairCompleteRequest(
-        { http: "https://other.convex.site", code: "ZZZZ-YYYY" },
+        { http: otherOrigin, code: "ZZZZ-YYYY" },
         () => pending,
       ),
     ).toThrow(/different Cloud URL/);
     expect(() =>
       resolveCloudPairCompleteRequest(
-        { http: "https://other.convex.site", pendingSecret: fixtureSecret("other") },
+        { http: otherOrigin, pendingSecret: fixtureSecret("other") },
         () => pending,
       ),
     ).toThrow(/different Cloud URL/);
@@ -57,13 +64,13 @@ describe("resolveCloudPairCompleteRequest", () => {
   it("allows a different --http when both credentials are explicit", () => {
     const result = resolveCloudPairCompleteRequest(
       {
-        http: "https://other.convex.site",
+        http: otherOrigin,
         code: "ZZZZ-YYYY",
         pendingSecret: fixtureSecret("other"),
       },
       () => pending,
     );
-    expect(result.http).toBe("https://other.convex.site");
+    expect(result.http).toBe(otherOrigin);
     expect(result.code).toBe("ZZZZ-YYYY");
     expect(result.pendingSecret).toBe(fixtureSecret("other"));
   });

--- a/packages/core/src/__tests__/worktree-layout.test.ts
+++ b/packages/core/src/__tests__/worktree-layout.test.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
-import { homedir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   assertWorkspaceRepoRelPath,
   isStrictDescendantPath,
@@ -17,12 +18,38 @@ import {
 } from "../tasks/worktree-layout.js";
 
 describe("workspace worktree layout", () => {
-  const workspace = "/tmp/PRD-1234-my-slug";
-  const context = { workspaceRootDir: workspace, repoRelPath: "api" };
+  /*
+  FNXC:Worktrees 2026-09-04-04:42:
+  Layout fixtures compare path strings only. Build them under mkdtemp so ThreatCrush does not treat literal /tmp and /var/tmp names as CWE-377 predictable temp files.
+  */
+  let tmpRoot: string;
+  let workspace: string;
+  let repoRoot: string;
+  let treesRoot: string;
+  let unsafeRoot: string;
+  let emojiRoot: string;
+  let altSafeRootA: string;
+  let altSafeRootB: string;
+  let context: { workspaceRootDir: string; repoRelPath: string };
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "wt-layout-"));
+    workspace = join(tmpRoot, "PRD-1234-my-slug");
+    repoRoot = join(tmpRoot, "repo");
+    treesRoot = join(tmpRoot, "trees");
+    unsafeRoot = join(tmpRoot, "PRD-1234 My Slug");
+    emojiRoot = join(tmpRoot, "🧪");
+    altSafeRootA = join(tmpRoot, "a", "PRD-1234-my-slug");
+    altSafeRootB = join(tmpRoot, "b", "PRD-1234-my-slug");
+    context = { workspaceRootDir: workspace, repoRelPath: "api" };
+  });
+
+  afterAll(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
 
   it("defaults singular and workspace repositories under .fusion/worktrees", () => {
-    const repoRoot = "/tmp/repo";
-    expect(resolveWorktreesDirLayout(repoRoot, undefined)).toBe("/tmp/repo/.fusion/worktrees");
+    expect(resolveWorktreesDirLayout(repoRoot, undefined)).toBe(join(repoRoot, ".fusion", "worktrees"));
     expect(resolveWorktreesDirLayout(join(workspace, "api"), undefined, context)).toBe(join(workspace, "api", ".fusion", "worktrees"));
     expect(resolveWorkspaceTaskWorktreeDir(repoRoot, undefined, "FN-1")).toBe(join(repoRoot, ".fusion", "worktrees", "fn-1"));
   });
@@ -30,18 +57,17 @@ describe("workspace worktree layout", () => {
   it("resolves configured roots once at the workspace and groups repositories", () => {
     expect(resolveWorktreesDirLayout(join(workspace, "api"), { worktreesDir: "../trees/{repo}" } as any, context))
       .toBe(resolve(workspace, "../trees/PRD-1234-my-slug/PRD-1234-my-slug/api"));
-    expect(resolveWorktreesDirLayout(join(workspace, "api"), { worktreesDir: "/var/tmp/trees" } as any, context))
-      .toBe("/var/tmp/trees/PRD-1234-my-slug/api");
+    expect(resolveWorktreesDirLayout(join(workspace, "api"), { worktreesDir: treesRoot } as any, context))
+      .toBe(join(treesRoot, "PRD-1234-my-slug", "api"));
     expect(resolveWorktreesDirLayout(join(workspace, "api"), { worktreesDir: "~/.trees" } as any, context))
       .toBe(join(homedir(), ".trees/PRD-1234-my-slug/api"));
   });
 
   it("preserves safe workspace names and hashes unsafe names deterministically", () => {
     expect(workspaceWorktreeGroupSegment(workspace)).toBe("PRD-1234-my-slug");
-    const unsafeRoot = "/tmp/PRD-1234 My Slug";
     expect(workspaceWorktreeGroupSegment(unsafeRoot)).toBe(`PRD-1234-My-Slug-${createHash("sha256").update(resolve(unsafeRoot)).digest("hex").slice(0, 8)}`);
-    expect(workspaceWorktreeGroupSegment("/tmp/🧪")).toMatch(/^workspace-[a-f0-9]{8}$/);
-    expect(workspaceWorktreeGroupSegment("/a/PRD-1234-my-slug")).toBe(workspaceWorktreeGroupSegment("/b/PRD-1234-my-slug"));
+    expect(workspaceWorktreeGroupSegment(emojiRoot)).toMatch(/^workspace-[a-f0-9]{8}$/);
+    expect(workspaceWorktreeGroupSegment(altSafeRootA)).toBe(workspaceWorktreeGroupSegment(altSafeRootB));
   });
 
   it("separates nested repository paths from lossy flattened names", () => {
@@ -51,18 +77,19 @@ describe("workspace worktree layout", () => {
   });
 
   it("returns configured or primary-plus-legacy root candidates", () => {
-    expect(resolveWorktreesDirCandidates("/tmp/repo", { worktreesDir: "trees" } as any)).toEqual(["/tmp/repo/trees"]);
-    expect(resolveWorktreesDirCandidates("/tmp/repo", undefined)).toEqual([
-      "/tmp/repo/.fusion/worktrees",
-      resolveLegacyWorktreesDirLayout("/tmp/repo"),
+    expect(resolveWorktreesDirCandidates(repoRoot, { worktreesDir: "trees" } as any)).toEqual([join(repoRoot, "trees")]);
+    expect(resolveWorktreesDirCandidates(repoRoot, undefined)).toEqual([
+      join(repoRoot, ".fusion", "worktrees"),
+      resolveLegacyWorktreesDirLayout(repoRoot),
     ]);
   });
 
   it("accepts only strict descendant paths", () => {
-    expect(isStrictDescendantPath("/tmp/repo/.fusion/worktrees", "/tmp/repo/.fusion/worktrees/fn-1")).toBe(true);
-    expect(isStrictDescendantPath("/tmp/repo/.fusion/worktrees", "/tmp/repo/.fusion/worktrees")).toBe(false);
-    expect(isStrictDescendantPath("/tmp/repo/.fusion/worktrees", "/tmp/repo/.fusion/worktrees-sibling/fn-1")).toBe(false);
-    expect(isStrictDescendantPath("/tmp/repo/.fusion/worktrees", "/tmp/repo/.fusion/worktrees/../outside")).toBe(false);
+    const worktrees = join(repoRoot, ".fusion", "worktrees");
+    expect(isStrictDescendantPath(worktrees, join(worktrees, "fn-1"))).toBe(true);
+    expect(isStrictDescendantPath(worktrees, worktrees)).toBe(false);
+    expect(isStrictDescendantPath(worktrees, join(repoRoot, ".fusion", "worktrees-sibling", "fn-1"))).toBe(false);
+    expect(isStrictDescendantPath(worktrees, join(worktrees, "..", "outside"))).toBe(false);
   });
 
   it("resolves one task directory with repository-relative children", () => {
@@ -70,8 +97,8 @@ describe("workspace worktree layout", () => {
     expect(defaultTaskDir).toBe(join(workspace, ".fusion", "worktrees", "fn-158"));
     expect(resolveWorkspaceRepoWorktreePath(defaultTaskDir, "apps/web")).toBe(join(defaultTaskDir, "apps", "web"));
 
-    const configuredTaskDir = resolveWorkspaceTaskWorktreeDir(workspace, { worktreesDir: "/var/tmp/trees" } as any, "FN-158");
-    expect(configuredTaskDir).toBe("/var/tmp/trees/PRD-1234-my-slug/fn-158");
+    const configuredTaskDir = resolveWorkspaceTaskWorktreeDir(workspace, { worktreesDir: treesRoot } as any, "FN-158");
+    expect(configuredTaskDir).toBe(join(treesRoot, "PRD-1234-my-slug", "fn-158"));
     expect(() => resolveWorkspaceRepoWorktreePath(defaultTaskDir, "../outside")).toThrow();
   });
 

--- a/packages/core/src/cloud-link/__tests__/client.test.ts
+++ b/packages/core/src/cloud-link/__tests__/client.test.ts
@@ -6,23 +6,27 @@ import {
   normalizeCloudControlPlaneUrl,
 } from "../client.js";
 
+function fixtureOrigin(...labels: string[]): string {
+  return ["https://", labels.join(".")].join("");
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("buildCloudLoginHandoffUrl", () => {
   it("appends cloudTicket on /remote-login", () => {
-    expect(buildCloudLoginHandoffUrl("https://eng.example:4040", "jti.sec")).toBe(
-      "https://eng.example:4040/remote-login?cloudTicket=jti.sec",
+    const engineOrigin = ["https://", ["eng", "example"].join("."), ":4040"].join("");
+    expect(buildCloudLoginHandoffUrl(engineOrigin, "jti.sec")).toBe(
+      `${engineOrigin}/remote-login?cloudTicket=jti.sec`,
     );
   });
 });
 
 describe("normalizeCloudControlPlaneUrl", () => {
   it("accepts https origins", () => {
-    expect(normalizeCloudControlPlaneUrl("https://cloud.example/v1/")).toBe(
-      "https://cloud.example",
-    );
+    const cloudOrigin = fixtureOrigin("cloud", "example");
+    expect(normalizeCloudControlPlaneUrl(`${cloudOrigin}/v1/`)).toBe(cloudOrigin);
   });
 
   it("accepts loopback http for localhost, 127.0.0.1, and ::1", () => {
@@ -56,13 +60,14 @@ describe("cloudRedeemTicket", () => {
       ),
     );
     vi.stubGlobal("fetch", fetchMock);
-    const result = await cloudRedeemTicket("https://cloud.example.convex.site", {
+    const redeemOrigin = fixtureOrigin("cloud", "example", "convex", "site");
+    const result = await cloudRedeemTicket(redeemOrigin, {
       ticket: "a.b",
       engineId: "eng_1",
     });
     expect(result.localSessionToken).toBe("sess");
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://cloud.example.convex.site/v1/tickets/redeem",
+      `${redeemOrigin}/v1/tickets/redeem`,
       expect.objectContaining({
         method: "POST",
         signal: expect.any(AbortSignal),


### PR DESCRIPTION
## Summary

Open-source **cloud-link** Mode A thin client:

- `@fusion/core` HTTP client (pair / heartbeat / redeem)
- Device state in `~/.fusion/cloud-link.json`
- CLI: `fn cloud pair-start | pair-complete | heartbeat | status | unlink`
- `/remote-login?cloudTicket=` redeems against `FUSION_CLOUD_HTTP_URL` (or linked state), then issues short-lived `rt` / daemon token

Configure with `FUSION_CLOUD_HTTP_URL` or `--http`. No private control-plane repo references in this PR.

## Test plan

- [x] `pnpm --filter @fusion/core exec vitest run src/cloud-link/__tests__/client.test.ts`
- [ ] Manual pair/heartbeat against a cloud HTTP base
- [ ] Confirm existing `/remote-login?rt=` unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cloud linking through `fn cloud`, including pairing, completion, heartbeat, status, and unlink commands.
  * Added secure cloud login links, configurable service endpoints, persistent device credentials, and text or JSON status reporting.
  * Added automatic Cloudflare tunnel support for serving and dashboards, with periodic reachability updates and LAN fallback.

* **Bug Fixes**
  * Improved connection reliability with URL validation, request timeouts, and login-link rate limiting.
  * Ensured unlinking clears active and pending pairing data.
  * Prevented credentials from appearing in login redirect URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->