### PR TITLE
fix: restore paired PostgreSQL backups safely

### DIFF
--- a/.changeset/kb-044-restore-migration-reconcile.md
+++ b/.changeset/kb-044-restore-migration-reconcile.md
@@ -4,4 +4,4 @@
 
 summary: Replay missing PostgreSQL migrations after restoring an older dump pair.
 category: fix
-dev: After a project restore, rewind public.fusion_schema_migrations from the earliest missing sentinel (0040 task-lifecycle relations) and run applySchemaBaseline.
+dev: After a project restore, rewind public.fusion_schema_migrations from the earliest missing CREATE-TABLE sentinel and run applySchemaBaseline; reconciliation failures roll back project/archive from the pre-restore pair. Remote reconciliation connections use ssl verify-full.

--- a/.changeset/kb-044-restore-migration-reconcile.md
+++ b/.changeset/kb-044-restore-migration-reconcile.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Replay missing PostgreSQL migrations after restoring an older dump pair.
+category: fix
+dev: After a project restore, rewind public.fusion_schema_migrations from the earliest missing sentinel (0040 task-lifecycle relations) and run applySchemaBaseline.

--- a/.changeset/kb-044-restore-migration-reconcile.md
+++ b/.changeset/kb-044-restore-migration-reconcile.md
@@ -4,4 +4,4 @@
 
 summary: Replay missing PostgreSQL migrations after restoring an older dump pair.
 category: fix
-dev: After a project restore, rewind public.fusion_schema_migrations from the earliest missing CREATE-TABLE sentinel and run applySchemaBaseline; reconciliation failures roll back project/archive from the pre-restore pair. Remote reconciliation connections use ssl verify-full.
+dev: After FN-9255 bookkeeping dumps restore, legacy two-member stems still rewind public.fusion_schema_migrations from the earliest missing CREATE-TABLE sentinel and replay; a thrown reconcile uses the same dump-group rollback. Remote reconciliation connections use ssl verify-full.

--- a/.changeset/kb-044-restore-migration-reconcile.md
+++ b/.changeset/kb-044-restore-migration-reconcile.md
@@ -4,4 +4,4 @@
 
 summary: Replay missing PostgreSQL migrations after restoring an older dump pair.
 category: fix
-dev: After FN-9255 bookkeeping dumps restore, legacy two-member stems still rewind public.fusion_schema_migrations from the earliest missing CREATE-TABLE sentinel and replay; a thrown reconcile uses the same dump-group rollback. Remote reconciliation connections use ssl verify-full.
+dev: After FN-9255 bookkeeping dumps restore, legacy stems rewind public.fusion_schema_migrations from the earliest missing table or ALTER column and replay inside one transaction; a thrown reconcile uses dump-group rollback. Remote reconciliation connections use ssl verify-full.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1354,7 +1354,9 @@ before mutation if a caller disables the pre-restore capture, because that captu
 the rollback source. If bookkeeping restore fails, Fusion rolls every committed group
 back from the retained stem. Selecting a `fusion-central-pg-*` dump is the explicit
 central-only operation and leaves bookkeeping untouched. Legacy two-member stems remain
-restorable and report bookkeeping as unavailable.
+restorable and report bookkeeping as unavailable; Fusion then rewinds
+`public.fusion_schema_migrations` from the earliest missing CREATE-TABLE sentinel
+and replays pending migrations so an older dump cannot skip later schema upgrades.
 
 Native backup commands do not provide cross-process locking or cluster-wide
 quiescence. Before list, create, cleanup, or especially restore, quiesce other

--- a/packages/cli/skill/fusion/references/cli-commands.md
+++ b/packages/cli/skill/fusion/references/cli-commands.md
@@ -116,8 +116,9 @@ Project/archive restores before central, each in its own transaction. If central
 fails, Fusion attempts project/archive rollback from the retained dump. The two
 dumps do not share one snapshot or one pair-wide transaction. In-progress backup
 artifacts are never listed or restorable, and cleanup removes only abandoned ones.
-Dump pairs exclude PostgreSQL migration bookkeeping in `public`; restoring data
-older than the running schema baseline requires reviewing migration state.
+After a project/archive restore, Fusion rewinds `public.fusion_schema_migrations`
+from the earliest missing sentinel relation and replays pending migrations so a
+pre-0040 dump cannot skip later schema upgrades.
 
 ## Multi-Project
 

--- a/packages/cli/skill/fusion/references/cli-commands.md
+++ b/packages/cli/skill/fusion/references/cli-commands.md
@@ -117,8 +117,9 @@ fails, Fusion attempts project/archive rollback from the retained dump. The two
 dumps do not share one snapshot or one pair-wide transaction. In-progress backup
 artifacts are never listed or restorable, and cleanup removes only abandoned ones.
 After a project/archive restore, Fusion rewinds `public.fusion_schema_migrations`
-from the earliest missing sentinel relation and replays pending migrations so a
-pre-0040 dump cannot skip later schema upgrades.
+from the earliest missing CREATE-TABLE sentinel and replays pending migrations.
+If that reconciliation fails, Fusion rolls project/archive back from the
+retained pre-restore dump.
 
 ## Multi-Project
 

--- a/packages/cli/skill/fusion/references/cli-commands.md
+++ b/packages/cli/skill/fusion/references/cli-commands.md
@@ -111,15 +111,13 @@ fn backup --cleanup                                     # Remove old pairs and a
 Before native backup operations, quiesce Fusion writers and competing
 create/list/cleanup/restore processes; the command has no cross-process lock.
 A restore validates every required archive and retains a current-state
-`fusion-pre-restore-pg-*` + `fusion-central-pre-restore-pg-*` pair first.
-Project/archive restores before central, each in its own transaction. If central
-fails, Fusion attempts project/archive rollback from the retained dump. The two
-dumps do not share one snapshot or one pair-wide transaction. In-progress backup
-artifacts are never listed or restorable, and cleanup removes only abandoned ones.
-After a project/archive restore, Fusion rewinds `public.fusion_schema_migrations`
-from the earliest missing CREATE-TABLE sentinel and replays pending migrations.
-If that reconciliation fails, Fusion rolls project/archive back from the
-retained pre-restore dump.
+`fusion-pre-restore-pg-*` + `fusion-central-pre-restore-pg-*` +
+`fusion-migrations-pre-restore-pg-*` stem first. Project/archive restores
+before central and captured migration bookkeeping. If a later group fails,
+Fusion rolls every committed group back from the retained stem. Legacy
+two-member stems remain restorable; Fusion then rewinds
+`public.fusion_schema_migrations` from the earliest missing CREATE-TABLE
+sentinel and replays pending migrations.
 
 ## Multi-Project
 

--- a/packages/cli/skill/fusion/workflows/dashboard-cli.md
+++ b/packages/cli/skill/fusion/workflows/dashboard-cli.md
@@ -75,10 +75,10 @@ fn backup --cleanup        # Remove old pairs and abandoned crash artifacts
 Quiesce Fusion writers and competing backup commands: backup operations have no
 cross-process lock or pair-wide restore transaction. In-progress artifacts are
 never listed or restorable; cleanup sweeps only abandoned artifacts. Dump pairs
-restore `project`, `archive`, and `central`. After a project restore, Fusion
-rewinds and replays schema migrations from the earliest missing CREATE-TABLE
-sentinel; a reconciliation failure rolls project/archive back from the
-pre-restore dump.
+restore `project`, `archive`, `central`, and captured migration bookkeeping.
+Legacy two-member stems rewind and replay schema migrations from the earliest
+missing CREATE-TABLE sentinel; a later-group failure rolls committed groups
+back from the pre-restore stem.
 
 **Multi-project support:**
 

--- a/packages/cli/skill/fusion/workflows/dashboard-cli.md
+++ b/packages/cli/skill/fusion/workflows/dashboard-cli.md
@@ -75,8 +75,8 @@ fn backup --cleanup        # Remove old pairs and abandoned crash artifacts
 Quiesce Fusion writers and competing backup commands: backup operations have no
 cross-process lock or pair-wide restore transaction. In-progress artifacts are
 never listed or restorable; cleanup sweeps only abandoned artifacts. Dump pairs
-restore `project`, `archive`, and `central` but not PostgreSQL migration
-bookkeeping in `public`, so an older dump requires migration-state review.
+restore `project`, `archive`, and `central`. After a project restore, Fusion
+rewinds and replays schema migrations whose restored relations are missing.
 
 **Multi-project support:**
 

--- a/packages/cli/skill/fusion/workflows/dashboard-cli.md
+++ b/packages/cli/skill/fusion/workflows/dashboard-cli.md
@@ -76,7 +76,9 @@ Quiesce Fusion writers and competing backup commands: backup operations have no
 cross-process lock or pair-wide restore transaction. In-progress artifacts are
 never listed or restorable; cleanup sweeps only abandoned artifacts. Dump pairs
 restore `project`, `archive`, and `central`. After a project restore, Fusion
-rewinds and replays schema migrations whose restored relations are missing.
+rewinds and replays schema migrations from the earliest missing CREATE-TABLE
+sentinel; a reconciliation failure rolls project/archive back from the
+pre-restore dump.
 
 **Multi-project support:**
 

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -10,9 +10,14 @@ import {
 } from "../backup/backup.js";
 import {
   reconcileRestoredSchemaMigrations,
+  reconciliationPostgresSsl,
+  RESTORED_SCHEMA_RELATION_SENTINELS,
   type RestoreMigrationCatalog,
 } from "../postgres/restore-migration-reconcile.js";
-import { TASK_LIFECYCLE_OUTBOX_VERSION } from "../postgres/schema-applier.js";
+import {
+  CONFIGURATION_REVISIONS_VERSION,
+  TASK_LIFECYCLE_OUTBOX_VERSION,
+} from "../postgres/schema-applier.js";
 import {
   clearActiveEmbeddedRuntimeUrl,
   EmbeddedRuntimeStoppingError,
@@ -34,11 +39,12 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-function createPre0040RestoreCatalog(): RestoreMigrationCatalog & {
+function createRestoreCatalog(presentRelations: readonly string[] = []): RestoreMigrationCatalog & {
   insertLifecycleSeq(projectId: string): Promise<void>;
+  insertConfigurationRevision(): Promise<void>;
 } {
-  const relations = new Set<string>();
-  const applied = new Set(["0039", TASK_LIFECYCLE_OUTBOX_VERSION, "0071"]);
+  const relations = new Set(presentRelations);
+  const applied = new Set(RESTORED_SCHEMA_RELATION_SENTINELS.map((sentinel) => sentinel.version));
   return {
     async relationExists(qualifiedName) {
       return relations.has(qualifiedName);
@@ -52,10 +58,10 @@ function createPre0040RestoreCatalog(): RestoreMigrationCatalog & {
       }
     },
     async replayPendingMigrations() {
-      if (!applied.has(TASK_LIFECYCLE_OUTBOX_VERSION)) {
-        relations.add("project.task_lifecycle_events");
-        relations.add("project.task_lifecycle_event_seq");
-        applied.add(TASK_LIFECYCLE_OUTBOX_VERSION);
+      for (const sentinel of RESTORED_SCHEMA_RELATION_SENTINELS) {
+        if (applied.has(sentinel.version)) continue;
+        for (const relation of sentinel.relations) relations.add(relation);
+        applied.add(sentinel.version);
       }
     },
     async insertLifecycleSeq(projectId: string) {
@@ -63,6 +69,11 @@ function createPre0040RestoreCatalog(): RestoreMigrationCatalog & {
         throw new Error('relation "project.task_lifecycle_event_seq" does not exist');
       }
       if (!projectId) throw new Error("projectId is required");
+    },
+    async insertConfigurationRevision() {
+      if (!relations.has("project.configuration_revisions")) {
+        throw new Error('relation "project.configuration_revisions" does not exist');
+      }
     },
   };
 }
@@ -359,7 +370,11 @@ describe("PostgreSQL paired restore orchestration", () => {
   it("replays 0040 relations after restoring a dump that lacks them while the ledger claims current", async () => {
     const root = await mkdtemp(join(tmpdir(), "fusion-restore-0040-rewind-"));
     try {
-      const catalog = createPre0040RestoreCatalog();
+      const catalog = createRestoreCatalog(
+        RESTORED_SCHEMA_RELATION_SENTINELS
+          .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(TASK_LIFECYCLE_OUTBOX_VERSION, 10))
+          .flatMap((sentinel) => [...sentinel.relations]),
+      );
       const fixture = await createRestoreFixture(root, {
         reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
       });
@@ -377,6 +392,61 @@ describe("PostgreSQL paired restore orchestration", () => {
       expect(await catalog.relationExists("project.task_lifecycle_event_seq")).toBe(true);
       expect(await catalog.relationExists("project.task_lifecycle_events")).toBe(true);
       await expect(catalog.insertLifecycleSeq("proj")).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rewinds past a missing pre-0040 relation so later inserts succeed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-pre-0040-rewind-"));
+    try {
+      const catalog = createRestoreCatalog(
+        RESTORED_SCHEMA_RELATION_SENTINELS
+          .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(CONFIGURATION_REVISIONS_VERSION, 10))
+          .flatMap((sentinel) => [...sentinel.relations]),
+      );
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0021-project");
+      await writeFile(fixture.centralPath, "central-source");
+
+      await expect(catalog.insertConfigurationRevision()).rejects.toThrow(
+        /configuration_revisions/,
+      );
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, {
+        createPreRestoreBackup: false,
+      });
+
+      expect(await catalog.relationExists("project.configuration_revisions")).toBe(true);
+      await expect(catalog.insertConfigurationRevision()).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rolls project/archive back when migration reconciliation fails after project restore", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-reconcile-rollback-"));
+    try {
+      let reconcileAttempts = 0;
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: async () => {
+          reconcileAttempts += 1;
+          if (reconcileAttempts === 1) throw new Error("reconcile exploded");
+        },
+      });
+      await writeFile(fixture.projectPath, "project-source");
+      await writeFile(fixture.centralPath, "central-source");
+
+      await expect(fixture.manager.restoreBackup(fixture.projectFilename)).rejects.toThrow(
+        /rolled back[\s\S]*reconcile exploded/i,
+      );
+      const restores = (await fixture.actions()).filter((action) => action.startsWith("RESTORE "));
+      expect(restores[0]).toContain(fixture.projectFilename);
+      expect(restores[1]).toMatch(/^RESTORE fusion-pre-restore-pg-/);
+      expect(restores.some((action) => action.includes(fixture.centralFilename))).toBe(false);
+      expect(reconcileAttempts).toBe(2);
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -408,6 +478,15 @@ describe("PostgreSQL paired restore orchestration", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("restore reconciliation TLS policy", () => {
+  it("keeps SSL off for loopback and requires verify-full for remote hosts", () => {
+    expect(reconciliationPostgresSsl(pgUrl("secret", "postgres", "127.0.0.1", 55432))).toBe(false);
+    expect(reconciliationPostgresSsl(pgUrl("secret", "postgres", "localhost"))).toBe(false);
+    expect(reconciliationPostgresSsl("host=/tmp/fusion-pg user=postgres dbname=fusion")).toBe(false);
+    expect(reconciliationPostgresSsl(pgUrl("secret", "operator", "db.example.test"))).toBe("verify-full");
   });
 });
 

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -6,7 +6,13 @@ import {
   BackupManager,
   createBackupManager,
   resolveBackendConnectionString,
+  type BackupOptions,
 } from "../backup/backup.js";
+import {
+  reconcileRestoredSchemaMigrations,
+  type RestoreMigrationCatalog,
+} from "../postgres/restore-migration-reconcile.js";
+import { TASK_LIFECYCLE_OUTBOX_VERSION } from "../postgres/schema-applier.js";
 import {
   clearActiveEmbeddedRuntimeUrl,
   EmbeddedRuntimeStoppingError,
@@ -28,7 +34,40 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-async function createRestoreFixture(root: string) {
+function createPre0040RestoreCatalog(): RestoreMigrationCatalog & {
+  insertLifecycleSeq(projectId: string): Promise<void>;
+} {
+  const relations = new Set<string>();
+  const applied = new Set(["0039", TASK_LIFECYCLE_OUTBOX_VERSION, "0071"]);
+  return {
+    async relationExists(qualifiedName) {
+      return relations.has(qualifiedName);
+    },
+    async unstampNumericVersionsFrom(version) {
+      const floor = Number.parseInt(version, 10);
+      for (const appliedVersion of [...applied]) {
+        if (/^[0-9]+$/.test(appliedVersion) && Number.parseInt(appliedVersion, 10) >= floor) {
+          applied.delete(appliedVersion);
+        }
+      }
+    },
+    async replayPendingMigrations() {
+      if (!applied.has(TASK_LIFECYCLE_OUTBOX_VERSION)) {
+        relations.add("project.task_lifecycle_events");
+        relations.add("project.task_lifecycle_event_seq");
+        applied.add(TASK_LIFECYCLE_OUTBOX_VERSION);
+      }
+    },
+    async insertLifecycleSeq(projectId: string) {
+      if (!relations.has("project.task_lifecycle_event_seq")) {
+        throw new Error('relation "project.task_lifecycle_event_seq" does not exist');
+      }
+      if (!projectId) throw new Error("projectId is required");
+    },
+  };
+}
+
+async function createRestoreFixture(root: string, backupOptions: BackupOptions = {}) {
   const fusionDir = join(root, "project", ".fusion");
   const backupDir = join(fusionDir, "backups");
   const actionsPath = join(root, "actions.log");
@@ -77,6 +116,8 @@ exit 0
     connectionString: embeddedUrl,
     pgDumpPath,
     pgRestorePath,
+    reconcileRestoredMigrations: async () => {},
+    ...backupOptions,
   });
   const actions = async () => {
     try {
@@ -312,6 +353,32 @@ describe("PostgreSQL paired restore orchestration", () => {
       } finally {
         await rm(root, { recursive: true, force: true });
       }
+    }
+  });
+
+  it("replays 0040 relations after restoring a dump that lacks them while the ledger claims current", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0040-rewind-"));
+    try {
+      const catalog = createPre0040RestoreCatalog();
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0040-project");
+      await writeFile(fixture.centralPath, "central-source");
+
+      await expect(catalog.insertLifecycleSeq("proj")).rejects.toThrow(
+        /task_lifecycle_event_seq/,
+      );
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, {
+        createPreRestoreBackup: false,
+      });
+
+      expect(await catalog.relationExists("project.task_lifecycle_event_seq")).toBe(true);
+      expect(await catalog.relationExists("project.task_lifecycle_events")).toBe(true);
+      await expect(catalog.insertLifecycleSeq("proj")).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -16,6 +16,7 @@ import {
   type RestoreMigrationCatalog,
 } from "../postgres/restore-migration-reconcile.js";
 import {
+  AGENT_RATING_PROJECT_ISOLATION_VERSION,
   ANALYTICS_ISOLATION_SCHEMA_VERSION,
   AUTOMATION_ISOLATION_SCHEMA_VERSION,
   CHAT_SESSION_PINS_VERSION,
@@ -517,6 +518,39 @@ describe("PostgreSQL paired restore orchestration", () => {
       expect(await catalog.columnExists("project.todo_lists", "owner_project_id")).toBe(true);
       expect(await catalog.columnExists("project.research_runs", "owner_project_id")).toBe(true);
       expect(catalog.hasApplied(OWNER_PROJECT_ID_SPLIT_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0054/0055 agent_ratings.project_id when later sentinels exist", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const catalogAtDetect = createRestoreCatalog(
+      allRelations,
+      sentinelColumnsExcept(AGENT_RATING_PROJECT_ISOLATION_VERSION),
+    );
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(AGENT_RATING_PROJECT_ISOLATION_VERSION);
+    expect(await catalogAtDetect.columnExists("project.agent_ratings", "project_id")).toBe(false);
+    expect(await catalogAtDetect.columnExists("project.messages", "archived")).toBe(true);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0054-ratings-"));
+    try {
+      const catalog = createRestoreCatalog(
+        allRelations,
+        sentinelColumnsExcept(AGENT_RATING_PROJECT_ISOLATION_VERSION),
+      );
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0054-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(await catalog.columnExists("project.agent_ratings", "project_id")).toBe(false);
+      expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.columnExists("project.agent_ratings", "project_id")).toBe(true);
+      expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -9,6 +9,7 @@ import {
   type BackupOptions,
 } from "../backup/backup.js";
 import {
+  detectRestoredSchemaRewindFloor,
   reconcileRestoredSchemaMigrations,
   reconciliationPostgresSsl,
   RESTORED_SCHEMA_RELATION_SENTINELS,
@@ -16,6 +17,8 @@ import {
 } from "../postgres/restore-migration-reconcile.js";
 import {
   CONFIGURATION_REVISIONS_VERSION,
+  CREDENTIAL_INSTANCE_SELECTION_VERSION,
+  MESSAGE_ARCHIVE_SCHEMA_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
 } from "../postgres/schema-applier.js";
@@ -463,6 +466,41 @@ describe("PostgreSQL paired restore orchestration", () => {
 
       expect(await catalog.relationExists("project.configuration_revisions")).toBe(true);
       await expect(catalog.insertConfigurationRevision()).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps omitted ALTER columns even when later CREATE TABLE sentinels exist", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const credentialCatalog = createRestoreCatalog(
+      allRelations,
+      sentinelColumnsBelow(CREDENTIAL_INSTANCE_SELECTION_VERSION),
+    );
+    expect(await detectRestoredSchemaRewindFloor(credentialCatalog)).toBe(CREDENTIAL_INSTANCE_SELECTION_VERSION);
+
+    const archiveCatalog = createRestoreCatalog(
+      allRelations,
+      sentinelColumnsBelow(MESSAGE_ARCHIVE_SCHEMA_VERSION),
+    );
+    expect(await detectRestoredSchemaRewindFloor(archiveCatalog)).toBe(MESSAGE_ARCHIVE_SCHEMA_VERSION);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-omitted-alter-"));
+    try {
+      const catalog = createRestoreCatalog(
+        allRelations,
+        sentinelColumnsBelow(CREDENTIAL_INSTANCE_SELECTION_VERSION),
+      );
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0039-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(await catalog.columnExists("project.tasks", "credential_instance_id")).toBe(false);
+      expect(await catalog.columnExists("project.messages", "archived")).toBe(false);
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+      expect(await catalog.columnExists("project.tasks", "credential_instance_id")).toBe(true);
+      expect(await catalog.columnExists("project.messages", "archived")).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -16,9 +16,16 @@ import {
   type RestoreMigrationCatalog,
 } from "../postgres/restore-migration-reconcile.js";
 import {
+  ANALYTICS_ISOLATION_SCHEMA_VERSION,
+  AUTOMATION_ISOLATION_SCHEMA_VERSION,
+  CHAT_SESSION_PINS_VERSION,
   CONFIGURATION_REVISIONS_VERSION,
   CREDENTIAL_INSTANCE_SELECTION_VERSION,
   MESSAGE_ARCHIVE_SCHEMA_VERSION,
+  MONITOR_APPROVAL_ISOLATION_SCHEMA_VERSION,
+  MULTI_PROJECT_CUTOVER_SCHEMA_VERSION,
+  OWNER_PROJECT_ID_SPLIT_VERSION,
+  PROJECT_OWNERSHIP_SCHEMA_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
 } from "../postgres/schema-applier.js";
@@ -128,6 +135,18 @@ function sentinelRelationsBelow(version: string): string[] {
 function sentinelColumnsBelow(version: string): Array<{ relation: string; column: string }> {
   return RESTORED_SCHEMA_RELATION_SENTINELS
     .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(version, 10))
+    .flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+}
+
+function sentinelRelationsExcept(version: string): string[] {
+  return RESTORED_SCHEMA_RELATION_SENTINELS
+    .filter((sentinel) => sentinel.version !== version)
+    .flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+}
+
+function sentinelColumnsExcept(version: string): Array<{ relation: string; column: string }> {
+  return RESTORED_SCHEMA_RELATION_SENTINELS
+    .filter((sentinel) => sentinel.version !== version)
     .flatMap((sentinel) => [...(sentinel.columns ?? [])]);
 }
 
@@ -469,6 +488,59 @@ describe("PostgreSQL paired restore orchestration", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("unstamps 0011 owner_project_id when a later 0012 sentinel already exists", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const catalogAtDetect = createRestoreCatalog(allRelations, sentinelColumnsExcept(OWNER_PROJECT_ID_SPLIT_VERSION));
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(OWNER_PROJECT_ID_SPLIT_VERSION);
+    expect(await catalogAtDetect.columnExists("project.chat_sessions", "pinned_at")).toBe(true);
+    expect(await catalogAtDetect.columnExists("project.chat_sessions", "owner_project_id")).toBe(false);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0011-rewind-"));
+    try {
+      const catalog = createRestoreCatalog(allRelations, sentinelColumnsExcept(OWNER_PROJECT_ID_SPLIT_VERSION));
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0011-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(await catalog.columnExists("project.chat_sessions", "owner_project_id")).toBe(false);
+      expect(await catalog.columnExists("project.todo_lists", "owner_project_id")).toBe(false);
+      expect(await catalog.columnExists("project.research_runs", "owner_project_id")).toBe(false);
+      expect(catalog.hasApplied(OWNER_PROJECT_ID_SPLIT_VERSION)).toBe(true);
+      expect(catalog.hasApplied(CHAT_SESSION_PINS_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.columnExists("project.chat_sessions", "owner_project_id")).toBe(true);
+      expect(await catalog.columnExists("project.todo_lists", "owner_project_id")).toBe(true);
+      expect(await catalog.columnExists("project.research_runs", "owner_project_id")).toBe(true);
+      expect(catalog.hasApplied(OWNER_PROJECT_ID_SPLIT_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps similarly numbered early migrations when their objects are missing", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const allColumns = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+
+    for (const version of [
+      AUTOMATION_ISOLATION_SCHEMA_VERSION,
+      ANALYTICS_ISOLATION_SCHEMA_VERSION,
+      MONITOR_APPROVAL_ISOLATION_SCHEMA_VERSION,
+      MULTI_PROJECT_CUTOVER_SCHEMA_VERSION,
+    ]) {
+      const catalog = createRestoreCatalog(allRelations, sentinelColumnsExcept(version));
+      expect(await detectRestoredSchemaRewindFloor(catalog)).toBe(version);
+    }
+
+    const ownershipCatalog = createRestoreCatalog(
+      sentinelRelationsExcept(PROJECT_OWNERSHIP_SCHEMA_VERSION),
+      allColumns,
+    );
+    expect(await detectRestoredSchemaRewindFloor(ownershipCatalog)).toBe(PROJECT_OWNERSHIP_SCHEMA_VERSION);
   });
 
   it("unstamps omitted ALTER columns even when later CREATE TABLE sentinels exist", async () => {

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -55,9 +55,17 @@ function columnKey(relation: string, column: string): string {
   return `${relation}.${column}`;
 }
 
+function expectedPrimaryKey(relation: string): readonly string[] | null {
+  const match = RESTORED_SCHEMA_RELATION_SENTINELS
+    .flatMap((sentinel) => [...(sentinel.primaryKeys ?? [])])
+    .find((entry) => entry.relation === relation);
+  return match ? match.columns : null;
+}
+
 function createRestoreCatalog(
   presentRelations: readonly string[] = [],
   presentColumns: ReadonlyArray<{ relation: string; column: string }> = [],
+  presentPrimaryKeys: ReadonlyArray<{ relation: string; columns: readonly string[] }> = [],
 ): RestoreMigrationCatalog & {
   insertLifecycleSeq(projectId: string): Promise<void>;
   insertConfigurationRevision(): Promise<void>;
@@ -66,6 +74,9 @@ function createRestoreCatalog(
 } {
   const relations = new Set(presentRelations);
   const columns = new Set(presentColumns.map((entry) => columnKey(entry.relation, entry.column)));
+  const primaryKeys = new Map<string, readonly string[]>(
+    presentPrimaryKeys.map((entry) => [entry.relation, entry.columns]),
+  );
   const applied = new Set(RESTORED_SCHEMA_RELATION_SENTINELS.map((sentinel) => sentinel.version));
   const catalog: RestoreMigrationCatalog & {
     insertLifecycleSeq(projectId: string): Promise<void>;
@@ -79,10 +90,16 @@ function createRestoreCatalog(
     async columnExists(qualifiedRelation, column) {
       return columns.has(columnKey(qualifiedRelation, column));
     },
+    async primaryKeyColumns(qualifiedRelation) {
+      if (primaryKeys.has(qualifiedRelation)) return [...primaryKeys.get(qualifiedRelation)!];
+      const expected = expectedPrimaryKey(qualifiedRelation);
+      return expected ? [...expected] : null;
+    },
     async applyRewindAndReplay(floor) {
       const snapshotApplied = new Set(applied);
       const snapshotRelations = new Set(relations);
       const snapshotColumns = new Set(columns);
+      const snapshotPrimaryKeys = new Map(primaryKeys);
       try {
         if (floor) {
           const parsedFloor = Number.parseInt(floor, 10);
@@ -97,6 +114,9 @@ function createRestoreCatalog(
           if (applied.has(sentinel.version)) continue;
           for (const relation of sentinel.relations ?? []) relations.add(relation);
           for (const column of sentinel.columns ?? []) columns.add(columnKey(column.relation, column.column));
+          for (const primaryKey of sentinel.primaryKeys ?? []) {
+            primaryKeys.set(primaryKey.relation, primaryKey.columns);
+          }
           applied.add(sentinel.version);
         }
       } catch (error) {
@@ -106,6 +126,10 @@ function createRestoreCatalog(
         for (const relation of snapshotRelations) relations.add(relation);
         columns.clear();
         for (const column of snapshotColumns) columns.add(column);
+        primaryKeys.clear();
+        for (const [relation, columnsForKey] of snapshotPrimaryKeys) {
+          primaryKeys.set(relation, columnsForKey);
+        }
         throw error;
       }
     },
@@ -550,6 +574,34 @@ describe("PostgreSQL paired restore orchestration", () => {
       await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
 
       expect(await catalog.columnExists("project.agent_ratings", "project_id")).toBe(true);
+      expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0054 when agent_ratings.project_id exists but the PK stayed (id)", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const allColumns = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+    const driftedPk = [{ relation: "project.agent_ratings", columns: ["id"] as const }];
+    const catalogAtDetect = createRestoreCatalog(allRelations, allColumns, driftedPk);
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(AGENT_RATING_PROJECT_ISOLATION_VERSION);
+    expect(await catalogAtDetect.columnExists("project.agent_ratings", "project_id")).toBe(true);
+    expect(await catalogAtDetect.primaryKeyColumns("project.agent_ratings")).toEqual(["id"]);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0054-ratings-pk-"));
+    try {
+      const catalog = createRestoreCatalog(allRelations, allColumns, driftedPk);
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0054-pk-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.primaryKeyColumns("project.agent_ratings")).toEqual(["project_id", "id"]);
       expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -28,6 +28,7 @@ import {
   MULTI_PROJECT_CUTOVER_SCHEMA_VERSION,
   OWNER_PROJECT_ID_SPLIT_VERSION,
   PROJECT_OWNERSHIP_SCHEMA_VERSION,
+  SPEC_LOCK_SOURCE_REVISION_BIGINT_VERSION,
   SYMBOL_LOCKS_SCHEMA_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
@@ -707,6 +708,42 @@ describe("PostgreSQL paired restore orchestration", () => {
 
       expect(await catalog.columnDataType("project.tasks", "token_usage_input_tokens")).toBe("bigint");
       expect(catalog.hasApplied(BIGINT_COUNTERS_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0051 when current_plan_evidence.source_revision exists as integer", async () => {
+    const allRelations = [
+      ...RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]),
+      "project.current_plan_evidence",
+    ];
+    const allColumns = [
+      ...RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]),
+      { relation: "project.current_plan_evidence", column: "source_revision" },
+    ];
+    const integerRevision = [
+      { relation: "project.current_plan_evidence", column: "source_revision", dataType: "integer" },
+    ];
+    const catalogAtDetect = createRestoreCatalog(allRelations, allColumns, [], integerRevision);
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(SPEC_LOCK_SOURCE_REVISION_BIGINT_VERSION);
+    expect(await catalogAtDetect.relationExists("project.spec_locks")).toBe(true);
+    expect(await catalogAtDetect.columnDataType("project.current_plan_evidence", "source_revision")).toBe("integer");
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0051-bigint-"));
+    try {
+      const catalog = createRestoreCatalog(allRelations, allColumns, [], integerRevision);
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0051-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(catalog.hasApplied(SPEC_LOCK_SOURCE_REVISION_BIGINT_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.columnDataType("project.current_plan_evidence", "source_revision")).toBe("bigint");
+      expect(catalog.hasApplied(SPEC_LOCK_SOURCE_REVISION_BIGINT_VERSION)).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -97,6 +97,7 @@ function createRestoreCatalog(
     triggers?: ReadonlyArray<{ relation: string; name: string }>;
     policies?: ReadonlyArray<{ relation: string; name: string }>;
     indexes?: ReadonlyArray<{ relation: string; name: string }>;
+    rlsForced?: readonly string[];
   } = {},
 ): RestoreMigrationCatalog & {
   insertLifecycleSeq(projectId: string): Promise<void>;
@@ -115,9 +116,11 @@ function createRestoreCatalog(
   const triggerOverride = extras.triggers !== undefined;
   const policyOverride = extras.policies !== undefined;
   const indexOverride = extras.indexes !== undefined;
+  const rlsForcedOverride = extras.rlsForced !== undefined;
   const triggers = new Set((extras.triggers ?? []).map((entry) => namedObjectKey(entry.relation, entry.name)));
   const policies = new Set((extras.policies ?? []).map((entry) => namedObjectKey(entry.relation, entry.name)));
   const indexes = new Set((extras.indexes ?? []).map((entry) => namedObjectKey(entry.relation, entry.name)));
+  const rlsForced = new Set(extras.rlsForced ?? []);
   const applied = new Set(RESTORED_SCHEMA_RELATION_SENTINELS.map((sentinel) => sentinel.version));
   const catalog: RestoreMigrationCatalog & {
     insertLifecycleSeq(projectId: string): Promise<void>;
@@ -154,6 +157,12 @@ function createRestoreCatalog(
       if (indexOverride) return indexes.has(namedObjectKey(qualifiedRelation, indexName));
       return expectedNamedObjects("indexes", qualifiedRelation).includes(indexName);
     },
+    async rowLevelSecurityForced(qualifiedRelation) {
+      if (rlsForcedOverride) return rlsForced.has(qualifiedRelation);
+      return RESTORED_SCHEMA_RELATION_SENTINELS
+        .flatMap((sentinel) => [...(sentinel.forcedRowLevelSecurity ?? [])])
+        .includes(qualifiedRelation);
+    },
     async applyRewindAndReplay(floor) {
       const snapshotApplied = new Set(applied);
       const snapshotRelations = new Set(relations);
@@ -163,6 +172,7 @@ function createRestoreCatalog(
       const snapshotTriggers = new Set(triggers);
       const snapshotPolicies = new Set(policies);
       const snapshotIndexes = new Set(indexes);
+      const snapshotRlsForced = new Set(rlsForced);
       try {
         if (floor) {
           const parsedFloor = Number.parseInt(floor, 10);
@@ -196,6 +206,9 @@ function createRestoreCatalog(
           for (const column of sentinel.absentColumns ?? []) {
             columns.delete(columnKey(column.relation, column.column));
           }
+          for (const relation of sentinel.forcedRowLevelSecurity ?? []) {
+            rlsForced.add(relation);
+          }
           applied.add(sentinel.version);
         }
       } catch (error) {
@@ -217,6 +230,8 @@ function createRestoreCatalog(
         for (const key of snapshotPolicies) policies.add(key);
         indexes.clear();
         for (const key of snapshotIndexes) indexes.add(key);
+        rlsForced.clear();
+        for (const relation of snapshotRlsForced) rlsForced.add(relation);
         throw error;
       }
     },
@@ -717,6 +732,34 @@ describe("PostgreSQL paired restore orchestration", () => {
       await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
 
       expect(await catalog.triggerExists("project.agent_ratings", "fusion_assign_project_id")).toBe(true);
+      expect(catalog.hasApplied(AGENT_RATINGS_PROJECT_PARTITION_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0055 when agent_ratings trigger and policy exist but RLS is not forced", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const allColumns = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+    const catalogAtDetect = createRestoreCatalog(allRelations, allColumns, [], [], { rlsForced: [] });
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(AGENT_RATINGS_PROJECT_PARTITION_VERSION);
+    expect(await catalogAtDetect.triggerExists("project.agent_ratings", "fusion_assign_project_id")).toBe(true);
+    expect(await catalogAtDetect.policyExists("project.agent_ratings", "fusion_project_isolation")).toBe(true);
+    expect(await catalogAtDetect.rowLevelSecurityForced("project.agent_ratings")).toBe(false);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0055-rls-"));
+    try {
+      const catalog = createRestoreCatalog(allRelations, allColumns, [], [], { rlsForced: [] });
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0055-rls-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(catalog.hasApplied(AGENT_RATINGS_PROJECT_PARTITION_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.rowLevelSecurityForced("project.agent_ratings")).toBe(true);
       expect(catalog.hasApplied(AGENT_RATINGS_PROJECT_PARTITION_VERSION)).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   AGENT_RATING_PROJECT_ISOLATION_VERSION,
   ANALYTICS_ISOLATION_SCHEMA_VERSION,
+  BIGINT_COUNTERS_VERSION,
   AUTOMATION_ISOLATION_SCHEMA_VERSION,
   CHAT_SESSION_PINS_VERSION,
   CONFIGURATION_REVISIONS_VERSION,
@@ -27,8 +28,10 @@ import {
   MULTI_PROJECT_CUTOVER_SCHEMA_VERSION,
   OWNER_PROJECT_ID_SPLIT_VERSION,
   PROJECT_OWNERSHIP_SCHEMA_VERSION,
+  SYMBOL_LOCKS_SCHEMA_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
+  TASK_VERIFICATION_REQUEST_VERSION,
 } from "../postgres/schema-applier.js";
 import {
   clearActiveEmbeddedRuntimeUrl,
@@ -62,10 +65,18 @@ function expectedPrimaryKey(relation: string): readonly string[] | null {
   return match ? match.columns : null;
 }
 
+function expectedColumnType(relation: string, column: string): string | null {
+  const match = RESTORED_SCHEMA_RELATION_SENTINELS
+    .flatMap((sentinel) => [...(sentinel.columnTypes ?? [])])
+    .find((entry) => entry.relation === relation && entry.column === column);
+  return match ? match.dataType : null;
+}
+
 function createRestoreCatalog(
   presentRelations: readonly string[] = [],
   presentColumns: ReadonlyArray<{ relation: string; column: string }> = [],
   presentPrimaryKeys: ReadonlyArray<{ relation: string; columns: readonly string[] }> = [],
+  presentColumnTypes: ReadonlyArray<{ relation: string; column: string; dataType: string }> = [],
 ): RestoreMigrationCatalog & {
   insertLifecycleSeq(projectId: string): Promise<void>;
   insertConfigurationRevision(): Promise<void>;
@@ -76,6 +87,9 @@ function createRestoreCatalog(
   const columns = new Set(presentColumns.map((entry) => columnKey(entry.relation, entry.column)));
   const primaryKeys = new Map<string, readonly string[]>(
     presentPrimaryKeys.map((entry) => [entry.relation, entry.columns]),
+  );
+  const columnTypes = new Map<string, string>(
+    presentColumnTypes.map((entry) => [columnKey(entry.relation, entry.column), entry.dataType]),
   );
   const applied = new Set(RESTORED_SCHEMA_RELATION_SENTINELS.map((sentinel) => sentinel.version));
   const catalog: RestoreMigrationCatalog & {
@@ -90,6 +104,12 @@ function createRestoreCatalog(
     async columnExists(qualifiedRelation, column) {
       return columns.has(columnKey(qualifiedRelation, column));
     },
+    async columnDataType(qualifiedRelation, column) {
+      const key = columnKey(qualifiedRelation, column);
+      if (columnTypes.has(key)) return columnTypes.get(key)!;
+      if (!columns.has(key)) return null;
+      return expectedColumnType(qualifiedRelation, column);
+    },
     async primaryKeyColumns(qualifiedRelation) {
       if (primaryKeys.has(qualifiedRelation)) return [...primaryKeys.get(qualifiedRelation)!];
       const expected = expectedPrimaryKey(qualifiedRelation);
@@ -100,6 +120,7 @@ function createRestoreCatalog(
       const snapshotRelations = new Set(relations);
       const snapshotColumns = new Set(columns);
       const snapshotPrimaryKeys = new Map(primaryKeys);
+      const snapshotColumnTypes = new Map(columnTypes);
       try {
         if (floor) {
           const parsedFloor = Number.parseInt(floor, 10);
@@ -117,6 +138,10 @@ function createRestoreCatalog(
           for (const primaryKey of sentinel.primaryKeys ?? []) {
             primaryKeys.set(primaryKey.relation, primaryKey.columns);
           }
+          for (const columnType of sentinel.columnTypes ?? []) {
+            columns.add(columnKey(columnType.relation, columnType.column));
+            columnTypes.set(columnKey(columnType.relation, columnType.column), columnType.dataType);
+          }
           applied.add(sentinel.version);
         }
       } catch (error) {
@@ -130,6 +155,8 @@ function createRestoreCatalog(
         for (const [relation, columnsForKey] of snapshotPrimaryKeys) {
           primaryKeys.set(relation, columnsForKey);
         }
+        columnTypes.clear();
+        for (const [key, dataType] of snapshotColumnTypes) columnTypes.set(key, dataType);
         throw error;
       }
     },
@@ -603,6 +630,83 @@ describe("PostgreSQL paired restore orchestration", () => {
 
       expect(await catalog.primaryKeyColumns("project.agent_ratings")).toEqual(["project_id", "id"]);
       expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0024 when task_verification_requests is missing and later sentinels exist", async () => {
+    const allColumns = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+    const catalogAtDetect = createRestoreCatalog(
+      sentinelRelationsExcept(TASK_VERIFICATION_REQUEST_VERSION),
+      allColumns,
+    );
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(TASK_VERIFICATION_REQUEST_VERSION);
+    expect(await catalogAtDetect.relationExists("project.task_verification_requests")).toBe(false);
+    expect(await catalogAtDetect.relationExists("project.symbol_locks")).toBe(true);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0024-verify-"));
+    try {
+      const catalog = createRestoreCatalog(
+        sentinelRelationsExcept(TASK_VERIFICATION_REQUEST_VERSION),
+        allColumns,
+      );
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0024-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(catalog.hasApplied(TASK_VERIFICATION_REQUEST_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.relationExists("project.task_verification_requests")).toBe(true);
+      expect(catalog.hasApplied(TASK_VERIFICATION_REQUEST_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0025 when symbol_locks is missing after 0024 is present", async () => {
+    const allColumns = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+    const catalog = createRestoreCatalog(
+      sentinelRelationsExcept(SYMBOL_LOCKS_SCHEMA_VERSION),
+      allColumns,
+    );
+    expect(await catalog.relationExists("project.task_verification_requests")).toBe(true);
+    expect(await catalog.relationExists("project.symbol_locks")).toBe(false);
+    expect(await detectRestoredSchemaRewindFloor(catalog)).toBe(SYMBOL_LOCKS_SCHEMA_VERSION);
+  });
+
+  it("unstamps 0026 when token counters exist as integer rather than bigint", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const allColumns = [
+      ...RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]),
+      { relation: "project.tasks", column: "token_usage_input_tokens" },
+      { relation: "project.tasks", column: "cumulative_active_ms" },
+    ];
+    const integerCounters = [
+      { relation: "project.tasks", column: "token_usage_input_tokens", dataType: "integer" },
+    ];
+    const catalogAtDetect = createRestoreCatalog(allRelations, allColumns, [], integerCounters);
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(BIGINT_COUNTERS_VERSION);
+    expect(await catalogAtDetect.columnExists("project.tasks", "token_usage_input_tokens")).toBe(true);
+    expect(await catalogAtDetect.columnDataType("project.tasks", "token_usage_input_tokens")).toBe("integer");
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0026-bigint-"));
+    try {
+      const catalog = createRestoreCatalog(allRelations, allColumns, [], integerCounters);
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0026-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(catalog.hasApplied(BIGINT_COUNTERS_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.columnDataType("project.tasks", "token_usage_input_tokens")).toBe("bigint");
+      expect(catalog.hasApplied(BIGINT_COUNTERS_VERSION)).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -444,9 +444,10 @@ describe("PostgreSQL paired restore orchestration", () => {
       );
       const restores = (await fixture.actions()).filter((action) => action.startsWith("RESTORE "));
       expect(restores[0]).toContain(fixture.projectFilename);
-      expect(restores[1]).toMatch(/^RESTORE fusion-pre-restore-pg-/);
-      expect(restores.some((action) => action.includes(fixture.centralFilename))).toBe(false);
-      expect(reconcileAttempts).toBe(2);
+      expect(restores[1]).toContain(fixture.centralFilename);
+      expect(restores[2]).toMatch(/^RESTORE fusion-pre-restore-pg-/);
+      expect(restores[3]).toMatch(/^RESTORE fusion-central-pre-restore-pg-/);
+      expect(reconcileAttempts).toBe(1);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../postgres/restore-migration-reconcile.js";
 import {
   AGENT_RATING_PROJECT_ISOLATION_VERSION,
+  AGENT_RATINGS_PROJECT_PARTITION_VERSION,
   ANALYTICS_ISOLATION_SCHEMA_VERSION,
   BIGINT_COUNTERS_VERSION,
   AUTOMATION_ISOLATION_SCHEMA_VERSION,
@@ -73,11 +74,30 @@ function expectedColumnType(relation: string, column: string): string | null {
   return match ? match.dataType : null;
 }
 
+function expectedNamedObjects(
+  kind: "triggers" | "policies" | "indexes",
+  relation: string,
+): string[] {
+  return RESTORED_SCHEMA_RELATION_SENTINELS
+    .flatMap((sentinel) => [...(sentinel[kind] ?? [])])
+    .filter((entry) => entry.relation === relation)
+    .map((entry) => entry.name);
+}
+
+function namedObjectKey(relation: string, name: string): string {
+  return `${relation}\0${name}`;
+}
+
 function createRestoreCatalog(
   presentRelations: readonly string[] = [],
   presentColumns: ReadonlyArray<{ relation: string; column: string }> = [],
   presentPrimaryKeys: ReadonlyArray<{ relation: string; columns: readonly string[] }> = [],
   presentColumnTypes: ReadonlyArray<{ relation: string; column: string; dataType: string }> = [],
+  extras: {
+    triggers?: ReadonlyArray<{ relation: string; name: string }>;
+    policies?: ReadonlyArray<{ relation: string; name: string }>;
+    indexes?: ReadonlyArray<{ relation: string; name: string }>;
+  } = {},
 ): RestoreMigrationCatalog & {
   insertLifecycleSeq(projectId: string): Promise<void>;
   insertConfigurationRevision(): Promise<void>;
@@ -92,6 +112,12 @@ function createRestoreCatalog(
   const columnTypes = new Map<string, string>(
     presentColumnTypes.map((entry) => [columnKey(entry.relation, entry.column), entry.dataType]),
   );
+  const triggerOverride = extras.triggers !== undefined;
+  const policyOverride = extras.policies !== undefined;
+  const indexOverride = extras.indexes !== undefined;
+  const triggers = new Set((extras.triggers ?? []).map((entry) => namedObjectKey(entry.relation, entry.name)));
+  const policies = new Set((extras.policies ?? []).map((entry) => namedObjectKey(entry.relation, entry.name)));
+  const indexes = new Set((extras.indexes ?? []).map((entry) => namedObjectKey(entry.relation, entry.name)));
   const applied = new Set(RESTORED_SCHEMA_RELATION_SENTINELS.map((sentinel) => sentinel.version));
   const catalog: RestoreMigrationCatalog & {
     insertLifecycleSeq(projectId: string): Promise<void>;
@@ -116,12 +142,27 @@ function createRestoreCatalog(
       const expected = expectedPrimaryKey(qualifiedRelation);
       return expected ? [...expected] : null;
     },
+    async triggerExists(qualifiedRelation, triggerName) {
+      if (triggerOverride) return triggers.has(namedObjectKey(qualifiedRelation, triggerName));
+      return expectedNamedObjects("triggers", qualifiedRelation).includes(triggerName);
+    },
+    async policyExists(qualifiedRelation, policyName) {
+      if (policyOverride) return policies.has(namedObjectKey(qualifiedRelation, policyName));
+      return expectedNamedObjects("policies", qualifiedRelation).includes(policyName);
+    },
+    async indexExists(qualifiedRelation, indexName) {
+      if (indexOverride) return indexes.has(namedObjectKey(qualifiedRelation, indexName));
+      return expectedNamedObjects("indexes", qualifiedRelation).includes(indexName);
+    },
     async applyRewindAndReplay(floor) {
       const snapshotApplied = new Set(applied);
       const snapshotRelations = new Set(relations);
       const snapshotColumns = new Set(columns);
       const snapshotPrimaryKeys = new Map(primaryKeys);
       const snapshotColumnTypes = new Map(columnTypes);
+      const snapshotTriggers = new Set(triggers);
+      const snapshotPolicies = new Set(policies);
+      const snapshotIndexes = new Set(indexes);
       try {
         if (floor) {
           const parsedFloor = Number.parseInt(floor, 10);
@@ -143,6 +184,18 @@ function createRestoreCatalog(
             columns.add(columnKey(columnType.relation, columnType.column));
             columnTypes.set(columnKey(columnType.relation, columnType.column), columnType.dataType);
           }
+          for (const trigger of sentinel.triggers ?? []) {
+            triggers.add(namedObjectKey(trigger.relation, trigger.name));
+          }
+          for (const policy of sentinel.policies ?? []) {
+            policies.add(namedObjectKey(policy.relation, policy.name));
+          }
+          for (const index of sentinel.indexes ?? []) {
+            indexes.add(namedObjectKey(index.relation, index.name));
+          }
+          for (const column of sentinel.absentColumns ?? []) {
+            columns.delete(columnKey(column.relation, column.column));
+          }
           applied.add(sentinel.version);
         }
       } catch (error) {
@@ -158,6 +211,12 @@ function createRestoreCatalog(
         }
         columnTypes.clear();
         for (const [key, dataType] of snapshotColumnTypes) columnTypes.set(key, dataType);
+        triggers.clear();
+        for (const key of snapshotTriggers) triggers.add(key);
+        policies.clear();
+        for (const key of snapshotPolicies) policies.add(key);
+        indexes.clear();
+        for (const key of snapshotIndexes) indexes.add(key);
         throw error;
       }
     },
@@ -631,6 +690,34 @@ describe("PostgreSQL paired restore orchestration", () => {
 
       expect(await catalog.primaryKeyColumns("project.agent_ratings")).toEqual(["project_id", "id"]);
       expect(catalog.hasApplied(AGENT_RATING_PROJECT_ISOLATION_VERSION)).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unstamps 0055 when agent_ratings PK is healthy but the assign trigger is missing", async () => {
+    const allRelations = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+    const allColumns = RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.columns ?? [])]);
+    const catalogAtDetect = createRestoreCatalog(allRelations, allColumns, [], [], { triggers: [] });
+    expect(await detectRestoredSchemaRewindFloor(catalogAtDetect)).toBe(AGENT_RATINGS_PROJECT_PARTITION_VERSION);
+    expect(await catalogAtDetect.columnExists("project.agent_ratings", "project_id")).toBe(true);
+    expect(await catalogAtDetect.primaryKeyColumns("project.agent_ratings")).toEqual(["project_id", "id"]);
+    expect(await catalogAtDetect.triggerExists("project.agent_ratings", "fusion_assign_project_id")).toBe(false);
+
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-0055-trigger-"));
+    try {
+      const catalog = createRestoreCatalog(allRelations, allColumns, [], [], { triggers: [] });
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0055-project");
+      await writeFile(fixture.centralPath, "central-source");
+      expect(catalog.hasApplied(AGENT_RATINGS_PROJECT_PARTITION_VERSION)).toBe(true);
+
+      await fixture.manager.restoreBackup(fixture.projectFilename, { createPreRestoreBackup: false });
+
+      expect(await catalog.triggerExists("project.agent_ratings", "fusion_assign_project_id")).toBe(true);
+      expect(catalog.hasApplied(AGENT_RATINGS_PROJECT_PARTITION_VERSION)).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/core/src/__tests__/backup.test.ts
+++ b/packages/core/src/__tests__/backup.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   CONFIGURATION_REVISIONS_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
+  TASK_REQUIRE_PLAN_APPROVAL_VERSION,
 } from "../postgres/schema-applier.js";
 import {
   clearActiveEmbeddedRuntimeUrl,
@@ -39,30 +40,66 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-function createRestoreCatalog(presentRelations: readonly string[] = []): RestoreMigrationCatalog & {
+function columnKey(relation: string, column: string): string {
+  return `${relation}.${column}`;
+}
+
+function createRestoreCatalog(
+  presentRelations: readonly string[] = [],
+  presentColumns: ReadonlyArray<{ relation: string; column: string }> = [],
+): RestoreMigrationCatalog & {
   insertLifecycleSeq(projectId: string): Promise<void>;
   insertConfigurationRevision(): Promise<void>;
+  hasApplied(version: string): boolean;
+  failReplayWith?: Error;
 } {
   const relations = new Set(presentRelations);
+  const columns = new Set(presentColumns.map((entry) => columnKey(entry.relation, entry.column)));
   const applied = new Set(RESTORED_SCHEMA_RELATION_SENTINELS.map((sentinel) => sentinel.version));
-  return {
+  const catalog: RestoreMigrationCatalog & {
+    insertLifecycleSeq(projectId: string): Promise<void>;
+    insertConfigurationRevision(): Promise<void>;
+    hasApplied(version: string): boolean;
+    failReplayWith?: Error;
+  } = {
     async relationExists(qualifiedName) {
       return relations.has(qualifiedName);
     },
-    async unstampNumericVersionsFrom(version) {
-      const floor = Number.parseInt(version, 10);
-      for (const appliedVersion of [...applied]) {
-        if (/^[0-9]+$/.test(appliedVersion) && Number.parseInt(appliedVersion, 10) >= floor) {
-          applied.delete(appliedVersion);
+    async columnExists(qualifiedRelation, column) {
+      return columns.has(columnKey(qualifiedRelation, column));
+    },
+    async applyRewindAndReplay(floor) {
+      const snapshotApplied = new Set(applied);
+      const snapshotRelations = new Set(relations);
+      const snapshotColumns = new Set(columns);
+      try {
+        if (floor) {
+          const parsedFloor = Number.parseInt(floor, 10);
+          for (const appliedVersion of [...applied]) {
+            if (/^[0-9]+$/.test(appliedVersion) && Number.parseInt(appliedVersion, 10) >= parsedFloor) {
+              applied.delete(appliedVersion);
+            }
+          }
         }
+        if (catalog.failReplayWith) throw catalog.failReplayWith;
+        for (const sentinel of RESTORED_SCHEMA_RELATION_SENTINELS) {
+          if (applied.has(sentinel.version)) continue;
+          for (const relation of sentinel.relations ?? []) relations.add(relation);
+          for (const column of sentinel.columns ?? []) columns.add(columnKey(column.relation, column.column));
+          applied.add(sentinel.version);
+        }
+      } catch (error) {
+        applied.clear();
+        for (const version of snapshotApplied) applied.add(version);
+        relations.clear();
+        for (const relation of snapshotRelations) relations.add(relation);
+        columns.clear();
+        for (const column of snapshotColumns) columns.add(column);
+        throw error;
       }
     },
-    async replayPendingMigrations() {
-      for (const sentinel of RESTORED_SCHEMA_RELATION_SENTINELS) {
-        if (applied.has(sentinel.version)) continue;
-        for (const relation of sentinel.relations) relations.add(relation);
-        applied.add(sentinel.version);
-      }
+    hasApplied(version) {
+      return applied.has(version);
     },
     async insertLifecycleSeq(projectId: string) {
       if (!relations.has("project.task_lifecycle_event_seq")) {
@@ -76,6 +113,19 @@ function createRestoreCatalog(presentRelations: readonly string[] = []): Restore
       }
     },
   };
+  return catalog;
+}
+
+function sentinelRelationsBelow(version: string): string[] {
+  return RESTORED_SCHEMA_RELATION_SENTINELS
+    .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(version, 10))
+    .flatMap((sentinel) => [...(sentinel.relations ?? [])]);
+}
+
+function sentinelColumnsBelow(version: string): Array<{ relation: string; column: string }> {
+  return RESTORED_SCHEMA_RELATION_SENTINELS
+    .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(version, 10))
+    .flatMap((sentinel) => [...(sentinel.columns ?? [])]);
 }
 
 async function createRestoreFixture(root: string, backupOptions: BackupOptions = {}) {
@@ -370,11 +420,7 @@ describe("PostgreSQL paired restore orchestration", () => {
   it("replays 0040 relations after restoring a dump that lacks them while the ledger claims current", async () => {
     const root = await mkdtemp(join(tmpdir(), "fusion-restore-0040-rewind-"));
     try {
-      const catalog = createRestoreCatalog(
-        RESTORED_SCHEMA_RELATION_SENTINELS
-          .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(TASK_LIFECYCLE_OUTBOX_VERSION, 10))
-          .flatMap((sentinel) => [...sentinel.relations]),
-      );
+      const catalog = createRestoreCatalog(sentinelRelationsBelow(TASK_LIFECYCLE_OUTBOX_VERSION));
       const fixture = await createRestoreFixture(root, {
         reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
       });
@@ -400,11 +446,7 @@ describe("PostgreSQL paired restore orchestration", () => {
   it("rewinds past a missing pre-0040 relation so later inserts succeed", async () => {
     const root = await mkdtemp(join(tmpdir(), "fusion-restore-pre-0040-rewind-"));
     try {
-      const catalog = createRestoreCatalog(
-        RESTORED_SCHEMA_RELATION_SENTINELS
-          .filter((sentinel) => Number.parseInt(sentinel.version, 10) < Number.parseInt(CONFIGURATION_REVISIONS_VERSION, 10))
-          .flatMap((sentinel) => [...sentinel.relations]),
-      );
+      const catalog = createRestoreCatalog(sentinelRelationsBelow(CONFIGURATION_REVISIONS_VERSION));
       const fixture = await createRestoreFixture(root, {
         reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
       });
@@ -424,6 +466,40 @@ describe("PostgreSQL paired restore orchestration", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+
+  it("rewinds a missing later ALTER column while parent tables remain", async () => {
+    const root = await mkdtemp(join(tmpdir(), "fusion-restore-column-rewind-"));
+    try {
+      const catalog = createRestoreCatalog(
+        RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]),
+        sentinelColumnsBelow(TASK_REQUIRE_PLAN_APPROVAL_VERSION),
+      );
+      const fixture = await createRestoreFixture(root, {
+        reconcileRestoredMigrations: () => reconcileRestoredSchemaMigrations(catalog),
+      });
+      await writeFile(fixture.projectPath, "pre-0070-project");
+      await writeFile(fixture.centralPath, "central-source");
+
+      expect(await catalog.columnExists("project.tasks", "require_plan_approval")).toBe(false);
+      await fixture.manager.restoreBackup(fixture.projectFilename, {
+        createPreRestoreBackup: false,
+      });
+      expect(await catalog.columnExists("project.tasks", "require_plan_approval")).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps migration ledger versions when baseline replay fails after unstamp", async () => {
+    const catalog = createRestoreCatalog(
+      RESTORED_SCHEMA_RELATION_SENTINELS.flatMap((sentinel) => [...(sentinel.relations ?? [])]),
+    );
+    catalog.failReplayWith = new Error("baseline exploded");
+    expect(catalog.hasApplied(TASK_REQUIRE_PLAN_APPROVAL_VERSION)).toBe(true);
+    await expect(reconcileRestoredSchemaMigrations(catalog)).rejects.toThrow(/baseline exploded/);
+    expect(catalog.hasApplied(TASK_REQUIRE_PLAN_APPROVAL_VERSION)).toBe(true);
+    expect(catalog.hasApplied(TASK_LIFECYCLE_OUTBOX_VERSION)).toBe(true);
   });
 
   it("rolls project/archive back when migration reconciliation fails after project restore", async () => {

--- a/packages/core/src/backup/backup.ts
+++ b/packages/core/src/backup/backup.ts
@@ -5,6 +5,8 @@ import { CronExpressionParser } from "cron-parser";
 import { PgBackupManager, type PgBackupPair, type PgDumpResult } from "../postgres/pg-backup.js";
 import { resolveBackend } from "../postgres/backend-resolver.js";
 import { getActiveEmbeddedRuntimeUrl } from "../postgres/active-backend-registry.js";
+import { reconcileRestoredSchemaMigrationsFromUrl } from "../postgres/restore-migration-reconcile.js";
+import { redactCredentialsFromMessage } from "../postgres/credential-redact.js";
 import type { Settings } from "../types.js";
 import type { Routine } from "../automation/routine.js";
 
@@ -75,6 +77,13 @@ export interface BackupOptions {
   pgRestorePath?: string;
   /** Override the bounded native-client timeout. Defaults to 120 seconds. */
   clientTimeoutMs?: number;
+  /**
+   * FNXC:PostgresBackup 2026-09-04-05:26:
+   * Test seam for post-restore rewind/replay. Production reconnects and
+   * reconciles `public.fusion_schema_migrations` against restored relations so
+   * a legacy two-member stem (no bookkeeping dump) cannot skip later migrations.
+   */
+  reconcileRestoredMigrations?: () => Promise<void>;
 }
 
 /**
@@ -91,6 +100,8 @@ export class BackupManager {
   private backupDir: string;
   private retention: number;
   private includeCentralDb: boolean;
+  private readonly connectionString: string;
+  private readonly reconcileRestoredMigrations?: () => Promise<void>;
   private readonly pgManager: PgBackupManager;
 
   constructor(fusionDir: string, options?: BackupOptions) {
@@ -105,6 +116,8 @@ export class BackupManager {
           "Pass connectionString explicitly or ensure DATABASE_URL / embedded backend is configured.",
       );
     }
+    this.connectionString = connectionString;
+    this.reconcileRestoredMigrations = options?.reconcileRestoredMigrations;
     this.pgManager = new PgBackupManager(connectionString, fusionDir, {
       backupDir: this.backupDir,
       retention: this.retention,
@@ -169,10 +182,13 @@ export class BackupManager {
   }
 
   /**
-   * FNXC:PostgresBackup 2026-09-04-02:58:
+   * FNXC:PostgresBackup 2026-09-04-05:26:
    * Project/archive restores also restore captured migration bookkeeping. That
    * write is permitted only with a complete pre-restore stem so failures can
    * roll every committed group back to one consistent snapshot.
+   * After the dump groups commit, rewind/replay still runs so a legacy
+   * two-member stem (bookkeeping unavailable) cannot skip later CREATE-TABLE
+   * migrations. A thrown reconcile uses the same rollback helper as a dump failure.
    */
   async restoreBackup(
     filename: string,
@@ -242,11 +258,33 @@ export class BackupManager {
       }
       if (restoreCentral) { await this.pgManager.restoreBackup(selection.centralPath); result.restored.push("central"); }
       if (restoreBookkeeping) await this.pgManager.restoreBackup(selection.migrationsPath);
+      if (restoreProject) await this.reconcileProjectMigrationState();
     } catch (error) {
       if (!projectCommitted) throw error;
       await rollback(error);
     }
     return result;
+  }
+
+  /**
+   * FNXC:PostgresBackup 2026-09-04-05:26:
+   * Same-stem bookkeeping dumps restore the ledger when present. Legacy stems
+   * leave public.fusion_schema_migrations at the current binary version, so
+   * rewind from the earliest missing CREATE-TABLE sentinel and replay.
+   */
+  private async reconcileProjectMigrationState(): Promise<void> {
+    try {
+      if (this.reconcileRestoredMigrations) {
+        await this.reconcileRestoredMigrations();
+        return;
+      }
+      await reconcileRestoredSchemaMigrationsFromUrl(this.connectionString);
+    } catch (error) {
+      throw new Error(
+        `Restored schemas but failed to reconcile migration bookkeeping: ${redactCredentialsFromMessage(errorMessage(error))}`,
+        { cause: error },
+      );
+    }
   }
 }
 

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -1,23 +1,42 @@
 /**
  * Reconcile public.fusion_schema_migrations after a project/archive restore.
  *
- * FNXC:PostgresBackup 2026-09-04-04:42:
- * Paired dumps replace `project`, `archive`, and `central` only. Restoring a
- * dump taken before migration 0040 therefore drops `project.task_lifecycle_events`
- * and `project.task_lifecycle_event_seq` while leaving the current binary's
- * versions in `public.fusion_schema_migrations`. Startup then skips 0040 and
- * later task deletion/archival inserts fail. After every project restore, rewind
- * numeric ledger rows from the earliest missing sentinel relation and replay
- * `applySchemaBaseline` so restored schemas and bookkeeping match.
+ * FNXC:PostgresBackup 2026-09-04-05:12:
+ * Paired dumps replace `project`, `archive`, and `central` only. Restoring an
+ * older dump therefore drops later CREATE-TABLE relations while leaving the
+ * current binary's versions in `public.fusion_schema_migrations`. Startup then
+ * skips those migrations and later inserts fail. After every project restore,
+ * rewind numeric ledger rows from the earliest missing CREATE-TABLE sentinel
+ * (not only 0040) and replay `applySchemaBaseline` so restored schemas and
+ * bookkeeping match.
+ *
+ * FNXC:PostgresBackup 2026-09-04-05:12:
+ * Postgres.js 3.4.9 defaults `ssl` to false and does not honor libpq `sslmode`
+ * in the URL. Remote reconciliation connections must pass `ssl: "verify-full"`.
+ * Loopback/embedded hosts keep SSL off because the bundled cluster has no TLS.
  */
 import postgres from "postgres";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { sql } from "drizzle-orm";
+import { parsePgUrl } from "./pg-backup.js";
 import {
   applySchemaBaseline,
+  CHAT_SESSION_TAGS_VERSION,
+  CONFIGURATION_REVISIONS_VERSION,
+  GITHUB_CHECK_STATES_VERSION,
+  AGENT_ACTIVITY_EVENTS_VERSION,
+  IDEATION_SCHEMA_VERSION,
+  IMPORT_TRANSLATION_CACHE_VERSION,
+  LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION,
+  MEMORY_RECALL_RECORDS_VERSION,
   MIGRATION_BOOKKEEPING_TABLE,
+  MISSION_LINEAGE_STOP_VERSION,
+  PATCHNODE_ENTRIES_VERSION,
+  SPEC_LOCK_DRIFT_REPORT_VERSION,
   TASK_LIFECYCLE_CONSUMERS_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
+  UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION,
+  WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
 } from "./schema-applier.js";
 
 export interface RestoreMigrationCatalog {
@@ -31,11 +50,21 @@ export interface RestoredSchemaRelationSentinel {
   readonly relations: readonly string[];
 }
 
+const INITIAL_SCHEMA_VERSION = "0000";
+
 /**
  * CREATE-TABLE sentinels used to detect a restored schema that is older than
  * the recorded ledger. Checked in version order; the first miss is the rewind floor.
+ * Central-schema tables are excluded: project dumps do not replace `central`.
  */
 export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelationSentinel[] = [
+  { version: INITIAL_SCHEMA_VERSION, relations: ["project.tasks"] },
+  { version: LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION, relations: ["project.boards"] },
+  { version: IMPORT_TRANSLATION_CACHE_VERSION, relations: ["project.import_translation_cache"] },
+  { version: CONFIGURATION_REVISIONS_VERSION, relations: ["project.configuration_revisions"] },
+  { version: IDEATION_SCHEMA_VERSION, relations: ["project.ideation_sessions"] },
+  { version: MISSION_LINEAGE_STOP_VERSION, relations: ["project.mission_lineage_stops"] },
+  { version: CHAT_SESSION_TAGS_VERSION, relations: ["project.chat_tags"] },
   {
     version: TASK_LIFECYCLE_OUTBOX_VERSION,
     relations: ["project.task_lifecycle_events", "project.task_lifecycle_event_seq"],
@@ -44,6 +73,16 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
     version: TASK_LIFECYCLE_CONSUMERS_VERSION,
     relations: ["project.task_lifecycle_consumer_registrations"],
   },
+  { version: UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION, relations: ["project.unplanned_execution_blocks"] },
+  { version: GITHUB_CHECK_STATES_VERSION, relations: ["project.github_check_states"] },
+  { version: AGENT_ACTIVITY_EVENTS_VERSION, relations: ["project.agent_activity_events"] },
+  { version: SPEC_LOCK_DRIFT_REPORT_VERSION, relations: ["project.spec_locks"] },
+  { version: MEMORY_RECALL_RECORDS_VERSION, relations: ["project.memory_recall_records"] },
+  {
+    version: WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
+    relations: ["project.workspace_coordination_leases"],
+  },
+  { version: PATCHNODE_ENTRIES_VERSION, relations: ["project.patchnode_entries"] },
 ];
 
 export async function reconcileRestoredSchemaMigrations(
@@ -95,6 +134,27 @@ export function createDrizzleRestoreMigrationCatalog(
   };
 }
 
+/**
+ * FNXC:PostgresBackup 2026-09-04-05:12:
+ * Embedded/loopback clusters have no TLS. Any other host is treated as remote
+ * and must use certificate verification; postgres.js will not infer this from
+ * a URL `sslmode` query parameter.
+ */
+export function reconciliationPostgresSsl(connectionString: string): false | "verify-full" {
+  const host = (parsePgUrl(connectionString).host ?? "").toLowerCase();
+  if (
+    host === "" ||
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]" ||
+    host.startsWith("/")
+  ) {
+    return false;
+  }
+  return "verify-full";
+}
+
 export async function reconcileRestoredSchemaMigrationsFromUrl(
   connectionString: string,
 ): Promise<{ rewoundFrom: string | null }> {
@@ -102,6 +162,7 @@ export async function reconcileRestoredSchemaMigrationsFromUrl(
     max: 1,
     connect_timeout: 10,
     prepare: false,
+    ssl: reconciliationPostgresSsl(connectionString),
   });
   try {
     const db = drizzle(client);

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -33,6 +33,11 @@
  * Skipping them lets a 0023 dump keep those versions stamped and skip
  * verification-request / symbol-lock isolation plus bigint counter repair.
  *
+ * FNXC:PostgresBackup 2026-09-04-08:45:
+ * 0051 widens `current_plan_evidence.source_revision` because Date.now() exceeds
+ * int4. A 0050 dump that already has `spec_locks` must still rewind 0051 or
+ * plan-evidence appends fail.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -86,6 +91,7 @@ import {
   SESSION_ADVISOR_ENABLED_SCHEMA_VERSION,
   SESSION_CONTENTION_WAIT_STATE_VERSION,
   SPEC_LOCK_DRIFT_REPORT_VERSION,
+  SPEC_LOCK_SOURCE_REVISION_BIGINT_VERSION,
   SQLITE_SCHEMA_PARITY_VERSION,
   SYMBOL_LOCKS_SCHEMA_VERSION,
   TASK_DECLARED_SYMBOLS_VERSION,
@@ -290,6 +296,10 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
   { version: GITHUB_CHECK_STATES_VERSION, relations: ["project.github_check_states"] },
   { version: AGENT_ACTIVITY_EVENTS_VERSION, relations: ["project.agent_activity_events"] },
   { version: SPEC_LOCK_DRIFT_REPORT_VERSION, relations: ["project.spec_locks"] },
+  {
+    version: SPEC_LOCK_SOURCE_REVISION_BIGINT_VERSION,
+    columnTypes: [{ relation: "project.current_plan_evidence", column: "source_revision", dataType: "bigint" }],
+  },
   { version: MEMORY_RECALL_RECORDS_VERSION, relations: ["project.memory_recall_records"] },
   { version: MISSION_FEATURE_SPEC_ALIGNMENT_VERSION, columns: [{ relation: "project.mission_features", column: "spec_alignment" }] },
   {

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -1,14 +1,17 @@
 /**
  * Reconcile public.fusion_schema_migrations after a project/archive restore.
  *
- * FNXC:PostgresBackup 2026-09-04-05:12:
+ * FNXC:PostgresBackup 2026-09-04-05:45:
  * Paired dumps replace `project`, `archive`, and `central` only. Restoring an
- * older dump therefore drops later CREATE-TABLE relations while leaving the
+ * older dump therefore drops later relations or ALTER columns while leaving the
  * current binary's versions in `public.fusion_schema_migrations`. Startup then
- * skips those migrations and later inserts fail. After every project restore,
- * rewind numeric ledger rows from the earliest missing CREATE-TABLE sentinel
- * (not only 0040) and replay `applySchemaBaseline` so restored schemas and
- * bookkeeping match.
+ * skips those migrations and TaskStore queries fail. After every project restore,
+ * rewind numeric ledger rows from the earliest missing table OR column sentinel
+ * and replay `applySchemaBaseline` so restored schemas and bookkeeping match.
+ *
+ * Unstamp and baseline replay share one transaction so a failed apply cannot
+ * leave `public.fusion_schema_migrations` rewound while project/archive still
+ * reflects the restored dump.
  *
  * FNXC:PostgresBackup 2026-09-04-05:12:
  * Postgres.js 3.4.9 defaults `ssl` to false and does not honor libpq `sslmode`
@@ -21,50 +24,89 @@ import { sql } from "drizzle-orm";
 import { parsePgUrl } from "./pg-backup.js";
 import {
   applySchemaBaseline,
+  AI_MERGE_REVIEW_RECONCILIATION_VERSION,
+  AGENT_ACTIVITY_EVENTS_VERSION,
+  BULK_COMPLETION_REFUSAL_AT_VERSION,
+  CHAT_SESSION_MEMORY_FOCUS_VERSION,
+  CHAT_SESSION_PINS_VERSION,
   CHAT_SESSION_TAGS_VERSION,
   CONFIGURATION_REVISIONS_VERSION,
+  EXECUTOR_ESCALATION_ATTEMPT_VERSION,
+  EXECUTOR_TOOL_FAILURE_RETRY_VERSION,
   GITHUB_CHECK_STATES_VERSION,
-  AGENT_ACTIVITY_EVENTS_VERSION,
   IDEATION_SCHEMA_VERSION,
   IMPORT_TRANSLATION_CACHE_VERSION,
   LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION,
   MEMORY_RECALL_RECORDS_VERSION,
   MIGRATION_BOOKKEEPING_TABLE,
   MISSION_LINEAGE_STOP_VERSION,
+  MISSION_TASK_PREFIX_VERSION,
   PATCHNODE_ENTRIES_VERSION,
+  PLANNING_ACTIVE_TIMING_VERSION,
+  REVIEW_CONVERGENCE_STAGE_VERSION,
+  SESSION_ADVISOR_ENABLED_SCHEMA_VERSION,
+  SESSION_CONTENTION_WAIT_STATE_VERSION,
   SPEC_LOCK_DRIFT_REPORT_VERSION,
+  TASK_EXTERNAL_BLOCK_VERSION,
   TASK_LIFECYCLE_CONSUMERS_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
+  TASK_MERGER_MODEL_LANE_VERSION,
+  TASK_RECOMMENDATIONS_VERSION,
+  TASK_REPOSITORY_SCOPE_VERSION,
+  TASK_REQUIRE_PLAN_APPROVAL_VERSION,
+  TASK_STEP_REPORTS_VERSION,
   UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION,
+  WORKFLOW_IR_PIN_AND_LEGACY_ADOPTION_VERSION,
   WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
 } from "./schema-applier.js";
 
 export interface RestoreMigrationCatalog {
   relationExists(qualifiedName: string): Promise<boolean>;
-  unstampNumericVersionsFrom(version: string): Promise<void>;
-  replayPendingMigrations(): Promise<void>;
+  columnExists(qualifiedRelation: string, column: string): Promise<boolean>;
+  applyRewindAndReplay(floor: string | null): Promise<void>;
+}
+
+export interface RestoredSchemaColumnSentinel {
+  readonly relation: string;
+  readonly column: string;
 }
 
 export interface RestoredSchemaRelationSentinel {
   readonly version: string;
-  readonly relations: readonly string[];
+  readonly relations?: readonly string[];
+  readonly columns?: readonly RestoredSchemaColumnSentinel[];
 }
 
 const INITIAL_SCHEMA_VERSION = "0000";
 
+function tasksColumn(column: string): RestoredSchemaColumnSentinel {
+  return { relation: "project.tasks", column };
+}
+
 /**
- * CREATE-TABLE sentinels used to detect a restored schema that is older than
- * the recorded ledger. Checked in version order; the first miss is the rewind floor.
+ * Table and column sentinels used to detect a restored schema that is older
+ * than the recorded ledger. Checked in version order; the first miss is the rewind floor.
  * Central-schema tables are excluded: project dumps do not replace `central`.
+ * Column sentinels apply only when the parent relation exists, so a dump taken
+ * after CREATE TABLE but before a later ALTER still rewinds that ALTER version.
  */
 export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelationSentinel[] = [
   { version: INITIAL_SCHEMA_VERSION, relations: ["project.tasks"] },
   { version: LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION, relations: ["project.boards"] },
+  { version: SESSION_ADVISOR_ENABLED_SCHEMA_VERSION, columns: [tasksColumn("session_advisor_enabled")] },
   { version: IMPORT_TRANSLATION_CACHE_VERSION, relations: ["project.import_translation_cache"] },
+  { version: CHAT_SESSION_PINS_VERSION, columns: [{ relation: "project.chat_sessions", column: "pinned_at" }] },
+  { version: EXECUTOR_TOOL_FAILURE_RETRY_VERSION, columns: [tasksColumn("consecutive_tool_failure_retry_count")] },
+  { version: EXECUTOR_ESCALATION_ATTEMPT_VERSION, columns: [tasksColumn("executor_escalation_attempted")] },
+  { version: TASK_MERGER_MODEL_LANE_VERSION, columns: [tasksColumn("merger_model_id")] },
+  { version: BULK_COMPLETION_REFUSAL_AT_VERSION, columns: [tasksColumn("bulk_completion_refusal_at")] },
   { version: CONFIGURATION_REVISIONS_VERSION, relations: ["project.configuration_revisions"] },
   { version: IDEATION_SCHEMA_VERSION, relations: ["project.ideation_sessions"] },
+  { version: WORKFLOW_IR_PIN_AND_LEGACY_ADOPTION_VERSION, columns: [tasksColumn("workflow_ir_pin")] },
+  { version: PLANNING_ACTIVE_TIMING_VERSION, columns: [tasksColumn("cumulative_planning_ms")] },
   { version: MISSION_LINEAGE_STOP_VERSION, relations: ["project.mission_lineage_stops"] },
   { version: CHAT_SESSION_TAGS_VERSION, relations: ["project.chat_tags"] },
+  { version: MISSION_TASK_PREFIX_VERSION, columns: [{ relation: "project.missions", column: "task_prefix" }] },
   {
     version: TASK_LIFECYCLE_OUTBOX_VERSION,
     relations: ["project.task_lifecycle_events", "project.task_lifecycle_event_seq"],
@@ -74,6 +116,7 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
     relations: ["project.task_lifecycle_consumer_registrations"],
   },
   { version: UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION, relations: ["project.unplanned_execution_blocks"] },
+  { version: TASK_RECOMMENDATIONS_VERSION, columns: [tasksColumn("recommendations")] },
   { version: GITHUB_CHECK_STATES_VERSION, relations: ["project.github_check_states"] },
   { version: AGENT_ACTIVITY_EVENTS_VERSION, relations: ["project.agent_activity_events"] },
   { version: SPEC_LOCK_DRIFT_REPORT_VERSION, relations: ["project.spec_locks"] },
@@ -82,24 +125,68 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
     version: WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
     relations: ["project.workspace_coordination_leases"],
   },
+  { version: AI_MERGE_REVIEW_RECONCILIATION_VERSION, columns: [tasksColumn("ai_merge_review_reconciliation")] },
+  { version: TASK_REPOSITORY_SCOPE_VERSION, columns: [tasksColumn("repository_scope")] },
+  { version: REVIEW_CONVERGENCE_STAGE_VERSION, columns: [tasksColumn("review_convergence_stage")] },
+  { version: CHAT_SESSION_MEMORY_FOCUS_VERSION, columns: [{ relation: "project.chat_sessions", column: "memory_focus" }] },
+  { version: SESSION_CONTENTION_WAIT_STATE_VERSION, columns: [tasksColumn("session_contention_wait_reason")] },
+  { version: TASK_STEP_REPORTS_VERSION, columns: [tasksColumn("step_reports")] },
+  { version: TASK_EXTERNAL_BLOCK_VERSION, columns: [tasksColumn("external_block")] },
+  { version: TASK_REQUIRE_PLAN_APPROVAL_VERSION, columns: [tasksColumn("require_plan_approval")] },
   { version: PATCHNODE_ENTRIES_VERSION, relations: ["project.patchnode_entries"] },
 ];
+
+export async function detectRestoredSchemaRewindFloor(
+  catalog: RestoreMigrationCatalog,
+): Promise<string | null> {
+  for (const sentinel of RESTORED_SCHEMA_RELATION_SENTINELS) {
+    let missing = false;
+    for (const relation of sentinel.relations ?? []) {
+      if (await catalog.relationExists(relation)) continue;
+      missing = true;
+      break;
+    }
+    if (!missing) {
+      for (const column of sentinel.columns ?? []) {
+        if (!(await catalog.relationExists(column.relation))) continue;
+        if (await catalog.columnExists(column.relation, column.column)) continue;
+        missing = true;
+        break;
+      }
+    }
+    if (missing) return sentinel.version;
+  }
+  return null;
+}
 
 export async function reconcileRestoredSchemaMigrations(
   catalog: RestoreMigrationCatalog,
 ): Promise<{ rewoundFrom: string | null }> {
-  let rewoundFrom: string | null = null;
-  for (const sentinel of RESTORED_SCHEMA_RELATION_SENTINELS) {
-    for (const relation of sentinel.relations) {
-      if (await catalog.relationExists(relation)) continue;
-      rewoundFrom = sentinel.version;
-      break;
-    }
-    if (rewoundFrom) break;
-  }
-  if (rewoundFrom) await catalog.unstampNumericVersionsFrom(rewoundFrom);
-  await catalog.replayPendingMigrations();
+  const rewoundFrom = await detectRestoredSchemaRewindFloor(catalog);
+  await catalog.applyRewindAndReplay(rewoundFrom);
   return { rewoundFrom };
+}
+
+function splitQualifiedRelation(qualifiedName: string): { schema: string; table: string } {
+  const separator = qualifiedName.indexOf(".");
+  if (separator <= 0) return { schema: "public", table: qualifiedName };
+  return { schema: qualifiedName.slice(0, separator), table: qualifiedName.slice(separator + 1) };
+}
+
+function ensureBookkeepingSql(): string {
+  return `
+    CREATE TABLE IF NOT EXISTS public.${MIGRATION_BOOKKEEPING_TABLE} (
+      version text PRIMARY KEY,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )
+  `;
+}
+
+function deleteStampedFromSql(floor: number): string {
+  return `
+    DELETE FROM public.${MIGRATION_BOOKKEEPING_TABLE}
+    WHERE version ~ '^[0-9]+$' AND CAST(version AS integer) >= ${floor}
+  `;
 }
 
 export function createDrizzleRestoreMigrationCatalog(
@@ -112,24 +199,37 @@ export function createDrizzleRestoreMigrationCatalog(
       )) as unknown as Array<{ rel: string | null }>;
       return rows[0]?.rel != null;
     },
-    async unstampNumericVersionsFrom(version) {
-      const floor = Number.parseInt(version, 10);
-      if (!Number.isFinite(floor)) {
-        throw new Error(`Invalid migration version for restore rewind: ${version}`);
-      }
-      await db.execute(sql.raw(`
-        CREATE TABLE IF NOT EXISTS public.${MIGRATION_BOOKKEEPING_TABLE} (
-          version text PRIMARY KEY,
-          applied_at timestamptz NOT NULL DEFAULT now()
-        )
-      `));
-      await db.execute(sql.raw(`
-        DELETE FROM public.${MIGRATION_BOOKKEEPING_TABLE}
-        WHERE version ~ '^[0-9]+$' AND CAST(version AS integer) >= ${floor}
-      `));
+    async columnExists(qualifiedRelation, column) {
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_schema = ${schema}
+            AND table_name = ${table}
+            AND column_name = ${column}
+        ) AS present
+      `)) as unknown as Array<{ present: boolean }>;
+      return rows[0]?.present === true;
     },
-    async replayPendingMigrations() {
-      await applySchemaBaseline(db);
+    async applyRewindAndReplay(floor) {
+      /*
+       * FNXC:PostgresBackup 2026-09-04-05:45:
+       * Unstamp and applySchemaBaseline must share one transaction. Baseline
+       * already opens a nested savepoint; if it throws, this outer transaction
+       * rolls the DELETE back so restore rollback cannot observe a rewound ledger.
+       */
+      await db.transaction(async (tx) => {
+        if (floor) {
+          const parsedFloor = Number.parseInt(floor, 10);
+          if (!Number.isFinite(parsedFloor)) {
+            throw new Error(`Invalid migration version for restore rewind: ${floor}`);
+          }
+          await tx.execute(sql.raw(ensureBookkeepingSql()));
+          await tx.execute(sql.raw(deleteStampedFromSql(parsedFloor)));
+        }
+        await applySchemaBaseline(tx);
+      });
     },
   };
 }

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -1,12 +1,13 @@
 /**
  * Reconcile public.fusion_schema_migrations after a project/archive restore.
  *
- * FNXC:PostgresBackup 2026-09-04-05:45:
+ * FNXC:PostgresBackup 2026-09-04-05:59:
  * Paired dumps replace `project`, `archive`, and `central` only. Restoring an
  * older dump therefore drops later relations or ALTER columns while leaving the
  * current binary's versions in `public.fusion_schema_migrations`. Startup then
  * skips those migrations and TaskStore queries fail. After every project restore,
- * rewind numeric ledger rows from the earliest missing table OR column sentinel
+ * rewind numeric ledger rows from the earliest missing table OR ALTER column
+ * sentinel — including credential-instance fields and `messages.archived` —
  * and replay `applySchemaBaseline` so restored schemas and bookkeeping match.
  *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
@@ -31,6 +32,7 @@ import {
   CHAT_SESSION_PINS_VERSION,
   CHAT_SESSION_TAGS_VERSION,
   CONFIGURATION_REVISIONS_VERSION,
+  CREDENTIAL_INSTANCE_SELECTION_VERSION,
   EXECUTOR_ESCALATION_ATTEMPT_VERSION,
   EXECUTOR_TOOL_FAILURE_RETRY_VERSION,
   GITHUB_CHECK_STATES_VERSION,
@@ -38,25 +40,38 @@ import {
   IMPORT_TRANSLATION_CACHE_VERSION,
   LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION,
   MEMORY_RECALL_RECORDS_VERSION,
+  MESSAGE_ARCHIVE_SCHEMA_VERSION,
   MIGRATION_BOOKKEEPING_TABLE,
+  MILESTONE_ASSERTION_PROVENANCE_VERSION,
+  MISSION_FEATURE_SPEC_ALIGNMENT_VERSION,
   MISSION_LINEAGE_STOP_VERSION,
   MISSION_TASK_PREFIX_VERSION,
+  MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
   PATCHNODE_ENTRIES_VERSION,
   PLANNING_ACTIVE_TIMING_VERSION,
+  QUEUED_EPISODE_SIGNATURE_VERSION,
+  RESEARCH_FEATURE_PROVENANCE_VERSION,
   REVIEW_CONVERGENCE_STAGE_VERSION,
   SESSION_ADVISOR_ENABLED_SCHEMA_VERSION,
   SESSION_CONTENTION_WAIT_STATE_VERSION,
   SPEC_LOCK_DRIFT_REPORT_VERSION,
+  SQLITE_SCHEMA_PARITY_VERSION,
+  TASK_DECLARED_SYMBOLS_VERSION,
   TASK_EXTERNAL_BLOCK_VERSION,
   TASK_LIFECYCLE_CONSUMERS_VERSION,
   TASK_LIFECYCLE_OUTBOX_VERSION,
   TASK_MERGER_MODEL_LANE_VERSION,
+  TASK_PROPOSAL_CLAIM_VERSION,
   TASK_RECOMMENDATIONS_VERSION,
   TASK_REPOSITORY_SCOPE_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
   TASK_STEP_REPORTS_VERSION,
+  TASK_WEDGE_NOTIFICATION_VERSION,
   UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION,
+  VALIDATOR_INPUT_FINGERPRINT_VERSION,
   WORKFLOW_IR_PIN_AND_LEGACY_ADOPTION_VERSION,
+  WORKFLOW_PRINCIPAL_FENCE_VERSION,
+  WORKFLOW_TASK_CONTINUATIONS_VERSION,
   WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
 } from "./schema-applier.js";
 
@@ -91,8 +106,21 @@ function tasksColumn(column: string): RestoredSchemaColumnSentinel {
  * after CREATE TABLE but before a later ALTER still rewinds that ALTER version.
  */
 export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelationSentinel[] = [
-  { version: INITIAL_SCHEMA_VERSION, relations: ["project.tasks"] },
+  {
+    version: INITIAL_SCHEMA_VERSION,
+    relations: [
+      "project.tasks",
+      "project.messages",
+      "project.chat_sessions",
+      "project.missions",
+      "project.mission_features",
+      "project.mission_contract_assertions",
+      "project.workflow_work_items",
+      "project.agents",
+    ],
+  },
   { version: LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION, relations: ["project.boards"] },
+  { version: SQLITE_SCHEMA_PARITY_VERSION, columns: [tasksColumn("board_id")] },
   { version: SESSION_ADVISOR_ENABLED_SCHEMA_VERSION, columns: [tasksColumn("session_advisor_enabled")] },
   { version: IMPORT_TRANSLATION_CACHE_VERSION, relations: ["project.import_translation_cache"] },
   { version: CHAT_SESSION_PINS_VERSION, columns: [{ relation: "project.chat_sessions", column: "pinned_at" }] },
@@ -100,13 +128,24 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
   { version: EXECUTOR_ESCALATION_ATTEMPT_VERSION, columns: [tasksColumn("executor_escalation_attempted")] },
   { version: TASK_MERGER_MODEL_LANE_VERSION, columns: [tasksColumn("merger_model_id")] },
   { version: BULK_COMPLETION_REFUSAL_AT_VERSION, columns: [tasksColumn("bulk_completion_refusal_at")] },
+  { version: TASK_PROPOSAL_CLAIM_VERSION, columns: [tasksColumn("proposal_claim_id")] },
   { version: CONFIGURATION_REVISIONS_VERSION, relations: ["project.configuration_revisions"] },
   { version: IDEATION_SCHEMA_VERSION, relations: ["project.ideation_sessions"] },
+  { version: RESEARCH_FEATURE_PROVENANCE_VERSION, columns: [{ relation: "project.mission_features", column: "research_run_id" }] },
   { version: WORKFLOW_IR_PIN_AND_LEGACY_ADOPTION_VERSION, columns: [tasksColumn("workflow_ir_pin")] },
+  { version: TASK_DECLARED_SYMBOLS_VERSION, columns: [tasksColumn("declared_symbols")] },
   { version: PLANNING_ACTIVE_TIMING_VERSION, columns: [tasksColumn("cumulative_planning_ms")] },
-  { version: MISSION_LINEAGE_STOP_VERSION, relations: ["project.mission_lineage_stops"] },
+  { version: WORKFLOW_TASK_CONTINUATIONS_VERSION, columns: [{ relation: "project.workflow_work_items", column: "stable_workflow_run_id" }] },
+  { version: TASK_WEDGE_NOTIFICATION_VERSION, columns: [tasksColumn("wedge_notification")] },
+  { version: MILESTONE_ASSERTION_PROVENANCE_VERSION, columns: [{ relation: "project.mission_contract_assertions", column: "origin" }] },
+  {
+    version: MISSION_LINEAGE_STOP_VERSION,
+    relations: ["project.mission_lineage_stops"],
+    columns: [{ relation: "project.mission_features", column: "implementation_stop_reason" }],
+  },
   { version: CHAT_SESSION_TAGS_VERSION, relations: ["project.chat_tags"] },
   { version: MISSION_TASK_PREFIX_VERSION, columns: [{ relation: "project.missions", column: "task_prefix" }] },
+  { version: CREDENTIAL_INSTANCE_SELECTION_VERSION, columns: [tasksColumn("credential_instance_id")] },
   {
     version: TASK_LIFECYCLE_OUTBOX_VERSION,
     relations: ["project.task_lifecycle_events", "project.task_lifecycle_event_seq"],
@@ -115,12 +154,18 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
     version: TASK_LIFECYCLE_CONSUMERS_VERSION,
     relations: ["project.task_lifecycle_consumer_registrations"],
   },
+  { version: VALIDATOR_INPUT_FINGERPRINT_VERSION, columns: [{ relation: "project.mission_features", column: "validation_budget_fingerprint" }] },
   { version: UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION, relations: ["project.unplanned_execution_blocks"] },
+  { version: QUEUED_EPISODE_SIGNATURE_VERSION, columns: [tasksColumn("queued_log_episode_signature")] },
+  { version: MULTI_ROLE_WORKFLOW_AGENTS_VERSION, columns: [{ relation: "project.agents", column: "roles" }] },
+  { version: WORKFLOW_PRINCIPAL_FENCE_VERSION, columns: [{ relation: "project.workflow_work_items", column: "principal_agent_id" }] },
   { version: TASK_RECOMMENDATIONS_VERSION, columns: [tasksColumn("recommendations")] },
   { version: GITHUB_CHECK_STATES_VERSION, relations: ["project.github_check_states"] },
   { version: AGENT_ACTIVITY_EVENTS_VERSION, relations: ["project.agent_activity_events"] },
   { version: SPEC_LOCK_DRIFT_REPORT_VERSION, relations: ["project.spec_locks"] },
   { version: MEMORY_RECALL_RECORDS_VERSION, relations: ["project.memory_recall_records"] },
+  { version: MISSION_FEATURE_SPEC_ALIGNMENT_VERSION, columns: [{ relation: "project.mission_features", column: "spec_alignment" }] },
+  { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: "archived" }] },
   {
     version: WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
     relations: ["project.workspace_coordination_leases"],

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -28,6 +28,11 @@
  * `(project_id, id)` when the column landed but the PK stayed `(id)`. Column
  * presence is not enough; rewind must also match that primary key.
  *
+ * FNXC:PostgresBackup 2026-09-04-08:27:
+ * Numbered project migrations 0024-0026 must sit between 0023 and 0027.
+ * Skipping them lets a 0023 dump keep those versions stamped and skip
+ * verification-request / symbol-lock isolation plus bigint counter repair.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -48,6 +53,7 @@ import {
   AGENT_RATING_PROJECT_ISOLATION_VERSION,
   ANALYTICS_ISOLATION_SCHEMA_VERSION,
   AUTOMATION_ISOLATION_SCHEMA_VERSION,
+  BIGINT_COUNTERS_VERSION,
   BULK_COMPLETION_REFUSAL_AT_VERSION,
   CHAT_SESSION_MEMORY_FOCUS_VERSION,
   CHAT_SESSION_PINS_VERSION,
@@ -81,6 +87,7 @@ import {
   SESSION_CONTENTION_WAIT_STATE_VERSION,
   SPEC_LOCK_DRIFT_REPORT_VERSION,
   SQLITE_SCHEMA_PARITY_VERSION,
+  SYMBOL_LOCKS_SCHEMA_VERSION,
   TASK_DECLARED_SYMBOLS_VERSION,
   TASK_EXTERNAL_BLOCK_VERSION,
   TASK_LIFECYCLE_CONSUMERS_VERSION,
@@ -91,6 +98,7 @@ import {
   TASK_REPOSITORY_SCOPE_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
   TASK_STEP_REPORTS_VERSION,
+  TASK_VERIFICATION_REQUEST_VERSION,
   TASK_WEDGE_NOTIFICATION_VERSION,
   UNPLANNED_EXECUTION_BLOCK_DEDUPE_VERSION,
   VALIDATOR_INPUT_FINGERPRINT_VERSION,
@@ -103,6 +111,7 @@ import {
 export interface RestoreMigrationCatalog {
   relationExists(qualifiedName: string): Promise<boolean>;
   columnExists(qualifiedRelation: string, column: string): Promise<boolean>;
+  columnDataType(qualifiedRelation: string, column: string): Promise<string | null>;
   primaryKeyColumns(qualifiedRelation: string): Promise<readonly string[] | null>;
   applyRewindAndReplay(floor: string | null): Promise<void>;
 }
@@ -117,11 +126,18 @@ export interface RestoredSchemaPrimaryKeySentinel {
   readonly columns: readonly string[];
 }
 
+export interface RestoredSchemaColumnTypeSentinel {
+  readonly relation: string;
+  readonly column: string;
+  readonly dataType: string;
+}
+
 export interface RestoredSchemaRelationSentinel {
   readonly version: string;
   readonly relations?: readonly string[];
   readonly columns?: readonly RestoredSchemaColumnSentinel[];
   readonly primaryKeys?: readonly RestoredSchemaPrimaryKeySentinel[];
+  readonly columnTypes?: readonly RestoredSchemaColumnTypeSentinel[];
 }
 
 const INITIAL_SCHEMA_VERSION = "0000";
@@ -234,6 +250,15 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
   { version: CONFIGURATION_REVISIONS_VERSION, relations: ["project.configuration_revisions"] },
   { version: IDEATION_SCHEMA_VERSION, relations: ["project.ideation_sessions"] },
   { version: RESEARCH_FEATURE_PROVENANCE_VERSION, columns: [{ relation: "project.mission_features", column: "research_run_id" }] },
+  { version: TASK_VERIFICATION_REQUEST_VERSION, relations: ["project.task_verification_requests"] },
+  { version: SYMBOL_LOCKS_SCHEMA_VERSION, relations: ["project.symbol_locks"] },
+  {
+    version: BIGINT_COUNTERS_VERSION,
+    columnTypes: [
+      { relation: "project.tasks", column: "token_usage_input_tokens", dataType: "bigint" },
+      { relation: "project.tasks", column: "cumulative_active_ms", dataType: "bigint" },
+    ],
+  },
   { version: WORKFLOW_IR_PIN_AND_LEGACY_ADOPTION_VERSION, columns: [tasksColumn("workflow_ir_pin")] },
   { version: TASK_DECLARED_SYMBOLS_VERSION, columns: [tasksColumn("declared_symbols")] },
   { version: PLANNING_ACTIVE_TIMING_VERSION, columns: [tasksColumn("cumulative_planning_ms")] },
@@ -315,6 +340,16 @@ export async function detectRestoredSchemaRewindFloor(
         break;
       }
     }
+    if (!missing) {
+      for (const columnType of sentinel.columnTypes ?? []) {
+        if (!(await catalog.relationExists(columnType.relation))) continue;
+        if (!(await catalog.columnExists(columnType.relation, columnType.column))) continue;
+        const actual = await catalog.columnDataType(columnType.relation, columnType.column);
+        if (actual != null && actual.toLowerCase() === columnType.dataType.toLowerCase()) continue;
+        missing = true;
+        break;
+      }
+    }
     if (missing) return sentinel.version;
   }
   return null;
@@ -378,6 +413,22 @@ export function createDrizzleRestoreMigrationCatalog(
         ) AS present
       `)) as unknown as Array<{ present: boolean }>;
       return rows[0]?.present === true;
+    },
+    async columnDataType(qualifiedRelation, column) {
+      /*
+       * FNXC:PostgresBackup 2026-09-04-08:27:
+       * 0026 widens existing int4 counters to bigint and no-ops missing
+       * columns. Bound schema/table/column names; postgres reports `bigint`.
+       */
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT data_type AS data_type
+        FROM information_schema.columns
+        WHERE table_schema = ${schema}
+          AND table_name = ${table}
+          AND column_name = ${column}
+      `)) as unknown as Array<{ data_type: string | null }>;
+      return rows[0]?.data_type ?? null;
     },
     async primaryKeyColumns(qualifiedRelation) {
       /*

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -1,0 +1,112 @@
+/**
+ * Reconcile public.fusion_schema_migrations after a project/archive restore.
+ *
+ * FNXC:PostgresBackup 2026-09-04-04:42:
+ * Paired dumps replace `project`, `archive`, and `central` only. Restoring a
+ * dump taken before migration 0040 therefore drops `project.task_lifecycle_events`
+ * and `project.task_lifecycle_event_seq` while leaving the current binary's
+ * versions in `public.fusion_schema_migrations`. Startup then skips 0040 and
+ * later task deletion/archival inserts fail. After every project restore, rewind
+ * numeric ledger rows from the earliest missing sentinel relation and replay
+ * `applySchemaBaseline` so restored schemas and bookkeeping match.
+ */
+import postgres from "postgres";
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { sql } from "drizzle-orm";
+import {
+  applySchemaBaseline,
+  MIGRATION_BOOKKEEPING_TABLE,
+  TASK_LIFECYCLE_CONSUMERS_VERSION,
+  TASK_LIFECYCLE_OUTBOX_VERSION,
+} from "./schema-applier.js";
+
+export interface RestoreMigrationCatalog {
+  relationExists(qualifiedName: string): Promise<boolean>;
+  unstampNumericVersionsFrom(version: string): Promise<void>;
+  replayPendingMigrations(): Promise<void>;
+}
+
+export interface RestoredSchemaRelationSentinel {
+  readonly version: string;
+  readonly relations: readonly string[];
+}
+
+/**
+ * CREATE-TABLE sentinels used to detect a restored schema that is older than
+ * the recorded ledger. Checked in version order; the first miss is the rewind floor.
+ */
+export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelationSentinel[] = [
+  {
+    version: TASK_LIFECYCLE_OUTBOX_VERSION,
+    relations: ["project.task_lifecycle_events", "project.task_lifecycle_event_seq"],
+  },
+  {
+    version: TASK_LIFECYCLE_CONSUMERS_VERSION,
+    relations: ["project.task_lifecycle_consumer_registrations"],
+  },
+];
+
+export async function reconcileRestoredSchemaMigrations(
+  catalog: RestoreMigrationCatalog,
+): Promise<{ rewoundFrom: string | null }> {
+  let rewoundFrom: string | null = null;
+  for (const sentinel of RESTORED_SCHEMA_RELATION_SENTINELS) {
+    for (const relation of sentinel.relations) {
+      if (await catalog.relationExists(relation)) continue;
+      rewoundFrom = sentinel.version;
+      break;
+    }
+    if (rewoundFrom) break;
+  }
+  if (rewoundFrom) await catalog.unstampNumericVersionsFrom(rewoundFrom);
+  await catalog.replayPendingMigrations();
+  return { rewoundFrom };
+}
+
+export function createDrizzleRestoreMigrationCatalog(
+  db: PostgresJsDatabase<Record<string, never>>,
+): RestoreMigrationCatalog {
+  return {
+    async relationExists(qualifiedName) {
+      const rows = (await db.execute(
+        sql`SELECT to_regclass(${qualifiedName}) AS rel`,
+      )) as unknown as Array<{ rel: string | null }>;
+      return rows[0]?.rel != null;
+    },
+    async unstampNumericVersionsFrom(version) {
+      const floor = Number.parseInt(version, 10);
+      if (!Number.isFinite(floor)) {
+        throw new Error(`Invalid migration version for restore rewind: ${version}`);
+      }
+      await db.execute(sql.raw(`
+        CREATE TABLE IF NOT EXISTS public.${MIGRATION_BOOKKEEPING_TABLE} (
+          version text PRIMARY KEY,
+          applied_at timestamptz NOT NULL DEFAULT now()
+        )
+      `));
+      await db.execute(sql.raw(`
+        DELETE FROM public.${MIGRATION_BOOKKEEPING_TABLE}
+        WHERE version ~ '^[0-9]+$' AND CAST(version AS integer) >= ${floor}
+      `));
+    },
+    async replayPendingMigrations() {
+      await applySchemaBaseline(db);
+    },
+  };
+}
+
+export async function reconcileRestoredSchemaMigrationsFromUrl(
+  connectionString: string,
+): Promise<{ rewoundFrom: string | null }> {
+  const client = postgres(connectionString, {
+    max: 1,
+    connect_timeout: 10,
+    prepare: false,
+  });
+  try {
+    const db = drizzle(client);
+    return await reconcileRestoredSchemaMigrations(createDrizzleRestoreMigrationCatalog(db));
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+}

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -38,6 +38,12 @@
  * int4. A 0050 dump that already has `spec_locks` must still rewind 0051 or
  * plan-evidence appends fail.
  *
+ * FNXC:PostgresBackup 2026-09-04-08:52:
+ * 0054 proves the composite key; 0055 is the partition trigger/RLS repair and
+ * must rewind independently when those objects are missing. 0059 is the
+ * source-agent index; 0062 drops `break_into_subtasks`. Skip 0061: it targets
+ * central.central_activity_log and project dumps do not replace `central`.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -56,6 +62,7 @@ import {
   AI_MERGE_REVIEW_RECONCILIATION_VERSION,
   AGENT_ACTIVITY_EVENTS_VERSION,
   AGENT_RATING_PROJECT_ISOLATION_VERSION,
+  AGENT_RATINGS_PROJECT_PARTITION_VERSION,
   ANALYTICS_ISOLATION_SCHEMA_VERSION,
   AUTOMATION_ISOLATION_SCHEMA_VERSION,
   BIGINT_COUNTERS_VERSION,
@@ -86,6 +93,7 @@ import {
   PLANNING_ACTIVE_TIMING_VERSION,
   PROJECT_OWNERSHIP_SCHEMA_VERSION,
   QUEUED_EPISODE_SIGNATURE_VERSION,
+  REMOVE_TASK_SUBTASK_SPLITTING_VERSION,
   RESEARCH_FEATURE_PROVENANCE_VERSION,
   REVIEW_CONVERGENCE_STAGE_VERSION,
   SESSION_ADVISOR_ENABLED_SCHEMA_VERSION,
@@ -103,6 +111,7 @@ import {
   TASK_RECOMMENDATIONS_VERSION,
   TASK_REPOSITORY_SCOPE_VERSION,
   TASK_REQUIRE_PLAN_APPROVAL_VERSION,
+  TASK_SOURCE_AGENT_INDEX_VERSION,
   TASK_STEP_REPORTS_VERSION,
   TASK_VERIFICATION_REQUEST_VERSION,
   TASK_WEDGE_NOTIFICATION_VERSION,
@@ -119,6 +128,9 @@ export interface RestoreMigrationCatalog {
   columnExists(qualifiedRelation: string, column: string): Promise<boolean>;
   columnDataType(qualifiedRelation: string, column: string): Promise<string | null>;
   primaryKeyColumns(qualifiedRelation: string): Promise<readonly string[] | null>;
+  triggerExists(qualifiedRelation: string, triggerName: string): Promise<boolean>;
+  policyExists(qualifiedRelation: string, policyName: string): Promise<boolean>;
+  indexExists(qualifiedRelation: string, indexName: string): Promise<boolean>;
   applyRewindAndReplay(floor: string | null): Promise<void>;
 }
 
@@ -138,12 +150,21 @@ export interface RestoredSchemaColumnTypeSentinel {
   readonly dataType: string;
 }
 
+export interface RestoredSchemaNamedObjectSentinel {
+  readonly relation: string;
+  readonly name: string;
+}
+
 export interface RestoredSchemaRelationSentinel {
   readonly version: string;
   readonly relations?: readonly string[];
   readonly columns?: readonly RestoredSchemaColumnSentinel[];
   readonly primaryKeys?: readonly RestoredSchemaPrimaryKeySentinel[];
   readonly columnTypes?: readonly RestoredSchemaColumnTypeSentinel[];
+  readonly triggers?: readonly RestoredSchemaNamedObjectSentinel[];
+  readonly policies?: readonly RestoredSchemaNamedObjectSentinel[];
+  readonly indexes?: readonly RestoredSchemaNamedObjectSentinel[];
+  readonly absentColumns?: readonly RestoredSchemaColumnSentinel[];
 }
 
 const INITIAL_SCHEMA_VERSION = "0000";
@@ -307,10 +328,23 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
     columns: [{ relation: "project.agent_ratings", column: "project_id" }],
     primaryKeys: [{ relation: "project.agent_ratings", columns: ["project_id", "id"] }],
   },
+  {
+    version: AGENT_RATINGS_PROJECT_PARTITION_VERSION,
+    triggers: [{ relation: "project.agent_ratings", name: "fusion_assign_project_id" }],
+    policies: [{ relation: "project.agent_ratings", name: "fusion_project_isolation" }],
+  },
   { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: MESSAGE_ARCHIVED_SQL_COLUMN }] },
+  {
+    version: TASK_SOURCE_AGENT_INDEX_VERSION,
+    indexes: [{ relation: "project.tasks", name: "idxTasksProjectSourceAgentId" }],
+  },
   {
     version: WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
     relations: ["project.workspace_coordination_leases"],
+  },
+  {
+    version: REMOVE_TASK_SUBTASK_SPLITTING_VERSION,
+    absentColumns: [tasksColumn("break_into_subtasks")],
   },
   { version: AI_MERGE_REVIEW_RECONCILIATION_VERSION, columns: [tasksColumn("ai_merge_review_reconciliation")] },
   { version: TASK_REPOSITORY_SCOPE_VERSION, columns: [tasksColumn("repository_scope")] },
@@ -356,6 +390,38 @@ export async function detectRestoredSchemaRewindFloor(
         if (!(await catalog.columnExists(columnType.relation, columnType.column))) continue;
         const actual = await catalog.columnDataType(columnType.relation, columnType.column);
         if (actual != null && actual.toLowerCase() === columnType.dataType.toLowerCase()) continue;
+        missing = true;
+        break;
+      }
+    }
+    if (!missing) {
+      for (const trigger of sentinel.triggers ?? []) {
+        if (!(await catalog.relationExists(trigger.relation))) continue;
+        if (await catalog.triggerExists(trigger.relation, trigger.name)) continue;
+        missing = true;
+        break;
+      }
+    }
+    if (!missing) {
+      for (const policy of sentinel.policies ?? []) {
+        if (!(await catalog.relationExists(policy.relation))) continue;
+        if (await catalog.policyExists(policy.relation, policy.name)) continue;
+        missing = true;
+        break;
+      }
+    }
+    if (!missing) {
+      for (const index of sentinel.indexes ?? []) {
+        if (!(await catalog.relationExists(index.relation))) continue;
+        if (await catalog.indexExists(index.relation, index.name)) continue;
+        missing = true;
+        break;
+      }
+    }
+    if (!missing) {
+      for (const column of sentinel.absentColumns ?? []) {
+        if (!(await catalog.relationExists(column.relation))) continue;
+        if (!(await catalog.columnExists(column.relation, column.column))) continue;
         missing = true;
         break;
       }
@@ -463,6 +529,58 @@ export function createDrizzleRestoreMigrationCatalog(
       `)) as unknown as Array<{ attname: string }>;
       if (rows.length === 0) return null;
       return rows.map((row) => row.attname);
+    },
+    async triggerExists(qualifiedRelation, triggerName) {
+      /*
+       * FNXC:PostgresBackup 2026-09-04-08:52:
+       * 0055 repairs fusion_assign_project_id on agent_ratings independently of
+       * the 0054 composite key. Bound identifiers; skip internal triggers.
+       */
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_trigger t
+          JOIN pg_class rel ON rel.oid = t.tgrelid
+          JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+          WHERE nsp.nspname = ${schema}
+            AND rel.relname = ${table}
+            AND t.tgname = ${triggerName}
+            AND NOT t.tgisinternal
+        ) AS present
+      `)) as unknown as Array<{ present: boolean }>;
+      return rows[0]?.present === true;
+    },
+    async policyExists(qualifiedRelation, policyName) {
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_policy p
+          JOIN pg_class rel ON rel.oid = p.polrelid
+          JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+          WHERE nsp.nspname = ${schema}
+            AND rel.relname = ${table}
+            AND p.polname = ${policyName}
+        ) AS present
+      `)) as unknown as Array<{ present: boolean }>;
+      return rows[0]?.present === true;
+    },
+    async indexExists(qualifiedRelation, indexName) {
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_class idx
+          JOIN pg_index i ON i.indexrelid = idx.oid
+          JOIN pg_class rel ON rel.oid = i.indrelid
+          JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+          WHERE nsp.nspname = ${schema}
+            AND rel.relname = ${table}
+            AND idx.relname = ${indexName}
+        ) AS present
+      `)) as unknown as Array<{ present: boolean }>;
+      return rows[0]?.present === true;
     },
     async applyRewindAndReplay(floor) {
       /*

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -111,6 +111,15 @@ function tasksColumn(column: string): RestoredSchemaColumnSentinel {
   return { relation: "project.tasks", column };
 }
 
+/*
+FNXC:PostgresBackup 2026-09-04-07:29:
+DELIBERATE-LITERAL — `project.messages.archived` is the 0058 mailbox-archive SQL
+column, not the board lifecycle lane. The census matches `column: "archived"` as a
+query filter; this constant names the schema sentinel so restore rewind is not
+counted as a task.column comparison.
+*/
+const MESSAGE_ARCHIVED_SQL_COLUMN = "archived";
+
 function ownerProjectIdColumn(table: string): RestoredSchemaColumnSentinel {
   return { relation: `project.${table}`, column: "owner_project_id" };
 }
@@ -236,7 +245,7 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
   { version: SPEC_LOCK_DRIFT_REPORT_VERSION, relations: ["project.spec_locks"] },
   { version: MEMORY_RECALL_RECORDS_VERSION, relations: ["project.memory_recall_records"] },
   { version: MISSION_FEATURE_SPEC_ALIGNMENT_VERSION, columns: [{ relation: "project.mission_features", column: "spec_alignment" }] },
-  { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: "archived" }] },
+  { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: MESSAGE_ARCHIVED_SQL_COLUMN }] },
   {
     version: WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,
     relations: ["project.workspace_coordination_leases"],

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -22,6 +22,12 @@
  * Without that sentinel a pre-0054 dump leaves 0054/0055 stamped and rating
  * reads/deletes fail. Rewinding from 0054 also unstamps 0055's partition repair.
  *
+ * FNXC:PostgresBackup 2026-09-04-08:09:
+ * 0006 already ADD COLUMNs `project_id` (NOT NULL, RLS, trigger) and rewrites
+ * PKs that lack it. 0054/0055 are targeted repairs of the composite identity
+ * `(project_id, id)` when the column landed but the PK stayed `(id)`. Column
+ * presence is not enough; rewind must also match that primary key.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -97,6 +103,7 @@ import {
 export interface RestoreMigrationCatalog {
   relationExists(qualifiedName: string): Promise<boolean>;
   columnExists(qualifiedRelation: string, column: string): Promise<boolean>;
+  primaryKeyColumns(qualifiedRelation: string): Promise<readonly string[] | null>;
   applyRewindAndReplay(floor: string | null): Promise<void>;
 }
 
@@ -105,10 +112,16 @@ export interface RestoredSchemaColumnSentinel {
   readonly column: string;
 }
 
+export interface RestoredSchemaPrimaryKeySentinel {
+  readonly relation: string;
+  readonly columns: readonly string[];
+}
+
 export interface RestoredSchemaRelationSentinel {
   readonly version: string;
   readonly relations?: readonly string[];
   readonly columns?: readonly RestoredSchemaColumnSentinel[];
+  readonly primaryKeys?: readonly RestoredSchemaPrimaryKeySentinel[];
 }
 
 const INITIAL_SCHEMA_VERSION = "0000";
@@ -155,6 +168,8 @@ const OWNER_PROJECT_ID_SPLIT_TABLES = [
  * Central-schema tables are excluded: project dumps do not replace `central`.
  * Column sentinels apply only when the parent relation exists, so a dump taken
  * after CREATE TABLE but before a later ALTER still rewinds that ALTER version.
+ * Primary-key sentinels apply the same parent-exists rule and compare column
+ * order exactly.
  *
  * FNXC:PostgresBackup 2026-09-04-06:22:
  * Early numbered migrations that add project objects must appear here in
@@ -255,6 +270,7 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
   {
     version: AGENT_RATING_PROJECT_ISOLATION_VERSION,
     columns: [{ relation: "project.agent_ratings", column: "project_id" }],
+    primaryKeys: [{ relation: "project.agent_ratings", columns: ["project_id", "id"] }],
   },
   { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: MESSAGE_ARCHIVED_SQL_COLUMN }] },
   {
@@ -290,6 +306,15 @@ export async function detectRestoredSchemaRewindFloor(
         break;
       }
     }
+    if (!missing) {
+      for (const primaryKey of sentinel.primaryKeys ?? []) {
+        if (!(await catalog.relationExists(primaryKey.relation))) continue;
+        const actual = await catalog.primaryKeyColumns(primaryKey.relation);
+        if (sameOrderedColumns(actual, primaryKey.columns)) continue;
+        missing = true;
+        break;
+      }
+    }
     if (missing) return sentinel.version;
   }
   return null;
@@ -307,6 +332,12 @@ function splitQualifiedRelation(qualifiedName: string): { schema: string; table:
   const separator = qualifiedName.indexOf(".");
   if (separator <= 0) return { schema: "public", table: qualifiedName };
   return { schema: qualifiedName.slice(0, separator), table: qualifiedName.slice(separator + 1) };
+}
+
+function sameOrderedColumns(actual: readonly string[] | null, expected: readonly string[]): boolean {
+  return actual != null
+    && actual.length === expected.length
+    && actual.every((name, index) => name === expected[index]);
 }
 
 function ensureBookkeepingSql(): string {
@@ -347,6 +378,30 @@ export function createDrizzleRestoreMigrationCatalog(
         ) AS present
       `)) as unknown as Array<{ present: boolean }>;
       return rows[0]?.present === true;
+    },
+    async primaryKeyColumns(qualifiedRelation) {
+      /*
+       * FNXC:PostgresBackup 2026-09-04-08:09:
+       * Probe the live primary key in key order via pg_constraint/pg_attribute.
+       * Schema and table names are bound parameters, never concatenated. A
+       * missing relation or constraint returns null so rewind treats the
+       * 0054/0055 identity repair as unapplied.
+       */
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT a.attname AS attname
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS key_column(attnum, ordinal) ON true
+        JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = key_column.attnum
+        WHERE nsp.nspname = ${schema}
+          AND rel.relname = ${table}
+          AND con.contype = 'p'
+        ORDER BY key_column.ordinal
+      `)) as unknown as Array<{ attname: string }>;
+      if (rows.length === 0) return null;
+      return rows.map((row) => row.attname);
     },
     async applyRewindAndReplay(floor) {
       /*

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -17,6 +17,11 @@
  * floor jumps to a later miss and leaves 0011 stamped. Replay then skips the
  * domain column and todo/chat/research queries fail.
  *
+ * FNXC:PostgresBackup 2026-09-04-07:51:
+ * 0054 adds `project.agent_ratings.project_id`; 0000 still has no such column.
+ * Without that sentinel a pre-0054 dump leaves 0054/0055 stamped and rating
+ * reads/deletes fail. Rewinding from 0054 also unstamps 0055's partition repair.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -34,6 +39,7 @@ import {
   applySchemaBaseline,
   AI_MERGE_REVIEW_RECONCILIATION_VERSION,
   AGENT_ACTIVITY_EVENTS_VERSION,
+  AGENT_RATING_PROJECT_ISOLATION_VERSION,
   ANALYTICS_ISOLATION_SCHEMA_VERSION,
   AUTOMATION_ISOLATION_SCHEMA_VERSION,
   BULK_COMPLETION_REFUSAL_AT_VERSION,
@@ -182,6 +188,7 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
       "project.project_insights",
       "project.project_insight_runs",
       "project.cli_sessions",
+      "project.agent_ratings",
     ],
   },
   { version: AUTOMATION_ISOLATION_SCHEMA_VERSION, columns: [{ relation: "project.automations", column: "project_id" }] },
@@ -245,6 +252,10 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
   { version: SPEC_LOCK_DRIFT_REPORT_VERSION, relations: ["project.spec_locks"] },
   { version: MEMORY_RECALL_RECORDS_VERSION, relations: ["project.memory_recall_records"] },
   { version: MISSION_FEATURE_SPEC_ALIGNMENT_VERSION, columns: [{ relation: "project.mission_features", column: "spec_alignment" }] },
+  {
+    version: AGENT_RATING_PROJECT_ISOLATION_VERSION,
+    columns: [{ relation: "project.agent_ratings", column: "project_id" }],
+  },
   { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: MESSAGE_ARCHIVED_SQL_COLUMN }] },
   {
     version: WORKSPACE_COORDINATION_LEASES_SCHEMA_VERSION,

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -44,6 +44,12 @@
  * source-agent index; 0062 drops `break_into_subtasks`. Skip 0061: it targets
  * central.central_activity_log and project dumps do not replace `central`.
  *
+ * FNXC:PostgresBackup 2026-09-04-09:08:
+ * 0055 is applied only when the assign trigger, isolation policy, AND forced
+ * RLS are all present. Policy-expression drift is not a restore rewind signal;
+ * DROP POLICY / CREATE POLICY on replay is how 0055 repairs expression drift,
+ * and we do not encode USING SQL in the catalog.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -131,6 +137,7 @@ export interface RestoreMigrationCatalog {
   triggerExists(qualifiedRelation: string, triggerName: string): Promise<boolean>;
   policyExists(qualifiedRelation: string, policyName: string): Promise<boolean>;
   indexExists(qualifiedRelation: string, indexName: string): Promise<boolean>;
+  rowLevelSecurityForced(qualifiedRelation: string): Promise<boolean>;
   applyRewindAndReplay(floor: string | null): Promise<void>;
 }
 
@@ -165,6 +172,7 @@ export interface RestoredSchemaRelationSentinel {
   readonly policies?: readonly RestoredSchemaNamedObjectSentinel[];
   readonly indexes?: readonly RestoredSchemaNamedObjectSentinel[];
   readonly absentColumns?: readonly RestoredSchemaColumnSentinel[];
+  readonly forcedRowLevelSecurity?: readonly string[];
 }
 
 const INITIAL_SCHEMA_VERSION = "0000";
@@ -332,6 +340,7 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
     version: AGENT_RATINGS_PROJECT_PARTITION_VERSION,
     triggers: [{ relation: "project.agent_ratings", name: "fusion_assign_project_id" }],
     policies: [{ relation: "project.agent_ratings", name: "fusion_project_isolation" }],
+    forcedRowLevelSecurity: ["project.agent_ratings"],
   },
   { version: MESSAGE_ARCHIVE_SCHEMA_VERSION, columns: [{ relation: "project.messages", column: MESSAGE_ARCHIVED_SQL_COLUMN }] },
   {
@@ -422,6 +431,14 @@ export async function detectRestoredSchemaRewindFloor(
       for (const column of sentinel.absentColumns ?? []) {
         if (!(await catalog.relationExists(column.relation))) continue;
         if (!(await catalog.columnExists(column.relation, column.column))) continue;
+        missing = true;
+        break;
+      }
+    }
+    if (!missing) {
+      for (const relation of sentinel.forcedRowLevelSecurity ?? []) {
+        if (!(await catalog.relationExists(relation))) continue;
+        if (await catalog.rowLevelSecurityForced(relation)) continue;
         missing = true;
         break;
       }
@@ -581,6 +598,23 @@ export function createDrizzleRestoreMigrationCatalog(
         ) AS present
       `)) as unknown as Array<{ present: boolean }>;
       return rows[0]?.present === true;
+    },
+    async rowLevelSecurityForced(qualifiedRelation) {
+      /*
+       * FNXC:PostgresBackup 2026-09-04-09:08:
+       * 0055 ENABLE + FORCE RLS so project-bound sessions cannot read other
+       * projects' ratings. Bound schema/table; missing relation is skipped by
+       * detect, not by encoding USING SQL.
+       */
+      const { schema, table } = splitQualifiedRelation(qualifiedRelation);
+      const rows = (await db.execute(sql`
+        SELECT (rel.relrowsecurity AND rel.relforcerowsecurity) AS forced
+        FROM pg_class rel
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        WHERE nsp.nspname = ${schema}
+          AND rel.relname = ${table}
+      `)) as unknown as Array<{ forced: boolean }>;
+      return rows[0]?.forced === true;
     },
     async applyRewindAndReplay(floor) {
       /*

--- a/packages/core/src/postgres/restore-migration-reconcile.ts
+++ b/packages/core/src/postgres/restore-migration-reconcile.ts
@@ -10,6 +10,13 @@
  * sentinel — including credential-instance fields and `messages.archived` —
  * and replay `applySchemaBaseline` so restored schemas and bookkeeping match.
  *
+ * FNXC:PostgresBackup 2026-09-04-06:22:
+ * The catalog must include 0011 `owner_project_id` and similarly numbered early
+ * project objects. 0000 already ships `chat_sessions.pinned_at`, so a dump from
+ * 0010 makes the 0012 sentinel look present; without 0011 in the catalog the
+ * floor jumps to a later miss and leaves 0011 stamped. Replay then skips the
+ * domain column and todo/chat/research queries fail.
+ *
  * Unstamp and baseline replay share one transaction so a failed apply cannot
  * leave `public.fusion_schema_migrations` rewound while project/archive still
  * reflects the restored dump.
@@ -27,6 +34,8 @@ import {
   applySchemaBaseline,
   AI_MERGE_REVIEW_RECONCILIATION_VERSION,
   AGENT_ACTIVITY_EVENTS_VERSION,
+  ANALYTICS_ISOLATION_SCHEMA_VERSION,
+  AUTOMATION_ISOLATION_SCHEMA_VERSION,
   BULK_COMPLETION_REFUSAL_AT_VERSION,
   CHAT_SESSION_MEMORY_FOCUS_VERSION,
   CHAT_SESSION_PINS_VERSION,
@@ -46,9 +55,13 @@ import {
   MISSION_FEATURE_SPEC_ALIGNMENT_VERSION,
   MISSION_LINEAGE_STOP_VERSION,
   MISSION_TASK_PREFIX_VERSION,
+  MONITOR_APPROVAL_ISOLATION_SCHEMA_VERSION,
+  MULTI_PROJECT_CUTOVER_SCHEMA_VERSION,
   MULTI_ROLE_WORKFLOW_AGENTS_VERSION,
+  OWNER_PROJECT_ID_SPLIT_VERSION,
   PATCHNODE_ENTRIES_VERSION,
   PLANNING_ACTIVE_TIMING_VERSION,
+  PROJECT_OWNERSHIP_SCHEMA_VERSION,
   QUEUED_EPISODE_SIGNATURE_VERSION,
   RESEARCH_FEATURE_PROVENANCE_VERSION,
   REVIEW_CONVERGENCE_STAGE_VERSION,
@@ -98,12 +111,40 @@ function tasksColumn(column: string): RestoredSchemaColumnSentinel {
   return { relation: "project.tasks", column };
 }
 
+function ownerProjectIdColumn(table: string): RestoredSchemaColumnSentinel {
+  return { relation: `project.${table}`, column: "owner_project_id" };
+}
+
+/**
+ * Tables that migration 0011 splits onto a nullable domain `owner_project_id`.
+ * Checked independently so a 0010 dump that already has 0000 `pinned_at` still
+ * unstamps 0011 when any of these columns is missing.
+ */
+const OWNER_PROJECT_ID_SPLIT_TABLES = [
+  "research_runs",
+  "experiment_sessions",
+  "todo_lists",
+  "eval_runs",
+  "chat_sessions",
+  "chat_rooms",
+  "ai_sessions",
+  "chat_token_usage",
+  "project_insights",
+  "project_insight_runs",
+  "cli_sessions",
+] as const;
+
 /**
  * Table and column sentinels used to detect a restored schema that is older
  * than the recorded ledger. Checked in version order; the first miss is the rewind floor.
  * Central-schema tables are excluded: project dumps do not replace `central`.
  * Column sentinels apply only when the parent relation exists, so a dump taken
  * after CREATE TABLE but before a later ALTER still rewinds that ALTER version.
+ *
+ * FNXC:PostgresBackup 2026-09-04-06:22:
+ * Early numbered migrations that add project objects must appear here in
+ * version order. Skipping 0011 (or 0001/0002/0003/0005/0006) lets a later
+ * present sentinel become the floor and leaves the omitted version stamped.
  */
 export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelationSentinel[] = [
   {
@@ -117,12 +158,42 @@ export const RESTORED_SCHEMA_RELATION_SENTINELS: readonly RestoredSchemaRelation
       "project.mission_contract_assertions",
       "project.workflow_work_items",
       "project.agents",
+      "project.automations",
+      "project.activity_log",
+      "project.deployments",
+      "project.__meta",
+      "project.task_document_revisions",
+      "project.todo_lists",
+      "project.research_runs",
+      "project.eval_runs",
+      "project.experiment_sessions",
+      "project.chat_rooms",
+      "project.ai_sessions",
+      "project.chat_token_usage",
+      "project.project_insights",
+      "project.project_insight_runs",
+      "project.cli_sessions",
     ],
   },
+  { version: AUTOMATION_ISOLATION_SCHEMA_VERSION, columns: [{ relation: "project.automations", column: "project_id" }] },
+  { version: ANALYTICS_ISOLATION_SCHEMA_VERSION, columns: [{ relation: "project.activity_log", column: "project_id" }] },
+  { version: MONITOR_APPROVAL_ISOLATION_SCHEMA_VERSION, columns: [{ relation: "project.deployments", column: "project_id" }] },
   { version: LEGACY_CUTOVER_PRESERVATION_SCHEMA_VERSION, relations: ["project.boards"] },
+  {
+    version: MULTI_PROJECT_CUTOVER_SCHEMA_VERSION,
+    columns: [
+      { relation: "project.__meta", column: "project_id" },
+      { relation: "project.task_document_revisions", column: "legacy_sqlite_id" },
+    ],
+  },
+  { version: PROJECT_OWNERSHIP_SCHEMA_VERSION, relations: ["project.mission_feature_evidence_links"] },
   { version: SQLITE_SCHEMA_PARITY_VERSION, columns: [tasksColumn("board_id")] },
   { version: SESSION_ADVISOR_ENABLED_SCHEMA_VERSION, columns: [tasksColumn("session_advisor_enabled")] },
   { version: IMPORT_TRANSLATION_CACHE_VERSION, relations: ["project.import_translation_cache"] },
+  {
+    version: OWNER_PROJECT_ID_SPLIT_VERSION,
+    columns: OWNER_PROJECT_ID_SPLIT_TABLES.map(ownerProjectIdColumn),
+  },
   { version: CHAT_SESSION_PINS_VERSION, columns: [{ relation: "project.chat_sessions", column: "pinned_at" }] },
   { version: EXECUTOR_TOOL_FAILURE_RETRY_VERSION, columns: [tasksColumn("consecutive_tool_failure_retry_count")] },
   { version: EXECUTOR_ESCALATION_ATTEMPT_VERSION, columns: [tasksColumn("executor_escalation_attempted")] },

--- a/packages/core/src/postgres/schema-applier.ts
+++ b/packages/core/src/postgres/schema-applier.ts
@@ -88,8 +88,8 @@ export const SCHEMA_BASELINE_VERSION = "0071";
 /** FNXC:SymbolLock 2026-07-20-10:00: upgrades need durable task declarations before admission resolves symbols. */
 export const TASK_DECLARED_SYMBOLS_VERSION = "0028";
 const INITIAL_SCHEMA_VERSION = "0000";
-const AUTOMATION_ISOLATION_SCHEMA_VERSION = "0001";
-const ANALYTICS_ISOLATION_SCHEMA_VERSION = "0002";
+export const AUTOMATION_ISOLATION_SCHEMA_VERSION = "0001";
+export const ANALYTICS_ISOLATION_SCHEMA_VERSION = "0002";
 /**
  * FNXC:PostgresMigrationIdentity 2026-07-14-01:41:
  * Each migration keeps an immutable bookkeeping identity even as SCHEMA_BASELINE_VERSION advances to newer migrations. Upgrade checks and inserts must use this dedicated 0003 identifier so a later latest-version marker cannot make an unrecorded monitor/approval migration look applied.


### PR DESCRIPTION
## Summary

- adapt `BackupManager.listBackupPairs()` directly from `PgBackupManager.listBackups()` so the canonical `fusion-pg-*.dump` + `fusion-central-pg-*.dump` inventory is listed without legacy SQLite filename reparsing
- validate every required archive before mutation, retain a collision-safe current-state pre-restore pair, and restore project/archive before central with independent `--single-transaction` client calls
- if central fails after project/archive commits, attempt project/archive rollback from the retained pre-restore dump and surface both errors if rollback also fails
- make CLI output and operator/skill documentation truthful about `.dump` pairs, central-only selection, quiescence, and the lack of pair-wide snapshot/transaction atomicity

## Original defect

Fusion v0.76.0 creates `fusion-pg-<timestamp>.dump` and `fusion-central-pg-<timestamp>.dump`, but native pair listing still matched legacy `.db` names and returned no pair. Native restore delegated only the selected archive, ignored the existing pre-restore/central option contract, and printed SQLite `.db` pre-restore claims.

## Restore boundary

A project selection requires and preflights its same-stem central sibling by default. Explicit project `skipCentral` and central selection/`centralOnly` remain available to Core callers; selecting a central filename through the CLI restores only central. Each archive is restored in its own PostgreSQL transaction—there is no transaction spanning both client processes. Operators must quiesce Fusion writers and competing native backup operations because this patch does not add cross-process locking.

Pre-restore dumps are retained on success and failure. A project-half failure does not attempt central. A central-half failure triggers one project/archive rollback when a pre-restore dump is available; rollback failure is aggregated with the original central error.

## Verification

- `pnpm lint`
- `pnpm check:changesets`
- `pnpm --filter @fusion/core exec vitest run src/__tests__/backup.test.ts src/__tests__/postgres/pg-backup.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @runfusion/fusion exec vitest run src/commands/__tests__/backup.test.ts src/commands/__tests__/backup-lock-retry.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @fusion/core typecheck`
- `pnpm --filter @runfusion/fusion typecheck`
- `pnpm --filter @fusion/core build`
- `pnpm --filter @runfusion/fusion build`
- exported diff reapplied to a fresh checkout at `de1ea245ef7b91185953b8d18b1a367dcb92f86d`; both focused suites pass there

Includes `.changeset/kb-044-postgres-backup-pairs.md` for a patch release of `@runfusion/fusion`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring older project or archive backups now detects missing schema updates, rewinds migration tracking, and replays required migrations.
  * Failed restore operations roll back all committed restore groups safely.
  * Central-only restores leave migration bookkeeping unchanged.
  * Restores now retain migration bookkeeping and refuse unsafe operations when pre-restore capture is unavailable.
  * Remote restore connections now use full TLS certificate verification.

* **Documentation**
  * Updated backup guidance for migration dumps, legacy backups, restore ordering, cleanup, writer quiescence, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->