### PR TITLE
test(cli): handle CommonJS node-pty namespace

### DIFF
--- a/packages/cli/src/__tests__/build-exe-cross.test.ts
+++ b/packages/cli/src/__tests__/build-exe-cross.test.ts
@@ -151,8 +151,12 @@ describe.skipIf(!SHOULD_RUN_BUILD_EXE)("build-exe-cross: --all builds all platfo
       "node-pty-umbrella",
       "index.js",
     );
-    const module = await import(pathToFileURL(entry).href);
-    expect(typeof module.spawn).toBe("function");
+    const stagedImport = await import(pathToFileURL(entry).href) as {
+      spawn?: unknown;
+      default?: { spawn?: unknown };
+    };
+    const module = typeof stagedImport.spawn === "function" ? stagedImport : stagedImport.default;
+    expect(typeof module?.spawn).toBe("function");
   });
 
   it("stages runtime native assets for current platform", () => {


### PR DESCRIPTION
## Summary
- normalize the staged CommonJS node-pty import before asserting its `spawn` export
- mirror the production loader's namespace/default interop behavior

## Test plan
- `FUSION_TEST_BUILD_EXE=1 pnpm --filter @runfusion/fusion exec vitest run --config vitest.build-exe.config.ts src/__tests__/build-exe-cross.test.ts --silent=passed-only --reporter=dot`
- `pnpm --filter @runfusion/fusion typecheck`
- `pnpm check:changesets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved cross-platform build validation to recognize both direct and wrapped module exports.
  - Increased test compatibility across different module-loading formats without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->