### PR TITLE
test(engine): canonicalize worktree path expectations

### DIFF
--- a/packages/engine/src/__tests__/worktree-default-location-migration.test.ts
+++ b/packages/engine/src/__tests__/worktree-default-location-migration.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -37,7 +37,13 @@ describe("default worktree location migration", () => {
     addWorktree(root, primary, "fusion/fn-primary");
     addWorktree(root, legacy, "fusion/fn-legacy");
 
-    await expect(scanIdleWorktrees(root, emptyStore)).resolves.toEqual(expect.arrayContaining([primary, legacy]));
+    /*
+    FNXC:WorktreePathTests 2026-08-30-20:16:
+    Real Git worktree paths are compared with Node's native realpath result so this regression remains independent of Fusion's canonicalization implementation.
+    */
+    await expect(scanIdleWorktrees(root, emptyStore)).resolves.toEqual(
+      expect.arrayContaining([realpathSync.native(primary), realpathSync.native(legacy)]),
+    );
     await expect(cleanupOrphanedWorktrees(root, emptyStore)).resolves.toBe(2);
 
     expect(existsSync(primary)).toBe(false);

--- a/packages/engine/src/__tests__/worktree-paths.test.ts
+++ b/packages/engine/src/__tests__/worktree-paths.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { homedir, tmpdir } from "node:os";
+import { realpathSync } from "node:fs";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
@@ -18,7 +19,7 @@ import {
 } from "../worktree/worktree-paths.js";
 
 describe("worktree-paths", () => {
-  const rootDir = "/tmp/repo-name";
+  const rootDir = join(tmpdir(), "repo-name");
 
   it("defaults to <rootDir>/.fusion/worktrees when unset", () => {
     expect(resolveWorktreesDir(rootDir, undefined)).toBe(join(rootDir, ".fusion", "worktrees"));
@@ -105,7 +106,15 @@ describe("worktree-paths", () => {
   it("accepts both default and legacy roots while unset", () => {
     const primary = join(rootDir, ".fusion", "worktrees");
     const legacy = join(rootDir, ".worktrees");
-    expect(resolveWorktreesDirScanRoots(rootDir, undefined)).toEqual([primary, legacy]);
+    /*
+    FNXC:WorktreePathTests 2026-08-30-20:16:
+    Scan-root expectations use Node's filesystem resolution as an independent oracle. Importing the production canonicalizer would let the implementation and test regress together.
+    */
+    const canonicalRootDir = join(realpathSync.native(tmpdir()), "repo-name");
+    expect(resolveWorktreesDirScanRoots(rootDir, undefined)).toEqual([
+      join(canonicalRootDir, ".fusion", "worktrees"),
+      join(canonicalRootDir, ".worktrees"),
+    ]);
     expect(isInsideConfiguredWorktreesDir(rootDir, undefined, join(primary, "fn-1"))).toBe(true);
     expect(isInsideConfiguredWorktreesDir(rootDir, undefined, join(legacy, "fn-1"))).toBe(true);
     expect(isInsideConfiguredWorktreesDir(rootDir, undefined, primary)).toBe(false);


### PR DESCRIPTION
## Summary
- canonicalize default and legacy worktree paths in assertions
- keep the migration tests portable across macOS `/tmp` symlink resolution

## Test Plan
- `pnpm --filter @fusion/engine exec vitest run src/__tests__/worktree-default-location-migration.test.ts src/__tests__/worktree-paths.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/engine typecheck`
- `pnpm check:changesets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved worktree path coverage to consistently handle canonicalized paths.
  * Added validation for both default and legacy worktree locations.
  * Made temporary directory handling portable across environments by using system-provided temporary paths.
  * Added regression coverage that independently verifies native filesystem path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->