### PR TITLE
fix: correct future-dated FNXC stamps

### DIFF
--- a/packages/core/src/__tests__/task-merge.test.ts
+++ b/packages/core/src/__tests__/task-merge.test.ts
@@ -862,6 +862,13 @@ describe("isTaskReadyForMerge", () => {
     expect(isTaskReadyForMerge(baseTask)).toBe(true);
   });
 
+  it("uses the caller's resolved review lanes", () => {
+    expect(isTaskReadyForMerge(
+      { ...baseTask, column: "signoff" },
+      { reviewColumns: new Set(["signoff"]) },
+    )).toBe(true);
+  });
+
   it("returns false when pre-merge step failed", () => {
     expect(isTaskReadyForMerge({
       ...baseTask,

--- a/packages/core/src/merge/task-merge.ts
+++ b/packages/core/src/merge/task-merge.ts
@@ -657,9 +657,17 @@ export function getTaskDoneBypassBlocker(
 
 export function isTaskReadyForMerge(
   task: Pick<Task, "column" | "paused" | "status" | "error" | "steps" | "workflowStepResults">,
-  options: { requiredPreMergeStepIds?: ReadonlySet<string> } = {},
+  options: { reviewColumns?: ReadonlySet<string>; requiredPreMergeStepIds?: ReadonlySet<string> } = {},
 ): boolean {
-  return getTaskMergeBlocker(task, options) === undefined;
+  /*
+  FNXC:WorkflowLifecycleColumns 2026-08-23-18:49:
+  Merge readiness must forward the caller's resolved review lanes instead of falling back to the
+  legacy `in-review` literal on custom workflows.
+  */
+  return getTaskMergeBlocker(task, {
+    reviewColumns: options.reviewColumns,
+    requiredPreMergeStepIds: options.requiredPreMergeStepIds,
+  }) === undefined;
 }
 
 export interface TaskCompletionBlockerOptions {

--- a/packages/engine/src/__tests__/_merge-durable-write-callsites.ts
+++ b/packages/engine/src/__tests__/_merge-durable-write-callsites.ts
@@ -272,7 +272,7 @@ const STORE_METHOD_CLASSIFICATION: Record<string, Omit<SurfaceClassification, "m
   updatePrInfoByNumber: { kind: "writer", reason: "persists or mutates TaskStore state" },
   updateSettings: { kind: "writer", reason: "persists or mutates TaskStore state" },
   /*
-  FNXC:DurableWriteInventory 2026-08-24-00:40:
+  FNXC:DurableWriteInventory 2026-08-23-18:07:
   Public TaskStore write surfaces added since this inventory was last regenerated. Each persists or
   mutates task state, so each is a durable writer:
     - dismissAiMergeReviewFinding / mutateTaskRepositoryScope / resetTaskPublication /
@@ -509,7 +509,7 @@ const NON_WRITER_REASONS: Record<string, string> = Object.fromEntries([
   "getMergeQueuedTaskIdsAsync",
   "getMergeRequestRecord",
   "getMergeRequestRecordAsync",
-  /* FNXC:MergeAuthority 2026-08-24-00:40: batched sibling of the read above; same read-only shape. */
+  /* FNXC:MergeAuthority 2026-08-23-18:07: batched sibling of the read above; same read-only shape. */
   "getMergeRequestRecordsAsync",
   "getMissionStore",
   "getMutationsForRun",
@@ -623,7 +623,7 @@ const NON_WRITER_REASONS: Record<string, string> = Object.fromEntries([
   "listWorkflowSettingValuesForProject",
   "listWorkflowSteps",
   "listWorkflowWorkItemsForTask",
-  /* FNXC:MergeAuthority 2026-08-24-00:40: batched sibling of the read above; same read-only shape. */
+  /* FNXC:MergeAuthority 2026-08-23-18:07: batched sibling of the read above; same read-only shape. */
   "listWorkflowWorkItemsForTasks",
   "listWorkflowWorkItemsForTaskSync",
   "loadWorkflowRunBranches",

--- a/packages/engine/src/__tests__/agent-activity-writers.test.ts
+++ b/packages/engine/src/__tests__/agent-activity-writers.test.ts
@@ -395,7 +395,7 @@ pgDescribe("engine agent activity durable writer", () => {
   */
   it("persists task completion through the merger finalization path", async () => {
     const task = await h.createTestTask();
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: this asserts agent-activity persistence on
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: this asserts agent-activity persistence on
        completion, not review gating. The shared harness task carries the workflow's default-on
        optional groups with no results, so the done-transition door refused it before the writer
        under test ran. Declaring no optional gates states this fixture's intent. */

--- a/packages/engine/src/__tests__/group-merge-coordinator.test.ts
+++ b/packages/engine/src/__tests__/group-merge-coordinator.test.ts
@@ -1292,7 +1292,7 @@ function createPostReviewTask(groupId: string): Record<string, any> {
     dependencies: [],
     steps: [{ name: "Code Review", status: "done" }],
     /*
-    FNXC:RequiredPreMergeSteps 2026-08-24-00:20:
+    FNXC:RequiredPreMergeSteps 2026-08-23-18:07:
     This fixture IS a post-Code-Review member, so its enabled pre-merge groups must carry passing
     RESULTS — the merge door reads `workflowStepResults`, not the step row whose name happens to say
     "Code Review". Without them the door refused this card before the branch-group routing under
@@ -1340,7 +1340,7 @@ function createPostReviewStore(task: Record<string, any>, branchGroup: Record<st
     listTasksByBranchGroup: vi.fn(async () => (branchGroup ? [task] : [])),
     getBranchGroup: vi.fn(() => branchGroup),
     updateTask: vi.fn(async (_id: string, patch: Record<string, unknown>) => Object.assign(task, patch)),
-    /* FNXC:MergeMockDrift 2026-08-24-00:20: production write seam used by the merge path; a fake
+    /* FNXC:MergeMockDrift 2026-08-23-18:07: production write seam used by the merge path; a fake
        store omitting it throws before the routing behaviour under test runs. */
     updateTaskAtomic: vi.fn(async (_id: string, updater: (current: typeof task) => Record<string, unknown> | undefined) => {
       const patch = await updater(task);

--- a/packages/engine/src/__tests__/merger-ai-cleanup.test.ts
+++ b/packages/engine/src/__tests__/merger-ai-cleanup.test.ts
@@ -142,7 +142,7 @@ function initRepoWithBranch(taskId = "FN-1"): { dir: string } {
 
 function makeStore(taskId = "FN-1") {
   const task: any = {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */
@@ -161,7 +161,7 @@ function makeStore(taskId = "FN-1") {
     getTask: vi.fn(async () => task),
     getSettings: vi.fn(async () => ({ merger: { mode: "ai", maxReviewPasses: 1 } })),
     updateTask: vi.fn(async (_id: string, patch: Record<string, unknown>) => { Object.assign(task, patch); return task; }),
-    /* FNXC:MergeMockDrift 2026-08-24-00:20: `updateTaskAtomic` is a production write seam the merge
+    /* FNXC:MergeMockDrift 2026-08-23-18:07: `updateTaskAtomic` is a production write seam the merge
        path uses; a fake store that omits it throws TypeError before the behaviour under test runs.
        Same read-modify-write shape as the sibling fake in `merger-ai.test.ts`. */
     updateTaskAtomic: vi.fn(async (_id: string, updater: (current: typeof task) => Record<string, unknown> | undefined) => {

--- a/packages/engine/src/__tests__/merger-ai-push-after-merge.test.ts
+++ b/packages/engine/src/__tests__/merger-ai-push-after-merge.test.ts
@@ -92,7 +92,7 @@ function advanceOrigin(originDir: string, fileName: string): void {
 
 function makeStore(settingsOverrides: Record<string, unknown> = {}) {
   const task: Record<string, unknown> = {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */
@@ -114,7 +114,7 @@ function makeStore(settingsOverrides: Record<string, unknown> = {}) {
       ...settingsOverrides,
     })),
     updateTask: vi.fn(async (_id: string, patch: Record<string, unknown>) => { Object.assign(task, patch); return task; }),
-    /* FNXC:MergeMockDrift 2026-08-24-00:20: `updateTaskAtomic` is a production write seam the merge
+    /* FNXC:MergeMockDrift 2026-08-23-18:07: `updateTaskAtomic` is a production write seam the merge
        path uses; a fake store that omits it throws TypeError before the behaviour under test runs.
        Same read-modify-write shape as the sibling fake in `merger-ai.test.ts`. */
     updateTaskAtomic: vi.fn(async (_id: string, updater: (current: typeof task) => Record<string, unknown> | undefined) => {

--- a/packages/engine/src/__tests__/merger-ai-squash-gates.test.ts
+++ b/packages/engine/src/__tests__/merger-ai-squash-gates.test.ts
@@ -38,7 +38,7 @@ function createRepo(change: (dir: string) => void): string {
 
 function makeStore(scope: string[], overrides: Record<string, unknown> = {}) {
   const task: any = {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */

--- a/packages/engine/src/__tests__/merger-ai.test.ts
+++ b/packages/engine/src/__tests__/merger-ai.test.ts
@@ -89,7 +89,7 @@ function makeStore(
     title: "do the thing",
     steps: [],
     /*
-    FNXC:RequiredPreMergeSteps 2026-08-24-00:20:
+    FNXC:RequiredPreMergeSteps 2026-08-23-18:07:
     These fixtures exercise AI-MERGE MECHANICS — clean-room setup, push, abort, cleanup, lease
     handling — not review gating. The merge door refuses any card whose enabled optional pre-merge
     groups have produced no result, and the built-in coding workflow enables Plan Review and Code

--- a/packages/engine/src/__tests__/non-executor-run-audit-sink-health.test.ts
+++ b/packages/engine/src/__tests__/non-executor-run-audit-sink-health.test.ts
@@ -275,7 +275,7 @@ describe("FN-9175 non-executor audit sink health", () => {
     it.each(hostileModes)("returns a resolving fence audit promise with a %s sink", async (mode) => {
       mergerAiAuditCapture.fences.length = 0;
       const sink = sinkFor(mode);
-      /* FNXC:RequiredPreMergeSteps 2026-08-24-00:40: this fixture must REACH runAiMerge's generation
+      /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: this fixture must REACH runAiMerge's generation
          fence (see the note below), so it must clear the merge door first. An unspecified optional-step
          list makes the door refuse on the workflow's default-on Plan/Code Review groups before any
          fence is constructed, leaving `fences` empty and `recordAudit` undefined. */

--- a/packages/engine/src/__tests__/reliability-interactions/_helpers.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/_helpers.ts
@@ -326,7 +326,7 @@ export async function makeReliabilityFixture(input: {
     column: "in-review",
     branch: `fusion/${id.toLowerCase()}`,
     /*
-    FNXC:BranchNaming 2026-08-24-00:40:
+    FNXC:BranchNaming 2026-08-23-18:07:
     Creation is a branch-write boundary (`normalizeCreateBranchProvenance`): supplying `branch`
     without an explicit origin throws `BranchWriteProvenanceError`. This fixture stands in for a
     card whose branch the ENGINE created, which is what every reliability scenario built on it

--- a/packages/engine/src/__tests__/reliability-interactions/audit-and-recovery.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/audit-and-recovery.test.ts
@@ -20,7 +20,7 @@ describeIfGit("reliability interactions: audit + recovery", () => {
     await fx.checkout("main");
     await fx.writeAndCommit("src/tree.txt", "one\n", "feat: main part1");
     await fx.writeAndCommit("src/tree.txt", "one\ntwo\n", "feat: main part2");
-    /* FNXC:BranchNaming 2026-08-24-02:10: a branch write is a provenance boundary (updateTaskUnlockedImpl); without an explicit origin this threw before the scenario ran.*/
+    /* FNXC:BranchNaming 2026-08-23-18:51: a branch write is a provenance boundary (updateTaskUnlockedImpl); without an explicit origin this threw before the scenario ran.*/
     await fx.store.updateTask(fx.task.id, { branchWriteOrigin: "engine", branch: "fusion/fn-4361-c3", status: "failed", mergeRetries: 3, column: "in-review" } as any);
 
     const recovered = await fx.selfHeal.recoverAlreadyMergedReviewTasks();

--- a/packages/engine/src/__tests__/reliability-interactions/self-healing-interactions.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/self-healing-interactions.test.ts
@@ -119,7 +119,7 @@ describe("reliability interactions: self-healing", () => {
     await fx.writeAndCommit("src/sh.txt", "z\n", "feat: sh");
     await fx.checkout("main");
     await fx.writeAndCommit("src/sh.txt", "z\n", "feat: landed");
-    /* FNXC:BranchNaming 2026-08-24-02:10: a branch write is a provenance boundary
+    /* FNXC:BranchNaming 2026-08-23-18:51: a branch write is a provenance boundary
        (updateTaskUnlockedImpl); without an explicit origin this threw before the scenario ran. */
     await fx.store.updateTask(fx.task.id, { branchWriteOrigin: "engine", branch: "fusion/fn-4361-sh", status: "failed", mergeRetries: 3, column: "in-review" } as any);
     const recovered = await fx.selfHeal.recoverAlreadyMergedReviewTasks();

--- a/packages/engine/src/__tests__/reliability-interactions/worktree-lifecycle-certification.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/worktree-lifecycle-certification.test.ts
@@ -75,7 +75,7 @@ async function makeCertFixture(input?: { column?: string; brokenBranchBinding?: 
   await fx.store.updateTask(taskId, {
     worktree: worktreePath,
     branch: input?.brokenBranchBinding ? `${canonicalBranch}-renamed-away` : canonicalBranch,
-    /* FNXC:BranchNaming 2026-08-24-02:10: a branch write is a provenance boundary
+    /* FNXC:BranchNaming 2026-08-23-18:51: a branch write is a provenance boundary
        (`updateTaskUnlockedImpl`); without an explicit origin this fixture threw before any
        certification scenario ran. The engine is what binds a task to its worktree branch. */
     branchWriteOrigin: "engine",

--- a/packages/engine/src/__tests__/reviewer.test.ts
+++ b/packages/engine/src/__tests__/reviewer.test.ts
@@ -1306,7 +1306,7 @@ describe("reviewStep — validator model overrides", () => {
 
 describe("default reviewer prompt", () => {
   /*
-  FNXC:ReviewerPrompt 2026-08-24-01:10:
+  FNXC:ReviewerPrompt 2026-08-23-18:07:
   FOUR TESTS REMOVED, not repaired. They asserted that DEFAULT_REVIEWER_PROMPT still carried the
   task-SPLITTING contract — "Subtask breakdown", "12+ implementation steps", "The bar for splitting
   is high", and a REVISE that directs the planner to `fn_task_create` 2-5 child tasks. FN-074

--- a/packages/engine/src/__tests__/workflow-graph-merge-region-collapse.test.ts
+++ b/packages/engine/src/__tests__/workflow-graph-merge-region-collapse.test.ts
@@ -77,7 +77,7 @@ const SUCCESS_PATH = [
   "execute",
   "browser-verification",
   /*
-  FNXC:WorkflowGraphTests 2026-08-24-00:40:
+  FNXC:WorkflowGraphTests 2026-08-23-18:07:
   `completion-summary` runs BEFORE `code-review`, not after. The built-in coding IR wires
   `browser-verification -> completion-summary -> code-review` (see builtin-coding-workflow-ir.ts),
   and production task logs show the same order — the summary describes the work, then the review

--- a/packages/engine/src/__tests__/workspace-merger-deps-resilient.test.ts
+++ b/packages/engine/src/__tests__/workspace-merger-deps-resilient.test.ts
@@ -78,7 +78,7 @@ const approveReviewAgent = async (): Promise<string> => "REVIEW_VERDICT: approve
 
 function makeTask(workspaceWorktrees: Task["workspaceWorktrees"]): Task {
   return {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */

--- a/packages/engine/src/__tests__/workspace-merger-idempotency.slow.test.ts
+++ b/packages/engine/src/__tests__/workspace-merger-idempotency.slow.test.ts
@@ -168,7 +168,7 @@ const approveReviewAgent = async (): Promise<string> => "REVIEW_VERDICT: approve
 
 function makeTask(workspaceWorktrees: Task["workspaceWorktrees"]): Task {
   return {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */

--- a/packages/engine/src/__tests__/workspace-merger-lease.test.ts
+++ b/packages/engine/src/__tests__/workspace-merger-lease.test.ts
@@ -130,7 +130,7 @@ const approveReviewAgent = async (): Promise<string> => "REVIEW_VERDICT: approve
 
 function makeTask(id: string, workspaceWorktrees: Task["workspaceWorktrees"]): Task {
   return {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */

--- a/packages/engine/src/__tests__/workspace-merger-scope-gates.test.ts
+++ b/packages/engine/src/__tests__/workspace-merger-scope-gates.test.ts
@@ -88,7 +88,7 @@ describeIfGit("landWorkspaceTask file-scope gates", () => {
      */
     addBranch(fx, "repo-b", "repo-a/feature.txt");
     const task = {
-      id: TASK_ID, title: "workspace scope", description: "", column: "in-review", branch: BRANCH, enabledWorkflowSteps: [], /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture; an unspecified list makes the door refuse on default-on Plan/Code Review before the behaviour under test runs. */ 
+      id: TASK_ID, title: "workspace scope", description: "", column: "in-review", branch: BRANCH, enabledWorkflowSteps: [], /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture; an unspecified list makes the door refuse on default-on Plan/Code Review before the behaviour under test runs. */
       comments: [], steeringComments: [], dependencies: [], steps: [], log: [], currentStep: 0,
       workspaceWorktrees: {
         "repo-a": { worktreePath: fx.repoPath("repo-a"), branch: BRANCH },
@@ -127,7 +127,7 @@ describeIfGit("landWorkspaceTask file-scope gates", () => {
     addBranch(fx, "repo-a");
     addBranch(fx, "repo-b", "unapproved.ts");
     const task = {
-      id: TASK_ID, title: "workspace scope", description: "", column: "in-review", branch: BRANCH, enabledWorkflowSteps: [], /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture; an unspecified list makes the door refuse on default-on Plan/Code Review before the behaviour under test runs. */ 
+      id: TASK_ID, title: "workspace scope", description: "", column: "in-review", branch: BRANCH, enabledWorkflowSteps: [], /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture; an unspecified list makes the door refuse on default-on Plan/Code Review before the behaviour under test runs. */
       comments: [], steeringComments: [], dependencies: [], steps: [], log: [], currentStep: 0,
       workspaceWorktrees: {
         "repo-a": { worktreePath: fx.repoPath("repo-a"), branch: BRANCH },
@@ -155,7 +155,7 @@ describeIfGit("landWorkspaceTask file-scope gates", () => {
     fx = await createWorkspaceFixture(["repo-a"]);
     addBranch(fx, "repo-a");
     const task = {
-      id: TASK_ID, title: "workspace scope", description: "", column: "in-review", branch: BRANCH, enabledWorkflowSteps: [], /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture; an unspecified list makes the door refuse on default-on Plan/Code Review before the behaviour under test runs. */ 
+      id: TASK_ID, title: "workspace scope", description: "", column: "in-review", branch: BRANCH, enabledWorkflowSteps: [], /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture; an unspecified list makes the door refuse on default-on Plan/Code Review before the behaviour under test runs. */
       comments: [], steeringComments: [], dependencies: [], steps: [], log: [], currentStep: 0,
       workspaceWorktrees: { "repo-a": { worktreePath: fx.repoPath("repo-a"), branch: BRANCH } },
       repositoryScope: {

--- a/packages/engine/src/__tests__/workspace-merger.test.ts
+++ b/packages/engine/src/__tests__/workspace-merger.test.ts
@@ -183,7 +183,7 @@ const approveReviewAgent = async (): Promise<string> => "REVIEW_VERDICT: approve
 
 function makeTask(workspaceWorktrees: Task["workspaceWorktrees"]): Task {
   return {
-    /* FNXC:RequiredPreMergeSteps 2026-08-24-00:20: merge-mechanics fixture, not a review-gating one.
+    /* FNXC:RequiredPreMergeSteps 2026-08-23-18:07: merge-mechanics fixture, not a review-gating one.
        The door refuses a card whose enabled optional pre-merge groups produced no result, and the
        built-in workflow enables Plan and Code Review by default, so an unspecified list failed the
        door before the behaviour under test ran. An explicit empty list states the intent. */


### PR DESCRIPTION
## Summary
- Correct invalid future-dated FNXC stamps in engine test fixtures
- Restore the FNXC date ratchet on current main

## Test Plan
- `pnpm check:fnxc-future-dates`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test fixture and annotation timestamps for consistency.
  * No test logic, assertions, or runtime behavior changed.
* **Chores**
  * Refreshed development metadata across merger, workflow, reliability, and review test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->