### PR TITLE
test(core): refresh lane-wiring baseline after merge readiness

### DIFF
--- a/scripts/lib/lane-wiring-baseline.json
+++ b/scripts/lib/lane-wiring-baseline.json
@@ -1,13 +1,11 @@
 {
   "counts": {
-    "packages/core/src/merge/task-merge.ts": 1,
     "packages/core/src/store.ts": 1,
     "packages/core/src/task-store/branch-and-pr-entities.ts": 1,
     "packages/core/src/task-store/moves.ts": 1,
     "packages/core/src/task-store/task-update.ts": 1,
     "packages/engine/src/merge/auto-merge-finalization.ts": 1,
     "packages/engine/src/project-engine.ts": 1,
-    "packages/engine/src/self-healing.ts": 1,
     "packages/engine/src/runtimes/in-process-runtime.ts": 1,
     "packages/engine/src/self-healing.ts": 1,
     "packages/dashboard/src/routes/register-task-workflow-routes.ts": 1,


### PR DESCRIPTION
## Summary
- Re-record the lane-wiring baseline after #3514 removed the final unwired merge-readiness call site.
- Normalize the duplicate `self-healing.ts` key while regenerating the canonical JSON baseline.

## Test Plan
- `node scripts/check-lane-wiring.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal baseline tracking to remove an obsolete merge-task entry.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->