### PR TITLE
fix(missions): dispatch admitted manual validator runs

### DIFF
--- a/.changeset/manual-validator-dispatch.md
+++ b/.changeset/manual-validator-dispatch.md
@@ -4,4 +4,4 @@
 
 summary: Run manual feature validation and repair re-runs instead of leaving them stuck in progress.
 category: fix
-dev: Dispatch the admitted run through its project executor while preserving admission and completion fences.
+dev: Dispatch admitted runs through their project executor, recover transient setup failures, and fence result writes and remediation admission against stale validators.

--- a/.changeset/manual-validator-dispatch.md
+++ b/.changeset/manual-validator-dispatch.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Run manual feature validation and repair re-runs instead of leaving them stuck in progress.
+category: fix
+dev: Dispatch the admitted run through its project executor while preserving admission and completion fences.

--- a/packages/core/src/__tests__/mission-store.sync-loop-transition.test.ts
+++ b/packages/core/src/__tests__/mission-store.sync-loop-transition.test.ts
@@ -11,6 +11,35 @@ import { MissionStore } from "../missions/mission-store.js";
 import type { MissionFeature } from "../missions/mission-types.js";
 
 describe("MissionStore synchronous loop transitions", () => {
+  it.each(["terminal", "replacement", "attempt", "loop", "trigger"])("rejects %s ownership loss without applying synchronous effects", (loss) => {
+    const db = {
+      transaction: (callback: () => unknown) => callback(),
+      transactionImmediate: (callback: () => unknown) => callback(),
+      prepare: vi.fn().mockReturnValue({ get: vi.fn().mockReturnValue(undefined), run: vi.fn().mockReturnValue({ changes: 1 }) }),
+      bumpLastModified: vi.fn(),
+    } as unknown as Database;
+    const store = new MissionStore("/tmp/fusion-mission-store-test", db);
+    const run = {
+      id: "VR-OLD", featureId: "F-OWNER", milestoneId: "MS-1", sliceId: "SL-1",
+      status: loss === "terminal" ? "error" : "running", triggerType: loss === "trigger" ? "scheduled" : "manual",
+      implementationAttempt: 0, validatorAttempt: 1,
+      startedAt: "2026-08-10T00:00:00.000Z", createdAt: "2026-08-10T00:00:00.000Z", updatedAt: "2026-08-10T00:00:00.000Z",
+    } as const;
+    vi.spyOn(store, "getValidatorRun").mockReturnValue(run);
+    vi.spyOn(store, "getFeature").mockReturnValue({
+      id: run.featureId, sliceId: run.sliceId, title: "Owner", status: "in-progress",
+      loopState: loss === "loop" ? "implementing" : "validating", lastValidatorRunId: loss === "replacement" ? "VR-NEW" : run.id,
+      validatorAttemptCount: loss === "attempt" ? 2 : 1,
+      createdAt: run.createdAt, updatedAt: run.updatedAt,
+    });
+    const emit = vi.spyOn(store, "emit");
+    vi.mocked(db.prepare).mockClear();
+    expect(store.completeValidatorRun(run.id, "passed", undefined, undefined, {
+      featureId: run.featureId, triggerType: "manual", assertions: [{ assertionId: "CA-1", status: "passed" }],
+    })).toMatchObject({ completionApplied: false });
+    expect(db.prepare).not.toHaveBeenCalled();
+    expect(emit).not.toHaveBeenCalled();
+  });
   it("allows startup recovery to move an interrupted validation back to implementing", () => {
     const db = {
       prepare: vi.fn().mockReturnValue({ get: vi.fn().mockReturnValue(undefined) }),

--- a/packages/core/src/__tests__/postgres/mission-store.pg.test.ts
+++ b/packages/core/src/__tests__/postgres/mission-store.pg.test.ts
@@ -23,6 +23,7 @@ import { readFile } from "node:fs/promises";
 import type { DbTransaction } from "../../postgres/data-layer.js";
 import type { TaskCreateInput } from "../../types/task/task-core.js";
 import type { MissionEvent, FeatureUnlinkedPayload } from "../../missions/mission-types.js";
+import { ValidatorRunOwnershipLostError } from "../../missions/mission-types.js";
 
 import {
   pgDescribe,
@@ -1591,6 +1592,125 @@ pgTest("MissionStore (PostgreSQL backend mode)", () => {
     );
   });
 
+  it("atomically applies validator effects only for the winning current running owner", async () => {
+    const m = missions();
+    const mission = await m.createMission({ title: "Completion effects" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "F", acceptanceCriteria: "observable result" });
+    const [assertion] = await m.ensureFeatureAssertionLinked(feature.id);
+    for (const milestoneAssertion of (await m.listContractAssertions(milestone.id)).filter((a) => a.scope === "milestone")) {
+      await m.updateContractAssertion(milestoneAssertion.id, { status: "passed" });
+    }
+    const old = await m.startValidatorRun(feature.id, "manual");
+    const current = await m.startValidatorRun(feature.id, "scheduled");
+    const effects = { featureId: feature.id, assertions: [{ assertionId: assertion!.id, status: "passed" as const }] };
+    const stale = await m.completeValidatorRun(old.id, "passed", "old pass", undefined, effects);
+    expect(stale.completionApplied).toBe(false);
+    expect((await m.getFeature(feature.id))?.status).not.toBe("done");
+    expect((await m.listAssertionsForFeature(feature.id))[0]?.status).toBe("pending");
+    const winner = await m.completeValidatorRun(current.id, "passed", "current pass", undefined, effects);
+    expect(winner.completionApplied).toBe(true);
+    expect((await m.getMilestone(milestone.id))?.validationState).toBe("passed");
+    expect((await m.getSlice(slice.id))?.status).toBe("complete");
+    expect(await m.getFeature(feature.id)).toMatchObject({ status: "done", loopState: "passed", lastValidatorRunId: current.id });
+    expect((await m.listAssertionsForFeature(feature.id))[0]?.status).toBe("passed");
+    const duplicate = await m.completeValidatorRun(current.id, "failed", "late fail", undefined, {
+      featureId: feature.id, assertions: [{ assertionId: assertion!.id, status: "failed" }],
+      failures: [{ featureId: feature.id, assertionId: assertion!.id, message: "late" }],
+    });
+    expect(duplicate.completionApplied).toBe(false);
+    expect((await m.listAssertionsForFeature(feature.id))[0]?.status).toBe("passed");
+    expect(await m.getFailuresForRun(current.id)).toEqual([]);
+  });
+
+  it.each(["reaper", "replacement"])("discards all effects when %s wins before the completion lock", async (winner) => {
+    const m = missions();
+    const competing = new AsyncMissionStore(h.layer(), h.store());
+    const mission = await m.createMission({ title: "Completion race" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "F" });
+    const [assertion] = await m.ensureFeatureAssertionLinked(feature.id);
+    const run = await m.startValidatorRun(feature.id, "manual");
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const original = h.layer().transactionImmediate.bind(h.layer());
+    const gate = vi.spyOn(h.layer(), "transactionImmediate").mockImplementationOnce(async (fn) => {
+      entered.resolve();
+      await release.promise;
+      return original(fn);
+    });
+    const emitted = vi.spyOn(m, "emit").mockClear();
+    const pending = m.completeValidatorRun(run.id, "failed", "late verdict", undefined, {
+      featureId: feature.id, triggerType: "manual",
+      assertions: [{ assertionId: assertion!.id, status: "failed" }],
+      failures: [{ featureId: feature.id, assertionId: assertion!.id, message: "late failure" }],
+    });
+    let expectedFeature;
+    let expectedRun;
+    try {
+      await entered.promise;
+      gate.mockRestore();
+      if (winner === "reaper") await competing.reapValidatorRun(run.id, "reaper won");
+      else await competing.startValidatorRun(feature.id, "scheduled");
+      expectedFeature = await competing.getFeature(feature.id);
+      expectedRun = await competing.getValidatorRun(run.id);
+    } finally {
+      gate.mockRestore();
+      release.resolve();
+    }
+    expect(await pending).toMatchObject({ ...expectedRun, completionApplied: false });
+    expect(await m.getFeature(feature.id)).toEqual(expectedFeature);
+    expect((await m.listAssertionsForFeature(feature.id))[0]?.status).toBe("pending");
+    expect(await m.getFailuresForRun(run.id)).toEqual([]);
+    expect(emitted).not.toHaveBeenCalled();
+  });
+
+  it("rolls back every validator effect and event when a later assertion is invalid", async () => {
+    const m = missions();
+    const mission = await m.createMission({ title: "Rollback" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "F" });
+    const [assertion] = await m.ensureFeatureAssertionLinked(feature.id);
+    const run = await m.startValidatorRun(feature.id, "manual");
+    const beforeFeature = await m.getFeature(feature.id);
+    const beforeMilestone = await m.getMilestone(milestone.id);
+    const emitted = vi.spyOn(m, "emit").mockClear();
+    await expect(m.completeValidatorRun(run.id, "passed", "invalid", undefined, {
+      featureId: feature.id,
+      assertions: [{ assertionId: assertion!.id, status: "passed" }, { assertionId: "CA-NOT-LINKED", status: "passed" }],
+      failures: [{ featureId: feature.id, assertionId: assertion!.id, message: "must roll back" }],
+    })).rejects.toThrow("not linked");
+    expect(await m.getValidatorRun(run.id)).toEqual(run);
+    expect(await m.getFeature(feature.id)).toEqual(beforeFeature);
+    expect(await m.getMilestone(milestone.id)).toEqual(beforeMilestone);
+    expect((await m.listAssertionsForFeature(feature.id))[0]?.status).toBe("pending");
+    expect(await m.getFailuresForRun(run.id)).toEqual([]);
+    expect(emitted).not.toHaveBeenCalled();
+  });
+
+  it("atomically refreshes every milestone owning accepted linked assertions", async () => {
+    const m = missions();
+    const mission = await m.createMission({ title: "Cross-milestone verdicts" });
+    const first = await m.addMilestone(mission.id, { title: "Source" });
+    const second = await m.addMilestone(mission.id, { title: "Shared contract" });
+    const slice = await m.addSlice(first.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "F" });
+    const [own] = await m.ensureFeatureAssertionLinked(feature.id);
+    const shared = await m.addContractAssertion(second.id, { title: "Shared", assertion: "Shared observable", status: "pending" });
+    await m.linkFeatureToAssertion(feature.id, shared.id);
+    const run = await m.startValidatorRun(feature.id, "manual");
+    const result = await m.completeValidatorRun(run.id, "passed", "verified", undefined, {
+      featureId: feature.id,
+      assertions: [{ assertionId: own!.id, status: "passed" }, { assertionId: shared.id, status: "passed" }],
+    });
+    expect(result.completionApplied).toBe(true);
+    expect((await m.getMilestone(first.id))?.validationState).toBe("passed");
+    expect((await m.getMilestone(second.id))?.validationState).toBe("passed");
+  });
+
   it("allows exactly one terminal validator transition when completion races the stale reaper", async () => {
     const primary = missions();
     const competing = new AsyncMissionStore(h.layer(), h.store());
@@ -1622,6 +1742,157 @@ pgTest("MissionStore (PostgreSQL backend mode)", () => {
       expect(persistedFeature?.loopState).toBe("needs_fix");
       expect(persistedFeature?.lastValidatorStatus).toBe("error");
     }
+  });
+
+  it("fences stale generated fixes after replacement without minting lineage or consuming budget", async () => {
+    const m = missions();
+    const mission = await m.createMission({ title: "Stale fix" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const feature = await m.addFeature(slice.id, { title: "F" });
+    const old = await m.startValidatorRun(feature.id, "manual");
+    await m.completeValidatorRun(old.id, "failed");
+    const current = await m.startValidatorRun(feature.id, "manual");
+    await expect(m.createGeneratedFixFeature(feature.id, old.id, [], "stale", undefined, undefined, { requireCurrentRun: true }))
+      .rejects.toMatchObject({ code: "VALIDATOR_RUN_OWNERSHIP_LOST" });
+    expect(await m.listFeatures(slice.id)).toHaveLength(1);
+    expect(await m.getFeature(feature.id)).toMatchObject({ implementationAttemptCount: 0, lastValidatorRunId: current.id, loopState: "validating" });
+    expect(await m.findGeneratedFixFeature(feature.id, old.id)).toBeUndefined();
+  });
+
+  it("rejects a delayed failed-child continuation after a newer root pass", async () => {
+    const m = missions();
+    const mission = await m.createMission({ title: "Superseded remediation" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const root = await m.addFeature(slice.id, { title: "Root" });
+    const initialRun = await m.startManualValidatorRun(root.id);
+    await m.completeValidatorRun(initialRun.run.id, "failed", "first failure");
+    const child = await m.createGeneratedFixFeature(root.id, initialRun.run.id, [], "repair");
+    await m.transitionLoopState(child.id, "implementing");
+    const childRun = await m.startValidatorRun(child.id, "scheduled");
+    await m.completeValidatorRun(childRun.id, "failed", "child failure");
+    const passedRun = await m.startValidatorRun(root.id, "scheduled");
+    await m.completeValidatorRun(passedRun.id, "passed", "root is correct now");
+    expect(await m.getFeature(child.id)).toMatchObject({ status: "done", loopState: "passed", lastValidatorRunId: childRun.id, lastValidatorStatus: "failed" });
+    const rootBefore = await m.getFeature(root.id);
+    const featuresBefore = await m.listFeatures(slice.id);
+    await expect(m.createGeneratedFixFeature(child.id, childRun.id, [], "late repair", undefined, undefined, { requireCurrentRun: true }))
+      .rejects.toBeInstanceOf(ValidatorRunOwnershipLostError);
+    expect(await m.getFeature(root.id)).toEqual(rootBefore);
+    expect(await m.listFeatures(slice.id)).toEqual(featuresBefore);
+  });
+
+  it("rejects delayed remediation while an intermediate ancestor pass awaits reconciliation", async () => {
+    const m = missions();
+    const competing = new AsyncMissionStore(h.layer(), h.store());
+    const mission = await m.createMission({ title: "Intermediate supersession" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const root = await m.addFeature(slice.id, { title: "Root" });
+    const failedRun = async (featureId: string) => {
+      const admission = await m.startManualValidatorRun(featureId);
+      await m.completeValidatorRun(admission.run.id, "failed", "repair");
+      return admission.run;
+    };
+    const rootRun = await failedRun(root.id);
+    const ancestor = await m.createGeneratedFixFeature(root.id, rootRun.id, [], "repair");
+    const ancestorRun = await failedRun(ancestor.id);
+    const child = await m.createGeneratedFixFeature(ancestor.id, ancestorRun.id, [], "repair");
+    const childRun = await failedRun(child.id);
+    const pass = await m.startManualValidatorRun(ancestor.id);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const reconcile = m.reconcileSupersededGeneratedFixFeatures.bind(m);
+    const gate = vi.spyOn(m, "reconcileSupersededGeneratedFixFeatures").mockImplementationOnce(async (sliceId) => {
+      entered.resolve();
+      await release.promise;
+      return reconcile(sliceId);
+    });
+    const pending = m.completeValidatorRun(pass.run.id, "passed", "ancestor verified");
+    try {
+      await entered.promise;
+      expect((await competing.getFeature(child.id))?.loopState).toBe("needs_fix");
+      const beforeRoot = await competing.getFeature(root.id);
+      await expect(competing.createGeneratedFixFeature(child.id, childRun.id, [], "late", undefined, undefined, { requireCurrentRun: true }))
+        .rejects.toBeInstanceOf(ValidatorRunOwnershipLostError);
+      expect(await competing.getFeature(root.id)).toEqual(beforeRoot);
+      expect(await competing.findGeneratedFixFeature(child.id, childRun.id)).toBeUndefined();
+    } finally {
+      release.resolve();
+      await pending;
+      gate.mockRestore();
+    }
+  });
+
+  it("serializes delayed remediation before reconciliation can invert ancestor row locks", async () => {
+    const m = missions();
+    const competing = new AsyncMissionStore(h.layer(), h.store());
+    const mission = await m.createMission({ title: "Lineage lock order" });
+    const milestone = await m.addMilestone(mission.id, { title: "MS" });
+    const slice = await m.addSlice(milestone.id, { title: "SL" });
+    const root = await m.addFeature(slice.id, { title: "Root" });
+    const fail = async (featureId: string) => {
+      const { run } = await m.startManualValidatorRun(featureId);
+      await m.completeValidatorRun(run.id, "failed");
+      return run;
+    };
+    const rootRun = await fail(root.id);
+    const ancestor = await m.createGeneratedFixFeature(root.id, rootRun.id, [], "repair");
+    const ancestorRun = await fail(ancestor.id);
+    const child = await m.createGeneratedFixFeature(ancestor.id, ancestorRun.id, [], "repair");
+    const childRun = await fail(child.id);
+    const { run: pass } = await m.startManualValidatorRun(ancestor.id);
+    const deferReconcile = vi.spyOn(m, "reconcileSupersededGeneratedFixFeatures").mockResolvedValueOnce({
+      supersededCount: 0, featureIds: [], repairedCount: 0, repairedFeatureIds: [],
+    });
+    await m.completeValidatorRun(pass.id, "passed");
+    deferReconcile.mockRestore();
+
+    const transaction = h.layer().transactionImmediate.bind(h.layer());
+    type Tx = Parameters<Parameters<typeof transaction>[0]>[0];
+    const locking = competing as unknown as { lockGeneratedFixLineage(tx: Tx): Promise<void> };
+    const lockLineage = locking.lockGeneratedFixLineage.bind(locking);
+    const entered = Promise.withResolvers<number>();
+    const release = Promise.withResolvers<void>();
+    const gate = vi.spyOn(locking, "lockGeneratedFixLineage").mockImplementationOnce(async (tx) => {
+      await lockLineage(tx);
+      // Force the permitted ancestor-first order of reconciliation's bulk row lock.
+      await tx.select({ id: schema.project.missionFeatures.id }).from(schema.project.missionFeatures)
+        .where(eq(schema.project.missionFeatures.id, ancestor.id)).for("update");
+      const rows = await tx.execute(sql`SELECT pg_backend_pid() AS pid`) as unknown as Array<{ pid: number }>;
+      entered.resolve(rows[0]!.pid);
+      await release.promise;
+      // A regression must fail promptly, not hang the suite waiting for a deadlock.
+      await tx.execute(sql`SET LOCAL lock_timeout = '500ms'`);
+    });
+    const reconciled = competing.reconcileSupersededGeneratedFixFeatures(slice.id).then(
+      (value) => ({ ok: true, value }), (error: unknown) => ({ ok: false, error }),
+    );
+    let admission: Promise<unknown> | undefined;
+    try {
+      const holderPid = await entered.promise;
+      admission = m.createGeneratedFixFeature(child.id, childRun.id, [], "late", undefined, undefined, { requireCurrentRun: true })
+        .then((value) => value, (error: unknown) => error);
+      const deadline = Date.now() + 5_000;
+      let blocked = false;
+      while (!blocked && Date.now() < deadline) {
+        const rows = await h.adminDb().execute(sql`SELECT EXISTS (
+          SELECT 1 FROM pg_stat_activity activity WHERE ${holderPid} = ANY(pg_blocking_pids(activity.pid))
+        ) AS blocked`) as unknown as Array<{ blocked: boolean }>;
+        blocked = rows[0]?.blocked === true;
+        if (!blocked) await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(blocked).toBe(true);
+    } finally {
+      release.resolve();
+      gate.mockRestore();
+    }
+    const [reconciliationResult, admissionResult] = await Promise.all([reconciled, admission]);
+    expect(reconciliationResult).toMatchObject({ ok: true });
+    expect(admissionResult).toBeInstanceOf(ValidatorRunOwnershipLostError);
+    expect(await m.findGeneratedFixFeature(child.id, childRun.id)).toBeUndefined();
+    expect((await m.getFeature(root.id))?.implementationAttemptCount).toBe(2);
   });
 
   it("creates one generated fix and consumes one retry under concurrent stores", async () => {

--- a/packages/core/src/async-stores/async-mission-store.ts
+++ b/packages/core/src/async-stores/async-mission-store.ts
@@ -10,6 +10,7 @@ const severityAuditLog = createLogger("core-async-mission-store");
  * events; reusable SQL and row mapping live in async-mission-store-queries.ts.
  */
 import { EventEmitter } from "node:events";
+import { ValidatorRunOwnershipLostError, type GeneratedFixFeatureOptions } from "../missions/mission-types.js";
 import { and, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import * as schema from "../postgres/schema/index.js";
 import type { AsyncDataLayer } from "../postgres/data-layer.js";
@@ -2150,31 +2151,83 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
     result: "passed" | "failed" | "blocked" | "error",
     summary?: string,
     blockedReason?: string,
-  ): Promise<MissionValidatorRun> {
+    effects?: import("../missions/mission-types.js").ValidatorRunCompletionEffects,
+  ): Promise<import("../missions/mission-types.js").ValidatorRunCompletion> {
     const run = await getValidatorRun(this.db, runId);
     if (!run) throw new Error(`Validator run ${runId} not found`);
-    if (run.status !== "running") throw new Error(`Validator run ${runId} is not in 'running' status`);
+    if (run.status !== "running") {
+      if (effects) return { ...run, completionApplied: false };
+      throw new Error(`Validator run ${runId} is not in 'running' status`);
+    }
     const now = new Date().toISOString();
     const loopState: FeatureLoopState = result === "passed" ? "passed" : result === "failed" ? "needs_fix" : result === "blocked" ? "blocked" : "validating";
     const updatedRun: MissionValidatorRun = { ...run, status: result, summary, blockedReason, completedAt: now, updatedAt: now };
+    let statusEvent: MissionEvent | undefined;
+    const milestoneIds = new Set(effects ? [run.milestoneId] : []);
+    for (const verdict of effects?.assertions ?? []) {
+      const assertion = await getContractAssertion(this.db, verdict.assertionId);
+      if (assertion) milestoneIds.add(assertion.milestoneId);
+    }
+    const validationRollups: MilestoneValidationRollup[] = [];
+    const changedAssertions: MissionContractAssertion[] = [];
     /*
     FNXC:MissionValidation 2026-08-11-05:26:
     A validator run becomes historical when a newer admission replaces feature.lastValidatorRunId. Complete the historical run, but only the current owner may project loop state or trigger passed-run reconciliation.
     */
     const completion = await this.layer.transactionImmediate(async (tx) => {
+      // FNXC:MissionValidation 2026-09-07-04:46: Serialize verdicts with assertion repairs before taking the feature lock; their milestone projection commits with the owning terminal transition.
+      // Linked feature evidence can belong to other milestones. Lock all of
+      // their assertion sets in one stable order before taking the feature lock.
+      for (const milestoneId of [...milestoneIds].sort()) await this.lockMilestoneAssertions(tx, milestoneId);
       await tx.select().from(schema.project.missionFeatures).where(and(
         eq(schema.project.missionFeatures.projectId, missionProjectId()),
         eq(schema.project.missionFeatures.id, run.featureId),
       )).for("update");
       const feature = await getFeature(tx, run.featureId);
       if (!feature) throw new Error(`Feature ${run.featureId} not found`);
+      if (effects && (effects.featureId !== run.featureId
+        || (effects.triggerType && effects.triggerType !== run.triggerType)
+        || feature.lastValidatorRunId !== run.id || feature.validatorAttemptCount !== run.validatorAttempt
+        || feature.loopState !== "validating")) return { won: false, ownsFeature: false, feature };
       const winner = await transitionRunningValidatorRun(tx, updatedRun);
       if (!winner) return { won: false, ownsFeature: false, feature };
       const ownsFeature = feature.lastValidatorRunId === run.id;
-      if (ownsFeature) await updateFeature(tx, { ...feature, loopState, lastValidatorStatus: result, updatedAt: now });
+      if (ownsFeature) {
+        if (effects) {
+          const linked = new Set((await listAssertionsForFeature(tx, feature.id)).map((assertion) => assertion.id));
+          for (const verdict of effects.assertions ?? []) {
+            if (!linked.has(verdict.assertionId)) throw new Error(`Assertion ${verdict.assertionId} is not linked to feature ${feature.id}`);
+            const assertion = await getContractAssertion(tx, verdict.assertionId);
+            if (!assertion) throw new Error(`Assertion ${verdict.assertionId} not found`);
+            if (!milestoneIds.has(assertion.milestoneId)) throw new Error(`Assertion ${verdict.assertionId} changed milestone during validator completion`);
+            const updatedAssertion = { ...assertion, status: verdict.status, updatedAt: now };
+            await updateContractAssertion(tx, updatedAssertion);
+            changedAssertions.push(updatedAssertion);
+          }
+          const failures = effects.failures ?? [];
+          if (failures.some((failure) => failure.featureId !== feature.id || !linked.has(failure.assertionId))) throw new Error("Validator failures do not belong to the current feature");
+          if (failures.length) await insertValidatorFailures(tx, failures.map((failure) => ({ ...failure, id: this.generateId("VF"), runId, createdAt: now })));
+        }
+        const status = effects && result === "passed" ? "done" : feature.status;
+        await updateFeature(tx, { ...feature, status, loopState, lastValidatorStatus: result, updatedAt: now });
+        if (status !== feature.status) statusEvent = await this.recordFeatureStatusChange(tx, feature, status, { type: "system", id: "mission-store", source: "validator-completion" });
+      }
+      if (ownsFeature) {
+        for (const milestoneId of [...milestoneIds].sort()) {
+          const rollup = await this.getMilestoneValidationRollup(milestoneId, tx);
+          await updateMilestoneValidationState(tx, milestoneId, rollup.state);
+          validationRollups.push(rollup);
+        }
+      }
       return { won: true, ownsFeature, feature };
     });
-    if (!completion.won) return (await getValidatorRun(this.db, runId)) ?? updatedRun;
+    if (!completion.won) {
+      const current = (await getValidatorRun(this.db, runId)) ?? run;
+      return effects ? { ...current, completionApplied: false } : current;
+    }
+    for (const rollup of validationRollups) this.emit("milestone:validation:updated", { milestoneId: rollup.milestoneId, state: rollup.state, rollup });
+    for (const assertion of changedAssertions) this.emit("assertion:updated", assertion);
+    if (statusEvent) this.emit("mission:event", statusEvent);
     if (completion.ownsFeature) {
       const updatedFeature = await getFeature(this.db, completion.feature.id);
       if (updatedFeature) this.emit("feature:updated", updatedFeature);
@@ -2183,7 +2236,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
     const durationMs = Math.max(0, Date.parse(now) - Date.parse(run.startedAt));
     this.emit("validator-run:completed", updatedRun, result, durationMs);
     if (result === "passed" && completion.ownsFeature) await this.reconcileSupersededGeneratedFixFeatures(completion.feature.sliceId);
-    return updatedRun;
+    return effects ? { ...updatedRun, completionApplied: completion.ownsFeature } : updatedRun;
   }
 
   async recordValidatorFailures(
@@ -2275,14 +2328,38 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
    * A generated fix is never a new budget owner. Resolve its parent chain while
    * the caller transaction is open; missing or cyclic evidence fails closed.
    */
-  private async resolveFixRoot(handle: QueryHandle, feature: MissionFeature): Promise<MissionFeature> {
+  private async lockGeneratedFixLineage(tx: QueryHandle): Promise<void> {
+    // Remediation admission walks child -> ancestors; reconciliation locks a set.
+    // Serialize those transactions before any feature-row lock to avoid inversion.
+    // Project-wide scope also covers generated chains that cross slice boundaries.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(
+      CONCAT('mission-generated-fixes:', COALESCE(NULLIF(current_setting('fusion.project_id', true), ''), '__legacy_unscoped__')),
+      0
+    ))`);
+  }
+
+  /**
+   * A generated fix is never a new budget owner. Resolve its parent chain while
+   * the caller transaction is open; missing or cyclic evidence fails closed.
+   */
+  private async resolveFixRoot(handle: QueryHandle, feature: MissionFeature, owningRunId?: string): Promise<MissionFeature> {
     const seen = new Set<string>();
     let current = feature;
     while (current.generatedFromFeatureId) {
       if (seen.has(current.id)) throw new Error("MISSION_LINEAGE_UNRESOLVED: cyclic generated-fix lineage");
       seen.add(current.id);
+      if (owningRunId) {
+        // The caller already holds the child lock. Walk upward, retaining each
+        // ancestor lock so a pass cannot race descendant remediation admission.
+        await handle.select({ id: schema.project.missionFeatures.id }).from(schema.project.missionFeatures)
+          .where(and(eq(schema.project.missionFeatures.projectId, missionProjectId()), eq(schema.project.missionFeatures.id, current.generatedFromFeatureId)))
+          .for("update");
+      }
       const parent = await getFeature(handle, current.generatedFromFeatureId);
       if (!parent) throw new Error("MISSION_LINEAGE_UNRESOLVED: missing generated-fix ancestor");
+      if (owningRunId && (parent.loopState === "passed" || parent.lastValidatorStatus === "passed")) {
+        throw new ValidatorRunOwnershipLostError(owningRunId);
+      }
       current = parent;
     }
     if (seen.has(current.id)) throw new Error("MISSION_LINEAGE_UNRESOLVED: cyclic generated-fix lineage");
@@ -2302,6 +2379,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
     failureReason?: string,
     title?: string,
     diagnostics?: ValidationDiagnostics,
+    options: GeneratedFixFeatureOptions = {},
   ): Promise<MissionFeature> {
     const run = await getValidatorRun(this.db, runId);
     if (!run) throw new Error(`Validator run ${runId} not found`);
@@ -2320,6 +2398,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
       | { kind: "exhausted" }
       | { kind: "stopped"; reason: string }
     > => {
+      await this.lockGeneratedFixLineage(tx);
       const locked = await tx
         .select({ id: schema.project.missionFeatures.id })
         .from(schema.project.missionFeatures)
@@ -2331,7 +2410,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
       if (locked.length === 0) throw new Error(`Feature ${sourceFeatureId} not found`);
       const source = await getFeature(tx, sourceFeatureId);
       if (!source) throw new Error(`Feature ${sourceFeatureId} not found`);
-      const root = await this.resolveFixRoot(tx, source);
+      const root = await this.resolveFixRoot(tx, source, options.requireCurrentRun ? runId : undefined);
       // Lock the canonical owner, not the generated child that happened to fail.
       const rootLocked = await tx.select({ id: schema.project.missionFeatures.id }).from(schema.project.missionFeatures)
         .where(and(
@@ -2341,6 +2420,15 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
       if (rootLocked.length !== 1) throw new Error("MISSION_LINEAGE_UNRESOLVED: canonical root disappeared");
       const lockedRoot = await getFeature(tx, root.id);
       if (!lockedRoot) throw new Error("MISSION_LINEAGE_UNRESOLVED: canonical root disappeared");
+      // FNXC:MissionValidation 2026-09-07-04:46: A failed-run continuation must recheck ownership under both locks before even reusing a fix or spending its root's retry budget.
+      if (options.requireCurrentRun) {
+        const currentRun = await getValidatorRun(tx, runId);
+        if (currentRun?.status !== "failed" || source.lastValidatorRunId !== runId
+          || source.validatorAttemptCount !== currentRun.validatorAttempt || source.lastValidatorStatus !== "failed"
+          || source.loopState === "passed" || lockedRoot.loopState === "passed" || lockedRoot.lastValidatorStatus === "passed") {
+          throw new ValidatorRunOwnershipLostError(runId);
+        }
+      }
       const durableStop = await this.getRootStop(tx, root.id);
       if (durableStop) return { kind: "stopped", reason: durableStop.reason };
       if (lockedRoot.loopState === "blocked") {
@@ -2459,6 +2547,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
     if (repairIds.size > 0) {
       const now = new Date().toISOString();
       const repaired = await this.layer.transactionImmediate(async (tx) => {
+        await this.lockGeneratedFixLineage(tx);
         const locked = await tx.select({ id: schema.project.missionFeatures.id })
           .from(schema.project.missionFeatures)
           .where(inArray(schema.project.missionFeatures.id, [...repairIds]))
@@ -2525,6 +2614,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
       Superseded generated fixes are one reconciliation set. Update their terminal status in one statement instead of routing every ID through updateFeature/getFeature/cascade reads; emit the same per-feature observable events after persistence.
       */
       const { events, updatedFeatures } = await this.layer.transactionImmediate(async (tx) => {
+        await this.lockGeneratedFixLineage(tx);
         /*
         FNXC:MissionStatusWrites 2026-08-10-13:21:
         The bulk reconciliation must lock and re-read its candidates inside this transaction.
@@ -3274,6 +3364,13 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
   publish snapshots in reverse order; the lock makes the committed current rollup
   the only state emitted to dashboard refresh consumers.
   */
+  private async lockMilestoneAssertions(tx: QueryHandle, milestoneId: string): Promise<void> {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(
+      CONCAT('mission-validation:', COALESCE(NULLIF(current_setting('fusion.project_id', true), ''), '__legacy_unscoped__'), ':', CAST(${milestoneId} AS text)),
+      0
+    ))`);
+  }
+
   private async mutateMilestoneAssertions<T>(
     milestoneId: string,
     mutation: (tx: QueryHandle) => Promise<T>,
@@ -3281,10 +3378,7 @@ export class AsyncMissionStore extends EventEmitter<MissionStoreEvents> {
     let result!: T;
     let rollup!: MilestoneValidationRollup;
     await this.layer.transactionImmediate(async (tx) => {
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(
-        CONCAT('mission-validation:', COALESCE(NULLIF(current_setting('fusion.project_id', true), ''), '__legacy_unscoped__'), ':', CAST(${milestoneId} AS text)),
-        0
-      ))`);
+      await this.lockMilestoneAssertions(tx, milestoneId);
       result = await mutation(tx);
       rollup = await this.getMilestoneValidationRollup(milestoneId, tx);
       await updateMilestoneValidationState(tx, milestoneId, rollup.state);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2065,6 +2065,9 @@ export type {
   FeatureLinkedPayload,
   FixFeatureCreatedPayload,
   // Validator run types
+  ValidatorRunCompletionEffects,
+  ValidatorRunCompletion,
+  GeneratedFixFeatureOptions,
   MissionValidatorRun,
   MissionAssertionFailureRecord,
   MissionFixFeatureLineage,
@@ -2087,6 +2090,7 @@ export type {
 } from "./missions/mission-types.js";
 export { normalizeMissionBlockerReason, createMissionBlockerDescriptor, isMissionBlockerDescriptor, sortMissionBlockerDescriptors, dedupeMissionBlockerDescriptors } from "./missions/mission-blockers.js";
 export { MissionStore } from "./missions/mission-store.js";
+export { ValidatorRunOwnershipLostError } from "./missions/mission-types.js";
 export type { MissionStoreEvents, MissionSummary } from "./missions/mission-store.js";
 export { AsyncMissionStore, MissionRemediationStoppedError, MissionResumeConflictError, MissionBlockedClearConflictError, RepairGroundTruthStaleError, RepairNotEligibleError, RepairValidatorRunInFlightError, RepairAssertionsMissingError, TerminalTaskReconciliationError } from "./async-stores/async-mission-store.js";
 export type { TerminalTaskReconciliationErrorCode } from "./async-stores/async-mission-store.js";

--- a/packages/core/src/missions/mission-store.ts
+++ b/packages/core/src/missions/mission-store.ts
@@ -15,6 +15,7 @@ const severityAuditLog = createLogger("core-mission-store");
  */
 
 import { EventEmitter } from "node:events";
+import { ValidatorRunOwnershipLostError, type GeneratedFixFeatureOptions } from "./mission-types.js";
 import type { Database } from "../db/db.js";
 import { fromJson, toJson, toJsonNullable } from "../db/db.js";
 import { FEATURE_LOOP_TRANSITIONS, normalizeMissionAssertionOrigin, normalizeMissionAssertionScope, normalizeMissionAssertionType, renderValidationCause, ROLLUP_OWNED_MILESTONE_STATUSES, ROLLUP_OWNED_MISSION_STATUSES, selectNextSerialMissionSlice, shouldApplyRecomputedStatus, VALIDATION_INFLIGHT_STALE_MAX_AGE_MS } from "./mission-types.js";
@@ -3068,7 +3069,9 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
     result: "passed" | "failed" | "blocked" | "error",
     summary?: string,
     blockedReason?: string,
-  ): MissionValidatorRun {
+    effects?: import("./mission-types.js").ValidatorRunCompletionEffects,
+  ): import("./mission-types.js").ValidatorRunCompletion {
+    if (effects) return this.completeValidatorRunWithEffects(runId, result, summary, blockedReason, effects);
     const run = this.getValidatorRun(runId);
     if (!run) {
       throw new Error(`Validator run ${runId} not found`);
@@ -3155,6 +3158,70 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
     }
 
     return updatedRun;
+  }
+
+  /* FNXC:MissionValidation 2026-09-07-04:46: Legacy injected stores retain the same invocation-local ownership token. Persist verdicts, failures and the feature projection together; publish nothing from a rolled-back or losing invocation. */
+  private completeValidatorRunWithEffects(
+    runId: string,
+    result: "passed" | "failed" | "blocked" | "error",
+    summary: string | undefined,
+    blockedReason: string | undefined,
+    effects: import("./mission-types.js").ValidatorRunCompletionEffects,
+  ): import("./mission-types.js").ValidatorRunCompletion {
+    const now = new Date().toISOString();
+    const changedAssertions: MissionContractAssertion[] = [];
+    let updatedFeature: MissionFeature | undefined;
+    const validationRollups: MilestoneValidationRollup[] = [];
+    const completion = this.db.transactionImmediate(() => {
+      const run = this.getValidatorRun(runId);
+      if (!run) throw new Error(`Validator run ${runId} not found`);
+      const feature = this.getFeature(run.featureId);
+      if (!feature) throw new Error(`Feature ${run.featureId} not found`);
+      if (run.status !== "running" || effects.featureId !== run.featureId
+        || (effects.triggerType && effects.triggerType !== run.triggerType)
+        || feature.lastValidatorRunId !== runId || feature.validatorAttemptCount !== run.validatorAttempt
+        || feature.loopState !== "validating") return { ...run, completionApplied: false };
+      const won = this.db.prepare(`UPDATE mission_validator_runs SET status = ?, summary = ?, blockedReason = ?, completedAt = ?, updatedAt = ? WHERE id = ? AND status = 'running'`)
+        .run(result, summary ?? null, blockedReason ?? null, now, now, runId);
+      if (won.changes !== 1) return { ...this.getValidatorRun(runId)!, completionApplied: false };
+      const linked = new Map(this.listAssertionsForFeature(feature.id).map((assertion) => [assertion.id, assertion]));
+      const milestoneIds = new Set([run.milestoneId]);
+      for (const verdict of effects.assertions ?? []) {
+        const assertion = linked.get(verdict.assertionId);
+        if (!assertion) throw new Error(`Assertion ${verdict.assertionId} is not linked to feature ${feature.id}`);
+        milestoneIds.add(assertion.milestoneId);
+        this.db.prepare("UPDATE mission_contract_assertions SET status = ?, updatedAt = ? WHERE id = ?")
+          .run(verdict.status, now, assertion.id);
+        changedAssertions.push({ ...assertion, status: verdict.status, updatedAt: now });
+      }
+      for (const failure of effects.failures ?? []) {
+        if (failure.featureId !== feature.id || !linked.has(failure.assertionId)) throw new Error("Validator failures do not belong to the current feature");
+        this.db.prepare(`INSERT INTO mission_validator_failures (id, runId, featureId, assertionId, message, expected, actual, createdAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+          .run(this.generateFailureId(), runId, feature.id, failure.assertionId, failure.message ?? null, failure.expected ?? null, failure.actual ?? null, now);
+      }
+      const loopState: FeatureLoopState = result === "passed" ? "passed" : result === "failed" ? "needs_fix" : result === "blocked" ? "blocked" : "validating";
+      updatedFeature = { ...feature, status: result === "passed" ? "done" : feature.status, loopState, lastValidatorStatus: result, updatedAt: now };
+      this.db.prepare("UPDATE mission_features SET status = ?, loopState = ?, lastValidatorStatus = ?, updatedAt = ? WHERE id = ?")
+        .run(updatedFeature.status, loopState, result, now, feature.id);
+      for (const milestoneId of milestoneIds) {
+        const rollup = this.getMilestoneValidationRollup(milestoneId);
+        this.db.prepare("UPDATE milestones SET validationState = ?, updatedAt = ? WHERE id = ?")
+          .run(rollup.state, now, milestoneId);
+        validationRollups.push(rollup);
+      }
+      return { ...run, status: result, summary, blockedReason, completedAt: now, updatedAt: now, completionApplied: true };
+    });
+    if (!completion.completionApplied) return completion;
+    this.db.bumpLastModified();
+    for (const rollup of validationRollups) this.emit("milestone:validation:updated", { milestoneId: rollup.milestoneId, state: rollup.state, rollup });
+    for (const assertion of changedAssertions) this.emit("assertion:updated", assertion);
+    if (updatedFeature) {
+      this.emit("feature:updated", updatedFeature);
+      this.recomputeSliceStatus(updatedFeature.sliceId);
+    }
+    this.emit("validator-run:completed", completion, result, Math.max(0, Date.parse(now) - Date.parse(completion.startedAt)));
+    if (result === "passed" && updatedFeature) this.reconcileSupersededGeneratedFixFeatures(updatedFeature.sliceId);
+    return completion;
   }
 
   /**
@@ -3380,6 +3447,7 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
     failureReason?: string,
     title?: string,
     diagnostics?: ValidationDiagnostics,
+    options: GeneratedFixFeatureOptions = {},
   ): MissionFeature {
     const sourceFeature = this.getFeature(sourceFeatureId);
     if (!sourceFeature) {
@@ -3394,6 +3462,24 @@ export class MissionStore extends EventEmitter<MissionStoreEvents> {
       throw new Error(
         `Validator run ${runId} belongs to feature ${run.featureId}, expected ${sourceFeatureId}`,
       );
+    }
+
+    if (options.requireCurrentRun && (run.status !== "failed" || sourceFeature.lastValidatorRunId !== runId
+      || sourceFeature.validatorAttemptCount !== run.validatorAttempt || sourceFeature.lastValidatorStatus !== "failed"
+      || sourceFeature.loopState === "passed")) {
+      throw new ValidatorRunOwnershipLostError(runId);
+    }
+    if (options.requireCurrentRun) {
+      const visited = new Set([sourceFeature.id]);
+      let ancestorId = sourceFeature.generatedFromFeatureId;
+      while (ancestorId) {
+        const ancestor = this.getFeature(ancestorId);
+        if (!ancestor || visited.has(ancestorId) || ancestor.loopState === "passed" || ancestor.lastValidatorStatus === "passed") {
+          throw new ValidatorRunOwnershipLostError(runId);
+        }
+        visited.add(ancestorId);
+        ancestorId = ancestor.generatedFromFeatureId;
+      }
     }
 
     // R22 — idempotency across re-drives.

--- a/packages/core/src/missions/mission-types.ts
+++ b/packages/core/src/missions/mission-types.ts
@@ -713,6 +713,33 @@ export interface ValidatorRunAdmissionInput {
  * A validator run represents a single execution of the validation phase
  * for a feature within the mission execution loop.
  */
+/* FNXC:MissionValidation 2026-09-07-04:33:
+ * Engine effects are accepted only with the current feature owner and a winning
+ * running-to-terminal transition in the same transaction. The returned token is
+ * invocation-local, never persisted or reconstructed from a terminal run.
+ */
+export interface ValidatorRunCompletionEffects {
+  featureId: string;
+  triggerType?: "manual";
+  assertions?: Array<{ assertionId: string; status: "passed" | "failed" | "blocked" }>;
+  failures?: Array<{ featureId: string; assertionId: string; message?: string; expected?: string; actual?: string }>;
+}
+
+export type ValidatorRunCompletion = MissionValidatorRun & { completionApplied?: boolean };
+
+export interface GeneratedFixFeatureOptions {
+  /** Engine continuations must still own the failed run; historical/manual callers may omit this fence. */
+  requireCurrentRun?: boolean;
+}
+
+export class ValidatorRunOwnershipLostError extends Error {
+  readonly code = "VALIDATOR_RUN_OWNERSHIP_LOST";
+  constructor(runId: string) {
+    super(`Validator run ${runId} no longer owns the feature's failed validation`);
+    this.name = "ValidatorRunOwnershipLostError";
+  }
+}
+
 export interface MissionValidatorRun {
   /** Unique identifier (e.g., "VR-XXXXXXXX-XXXX") */
   id: string;

--- a/packages/dashboard/src/__tests__/mission-task-prefix-routes.test.ts
+++ b/packages/dashboard/src/__tests__/mission-task-prefix-routes.test.ts
@@ -29,6 +29,7 @@ type MissionRecord = {
 };
 
 function createFixture() {
+  const executionLoop = { isRunning: () => true, recoverActiveMissions: vi.fn(), executeManualValidatorRun: vi.fn(async () => {}) };
   const missions = new Map<string, MissionRecord>();
   let seq = 0;
 
@@ -93,17 +94,18 @@ function createFixture() {
 
   const app = express();
   app.use(express.json());
-  app.use("/api/missions", createMissionRouter(store));
+  app.use("/api/missions", createMissionRouter(store, undefined, undefined, executionLoop));
 
-  return { app, missionStore, missions };
+  return { app, missionStore, missions, executionLoop };
 }
 
 describe("mission taskPrefix routes", () => {
   let app: express.Express;
   let missionStore: ReturnType<typeof createFixture>["missionStore"];
+  let executionLoop: ReturnType<typeof createFixture>["executionLoop"];
 
   beforeEach(() => {
-    ({ app, missionStore } = createFixture());
+    ({ app, missionStore, executionLoop } = createFixture());
   });
 
   /*
@@ -123,6 +125,7 @@ describe("mission taskPrefix routes", () => {
     const response = await request(app, "POST", "/api/missions/features/F-1/repair-validation", JSON.stringify({ action: "re_run" }), { "content-type": "application/json" });
     expect(response.status).toBe(202);
     expect(response.body).toMatchObject({ runId: "VR-1", featureId: "F-1", status: "running" });
+    expect(executionLoop.executeManualValidatorRun).toHaveBeenCalledWith(expect.objectContaining({ id: "VR-1", featureId: "F-1", triggerType: "manual" }));
     expect((missionStore as typeof missionStore & { repairFeatureValidationState: ReturnType<typeof vi.fn> }).repairFeatureValidationState)
       .toHaveBeenCalledWith("F-1", expect.objectContaining({ action: "re_run", actor: expect.objectContaining({ type: "operator" }) }));
   });
@@ -149,6 +152,7 @@ describe("mission taskPrefix routes", () => {
     const lockedRace = await request(app, "POST", "/api/missions/features/F-1/repair-validation", JSON.stringify({ action: "re_run" }), { "content-type": "application/json" });
     expect(lockedRace.status).toBe(409);
     expect(lockedRace.body.error).toContain("not eligible");
+    expect(executionLoop.executeManualValidatorRun).not.toHaveBeenCalled();
   });
 
   it("clears a blocked badge with server-derived targets and rejects ineligible repair", async () => {
@@ -170,6 +174,7 @@ describe("mission taskPrefix routes", () => {
     const rejected = await request(app, "POST", "/api/missions/features/F-1/repair-validation", JSON.stringify({ action: "clear" }), { "content-type": "application/json" });
     expect(rejected.status).toBe(409);
     expect(repairFeatureValidationState).toHaveBeenCalledTimes(1);
+    expect(executionLoop.executeManualValidatorRun).not.toHaveBeenCalled();
   });
 
   it("clears a stored taskPrefix when PATCH sends null", async () => {
@@ -283,7 +288,9 @@ pgDescribe("mission validation repair routes", () => {
   function app() {
     const server = express();
     server.use(express.json());
-    server.use("/api/missions", createMissionRouter(h.store()));
+    server.use("/api/missions", createMissionRouter(h.store(), undefined, undefined, {
+      isRunning: () => true, recoverActiveMissions: vi.fn(), executeManualValidatorRun: vi.fn(async () => {}),
+    }));
     return server;
   }
 

--- a/packages/dashboard/src/__tests__/mission-validate-inflight-guard.test.ts
+++ b/packages/dashboard/src/__tests__/mission-validate-inflight-guard.test.ts
@@ -2,13 +2,15 @@
 import { describe, expect, it, vi } from "vitest";
 import express from "express";
 import type { TaskStore } from "@fusion/core";
+import type { ServerOptions } from "../server.js";
 import { createMissionRouter } from "../mission-routes.js";
 import { request } from "../test-request.js";
 
 const feature = { id: "F-TEST", sliceId: "SL-TEST", status: "defined", loopState: "idle" };
 const run = { id: "VR-FIRST", featureId: feature.id, status: "running", triggerType: "manual", implementationAttempt: 0, validatorAttempt: 1, startedAt: "2026-08-11T03:43:00.000Z" };
 
-function fixture(options: { manual?: boolean; assertions?: unknown[]; exists?: boolean } = {}) {
+function fixture(options: { manual?: boolean; assertions?: unknown[]; exists?: boolean; executor?: boolean; running?: boolean } = {}) {
+  const executionLoop = { isRunning: () => options.running !== false, recoverActiveMissions: vi.fn(), executeManualValidatorRun: vi.fn(() => new Promise<void>(() => {})) };
   const startManualValidatorRun = options.manual === false ? undefined : vi.fn()
     .mockResolvedValueOnce({ outcome: "started", run })
     .mockResolvedValue({ outcome: "already-running", run });
@@ -26,18 +28,63 @@ function fixture(options: { manual?: boolean; assertions?: unknown[]; exists?: b
   } as unknown as TaskStore;
   const app = express();
   app.use(express.json());
-  app.use("/api/missions", createMissionRouter(store));
-  return { app, missionStore };
+  app.use("/api/missions", createMissionRouter(store, undefined, undefined, options.executor === false ? undefined : executionLoop));
+  return { app, missionStore, executionLoop, store };
 }
 
 describe("manual mission validation in-flight guard", () => {
+  it.each([{ executor: false }, { running: false }])("refuses admission when the executor is unavailable: %j", async (options) => {
+    const { app, missionStore, executionLoop } = fixture(options);
+    expect((await request(app, "POST", "/api/missions/features/F-TEST/validate")).status).toBe(409);
+    expect(missionStore.startManualValidatorRun).not.toHaveBeenCalled();
+    expect(missionStore.startValidatorRun).not.toHaveBeenCalled();
+    expect(executionLoop.executeManualValidatorRun).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])("uses only the selected project's executor (available=%s)", async (available) => {
+    const launch = fixture();
+    const selected = fixture();
+    const engine = { getTaskStore: () => selected.store, getRuntime: () => ({ getMissionExecutionLoop: () => available ? selected.executionLoop : undefined }) };
+    const manager = { getEngine: vi.fn(() => engine) } as unknown as NonNullable<ServerOptions["engineManager"]>;
+    const app = express();
+    app.use(express.json());
+    app.use("/api/missions", createMissionRouter(launch.store, undefined, undefined, launch.executionLoop, manager, undefined, { engineManager: manager }));
+    const response = await request(app, "POST", "/api/missions/features/F-TEST/validate?projectId=selected");
+    expect(response.status).toBe(available ? 202 : 409);
+    expect(launch.missionStore.startManualValidatorRun).not.toHaveBeenCalled();
+    expect(launch.executionLoop.executeManualValidatorRun).not.toHaveBeenCalled();
+    expect(selected.missionStore.startManualValidatorRun).toHaveBeenCalledTimes(available ? 1 : 0);
+    expect(selected.executionLoop.executeManualValidatorRun).toHaveBeenCalledTimes(available ? 1 : 0);
+  });
+
+  it("does not fall back to the injected executor when the managed launch engine is absent", async () => {
+    const launch = fixture();
+    const manager = { getEngine: vi.fn(() => undefined) } as unknown as NonNullable<ServerOptions["engineManager"]>;
+    const options = { engineManager: manager, engine: { getProjectId: () => "launch" } } as ServerOptions;
+    const app = express();
+    app.use(express.json());
+    app.use("/api/missions", createMissionRouter(launch.store, undefined, undefined, launch.executionLoop, manager, undefined, options));
+    const response = await request(app, "POST", "/api/missions/features/F-TEST/validate");
+    expect(response.status).toBe(409);
+    expect(launch.missionStore.startManualValidatorRun).not.toHaveBeenCalled();
+    expect(launch.executionLoop.executeManualValidatorRun).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the exact admitted run without waiting for validation to finish", async () => {
+    const { app, executionLoop } = fixture();
+    const response = await request(app, "POST", "/api/missions/features/F-TEST/validate");
+    expect(response.status).toBe(202);
+    expect(executionLoop.executeManualValidatorRun).toHaveBeenCalledWith(run);
+  });
+
   it("returns a precise conflict without a feature write after the first start", async () => {
-    const { app, missionStore } = fixture();
+    const { app, missionStore, executionLoop } = fixture();
     expect((await request(app, "POST", "/api/missions/features/F-TEST/validate")).status).toBe(202);
     const second = await request(app, "POST", "/api/missions/features/F-TEST/validate");
     expect(second.status).toBe(409);
     expect(second.body).toMatchObject({ error: "Validation is already running for this feature", details: { code: "VALIDATION_ALREADY_RUNNING", runId: run.id, featureId: feature.id, startedAt: run.startedAt } });
     expect(missionStore.updateFeature).not.toHaveBeenCalled();
+    expect(executionLoop.executeManualValidatorRun).toHaveBeenCalledOnce();
   });
 
   it("preserves missing-feature and assertion precedence", async () => {

--- a/packages/dashboard/src/mission-routes.ts
+++ b/packages/dashboard/src/mission-routes.ts
@@ -33,6 +33,7 @@ import type { AsyncMissionStore, Goal, Settings, ThinkingLevel } from "@fusion/c
 import { hasTerminalReconcileCapability, reconcileMissionState, resolveFeatureRepairTargets, resolvePlanningThinkingLevel } from "@fusion/engine";
 import {
   getScopedStore as resolveScopedRequestStore,
+  resolveRequestProjectId,
   getProjectContext as resolveSharedProjectContext,
 } from "./routes/context.js";
 import type { ServerOptions } from "./server.js";
@@ -375,6 +376,7 @@ export function createMissionRouter(
   missionExecutionLoop?: {
     recoverActiveMissions(): Promise<{ recoveredCount: number }>;
     isRunning(): boolean;
+    executeManualValidatorRun?(run: { id: string; featureId: string }): Promise<void>;
   },
   engineManager?: import("@fusion/engine").ProjectEngineManager,
   pluginRunner?: Parameters<typeof import("@fusion/engine").buildSessionSkillContextSync>[3],
@@ -385,6 +387,29 @@ export function createMissionRouter(
 
   function getScopedStore(): TaskStore {
     return requestContext.getStore() ?? store;
+  }
+
+  /**
+   * FNXC:MissionValidation 2026-09-07-03:43:
+   * Admit manual work only with its existing project-scoped executor available.
+   * A foreign or stopped engine must not leave an ownerless running row, and a
+   * managed project must never fall back to the launch project's validator.
+   */
+  function requireManualValidator(req: Request) {
+    const projectId = resolveRequestProjectId(req, options);
+    const manager = engineManager ?? options?.engineManager;
+    const engine = projectId && manager ? manager.getEngine(projectId) : undefined;
+    const loop = projectId && manager
+      ? engine?.getTaskStore() === getScopedStore() ? engine.getRuntime().getMissionExecutionLoop() : undefined
+      : getScopedStore() === store ? missionExecutionLoop : undefined;
+    if (!loop?.isRunning() || typeof loop.executeManualValidatorRun !== "function") {
+      throw conflict("Mission validation executor is not available for this project");
+    }
+    return (run: { id: string; featureId: string }) => {
+      void loop.executeManualValidatorRun!(run).catch((error) => {
+        missionRoutesLog.error(`Manual validator dispatch failed for run ${run.id}:`, error);
+      });
+    };
   }
 
   function getScopedMissionStore() {
@@ -2466,6 +2491,7 @@ export function createMissionRouter(
           | { outcome: "already-running"; run: { id: string; startedAt: string } }
         >;
       };
+      const dispatch = requireManualValidator(req);
       const admission = typeof manualAdmissionStore.startManualValidatorRun === "function"
         ? await manualAdmissionStore.startManualValidatorRun(featureId)
         : { outcome: "started" as const, run: await missionStore.startValidatorRun(featureId, "manual") };
@@ -2478,6 +2504,7 @@ export function createMissionRouter(
         });
       }
       const run = admission.run;
+      dispatch(run);
 
       res.status(202).json({
         runId: run.id,
@@ -2526,6 +2553,7 @@ export function createMissionRouter(
         throw conflict(`Validation repair '${action}' is not eligible for status '${feature.status}' and loop state '${feature.loopState ?? "idle"}'`);
       }
 
+      const dispatch = action === "re_run" ? requireManualValidator(req) : undefined;
       const repair = async () => {
         if (action === "re_run") {
           return repairMissionStore.repairFeatureValidationState(featureId, {
@@ -2571,6 +2599,7 @@ export function createMissionRouter(
       if (action === "re_run") {
         const run = result.run;
         if (!run) throw new Error("Validation repair did not create a validator run");
+        dispatch!(run);
         res.status(202).json({
           runId: run.id,
           featureId: run.featureId,

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -331,6 +331,7 @@ export interface ServerOptions {
   missionExecutionLoop?: {
     recoverActiveMissions(): Promise<{ recoveredCount: number }>;
     isRunning(): boolean;
+    executeManualValidatorRun?(run: { id: string; featureId: string }): Promise<void>;
   };
   /** Optional HeartbeatMonitor for triggering agent execution runs */
   heartbeatMonitor?: {

--- a/packages/engine/src/__tests__/mission-execution-loop.test.ts
+++ b/packages/engine/src/__tests__/mission-execution-loop.test.ts
@@ -564,6 +564,99 @@ describe("MissionExecutionLoop", () => {
     vi.restoreAllMocks();
   });
 
+  describe("executeManualValidatorRun", () => {
+    function admitManualRun() {
+      const feature = createMockFeature({ loopState: "validating", lastValidatorRunId: "VR-001", validatorAttemptCount: 1 });
+      missionStore._setFeature(feature);
+      missionStore._setAssertionsForFeature(feature.id, makeAssertions(1));
+      const run = missionStore.startValidatorRun(feature.id);
+      run.triggerType = "manual";
+      missionStore.startValidatorRun.mockClear();
+      mockSessionHolder.session.state.messages = makeMockSession(JSON.stringify({ status: "pass", assertions: [{ assertionId: "CA-1", passed: true }], summary: "Verified contract" })).state.messages;
+      loop = new MissionExecutionLoop({ taskStore: taskStore as any, missionStore: missionStore as any, rootDir: "/tmp" });
+      loop.start();
+      return { feature, run };
+    }
+
+    it.each(["duplicate", "completed", "foreign-feature", "automatic", "superseded"])("does not execute a %s delivery twice or outside its admission fence", async (kind) => {
+      const { feature, run } = admitManualRun();
+      if (kind === "duplicate") {
+        await Promise.all([loop.executeManualValidatorRun(run), loop.executeManualValidatorRun(run)]);
+        expect(createResolvedAgentSession).toHaveBeenCalledOnce();
+        expect(missionStore.completeValidatorRun).toHaveBeenCalledOnce();
+        await loop.executeManualValidatorRun(run);
+        expect(createResolvedAgentSession).toHaveBeenCalledOnce();
+        return;
+      }
+      if (kind === "completed") run.status = "passed";
+      if (kind === "automatic") run.triggerType = "task_completion";
+      if (kind === "superseded") missionStore.updateFeature(feature.id, { lastValidatorRunId: "VR-NEW" });
+      await loop.executeManualValidatorRun({ id: run.id, featureId: kind === "foreign-feature" ? "F-OTHER" : feature.id });
+      expect(createResolvedAgentSession).not.toHaveBeenCalled();
+      expect(missionStore.completeValidatorRun).not.toHaveBeenCalled();
+    });
+
+    it.each(["assertion-lookup", "session-setup", "stopped", "empty-assertions"])("terminalizes %s failures on the admitted row without creating a fix", async (failure) => {
+      const { run } = admitManualRun();
+      if (failure === "assertion-lookup") missionStore.listAssertionsForFeature.mockImplementationOnce(() => { throw new Error("lookup unavailable"); });
+      if (failure === "session-setup") vi.mocked(createResolvedAgentSession).mockRejectedValueOnce(new Error("session unavailable"));
+      if (failure === "stopped") loop.stop();
+      if (failure === "empty-assertions") {
+        missionStore.listAssertionsForFeature.mockReturnValue([]);
+        missionStore.ensureFeatureAssertionLinked.mockReturnValue([]);
+      }
+      await loop.executeManualValidatorRun(run);
+      expect(missionStore.getValidatorRun(run.id)).toMatchObject({ status: "error" });
+      expect(missionStore.getFeature(run.featureId)).toMatchObject({ lastValidatorStatus: "error" });
+      expect(missionStore.startValidatorRun).not.toHaveBeenCalled();
+      expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
+    });
+
+    it("fences a replaced run before assertion and feature bookkeeping", async () => {
+      const { feature, run } = admitManualRun();
+      const updateContractAssertion = vi.fn();
+      Object.assign(missionStore, { updateContractAssertion });
+      vi.mocked(createResolvedAgentSession).mockImplementationOnce(async () => {
+        missionStore.updateFeature(feature.id, { lastValidatorRunId: "VR-NEW" });
+        return { session: mockSessionHolder.session as any, sessionFile: undefined, runtimeId: "test-runtime", wasConfigured: true };
+      });
+      await loop.executeManualValidatorRun(run);
+      expect(updateContractAssertion).not.toHaveBeenCalled();
+      expect(missionStore.completeValidatorRun).not.toHaveBeenCalled();
+      expect(mockSessionHolder.session.dispose).toHaveBeenCalledOnce();
+    });
+
+    it("does not accept the judge's behavioral pass without genuine verification", async () => {
+      const { feature, run } = admitManualRun();
+      missionStore._setAssertionsForFeature(feature.id, makeAssertions(1).map((assertion) => ({ ...assertion, type: "behavioral" })));
+      await loop.executeManualValidatorRun(run);
+      expect(createResolvedAgentSession).toHaveBeenCalledOnce();
+      expect(missionStore.getValidatorRun(run.id)?.status).not.toBe("passed");
+      expect(missionStore.getFeature(feature.id)?.lastValidatorStatus).not.toBe("passed");
+    });
+
+    it("executes the admitted run through the judge and shared completion without readmission", async () => {
+      const feature = createMockFeature({ loopState: "validating", lastValidatorRunId: "VR-001", validatorAttemptCount: 1 });
+      missionStore._setFeature(feature);
+      missionStore._setAssertionsForFeature(feature.id, makeAssertions(1));
+      const run = missionStore.startValidatorRun(feature.id);
+      run.triggerType = "manual";
+      missionStore.startValidatorRun.mockClear();
+      mockSessionHolder.session.state.messages = makeMockSession(JSON.stringify({ status: "pass", assertions: [{ assertionId: "CA-1", passed: true }], summary: "Verified contract" })).state.messages;
+      loop = new MissionExecutionLoop({ taskStore: taskStore as any, missionStore: missionStore as any, rootDir: "/tmp" });
+      loop.start();
+
+      await loop.executeManualValidatorRun(run);
+
+      expect(createResolvedAgentSession).toHaveBeenCalledOnce();
+      expect(missionStore.startValidatorRun).not.toHaveBeenCalled();
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(run.id, "passed", "Verified contract");
+      expect(missionStore.getFeature(feature.id)).toMatchObject({ loopState: "passed", lastValidatorStatus: "passed" });
+      expect(mockSessionHolder.session.dispose).toHaveBeenCalledOnce();
+      expectNoValidationBoardTaskMutation(taskStore);
+    });
+  });
+
   // ── Lifecycle ────────────────────────────────────────────────────────────
 
   describe("start/stop", () => {

--- a/packages/engine/src/__tests__/mission-execution-loop.test.ts
+++ b/packages/engine/src/__tests__/mission-execution-loop.test.ts
@@ -10,7 +10,7 @@ import { execSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { TEST_MODE_RESOLVED } from "@fusion/core";
+import { TEST_MODE_RESOLVED, ValidatorRunOwnershipLostError } from "@fusion/core";
 import type {
   Mission,
   Milestone,
@@ -207,7 +207,7 @@ function createMockMissionStore() {
       features.set(id, updated);
       return updated;
     }),
-    listAssertionsForFeature: vi.fn((featureId: string) => assertionsByFeature.get(featureId) ?? []),
+    listAssertionsForFeature: vi.fn((featureId: string): NonNullable<ReturnType<typeof assertionsByFeature.get>> | Promise<NonNullable<ReturnType<typeof assertionsByFeature.get>>> => assertionsByFeature.get(featureId) ?? []),
     ensureFeatureAssertionLinked: vi.fn((featureId: string) => {
       const feature = features.get(featureId);
       if (!feature) {
@@ -230,8 +230,10 @@ function createMockMissionStore() {
 
     // Validator run methods
     startValidatorRun: vi.fn((featureId: string, _triggerType?: string, _taskId?: string, inputFingerprint?: string) => {
-      const run = createMockValidatorRun({ featureId, inputFingerprint });
+      const feature = features.get(featureId);
+      const run = createMockValidatorRun({ featureId, inputFingerprint, validatorAttempt: (feature?.validatorAttemptCount ?? 0) + 1 });
       validatorRuns.set(run.id, run);
+      if (feature) features.set(featureId, { ...feature, lastValidatorRunId: run.id, validatorAttemptCount: run.validatorAttempt, loopState: "validating" });
       return run;
     }),
     listStaleRunningValidatorRuns: vi.fn((_maxAgeMs: number) => [...validatorRuns.values()].filter((run) => run.status === "running")),
@@ -265,9 +267,14 @@ function createMockMissionStore() {
       return updated;
     }),
     getValidatorRun: vi.fn((id: string) => validatorRuns.get(id)),
-    completeValidatorRun: vi.fn((id: string, status: MissionValidatorRun["status"], summary?: string) => {
-      const run = validatorRuns.get(id);
+    completeValidatorRun: vi.fn((id: string, status: MissionValidatorRun["status"], summary?: string, _blockedReason?: string, effects?: import("@fusion/core").ValidatorRunCompletionEffects): import("@fusion/core").ValidatorRunCompletion => {
+      const run = store.getValidatorRun(id);
       if (!run) throw new Error(`Validator run ${id} not found`);
+      const feature = store.getFeature(run.featureId);
+      if (effects && (run.status !== "running" || !feature || effects.featureId !== run.featureId
+        || (effects.triggerType && effects.triggerType !== run.triggerType)
+        || feature.lastValidatorRunId !== run.id || feature.validatorAttemptCount !== run.validatorAttempt
+        || feature.loopState !== "validating")) return { ...run, completionApplied: false };
       if (run.status !== "running") {
         throw new Error(`Validator run ${id} is not in 'running' status`);
       }
@@ -280,11 +287,11 @@ function createMockMissionStore() {
       };
       validatorRuns.set(id, updated);
 
-      const feature = features.get(run.featureId);
       if (feature) {
         if (status === "passed") {
           features.set(run.featureId, {
             ...feature,
+            ...(effects ? { status: "done" as const } : {}),
             loopState: "passed",
             lastValidatorStatus: "passed",
             updatedAt: new Date().toISOString(),
@@ -313,7 +320,11 @@ function createMockMissionStore() {
         }
       }
 
-      return updated;
+      for (const verdict of effects?.assertions ?? []) {
+        const assertion = assertionsByFeature.get(run.featureId)?.find((entry) => entry.id === verdict.assertionId);
+        if (assertion) assertion.status = verdict.status;
+      }
+      return effects ? { ...updated, completionApplied: true } : updated;
     }),
     recordValidatorFailures: vi.fn(() => []),
     createGeneratedFixFeature: vi.fn((sourceFeatureId: string, runId: string, _failedAssertionIds: string[]) => {
@@ -578,6 +589,66 @@ describe("MissionExecutionLoop", () => {
       return { feature, run };
     }
 
+    it("waits for an automatic pre-admission owner, then executes the admitted manual row once", async () => {
+      const { feature, run } = admitManualRun();
+      let release!: () => void;
+      let entered!: () => void;
+      const waiting = new Promise<void>((resolve) => { entered = resolve; });
+      const blocked = new Promise<void>((resolve) => { release = resolve; });
+      missionStore.listAssertionsForFeature.mockImplementationOnce(async () => {
+        entered();
+        await blocked;
+        return makeAssertions(1);
+      });
+      // The automatic fallback loses database admission to the manual row.
+      missionStore.startValidatorRun.mockImplementationOnce(() => { throw new Error("manual row already running"); });
+      const automatic = (loop as any).runFeatureValidation(feature).catch(() => undefined);
+      await waiting;
+      const manual = loop.executeManualValidatorRun(run);
+      await loop.executeManualValidatorRun(run);
+      expect(missionStore.getValidatorRun(run.id)?.status).toBe("running");
+      release();
+      await Promise.all([automatic, manual]);
+      expect(createResolvedAgentSession).toHaveBeenCalledOnce();
+      expect(missionStore.getValidatorRun(run.id)?.status).toBe("passed");
+    });
+
+    it.each(["reaped", "replaced"])("reloads a %s manual admission after the automatic owner releases", async (change) => {
+      const { feature, run } = admitManualRun();
+      let release!: () => void;
+      let entered!: () => void;
+      let checked!: () => void;
+      const ownerEntered = new Promise<void>((resolve) => { entered = resolve; });
+      const ownerBlocked = new Promise<void>((resolve) => { release = resolve; });
+      const admissionChecked = new Promise<void>((resolve) => { checked = resolve; });
+      missionStore.listAssertionsForFeature.mockImplementationOnce(async () => {
+        entered();
+        await ownerBlocked;
+        return makeAssertions(1);
+      });
+      missionStore.startValidatorRun.mockImplementationOnce(() => { throw new Error("manual row already running"); });
+      const automatic = (loop as any).runFeatureValidation(feature).catch(() => undefined);
+      await ownerEntered;
+      const getFeature = missionStore.getFeature.getMockImplementation()!;
+      missionStore.getFeature.mockImplementationOnce((id) => {
+        const snapshot = getFeature(id);
+        checked();
+        return snapshot;
+      });
+      const manual = loop.executeManualValidatorRun(run);
+      await admissionChecked;
+      if (change === "reaped") missionStore.reapValidatorRun(run.id, "reaped while waiting");
+      else missionStore.updateFeature(feature.id, { lastValidatorRunId: "VR-NEW" });
+      release();
+      await Promise.all([automatic, manual]);
+
+      expect(createResolvedAgentSession).not.toHaveBeenCalled();
+      expect(missionStore.completeValidatorRun).not.toHaveBeenCalled();
+      expect(missionStore.getValidatorRun(run.id)?.status).toBe(change === "reaped" ? "error" : "running");
+      expect(missionStore.getFeature(feature.id)?.status).not.toBe("done");
+      expect(missionStore.getAssertionsForFeature(feature.id)).toMatchObject([{ id: "CA-1", status: "pending" }]);
+    });
+
     it.each(["duplicate", "completed", "foreign-feature", "automatic", "superseded"])("does not execute a %s delivery twice or outside its admission fence", async (kind) => {
       const { feature, run } = admitManualRun();
       if (kind === "duplicate") {
@@ -594,6 +665,25 @@ describe("MissionExecutionLoop", () => {
       await loop.executeManualValidatorRun({ id: run.id, featureId: kind === "foreign-feature" ? "F-OTHER" : feature.id });
       expect(createResolvedAgentSession).not.toHaveBeenCalled();
       expect(missionStore.completeValidatorRun).not.toHaveBeenCalled();
+    });
+
+    it.each(["run-read", "feature-read", "recovery-read", "recovery-write"])("recovers an admitted dispatch after a transient %s failure", async (failure) => {
+      const { run } = admitManualRun();
+      if (failure === "run-read") missionStore.getValidatorRun.mockImplementationOnce(() => { throw new Error("run read unavailable"); });
+      if (failure === "feature-read") missionStore.getFeature.mockImplementationOnce(() => { throw new Error("feature read unavailable"); });
+      if (failure === "recovery-write") {
+        missionStore.listAssertionsForFeature.mockImplementationOnce(() => { throw new Error("assertions unavailable"); });
+        missionStore.completeValidatorRun.mockImplementationOnce(() => { throw new Error("terminal write unavailable"); });
+      }
+      if (failure === "recovery-read") {
+        missionStore.listAssertionsForFeature.mockImplementationOnce(() => {
+          missionStore.getValidatorRun.mockImplementationOnce(() => { throw new Error("recovery read unavailable"); });
+          throw new Error("assertions unavailable");
+        });
+      }
+      await expect(loop.executeManualValidatorRun(run)).resolves.toBeUndefined();
+      expect(missionStore.getValidatorRun(run.id)?.status).not.toBe("running");
+      expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
     });
 
     it.each(["assertion-lookup", "session-setup", "stopped", "empty-assertions"])("terminalizes %s failures on the admitted row without creating a fix", async (failure) => {
@@ -613,17 +703,64 @@ describe("MissionExecutionLoop", () => {
     });
 
     it("fences a replaced run before assertion and feature bookkeeping", async () => {
+      /* FNXC:MissionValidation 2026-09-07-04:52:
+       * A late grade must reach the atomic fence but may not mutate assertions,
+       * complete its replacement, or announce a pass after losing ownership.
+       */
       const { feature, run } = admitManualRun();
       const updateContractAssertion = vi.fn();
       Object.assign(missionStore, { updateContractAssertion });
+      const emitSpy = vi.spyOn(loop, "emit");
       vi.mocked(createResolvedAgentSession).mockImplementationOnce(async () => {
         missionStore.updateFeature(feature.id, { lastValidatorRunId: "VR-NEW" });
         return { session: mockSessionHolder.session as any, sessionFile: undefined, runtimeId: "test-runtime", wasConfigured: true };
       });
       await loop.executeManualValidatorRun(run);
       expect(updateContractAssertion).not.toHaveBeenCalled();
-      expect(missionStore.completeValidatorRun).not.toHaveBeenCalled();
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledExactlyOnceWith(run.id, "passed", "Verified contract", undefined, {
+        featureId: feature.id,
+        assertions: [{ assertionId: "CA-1", status: "passed" }],
+      });
+      expect(missionStore.completeValidatorRun).toHaveReturnedWith(expect.objectContaining({ completionApplied: false }));
+      expect(missionStore.getValidatorRun(run.id)?.status).toBe("running");
+      expect(missionStore.getFeature(feature.id)).toMatchObject({ lastValidatorRunId: "VR-NEW", loopState: "validating" });
+      expect(missionStore.getFeature(feature.id)?.status).not.toBe("done");
+      expect(missionStore.getAssertionsForFeature(feature.id)).toMatchObject([{ id: "CA-1", status: "pending" }]);
+      expect(emitSpy).not.toHaveBeenCalled();
       expect(mockSessionHolder.session.dispose).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+      ["manual", "pass"], ["automatic", "pass"],
+      ["manual", "fail"], ["automatic", "fail"],
+      ["manual", "blocked"], ["automatic", "blocked"],
+      ["manual", "inconclusive"], ["automatic", "inconclusive"],
+      ["manual", "error"], ["automatic", "error"],
+    ] as const)("suppresses all posthooks when %s %s completion loses its atomic transition", async (surface, status) => {
+      const { feature, run } = admitManualRun();
+      const updateContractAssertion = vi.fn();
+      Object.assign(missionStore, { updateContractAssertion });
+      const emitSpy = vi.spyOn(loop, "emit");
+      const notifyValidationPass = vi.spyOn(loop as any, "notifyValidationPass");
+      vi.spyOn(loop as any, "runValidation").mockResolvedValue({
+        result: { status, assertions: [{ assertionId: "CA-1", verdict: status === "pass" ? "pass" : "fail", passed: status === "pass", message: "Observed grade" }], summary: "Observed grade" },
+        inspection: { inspectionRoot: "/tmp", fallbackUsed: false, workspaceStale: false },
+      });
+      missionStore.completeValidatorRun.mockImplementationOnce(() => ({ ...run, status: "passed", completionApplied: false }));
+      if (surface === "manual") await loop.executeManualValidatorRun(run);
+      else await (loop as any).runFeatureValidation(feature);
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledOnce();
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(run.id, status === "pass" ? "passed" : status === "fail" ? "failed" : status === "inconclusive" ? "blocked" : status, "Observed grade", undefined, expect.objectContaining({ featureId: feature.id }));
+      expect(updateContractAssertion).not.toHaveBeenCalled();
+      expect(missionStore.updateFeatureStatus).not.toHaveBeenCalled();
+      expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
+      expect(missionStore.triageFeature).not.toHaveBeenCalled();
+      expect(missionStore.recordValidatorFailures).not.toHaveBeenCalled();
+      expect(missionStore.logMissionEvent).not.toHaveBeenCalled();
+      expect(notifyValidationPass).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(missionStore.getFeature(feature.id)?.status).not.toBe("done");
+      expect(missionStore.getAssertionsForFeature(feature.id)).toMatchObject([{ id: "CA-1", status: "pending" }]);
     });
 
     it("does not accept the judge's behavioral pass without genuine verification", async () => {
@@ -650,8 +787,13 @@ describe("MissionExecutionLoop", () => {
 
       expect(createResolvedAgentSession).toHaveBeenCalledOnce();
       expect(missionStore.startValidatorRun).not.toHaveBeenCalled();
-      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(run.id, "passed", "Verified contract");
-      expect(missionStore.getFeature(feature.id)).toMatchObject({ loopState: "passed", lastValidatorStatus: "passed" });
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(run.id, "passed", "Verified contract", undefined, {
+        featureId: feature.id,
+        assertions: [{ assertionId: "CA-1", status: "passed" }],
+      });
+      expect(missionStore.getFeature(feature.id)).toMatchObject({ status: "done", loopState: "passed", lastValidatorStatus: "passed" });
+      expect(missionStore.getAssertionsForFeature(feature.id)).toMatchObject([{ id: "CA-1", status: "passed" }]);
+      expect(missionStore.updateFeatureStatus).not.toHaveBeenCalled();
       expect(mockSessionHolder.session.dispose).toHaveBeenCalledOnce();
       expectNoValidationBoardTaskMutation(taskStore);
     });
@@ -1123,7 +1265,7 @@ describe("MissionExecutionLoop", () => {
         rootDir: "/tmp",
       });
       vi.spyOn(loop as any, "runValidation").mockResolvedValue({
-        result: { status: "pass", summary: "ok" },
+        result: { status: "pass", assertions: [{ assertionId: "CA-F-001", verdict: "pass", passed: true }], summary: "ok" },
         inspection: { inspectionRoot: "/tmp", landedSha: undefined, fallbackUsed: true, workspaceStale: false },
       });
       loop.start();
@@ -1183,7 +1325,7 @@ describe("MissionExecutionLoop", () => {
       Object.assign(missionStore, { startManualValidatorRun });
       loop = new MissionExecutionLoop({ taskStore: taskStore as any, missionStore: missionStore as any, rootDir: "/tmp" });
       vi.spyOn(loop as any, "runValidation").mockResolvedValue({
-        result: { status: "pass", summary: "ok" },
+        result: { status: "pass", assertions: [{ assertionId: "CA-F-001", verdict: "pass", passed: true }], summary: "ok" },
         inspection: { inspectionRoot: "/tmp", landedSha: undefined, fallbackUsed: true, workspaceStale: false },
       });
       loop.start();
@@ -1224,7 +1366,10 @@ describe("MissionExecutionLoop", () => {
 
       expect(missionStore.transitionLoopState).toHaveBeenCalledWith("F-001", "implementing");
       expect(missionStore.startValidatorRun).toHaveBeenCalled();
-      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(expect.any(String), "passed", "Recovered validation passed");
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(expect.any(String), "passed", "Recovered validation passed", undefined, {
+        featureId: "F-001",
+        assertions: [{ assertionId: "CA-1", status: "passed" }],
+      });
     });
 
     it("lazy-ensures a managed assertion and routes zero-assertion features through validation", async () => {
@@ -1250,7 +1395,7 @@ describe("MissionExecutionLoop", () => {
       });
       const emitSpy = vi.spyOn(loop, "emit");
       vi.spyOn(loop as any, "runValidation").mockResolvedValue({
-        result: { status: "pass", summary: "ok" },
+        result: { status: "pass", assertions: [{ assertionId: "CA-F-001", verdict: "pass", passed: true }], summary: "ok" },
         inspection: { inspectionRoot: "/tmp", landedSha: undefined, fallbackUsed: true, workspaceStale: false },
       });
       loop.start();
@@ -1643,10 +1788,14 @@ describe("MissionExecutionLoop", () => {
       await loop.processTaskOutcome("FN-ASSERT-PASS");
 
       expect(missionStore.startValidatorRun).toHaveBeenCalledWith("F-001", "task_completion", "FN-ASSERT-PASS");
-      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(expect.any(String), "passed", expect.any(String));
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(expect.any(String), "passed", expect.any(String), undefined, {
+        featureId: "F-001",
+        assertions: [{ assertionId: "CA-1", status: "passed" }, { assertionId: "CA-2", status: "passed" }],
+      });
       expect(missionStore.getFeature("F-001")?.loopState).toBe("passed");
       expect(missionStore.getFeature("F-001")?.lastValidatorStatus).toBe("passed");
-      expect(missionStore.updateFeatureStatus).toHaveBeenCalledWith("F-001", "done");
+      expect(missionStore.getFeature("F-001")?.status).toBe("done");
+      expect(missionStore.updateFeatureStatus).not.toHaveBeenCalled();
     });
 
     it("defers failed assertion validation when landed-code inspection is unavailable", async () => {
@@ -1668,7 +1817,10 @@ describe("MissionExecutionLoop", () => {
 
       await loop.processTaskOutcome("FN-ASSERT-FAIL");
 
-      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(expect.any(String), "blocked", expect.any(String));
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(expect.any(String), "blocked", expect.any(String), undefined, {
+        featureId: "F-001",
+        assertions: [],
+      });
       expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
       expect(missionStore.getFeature("F-001")?.lastValidatorStatus).toBe("blocked");
       expect(missionStore.getFeature("F-001")?.loopState).toBe("blocked");
@@ -2045,6 +2197,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "passed",
         expect.any(String),
+        undefined,
+        { featureId: "F-001", assertions: [{ assertionId: "CA-1", status: "passed" }, { assertionId: "CA-2", status: "passed" }] },
       );
       expect(missionStore.updateFeature).not.toHaveBeenCalled();
       expectNoValidationBoardTaskMutation(taskStore);
@@ -2139,6 +2293,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "blocked",
         expect.any(String),
+        undefined,
+        { featureId: "F-001", assertions: [] },
       );
 
       // No remediation is created until the judge can inspect landed code.
@@ -2271,7 +2427,7 @@ describe("MissionExecutionLoop", () => {
       });
       const emitSpy = vi.spyOn(loop, "emit");
       vi.spyOn(loop as any, "runValidation").mockResolvedValue({
-        result: { status: "pass", summary: "ok" },
+        result: { status: "pass", assertions: [{ assertionId: "CA-F-001", verdict: "pass", passed: true }], summary: "ok" },
         inspection: { inspectionRoot: "/tmp", landedSha: undefined, fallbackUsed: true, workspaceStale: false },
       });
       loop.start();
@@ -2307,7 +2463,9 @@ describe("MissionExecutionLoop", () => {
       const feature = createMockFeature({ loopState: "implementing", taskId: "FN-REAPED", id: "F-REAPED" });
       missionStore._setFeature(feature);
       missionStore.getFeatureByTaskId = vi.fn().mockReturnValue(feature);
-      missionStore.listAssertionsForFeature = vi.fn().mockReturnValue(assertions);
+      missionStore._setAssertionsForFeature(feature.id, assertions);
+      const updateContractAssertion = vi.fn();
+      Object.assign(missionStore, { updateContractAssertion });
       taskStore._setTask({ id: "FN-REAPED", title: "Test", description: "Implementation", log: [] });
 
       const originalStartValidatorRun = missionStore.startValidatorRun;
@@ -2327,8 +2485,18 @@ describe("MissionExecutionLoop", () => {
 
       await expect(loop.processTaskOutcome("FN-REAPED")).resolves.not.toThrow();
 
-      expect(missionStore.completeValidatorRun).not.toHaveBeenCalledWith(expect.any(String), "passed", expect.any(String));
-      expect(emitSpy).toHaveBeenCalledWith(
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledExactlyOnceWith("VR-001", "passed", "All assertions passed", undefined, {
+        featureId: feature.id,
+        assertions: [{ assertionId: "CA-1", status: "passed" }],
+      });
+      expect(missionStore.completeValidatorRun).toHaveReturnedWith(expect.objectContaining({ completionApplied: false }));
+      expect(missionStore.getValidatorRun("VR-001")).toMatchObject({ status: "error", summary: "stale" });
+      expect(missionStore.getFeature(feature.id)).toMatchObject({ loopState: "needs_fix", lastValidatorStatus: "error" });
+      expect(missionStore.getFeature(feature.id)?.status).not.toBe("done");
+      expect(missionStore.getAssertionsForFeature(feature.id)).toMatchObject([{ id: "CA-1", status: "pending" }]);
+      expect(updateContractAssertion).not.toHaveBeenCalled();
+      expect(missionStore.updateFeatureStatus).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalledWith(
         "validation:passed",
         expect.objectContaining({ featureId: "F-REAPED" }),
       );
@@ -2338,6 +2506,48 @@ describe("MissionExecutionLoop", () => {
   // ── handleValidationFail ──────────────────────────────────────────────────
 
   describe("handleValidationFail", () => {
+    it("suppresses remediation posthooks when ownership is lost after failed completion wins", async () => {
+      const feature = createMockFeature({ loopState: "validating", implementationAttemptCount: 1 });
+      missionStore._setFeature(feature);
+      missionStore._setAssertionsForFeature(feature.id, makeAssertions(1));
+      const run = missionStore.startValidatorRun(feature.id, "task_completion");
+      const notifyValidationComplete = vi.fn();
+      loop = new MissionExecutionLoop({
+        taskStore: taskStore as any,
+        missionStore: missionStore as any,
+        rootDir: "/tmp",
+        missionAutopilot: { notifyValidationComplete },
+      });
+      const emitSpy = vi.spyOn(loop, "emit");
+      missionStore.createGeneratedFixFeature.mockImplementationOnce(() => {
+        expect(missionStore.getValidatorRun(run.id)?.status).toBe("failed");
+        missionStore.updateFeature(feature.id, { lastValidatorRunId: "VR-NEW", validatorAttemptCount: run.validatorAttempt + 1, loopState: "validating" });
+        throw new ValidatorRunOwnershipLostError(run.id);
+      });
+
+      await (loop as any).handleValidationFail(feature.id, run.id, {
+        status: "fail",
+        assertions: [{ assertionId: "CA-1", verdict: "fail", passed: false, message: "Expected outcome missing" }],
+        summary: "failed",
+      }, { featureId: feature.id, assertions: [{ assertionId: "CA-1", status: "failed" }] });
+
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledOnce();
+      expect(missionStore.completeValidatorRun).toHaveReturnedWith(expect.objectContaining({ status: "failed", completionApplied: true }));
+      expect(missionStore.createGeneratedFixFeature).toHaveBeenCalledExactlyOnceWith(
+        feature.id, run.id, ["CA-1"], expect.stringContaining("Expected outcome missing"), undefined,
+        expect.objectContaining({ runId: run.id, sourceFeatureId: feature.id, outcome: "fail" }),
+        { requireCurrentRun: true },
+      );
+      expect(missionStore.getFeature(feature.id)).toMatchObject({ lastValidatorRunId: "VR-NEW", loopState: "validating" });
+      expect(missionStore.getAssertionsForFeature(feature.id)).toMatchObject([{ id: "CA-1", status: "failed" }]);
+      expect(missionStore.triageFeature).not.toHaveBeenCalled();
+      expect(emitSpy).not.toHaveBeenCalled();
+      expect(notifyValidationComplete).not.toHaveBeenCalled();
+      expect(missionStore.logMissionEvent).not.toHaveBeenCalledWith(
+        expect.any(String), expect.any(String), expect.any(String), expect.objectContaining({ code: "fix_feature_creation_needs_attention" }),
+      );
+    });
+
     it("persists failed validation report-only without minting remediation when autonomy is off", async () => {
       const feature = createMockFeature({ id: "F-REPORT", loopState: "validating", implementationAttemptCount: 1 });
       missionStore._setFeature(feature);
@@ -2351,7 +2561,10 @@ describe("MissionExecutionLoop", () => {
         summary: "failed",
       });
 
-      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(run.id, "failed", "failed");
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledWith(run.id, "failed", "failed", undefined, {
+        featureId: "F-REPORT",
+        failures: [{ featureId: "F-REPORT", assertionId: "CA-REPORT", message: "Expected outcome missing", expected: undefined, actual: undefined }],
+      });
       expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
       expect(missionStore.triageFeature).not.toHaveBeenCalled();
       expect(missionStore.logMissionEvent).toHaveBeenCalledWith(
@@ -2412,6 +2625,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "blocked",
         expect.any(String),
+        undefined,
+        { featureId: "F-001", assertions: [] },
       );
       expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
       expect(missionStore.triageFeature).not.toHaveBeenCalled();
@@ -2542,6 +2757,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "blocked",
         expect.stringContaining("code not merged yet"),
+        undefined,
+        { featureId: "F-001", assertions: [] },
       );
       expect(emitSpy).toHaveBeenCalledWith(
         "validation:inconclusive",
@@ -2674,6 +2891,8 @@ describe("MissionExecutionLoop", () => {
           expect.any(String),
           "blocked",
           expect.stringContaining("predates the merged code"),
+          undefined,
+          { featureId: "F-001", assertions: [] },
         );
         expect(emitSpy).toHaveBeenCalledWith(
           "validation:inconclusive",
@@ -2928,6 +3147,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "blocked",
         expect.stringContaining("External API not available"),
+        undefined,
+        { featureId: "F-001", assertions: [{ assertionId: "CA-1", status: "failed" }] },
       );
 
       // createGeneratedFixFeature should NOT be called
@@ -2975,6 +3196,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "error",
         "Validation failed due to error: 401 insufficient credits",
+        undefined,
+        { featureId: "F-001", assertions: [{ assertionId: "CA-1", status: "failed" }] },
       );
       expect(missionStore.createGeneratedFixFeature).not.toHaveBeenCalled();
       expect(emitSpy).toHaveBeenCalledWith(
@@ -3028,6 +3251,8 @@ describe("MissionExecutionLoop", () => {
         expect.any(String),
         "error",
         "Invalid status in validation response",
+        undefined,
+        { featureId: "F-001", assertions: [{ assertionId: "CA-1", status: "failed" }] },
       );
       expect(emitSpy).toHaveBeenCalledWith(
         "validation:error",
@@ -3088,6 +3313,11 @@ describe("MissionExecutionLoop", () => {
 
       await loop.processTaskOutcome("FN-PARENT-ONLY");
 
+      expect(missionStore.startValidatorRun).toHaveBeenCalledExactlyOnceWith(feature.id, "task_completion", feature.taskId);
+      expect(missionStore.completeValidatorRun).toHaveBeenCalledExactlyOnceWith("VR-001", "passed", "No assertions linked to feature", undefined, { featureId: feature.id });
+      expect(missionStore.getValidatorRun("VR-001")?.status).toBe("passed");
+      expect(missionStore.getFeature(feature.id)).toMatchObject({ status: "done", loopState: "passed", lastValidatorStatus: "passed" });
+      expect(missionStore.updateFeatureStatus).not.toHaveBeenCalled();
       expect(missionStore.updateContractAssertion).toHaveBeenCalledWith("CA-MILESTONE", { status: "passed" });
     });
 

--- a/packages/engine/src/missions/mission-execution-loop.ts
+++ b/packages/engine/src/missions/mission-execution-loop.ts
@@ -617,6 +617,44 @@ export class MissionExecutionLoop extends EventEmitter {
   }
 
   /**
+   * FNXC:MissionValidation 2026-09-07-03:43:
+   * Manual routes already own atomic admission. Execute that exact current run
+   * through the shared judge, behavioral verification, and completion pipeline;
+   * never re-admit it or substitute a status-only pass. Duplicate deliveries are
+   * inert, and pipeline setup failures terminalize a still-readable current run.
+   */
+  async executeManualValidatorRun(admitted: Pick<MissionValidatorRun, "id" | "featureId">): Promise<void> {
+    if (this.activeManualRuns.has(admitted.id)) return;
+    this.activeManualRuns.add(admitted.id);
+    try {
+      const current = await this.getCurrentManualValidation(admitted);
+      if (!current) return;
+      try {
+        if (!this.running) throw new Error("Mission execution loop is not running");
+        if (this.activeValidations.has(current.feature.id)) throw new Error("Feature validation is already owned by this process; retry manual validation");
+        await this.runFeatureValidation(current.feature, undefined, current.run);
+      } catch (error) {
+        if (await this.getCurrentManualValidation(admitted)) {
+          await this.handleValidationError(admitted.featureId, admitted.id, error instanceof Error ? error.message : String(error));
+        }
+      }
+    } finally {
+      this.activeManualRuns.delete(admitted.id);
+    }
+  }
+
+  private activeManualRuns = new Set<string>();
+
+  private async getCurrentManualValidation(admitted: Pick<MissionValidatorRun, "id" | "featureId">): Promise<{ feature: MissionFeature; run: MissionValidatorRun } | undefined> {
+    const run = await this.missionStore.getValidatorRun(admitted.id);
+    if (!run || run.featureId !== admitted.featureId || run.triggerType !== "manual" || run.status !== "running") return;
+    const feature = await this.missionStore.getFeature(admitted.featureId);
+    if (!feature || feature.lastValidatorRunId !== run.id || feature.loopState !== "validating"
+      || feature.validatorAttemptCount !== run.validatorAttempt) return;
+    return { feature, run };
+  }
+
+  /**
    * Run assertion validation for a feature and apply the outcome.
    *
    * Shared by processTaskOutcome (task-triggered) and recoverActiveMissions
@@ -628,6 +666,7 @@ export class MissionExecutionLoop extends EventEmitter {
   private async runFeatureValidation(
     feature: MissionFeature,
     preparedMemo?: PreparedValidationMemoization,
+    admittedRun?: MissionValidatorRun,
   ): Promise<void> {
     /*
     FNXC:MissionValidation 2026-08-01-17:14:
@@ -660,6 +699,7 @@ export class MissionExecutionLoop extends EventEmitter {
           await memoToDispose.checkout.dispose().catch((error) => loopLog.warn(`Error disposing unused validation checkout for ${feature.id}:`, error));
           memoToDispose = undefined;
         }
+        if (admittedRun) throw new Error("Manual validation has no linked assertions");
         await this.handleValidationPass(feature.id, undefined, "No assertions linked to feature");
         await this.runMilestoneValidationIfReady(feature);
         return;
@@ -669,7 +709,7 @@ export class MissionExecutionLoop extends EventEmitter {
 
       // The asynchronous store owns cross-process admission; legacy synchronous
       // stores retain the existing fail-open path.
-      const memo = memoToDispose ?? await this.prepareValidationMemoization(feature, assertions);
+      const memo = admittedRun ? undefined : memoToDispose ?? await this.prepareValidationMemoization(feature, assertions);
       memoToDispose = memo;
       const disposeUnusedMemo = async () => {
         if (memoToDispose) {
@@ -679,7 +719,9 @@ export class MissionExecutionLoop extends EventEmitter {
       };
       const admissionStore = this.missionStore as typeof this.missionStore & { admitValidatorRun?: (featureId: string, input: { inputFingerprint: string; taskId?: string; reusePass: boolean; failureBudget: number }) => Promise<{ outcome: "start" | "running" | "reuse-pass" | "budget-exhausted"; run?: MissionValidatorRun }> };
       let run: MissionValidatorRun;
-      if (memo && admissionStore.admitValidatorRun) {
+      if (admittedRun) {
+        run = admittedRun;
+      } else if (memo && admissionStore.admitValidatorRun) {
         const admission = await admissionStore.admitValidatorRun(feature.id, { inputFingerprint: memo.fingerprint, taskId: feature.taskId, reusePass: !memo.hasBehavioralAssertions, failureBudget: VALIDATION_FAILURE_BUDGET_PER_FINGERPRINT });
         if (admission.outcome === "running" || admission.outcome === "budget-exhausted") {
           await disposeUnusedMemo();
@@ -708,6 +750,8 @@ export class MissionExecutionLoop extends EventEmitter {
       // runValidation takes sole ownership of a started run's checkout.
       memoToDispose = undefined;
       const { result, inspection } = await this.runValidation(feature, assertions, run, "feature", memo);
+
+      if (admittedRun && !(await this.getCurrentManualValidation(admittedRun))) return;
 
       // A fail is not durable evidence until its inspection root is trusted.
       // Do this before mutating assertion state: a pre-merge or stale checkout

--- a/packages/engine/src/missions/mission-execution-loop.ts
+++ b/packages/engine/src/missions/mission-execution-loop.ts
@@ -26,7 +26,7 @@ import type {
   Mission,
   ValidationDiagnostics,
 } from "@fusion/core";
-import { MissionRemediationStoppedError, normalizeMissionAssertionType, normalizeValidationDiagnostics, renderValidationFailureDescription,
+import { MissionRemediationStoppedError, ValidatorRunOwnershipLostError, normalizeMissionAssertionType, normalizeValidationDiagnostics, renderValidationFailureDescription,
   resolveTaskLifecycleColumns, resolveWorkflowIrForTask, columnsWithFlag,
 } from "@fusion/core";
 import { GitCheckoutMaterializer, type CheckoutMaterializer, type DisposableCheckout, type VerificationOutcome } from "./mission-verification.js";
@@ -627,16 +627,34 @@ export class MissionExecutionLoop extends EventEmitter {
     if (this.activeManualRuns.has(admitted.id)) return;
     this.activeManualRuns.add(admitted.id);
     try {
-      const current = await this.getCurrentManualValidation(admitted);
-      if (!current) return;
       try {
-        if (!this.running) throw new Error("Mission execution loop is not running");
-        if (this.activeValidations.has(current.feature.id)) throw new Error("Feature validation is already owned by this process; retry manual validation");
-        await this.runFeatureValidation(current.feature, undefined, current.run);
-      } catch (error) {
-        if (await this.getCurrentManualValidation(admitted)) {
-          await this.handleValidationError(admitted.featureId, admitted.id, error instanceof Error ? error.message : String(error));
+        /* FNXC:MissionValidation 2026-09-07-04:33:
+         * A manual admission may beat an automatic owner's database admission.
+         * Join its release without polling, then reload ownership before claiming.
+         * Recheck local ownership after every asynchronous database lookup.
+         */
+        for (;;) {
+          const current = await this.getCurrentManualValidation(admitted);
+          if (!current) return;
+          if (!this.running) throw new Error("Mission execution loop is not running");
+          const owner = this.validationOwners.get(current.feature.id);
+          if (owner) {
+            await owner;
+            continue;
+          }
+          await this.runFeatureValidation(current.feature, undefined, current.run);
+          break;
         }
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        // Recovery uses the immutable admission, not the lookup that just failed.
+        // The terminal CAS itself checks ownership and rejects foreign/stale runs.
+        const terminalize = () => this.completeValidatorRunIfStillRunning(
+          admitted.featureId, admitted.id, "error", reason,
+          { featureId: admitted.featureId, triggerType: "manual" },
+        );
+        const applied = await terminalize().catch(() => terminalize());
+        if (applied) await this.notifyValidationError(admitted.featureId, admitted.id, reason);
       }
     } finally {
       this.activeManualRuns.delete(admitted.id);
@@ -644,6 +662,7 @@ export class MissionExecutionLoop extends EventEmitter {
   }
 
   private activeManualRuns = new Set<string>();
+  private validationOwners = new Map<string, Promise<void>>();
 
   private async getCurrentManualValidation(admitted: Pick<MissionValidatorRun, "id" | "featureId">): Promise<{ feature: MissionFeature; run: MissionValidatorRun } | undefined> {
     const run = await this.missionStore.getValidatorRun(admitted.id);
@@ -680,6 +699,9 @@ export class MissionExecutionLoop extends EventEmitter {
     completion events must share one validator run, including the lazy-link path.
     */
     this.activeValidations.add(feature.id);
+    let releaseOwner!: () => void;
+    const owner = new Promise<void>((resolve) => { releaseOwner = resolve; });
+    this.validationOwners.set(feature.id, owner);
     let memoToDispose = preparedMemo;
 
     try {
@@ -700,8 +722,10 @@ export class MissionExecutionLoop extends EventEmitter {
           memoToDispose = undefined;
         }
         if (admittedRun) throw new Error("Manual validation has no linked assertions");
-        await this.handleValidationPass(feature.id, undefined, "No assertions linked to feature");
-        await this.runMilestoneValidationIfReady(feature);
+        const emptyRun = await this.missionStore.startValidatorRun(feature.id, "task_completion", feature.taskId);
+        if (await this.handleValidationPass(feature.id, emptyRun.id, "No assertions linked to feature")) {
+          await this.runMilestoneValidationIfReady(feature);
+        }
         return;
       }
 
@@ -729,7 +753,9 @@ export class MissionExecutionLoop extends EventEmitter {
         }
         if (admission.outcome === "reuse-pass") {
           await disposeUnusedMemo();
-          await this.handleValidationPass(feature.id, admission.run?.id, "Reused content-addressed validator pass");
+          // Admission has already applied the cached pass under its feature lock.
+          // Do not try to complete the historical terminal row a second time.
+          await this.notifyValidationPass(feature.id, admission.run?.id, "Reused content-addressed validator pass");
           await this.runMilestoneValidationIfReady(feature);
           return;
         }
@@ -751,7 +777,6 @@ export class MissionExecutionLoop extends EventEmitter {
       memoToDispose = undefined;
       const { result, inspection } = await this.runValidation(feature, assertions, run, "feature", memo);
 
-      if (admittedRun && !(await this.getCurrentManualValidation(admittedRun))) return;
 
       // A fail is not durable evidence until its inspection root is trusted.
       // Do this before mutating assertion state: a pre-merge or stale checkout
@@ -762,25 +787,21 @@ export class MissionExecutionLoop extends EventEmitter {
       const deferredFail = result.status === "fail"
         && (Boolean(premergeColumn) || inspection.workspaceStale || Boolean(inspection.inspectionUnavailableReason));
 
-      // Persist only authoritative results from a trusted inspection. The rollup
-      // readiness gate consumes these statuses instead of model summary prose.
-      const updateAssertion = (this.missionStore as unknown as {
-        updateContractAssertion?: (id: string, updates: { status: "passed" | "blocked" | "failed" }) => unknown;
-      }).updateContractAssertion;
-      if (!deferredFail && typeof updateAssertion === "function") {
-        for (const assertion of assertions) {
+      // FNXC:MissionValidation 2026-09-07-04:33: Verdicts travel into the
+      // terminal CAS, never through a preflight read followed by separate writes.
+      const effects: import("@fusion/core").ValidatorRunCompletionEffects = {
+        featureId: feature.id,
+        assertions: deferredFail ? [] : assertions.flatMap((assertion) => {
           const verdict = result.assertions.find((entry) => entry.assertionId === assertion.id);
-          if (!verdict) continue;
-          await updateAssertion.call(this.missionStore, assertion.id, {
-            status: verdict.passed ? "passed" : verdict.verdict === "blocked" ? "blocked" : "failed",
-          });
-        }
-      }
+          return verdict ? [{ assertionId: assertion.id, status: verdict.passed ? "passed" : verdict.verdict === "blocked" ? "blocked" : "failed" }] : [];
+        }),
+      };
 
       // Handle the result
       if (result.status === "pass") {
-        await this.handleValidationPass(feature.id, run.id, result.summary);
-        await this.runMilestoneValidationIfReady(feature);
+        if (await this.handleValidationPass(feature.id, run.id, result.summary, effects)) {
+          await this.runMilestoneValidationIfReady(feature);
+        }
       } else if (result.status === "fail") {
         // A "fail" verdict is only trustworthy once the linked task's code has
         // actually landed in its workflow Complete column. If the task is still mid-pipeline
@@ -794,6 +815,7 @@ export class MissionExecutionLoop extends EventEmitter {
             feature.id,
             run.id,
             `linked task ${feature.taskId} is still "${premergeColumn}" (code not merged yet) — validation deferred`,
+            effects,
           );
         } else if (inspection.workspaceStale || inspection.inspectionUnavailableReason) {
           // FNXC:MissionValidation 2026-07-16-14:00:
@@ -804,9 +826,9 @@ export class MissionExecutionLoop extends EventEmitter {
           const reason = inspection.workspaceStale
             ? `validation workspace predates the merged code for ${feature.taskId} — validation deferred`
             : `validation could not prove the inspected workspace contains merged code (${inspection.inspectionUnavailableReason}) — validation deferred`;
-          await this.handleValidationInconclusive(feature.id, run.id, reason);
+          await this.handleValidationInconclusive(feature.id, run.id, reason, effects);
         } else {
-          await this.handleValidationFail(feature.id, run.id, result);
+          await this.handleValidationFail(feature.id, run.id, result, effects);
         }
       } else if (result.status === "inconclusive") {
         // R21 — "verification could not run" is distinct from "behavior observed
@@ -814,17 +836,21 @@ export class MissionExecutionLoop extends EventEmitter {
         // isolation setup failure, rejected proof) routes to a blocked/needs-
         // attention outcome that spawns NO Fix Feature, and is tracked with a
         // distinguishable infra-failure event so it is separable from real fails.
-        await this.handleValidationInconclusive(feature.id, run.id, result.blockedReason ?? result.summary);
+        await this.handleValidationInconclusive(feature.id, run.id, result.blockedReason ?? result.summary, effects);
       } else if (result.status === "blocked") {
-        await this.handleValidationBlocked(feature.id, run.id, result.blockedReason ?? result.summary);
+        await this.handleValidationBlocked(feature.id, run.id, result.blockedReason ?? result.summary, effects);
       } else if (result.status === "error") {
-        await this.handleValidationError(feature.id, run.id, result.summary);
+        await this.handleValidationError(feature.id, run.id, result.summary, effects);
       }
     } finally {
       if (memoToDispose) {
         await memoToDispose.checkout.dispose().catch((error) => loopLog.warn(`Error disposing abandoned validation checkout for ${feature.id}:`, error));
       }
-      this.activeValidations.delete(feature.id);
+      if (this.validationOwners.get(feature.id) === owner) {
+        this.activeValidations.delete(feature.id);
+        this.validationOwners.delete(feature.id);
+      }
+      releaseOwner();
     }
   }
 
@@ -1902,27 +1928,15 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
   }
 
   private async completeValidatorRunIfStillRunning(
+    featureId: string,
     runId: string | undefined,
     status: "passed" | "failed" | "blocked" | "error",
     summaryOrReason?: string,
+    effects: import("@fusion/core").ValidatorRunCompletionEffects = { featureId },
   ): Promise<boolean> {
-    if (!runId) {
-      return false;
-    }
-
-    if (typeof this.missionStore.getValidatorRun !== "function") {
-      await this.missionStore.completeValidatorRun(runId, status, summaryOrReason);
-      return true;
-    }
-
-    const run = await this.missionStore.getValidatorRun(runId);
-    if (!run || run.status !== "running") {
-      loopLog.warn(`Validator run ${runId} is no longer running; skipping ${status} completion.`);
-      return false;
-    }
-
-    await this.missionStore.completeValidatorRun(runId, status, summaryOrReason);
-    return true;
+    if (!runId) return false;
+    const completion = await this.missionStore.completeValidatorRun(runId, status, summaryOrReason, undefined, effects);
+    return completion.completionApplied === true;
   }
 
   /**
@@ -1931,16 +1945,16 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
   private async handleValidationPass(
     featureId: string,
     runId: string | undefined,
-    summary: string,
-  ): Promise<void> {
+    summary?: string,
+    effects?: import("@fusion/core").ValidatorRunCompletionEffects,
+  ): Promise<boolean> {
+    if (!(await this.completeValidatorRunIfStillRunning(featureId, runId, "passed", summary, effects))) return false;
+    await this.notifyValidationPass(featureId, runId, summary);
+    return true;
+  }
+
+  private async notifyValidationPass(featureId: string, runId: string | undefined, summary?: string): Promise<void> {
     try {
-      await this.completeValidatorRunIfStillRunning(runId, "passed", summary);
-
-      const feature = await this.missionStore.getFeature(featureId);
-      if (feature && feature.status !== "done") {
-        await this.missionStore.updateFeatureStatus(featureId, "done");
-      }
-
       loopLog.log(`Feature ${featureId} passed validation`);
 
       // Notify autopilot if configured
@@ -1961,31 +1975,24 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
     featureId: string,
     runId: string | undefined,
     result: ValidationResult,
+    effects?: import("@fusion/core").ValidatorRunCompletionEffects,
   ): Promise<void> {
     // Tracks how autopilot should be notified. A retry-budget-exhausted feature
     // transitions to blocked, so autopilot must be told "blocked" (not "failed")
     // to stay in sync with the validator-run state.
     let terminalStatus: "failed" | "blocked" = "failed";
+    const failures = result.assertions
+      .filter((a) => !a.passed)
+      .map((a) => ({
+        featureId,
+        assertionId: a.assertionId,
+        message: a.message || "Assertion failed",
+        expected: a.expected,
+        actual: a.actual,
+      }));
+    if (!(await this.completeValidatorRunIfStillRunning(featureId, runId, "failed", result.summary, { ...effects, featureId, failures }))) return;
+
     try {
-      // Record the failures
-      const failures = result.assertions
-        .filter((a) => !a.passed)
-        .map((a) => ({
-          featureId,
-          assertionId: a.assertionId,
-          message: a.message || "Assertion failed",
-          expected: a.expected,
-          actual: a.actual,
-        }));
-
-      const canCompleteRun = runId ? (await this.missionStore.getValidatorRun(runId))?.status === "running" : false;
-
-      if (runId && failures.length > 0 && canCompleteRun) {
-        await this.missionStore.recordValidatorFailures(runId, failures);
-      }
-
-      await this.completeValidatorRunIfStillRunning(runId, "failed", result.summary);
-
       loopLog.log(`Feature ${featureId} failed validation with ${failures.length} failures`);
 
       // FNXC:MissionValidationDiagnostics 2026-07-23-12:00: The normalized verdict—not an LLM summary—drives every persisted failure surface.
@@ -2041,6 +2048,7 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
           failureReason,
           undefined,
           diagnostics,
+          { requireCurrentRun: true },
         );
         loopLog.log(`Created fix feature ${fixFeature.id} for ${featureId}`);
 
@@ -2100,6 +2108,10 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
           });
         } catch (fixErr) {
         const message = fixErr instanceof Error ? fixErr.message : String(fixErr);
+        if (fixErr instanceof ValidatorRunOwnershipLostError) {
+          loopLog.log(`Validator run ${runId} lost ownership before remediation admission; skipping fix creation`);
+          return;
+        }
         if (fixErr instanceof MissionRemediationStoppedError) {
           /*
           FNXC:MissionLineageBudget 2026-07-22-15:15:
@@ -2184,9 +2196,10 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
     featureId: string,
     runId: string | undefined,
     reason: string | undefined,
+    effects?: import("@fusion/core").ValidatorRunCompletionEffects,
   ): Promise<void> {
+    if (!(await this.completeValidatorRunIfStillRunning(featureId, runId, "blocked", reason, effects))) return;
     try {
-      await this.completeValidatorRunIfStillRunning(runId, "blocked", reason);
       loopLog.warn(`Feature ${featureId} verification inconclusive: ${reason ?? "no reason provided"}`);
 
       // R16/R21 — durable, distinguishable infra-failure event. The `outcome`
@@ -2219,9 +2232,10 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
     featureId: string,
     runId: string | undefined,
     blockedReason: string | undefined,
+    effects?: import("@fusion/core").ValidatorRunCompletionEffects,
   ): Promise<void> {
+    if (!(await this.completeValidatorRunIfStillRunning(featureId, runId, "blocked", blockedReason, effects))) return;
     try {
-      await this.completeValidatorRunIfStillRunning(runId, "blocked", blockedReason);
       loopLog.log(`Feature ${featureId} blocked: ${blockedReason}`);
       await this.logFeatureErrorEvent(featureId, "validation_blocked", `Validation blocked for feature ${featureId}: ${blockedReason ?? "no reason provided"}`, {
         runId,
@@ -2246,9 +2260,14 @@ ${taskContext ? `\n\nImplementation context:\n${taskContext}` : ""}`;
     featureId: string,
     runId: string | undefined,
     error: string,
+    effects?: import("@fusion/core").ValidatorRunCompletionEffects,
   ): Promise<void> {
+    if (!(await this.completeValidatorRunIfStillRunning(featureId, runId, "error", error, effects))) return;
+    await this.notifyValidationError(featureId, runId, error);
+  }
+
+  private async notifyValidationError(featureId: string, runId: string | undefined, error: string): Promise<void> {
     try {
-      await this.completeValidatorRunIfStillRunning(runId, "error", error);
       loopLog.error(`Feature ${featureId} validation error: ${error}`);
       await this.logFeatureErrorEvent(featureId, "validation_error", `Validation error for feature ${featureId}: ${error}`, {
         runId,


### PR DESCRIPTION
## Summary

Manual feature validation and `repair-validation` reruns currently admit a running validator row without dispatching it. Route each admitted run through the existing project-scoped mission execution loop and shared validation pipeline.

- Require an available, running executor belonging to the request's project before admission.
- Execute the exact admitted manual run without creating a second run or reusing an automatic memoized pass.
- Preserve existing judge and behavioral verification gates; reject duplicate/stale deliveries and empty assertion sets.
- Dispatch repair reruns through the same path; leave repair-clear semantics unchanged.

## Verification

- Engine regression suite: 107 passed.
- Dashboard targeted route suite: 21 passed on both the upstream branch and matching local-runtime patch, including three cases against an isolated PostgreSQL cluster. The isolated cluster rerun superseded the initial default-harness authentication failure.
- Red/green route and engine regression checks performed.
- Engine/dashboard typechecks, scoped ESLint, engine/dependency/dashboard builds, static gate, changeset validation, and diff checks passed on the upstream port.
- Full merge gate and full workspace build passed on the matching local-runtime patch.
- Full workspace build and boot smoke also passed on the upstream branch. Local smoke required restoring the installed embedded-PostgreSQL package's missing `libicudata.68.dylib` symlink to its existing ABI-compatible `libicudata.68.2.dylib`; no tracked files changed for that environment repair.
- Live manual validation completed through the real judge with a passed owning run. Feature state remained Done/Passed through explicit reconciliation and the subsequent periodic autopilot health check. No validator status was forced.

## Current CI / review status

Build, Typecheck, Gate, Desktop packaging, and security checks pass. The Lint job passes ESLint but fails `check:lifecycle-columns`; the independent baseline check reproduces the same policy-census failure at base `540b0b6f8996f9cd2b286b34d321d73ac2ddd6b8`, outside this patch. The census has not been weakened or baselined away.

Automated review threads remain open, including the automatic/manual ownership collision, initial lookup failure recovery, and atomic result persistence. This PR is not claimed merge-ready merely because normal dispatch passed live verification.

## Scope and known limitations

This restores normal manual dispatch; it does not implement durable dispatch delivery. A transient failure in the initial ownership lookup can still leave an admitted run running until existing stale recovery.

Independent baseline comparison also confirmed a pre-existing completion-ownership race: shared completion handlers perform feature effects after the store transaction. This patch adds an early stale-run rejection, but does not make those shared effects atomic or fix stop-linked cancellation. Those require separate lifecycle hardening; no stronger guarantee is claimed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Manual validation and repair reruns now launch through the appropriate project execution engine.
  - Transient setup or execution issues can recover and retry safely.

- **Bug Fixes**
  - Prevented stale or replaced validation runs from overwriting newer results.
  - Validation outcomes, assertion updates, feature status, and remediation are now applied atomically.
  - Duplicate or out-of-date completions no longer trigger incorrect notifications or repair actions.
  - Validation runs without assertions now complete through the standard execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->