### PR TITLE
fix: recover stale manual merge hold failures

### DIFF
--- a/.changeset/manual-merge-hold-pause-abort-rescue.md
+++ b/.changeset/manual-merge-hold-pause-abort-rescue.md
@@ -1,0 +1,7 @@
+---
+"@runfusion/fusion": patch
+---
+
+summary: Clear stale pause-abort failures on manual merge holds without retrying or moving the task.
+category: fix
+dev: Restore quarantined merge-abort coverage with lifecycle-containment and pause/cancel regression tests.

--- a/docs/solutions/test-failures/suite-only-flakes-observed-register.md
+++ b/docs/solutions/test-failures/suite-only-flakes-observed-register.md
@@ -227,7 +227,7 @@ Quarantine was not available as an alternative. Core PostgreSQL files cannot be 
 
 ### 14. Merge-node paused-abort retry sequence
 
-- **Status:** Quarantined 2026-08-29 after a second sequence-only sighting — rescue owner FN-9283 (mission M-MTU4YAJI-0001-PAJK), deletion-ratchet deadline 2026-09-12 (quarantinedAt + 14d).
+- **Status:** Rescued 2026-09-09 after a root-cause repair; the original quarantine began 2026-08-29. Rescue owner FN-9283 (mission M-MTU4YAJI-0001-PAJK); original deletion-ratchet deadline 2026-09-12 (quarantinedAt + 14d).
 - **File:** `packages/engine/src/__tests__/reliability-interactions/merge-node-paused-abort-retryable.test.ts`
 - **Exact test:** `merge-node paused-abort retry classification (FN-6735) > re-enqueues benign paused merge graph failure at node %s without operator-action failure` (parameterized `it.each`; the observed case was `%s` = `merge`, plus 12 sibling sequence failures).
 - **Observed tree/SHA:** first sighting `f3e1e7d1f`; second sighting during FN-249 verification after `2ab621ac6`.
@@ -240,7 +240,15 @@ Quarantine was not available as an alternative. Core PostgreSQL files cannot be 
 | second file as `engine-reliability` | **13 failed / 44 passed** with the same recovery-write misses |
 | second selected exact subject alone | passed (exit 0) |
 
-The failure remains sequence-only evidence, not an attribution to FN-249: its changed user-cancellation path is not enabled by this fixture, and the selected pre-existing engine-abort subject passes in isolation. Per the mandatory deletion ratchet, the second sighting is quarantined in `scripts/lib/test-quarantine.json` and the matching `engine-reliability` exclude; no timeout, retry, or assertion was changed. Rescue requires a root-cause fix that proves the file's recovery coverage is stable.
+The historical runs established sequence-only evidence, not attribution to FN-249. On `a8b29f77fa`, running the entire file reproduced 13 failures: 12 assertions still expected automatic review-to-WIP movement forbidden by the current lifecycle contract, and one stale manual-hold recovery was blocked by the earlier durable merger-park guard. The rescue keeps review failures in place, retains positive already-WIP resume/worktree coverage, and lets only fully classified benign manual holds reach the existing recovery branch.
+
+The expanded full-file negative control failed all 16 stale-hold cases across eight merge aliases and default/renamed review lanes, while 304 pause/cancel/blocker and lifecycle cases passed. With the production ordering fix, all 320 cases passed. The adjacent `lifecycle-containment-resume`, `executor-user-cancel-terminal-graph-exit`, and `review-empty-content-terminal` files passed all 38 tests. These results prove a regression-catching root fix, not a timeout/retry or stabilization-only rescue; they do not retroactively identify every historical failure. The ledger and `engine-reliability` exclusion are removed together.
+
+Reproduce the full-file gate with a disposable `HOME` and `TMPDIR` (the shared test teardown cleans its temporary root):
+
+```sh
+pnpm --filter @fusion/engine exec vitest run --project engine-reliability src/__tests__/reliability-interactions/merge-node-paused-abort-retryable.test.ts
+```
 
 
 ### Common shape and investigated result

--- a/packages/engine/src/__tests__/reliability-interactions/merge-node-paused-abort-retryable.test.ts
+++ b/packages/engine/src/__tests__/reliability-interactions/merge-node-paused-abort-retryable.test.ts
@@ -3,9 +3,38 @@ import "../executor-test-helpers.js";
 import { TaskExecutor } from "../../executor.js";
 import { runWorkflowMergeAttemptNode } from "../../workflows/workflow-merge-nodes.js";
 import { createMockStore, resetExecutorMocks } from "../executor-test-helpers.js";
-import type { TaskDetail } from "@fusion/core";
+import type { TaskDetail, WorkflowIr } from "@fusion/core";
 
 const now = "2026-06-19T00:00:00.000Z";
+const mergeNodes = [
+  "merge", "requestMerge", "merge-gate", "merge-attempt",
+  "manual-merge-hold", "merge-manual-hold", "retry-backoff", "merge-retry",
+] as const;
+const mergeReviewSurfaces = ["in-review", "approval-desk"].flatMap((column) =>
+  mergeNodes.map((nodeId) => ({ column, nodeId })),
+);
+
+function stalePauseAbortError(nodeId: string, column = "in-review"): string {
+  return `Workflow graph failure surfaced after paused engine abort during pause/resume in '${column}' at node '${nodeId}' — operator action required; retry or explicitly unpause/resume after inspecting the task`;
+}
+
+function configureRenamedLanes(store: ReturnType<typeof createMockStore>): void {
+  const ir: WorkflowIr = {
+    version: "v2",
+    name: "Renamed lifecycle lanes",
+    columns: [
+      { id: "planning-desk", name: "Planning", traits: [{ trait: "hold" }] },
+      { id: "implementation-desk", name: "Implementation", traits: [{ trait: "wip" }] },
+      { id: "approval-desk", name: "Approval", traits: [{ trait: "merge" }, { trait: "merge-blocker" }, { trait: "human-review" }] },
+      { id: "shipped", name: "Shipped", traits: [{ trait: "complete" }] },
+    ],
+    nodes: [{ id: "start", kind: "start" }, { id: "end", kind: "end" }],
+    edges: [{ from: "start", to: "end" }],
+  };
+  store.getTaskWorkflowSelectionAsync.mockResolvedValue({ workflowId: "WF-rescue", stepIds: [] });
+  store.getTaskWorkflowSelection.mockReturnValue({ workflowId: "WF-rescue", stepIds: [] });
+  store.getWorkflowDefinition = vi.fn(async () => ({ id: "WF-rescue", name: ir.name, ir }));
+}
 
 function makeInReviewTask(overrides: Partial<TaskDetail> = {}): TaskDetail {
   return {
@@ -49,6 +78,9 @@ function makeHarness(taskOverrides: Partial<TaskDetail> = {}, settingsOverrides:
     worktreeInitCommand: undefined,
     ...settingsOverrides,
   });
+  if (["approval-desk", "implementation-desk", "planning-desk", "shipped"].includes(task.column)) {
+    configureRenamedLanes(store);
+  }
   const executor = new TaskExecutor(store, "/tmp/test", {});
   const mergeRequester = vi.fn(async () => ({
     task,
@@ -284,17 +316,65 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     expect(logText(store)).toContain("manual merge hold with auto-merge off");
   });
 
-  it("clears stale already-parked autoMerge:false merge-node pause-abort failures in place", async () => {
-    const staleError = "Workflow graph failure surfaced after paused engine abort during pause/resume in 'in-review' at node 'merge-manual-hold' — operator action required; retry or explicitly unpause/resume after inspecting the task";
-    const { store, task, executor, mergeRequester } = makeHarness({ autoMerge: undefined, paused: false, status: "failed", error: staleError }, { autoMerge: false });
+  /*
+  FNXC:ManualMergeHoldRescue 2026-09-09-09:13:
+  Stale pause-abort errors are not durable merger blockers. Recover only the matching merge-node
+  signature on an unpaused, human-gated review row, across aliases and workflow-renamed lanes.
+  The same rows with real pause/cancel/blocker evidence must remain untouched.
+  */
+  it.each(mergeReviewSurfaces)("clears a stale manual hold at $nodeId in $column in place", async ({ nodeId, column }) => {
+    const { store, task, executor, mergeRequester } = makeHarness({
+      column, autoMerge: undefined, paused: false, status: "failed", error: stalePauseAbortError(nodeId, column),
+    }, { autoMerge: false });
+    (executor as any).addActiveWorktree(task.id, task.worktree);
 
-    await invokeGraphFailure(executor, task, "merge-manual-hold", "merge-finalize-blocked");
+    await invokeGraphFailure(executor, task, nodeId, "merge-finalize-blocked");
 
     expect(mergeRequester).not.toHaveBeenCalled();
-    expect(store.updateTask).toHaveBeenCalledWith(task.id, { status: null, error: null }, undefined);
+    expect(store.updateTask).toHaveBeenCalledExactlyOnceWith(task.id, { status: null, error: null }, undefined);
+    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(await store.getTask(task.id)).toMatchObject({ column, status: null, error: null, steps: task.steps, worktree: task.worktree });
+    expect((executor as any).activeWorktrees.has(task.id)).toBe(false);
+    expect((executor as any).pausedAborted.has(task.id)).toBe(false);
     expect(logText(store)).toContain("Auto-recovered: cleared stale auto-merge-off manual merge hold pause-abort failure — failure notification suppressed");
-    expect(logText(store)).not.toContain("Workflow graph failure surfaced after paused engine abort during pause/resume");
+    expect(logText(store)).not.toContain("honoring park, not retrying or resuming merge");
   });
+
+  const recoveryFences: Array<{ name: string; overrides?: Partial<TaskDetail>; value?: string; provenance?: string; cancel?: boolean; clearAbort?: boolean }> = [
+    { name: "live system pause", overrides: { paused: true, pausedReason: "system-pause-park" } },
+    { name: "explicit user pause", overrides: { userPaused: true } },
+    { name: "global pause", provenance: "global-pause" },
+    { name: "operator cancellation", cancel: true },
+    { name: "absent abort marker", clearAbort: true },
+    { name: "merge conflict", value: "merge-conflict" },
+    { name: "contamination", value: "foreign-only-contamination" },
+    { name: "retry exhaustion", value: "merge-retry-exhausted" },
+    { name: "unproven merge boundary", value: "merge-boundary-unproven" },
+    { name: "real failure", overrides: { error: "real failure before graph unwind" } },
+    { name: "durable dependency blocker", overrides: { error: "BLOCKED: dependency unavailable" } },
+    { name: "empty review park", overrides: { error: "NO REVIEWABLE CONTENT: no task diff" } },
+    { name: "auto merge enabled", overrides: { autoMerge: true } },
+    { name: "different stale node", overrides: { error: stalePauseAbortError("parse") } },
+  ];
+  it.each(mergeReviewSurfaces.flatMap((surface) => recoveryFences.map((fence) => ({ ...surface, ...fence }))))(
+    "preserves $name at $nodeId in $column instead of clearing a manual hold",
+    async ({ nodeId, column, overrides, value, provenance, cancel, clearAbort }) => {
+      const { store, task, executor, mergeRequester } = makeHarness({
+        column, autoMerge: undefined, paused: false, status: "failed", error: stalePauseAbortError(nodeId, column), ...overrides,
+      }, { autoMerge: false });
+      if (provenance) (executor as any).markPausedAborted(task.id, provenance);
+      if (cancel) (executor as any).userCanceledTaskIds.add(task.id);
+      if (clearAbort) (executor as any).clearPausedAborted(task.id);
+
+      await invokeGraphFailure(executor, task, nodeId, value ?? "merge-finalize-blocked");
+
+      expect(mergeRequester).not.toHaveBeenCalled();
+      expect(store.updateTask).not.toHaveBeenCalled();
+      expect(store.moveTask).not.toHaveBeenCalled();
+      expect(await store.getTask(task.id)).toMatchObject({ column, status: task.status, error: task.error });
+      expect(logText(store)).not.toContain("Auto-recovered: cleared stale");
+    },
+  );
 
   it("preserves global and explicit user pause terminal behavior", async () => {
     const globalHarness = makeHarness();
@@ -371,7 +451,7 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     expect((executor as any).activeWorktrees.has(task.id)).toBe(false);
   });
 
-  it.each(["merge-attempt", "merge"] as const)("routes primitive-produced implementation-incomplete resumable failure at node %s without requesting merge", async (nodeId) => {
+  it.each(["merge-attempt", "merge"] as const)("contains primitive-produced implementation-incomplete review failure at node %s without requesting merge", async (nodeId) => {
     const worktreePath = "/tmp/fusion-fn-9166-resumable";
     const { store, task, executor, mergeRequester } = makeHarness({
       steps: [
@@ -391,9 +471,10 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     await invokeGraphFailure(executor, task, nodeId, value);
 
     expect(mergeRequester).not.toHaveBeenCalled();
-    expect(store.moveTask).toHaveBeenCalledWith(task.id, "in-progress", expect.objectContaining({ preserveProgress: true }));
-    expect(logText(store)).toContain(`Workflow graph failed at node '${nodeId}' (implementation-incomplete) with incomplete steps — resuming execution in 'in-progress'`);
-    expect((executor as any).getActiveWorktreePaths(task.id)).toEqual([worktreePath]);
+    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(logText(store)).toContain("automatic recovery cannot move 'in-review' backward");
+    expect(await store.getTask(task.id)).toMatchObject({ column: "in-review", status: "failed", steps: task.steps, worktree: worktreePath });
+    expect((executor as any).activeWorktrees.has(task.id)).toBe(false);
   });
 
   it.each(implementationIncompleteMergeNodes)("fails implementation-incomplete no-proof merge pause abort at node %s without requesting no-op merge", async (nodeId) => {
@@ -451,8 +532,16 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     expect(messages).not.toContain("routed to bounded auto-merge retry after benign pause/resume abort");
   });
 
-  it.each(implementationIncompleteMergeNodes)("requeues resumable implementation-incomplete parsed steps at node %s without requesting merge", async (nodeId) => {
+  /*
+  FNXC:LifecycleContainment 2026-09-09-09:13:
+  Automatic merge recovery never grants review-to-WIP authority. Incomplete review work stays
+  failed in review; the same pending work already in WIP resumes in place, including renamed lanes.
+  */
+  it.each(["in-review", "approval-desk", "in-progress", "implementation-desk"].flatMap((column) =>
+    mergeNodes.map((nodeId) => ({ column, nodeId })),
+  ))("contains implementation-incomplete parsed steps at $nodeId in $column without requesting merge", async ({ nodeId, column }) => {
     const { store, task, executor, mergeRequester } = makeHarness({
+      column,
       steps: [
         { name: "Preflight", status: "done" },
         { name: "Implement", status: "pending" },
@@ -468,15 +557,20 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     await invokeGraphFailure(executor, task, nodeId, "implementation-incomplete");
 
     expect(mergeRequester).not.toHaveBeenCalled();
-    expect(store.updateTask).toHaveBeenCalledWith(task.id, { status: null, error: null }, undefined);
-    expect(store.moveTask).toHaveBeenCalledWith(task.id, "in-progress", expect.objectContaining({
-      preserveProgress: true,
-      moveSource: "engine",
-      recoveryRehome: true,
-    }));
-    expect(store.moveTask).not.toHaveBeenCalledWith(task.id, "done", expect.anything());
+    expect(store.moveTask).not.toHaveBeenCalled();
     const messages = logText(store);
-    expect(messages).toContain(`Workflow graph failed at node '${nodeId}' (implementation-incomplete) with incomplete steps — resuming execution in 'in-progress'`);
+    if (column === "in-progress" || column === "implementation-desk") {
+      expect(store.updateTask).toHaveBeenCalledWith(task.id, { status: null, error: null }, undefined);
+      expect(await store.getTask(task.id)).toMatchObject({ column, status: null, error: null, steps: task.steps });
+      expect(messages).toContain(`with incomplete work — resuming in place in '${column}'`);
+    } else {
+      expect(store.updateTask).toHaveBeenCalledWith(task.id, {
+        status: "failed",
+        error: expect.stringContaining("implementation incomplete with no executable proof to resume"),
+      }, undefined);
+      expect(await store.getTask(task.id)).toMatchObject({ column, status: "failed", steps: task.steps });
+      expect(messages).toContain(`automatic recovery cannot move '${column}' backward`);
+    }
     expect(messages).not.toContain("routed to bounded auto-merge retry after benign pause/resume abort");
   });
 
@@ -519,9 +613,10 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     expect((executor as any).activeWorktrees.has(task.id)).toBe(false);
   });
 
-  it("requeues system-paused implementation-incomplete incomplete steps and keeps active worktree tracking", async () => {
+  it("resumes system-paused implementation-incomplete WIP steps in place and keeps active worktree tracking", async () => {
     const worktreePath = "/tmp/fusion-fn-1165-resumable-wt";
     const { store, task, executor, mergeRequester } = makeHarness({
+      column: "in-progress",
       steps: [
         { name: "Preflight", status: "done" },
         { name: "Implement", status: "pending" },
@@ -540,28 +635,26 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     await invokeGraphFailure(executor, task, "merge", "implementation-incomplete");
 
     expect(mergeRequester).not.toHaveBeenCalled();
-    // System pause park must be cleared so the requeued todo row is dispatchable.
+    // FNXC:LifecycleContainment 2026-09-09-09:13: Clear system pause without moving the WIP row.
     expect(store.updateTask).toHaveBeenCalledWith(
       task.id,
       expect.objectContaining({ paused: false, pausedReason: null }),
       undefined,
     );
-    expect(store.moveTask).toHaveBeenCalledWith(task.id, "in-progress", expect.objectContaining({
-      preserveProgress: true,
-      moveSource: "engine",
-      recoveryRehome: true,
-    }));
+    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(await store.getTask(task.id)).toMatchObject({ column: "in-progress", status: null, error: null, paused: false, steps: task.steps });
     const messages = logText(store);
-    expect(messages).toContain("Workflow graph failed at node 'merge' (implementation-incomplete) with incomplete steps — resuming execution in 'in-progress'");
+    expect(messages).toContain("with incomplete work — resuming in place in 'in-progress'");
     expect(messages).not.toContain("operator action required");
     // Resumable path keeps active registration so the preserved worktree stays counted.
     expect((executor as any).activeWorktrees.has(task.id)).toBe(true);
     expect((executor as any).getActiveWorktreePaths(task.id)).toEqual([worktreePath]);
   });
 
-  it("keeps active worktree tracking on non-paused resumable implementation-incomplete requeue", async () => {
+  it("keeps active worktree tracking on non-paused implementation-incomplete WIP resume", async () => {
     const worktreePath = "/tmp/fusion-fn-1165-unpaused-resumable-wt";
     const { store, task, executor, mergeRequester } = makeHarness({
+      column: "in-progress",
       steps: [
         { name: "Preflight", status: "done" },
         { name: "Implement", status: "pending" },
@@ -578,7 +671,8 @@ describe("merge-node paused-abort retry classification (FN-6735)", () => {
     await invokeGraphFailure(executor, task, "merge-gate", "implementation-incomplete");
 
     expect(mergeRequester).not.toHaveBeenCalled();
-    expect(store.moveTask).toHaveBeenCalledWith(task.id, "in-progress", expect.objectContaining({ preserveProgress: true }));
+    expect(store.moveTask).not.toHaveBeenCalled();
+    expect(await store.getTask(task.id)).toMatchObject({ column: "in-progress", status: null, error: null, steps: task.steps, worktree: worktreePath });
     expect((executor as any).activeWorktrees.has(task.id)).toBe(true);
     expect((executor as any).getActiveWorktreePaths(task.id)).toEqual([worktreePath]);
   });

--- a/packages/engine/src/executor/handle-graph-failure.ts
+++ b/packages/engine/src/executor/handle-graph-failure.ts
@@ -288,8 +288,22 @@ export async function handleGraphFailure(
       failure. The review lane already consumes no WIP capacity, so this branch performs no move.
       */
       const parkedMergeNode = result.visitedNodeIds[result.visitedNodeIds.length - 1];
+      /*
+      FNXC:ManualMergeHoldRescue 2026-09-09-09:28:
+      A recognized stale pause-abort failure is not a durable merger refusal. Let only the existing
+      human-hold classifier's fully qualified review rows reach its in-place recovery below;
+      cancellation, live pauses, terminal merge failures, and real blockers still honor the park.
+      */
+      const recoverableManualHold = live.error != null
+        && live.status === "failed"
+        && live.column === failureLanes.review
+        && !deps.userCanceledTaskIds.has(task.id)
+        && await deps.isBenignManualMergeHoldPauseAbort(
+          live, result, deps.pausedAbortProvenance.get(task.id), deps.pausedAborted.has(task.id), resumeLanesMemo,
+        );
       if (
         live.error != null &&
+        !recoverableManualHold &&
         (live.column === failureLanes.hold
           || (live.column === failureLanes.review && live.status === "failed")) &&
         isMergeGraphFailure(parkedMergeNode)
@@ -636,7 +650,7 @@ export async function handleGraphFailure(
           return;
         }
       }
-      if (genuinePauseAbort && await deps.isBenignManualMergeHoldPauseAbort(live, result, abortProvenance, pausedAborted, resumeLanesMemo)) {
+      if (genuinePauseAbort && (recoverableManualHold || await deps.isBenignManualMergeHoldPauseAbort(live, result, abortProvenance, pausedAborted, resumeLanesMemo))) {
         /*
         FNXC:WorkflowLifecycle 2026-07-09-14:56:
         FN-7749 / Runfusion#1979: auto-merge-off manual merge hold is terminal-until-human-merged, not an executor failure. Preserve the `in-review` row for Merge & Close, do not invoke merge retry, and clear only stale pause-abort status/error so FN-5147's no-backward-move/no-reenqueue contract stays intact.

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -483,12 +483,11 @@ export default defineConfig({
             // FNXC:PgMigrationQuarantine 2026-07-16-12:30:
             // FN-8118 verified the already-landed post-done continuation rescue: this pure in-memory suite has no PG fixture and passed its serialized reliability lane three times. Keep it absent from this quarantine list while preserving the engine-default reliability partition exclusion.
             /*
-            FNXC:ReliabilityQuarantine 2026-08-29-03:11:
-            FN-249 observed the second sequence-only failure of this file: the selected engine-abort
-            subject passes alone, while the serialized file misses recovery writes after sibling cases.
-            Quarantine the whole file under the deletion ratchet rather than weaken its assertions.
+            FNXC:ManualMergeHoldRescue 2026-09-09-09:28:
+            Restore merge-node paused-abort coverage after fixing the durable-park classifier ordering
+            and replacing obsolete review-to-WIP expectations with in-place lifecycle assertions.
+            The full file proves recovery across merge aliases while preserving pause/cancel blockers.
             */
-            "src/__tests__/reliability-interactions/merge-node-paused-abort-retryable.test.ts",
           ],
           // These tests assert event ordering across real worktrees. Parallel
           // execution under merger load caused subprocess-guard timeouts and

--- a/scripts/lib/test-quarantine.json
+++ b/scripts/lib/test-quarantine.json
@@ -2,11 +2,6 @@
   "$comment": "Flaky-test quarantine ledger (deletion ratchet \u2014 see AGENTS.md 'Flaky tests: quarantine on sight' and docs/testing.md 'Quarantine ledger and the deletion ratchet'). A test observed failing without a corresponding real bug is quarantined ON SIGHT: add an entry here AND a matching one-line `exclude` entry in that package's vitest config, in the same commit. Every entry needs a non-empty `reason` (link the failing run) and a `quarantinedAt` date \u2014 the entry expires 14 days later, at which point the test file is DELETED unless someone rescues it with evidence it catches real regressions plus a root-cause fix (never appeasement). scripts/check-quarantine-ledger.mjs mechanically verifies this ledger and concrete `exclude:` array entries stay in lockstep.",
   "entries": [
     {
-      "file": "packages/engine/src/__tests__/reliability-interactions/merge-node-paused-abort-retryable.test.ts",
-      "reason": "SECOND sighting of the sequence-only reliability failure recorded in docs/solutions/test-failures/suite-only-flakes-observed-register.md entry 14. FN-249's selected engine-reliability file run failed 13 sibling recovery assertions after prior cases, while the exact benign merge-abort subject passed immediately in isolation. The user-cancellation path is not enabled by this fixture; no timeout, retry, or assertion was changed. Quarantined under AGENTS.md's mandatory deletion ratchet until a root-cause repair proves the file's recovery coverage can be rescued.",
-      "quarantinedAt": "2026-08-29"
-    },
-    {
       "file": "packages/engine/src/__tests__/spec-drift-reconciler.test.ts",
       "reason": "SECOND sighting of the timer-driven exponential-backoff failure recorded in docs/solutions/test-failures/suite-only-flakes-observed-register.md. FN-9272's selected engine test command observed three persistence attempts after the second 1-second fake-timer advance, while the test expects two; this parser-only change does not touch the reconciler. Quarantined under AGENTS.md's mandatory deletion ratchet without weakening the timing assertion.",
       "quarantinedAt": "2026-09-09"


### PR DESCRIPTION
## Summary
- Let the existing benign manual-merge-hold classifier clear stale pause-abort failures before the broad durable merger-park guard intercepts them. Recovery stays in review and never requests a merge or re-enqueues the task.
- Preserve live pause, cancellation, confirmed-merge, and real blocker fences across merge-node aliases and renamed workflow lanes.
- Restore the quarantined regression suite and update obsolete review-to-WIP expectations to the current lifecycle-containment contract. Remove its ledger entry and exclusion together; preserve the unrelated spec-drift quarantine and recorded rescue ownership.

## Test plan
- [x] Regression negative control: 16 stale-hold cases fail without the ordering fix; all 320 rescued cases pass with it.
- [x] Current-base focused engine verification: 6 files, 398 tests pass, zero skipped.
- [x] Engine typecheck and full configured `pnpm lint`.
- [x] Strict quarantine ledger, changeset format, FNXC dates, and whitespace checks.
- [ ] Build and full Gate in CI. Local PostgreSQL gate is unavailable because no isolated test server is configured; no production database was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stale pause-abort failures during manual merge holds are now cleared in place without moving tasks.
  - Review-column tasks remain in place when recovery is incomplete, while eligible work-in-progress tasks resume without unnecessary relocation.
  - Durable pauses, cancellations, blockers, conflicts, and genuine failures continue to be preserved.

- **Tests**
  - Restored coverage for renamed workflow lanes and merge-node recovery scenarios.
  - Removed the related test from quarantine after resolving the underlying reliability issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->